### PR TITLE
Replace the repo’s one-off Cloudflare Tunnel guidance with a stable named-tunnel deployment path and tunnel-aware verification so dazbeez.com stops serving Cloudflare 1033 when the local origin is up.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Copy this file to .env before starting the production profile:
+# cp .env.example .env
+# Cloudflare Tunnel token for the dazbeez.com tunnel.
+CLOUDFLARE_TUNNEL_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -18,4 +18,34 @@ AI, Automation & Data Solutions website built with Next.js 16.2.1.
 ## Quick Start
 
 ### Development
+1. Install dependencies with `npm install`.
+2. Start the app with `npm run dev`.
+3. Open `http://localhost:3000`.
 
+### Production Deployment With Cloudflare Tunnel
+`dazbeez.com` requires the Docker Compose `production` profile. Running only `docker compose up -d` starts the app container, but it does not start `nginx` or `cloudflared`, which leaves Cloudflare serving Error 1033.
+
+1. Create the production env file:
+   `cp .env.example .env`
+2. Edit `.env` and set `CLOUDFLARE_TUNNEL_TOKEN` to the token for the `dazbeez.com` tunnel in Cloudflare Zero Trust.
+3. Build and start the production stack:
+   `docker compose --profile production up -d --build`
+4. Confirm the tunnel path is running:
+   `docker compose --profile production ps`
+5. Verify public reachability:
+   `./scripts/check-cloudflare-tunnel.sh dazbeez.com`
+
+If Cloudflare shows Error 1033, the first things to check are:
+- `.env` exists in the project root.
+- `CLOUDFLARE_TUNNEL_TOKEN` is set correctly.
+- `cloudflared` is running under the `production` profile.
+
+Inspect tunnel logs with:
+`docker compose --profile production logs cloudflared --tail=50`
+
+### Direct Origin Checks
+`./scripts/check-domain-resolution.sh` is for direct-origin validation against a local IP or reverse proxy. For the public `dazbeez.com` path behind Cloudflare Tunnel, use `./scripts/check-cloudflare-tunnel.sh` instead.
+
+### Optional Ollama Profile
+Start the LLM sidecar with:
+`docker compose --profile llm up -d`

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,9 +22,10 @@ export const metadata: Metadata = {
     siteName: "Dazbeez",
     images: [
       {
-        url: "https://dazbeez.com/og-image.jpg",
+        url: "/opengraph-image",
         width: 1200,
         height: 630,
+        alt: "Dazbeez AI, Automation & Data Solutions",
       },
     ],
     locale: "en_US",
@@ -34,7 +35,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "Dazbeez - AI, Automation & Data Solutions",
     description: "Transform your business with AI integration, automation, data management, and governance services.",
-    images: ["https://dazbeez.com/og-image.jpg"],
+    images: ["/opengraph-image"],
   },
 };
 

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,0 +1,130 @@
+import { ImageResponse } from "next/og";
+
+export const alt = "Dazbeez AI, Automation & Data Solutions";
+export const size = {
+  width: 1200,
+  height: 630,
+};
+export const contentType = "image/png";
+
+export default function OpenGraphImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          alignItems: "stretch",
+          background:
+            "linear-gradient(135deg, #111827 0%, #1f2937 58%, #111827 100%)",
+          color: "#f9fafb",
+          display: "flex",
+          height: "100%",
+          padding: "56px",
+          width: "100%",
+        }}
+      >
+        <div
+          style={{
+            border: "1px solid rgba(245, 158, 11, 0.3)",
+            borderRadius: "36px",
+            display: "flex",
+            flex: 1,
+            overflow: "hidden",
+          }}
+        >
+          <div
+            style={{
+              background:
+                "radial-gradient(circle at top left, rgba(245, 158, 11, 0.28), transparent 55%)",
+              display: "flex",
+              flex: 1,
+              flexDirection: "column",
+              justifyContent: "space-between",
+              padding: "56px",
+            }}
+          >
+            <div
+              style={{
+                alignItems: "center",
+                display: "flex",
+                gap: "20px",
+              }}
+            >
+              <div
+                style={{
+                  alignItems: "center",
+                  background: "linear-gradient(135deg, #fbbf24, #d97706)",
+                  borderRadius: "9999px",
+                  color: "#111827",
+                  display: "flex",
+                  fontSize: "34px",
+                  fontWeight: 800,
+                  height: "84px",
+                  justifyContent: "center",
+                  width: "84px",
+                }}
+              >
+                D
+              </div>
+              <div
+                style={{
+                  color: "#fbbf24",
+                  display: "flex",
+                  fontSize: "34px",
+                  fontWeight: 700,
+                  letterSpacing: "0.08em",
+                  textTransform: "uppercase",
+                }}
+              >
+                Dazbeez
+              </div>
+            </div>
+
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                gap: "22px",
+                maxWidth: "760px",
+              }}
+            >
+              <div
+                style={{
+                  display: "flex",
+                  fontSize: "76px",
+                  fontWeight: 800,
+                  lineHeight: 1.05,
+                }}
+              >
+                AI, Automation & Data Solutions
+              </div>
+              <div
+                style={{
+                  color: "#d1d5db",
+                  display: "flex",
+                  fontSize: "30px",
+                  lineHeight: 1.35,
+                }}
+              >
+                Strategy, delivery, and modern data systems for businesses that
+                need practical transformation.
+              </div>
+            </div>
+
+            <div
+              style={{
+                color: "#fbbf24",
+                display: "flex",
+                fontSize: "24px",
+                fontWeight: 600,
+                letterSpacing: "0.04em",
+              }}
+            >
+              dazbeez.com
+            </div>
+          </div>
+        </div>
+      </div>
+    ),
+    size,
+  );
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
   # Cloudflare Tunnel service
   cloudflared:
     image: cloudflare/cloudflared:latest
-    command: tunnel --no-autoupdate run --token ${CLOUDFLARE_TUNNEL_TOKEN}
+    command: tunnel --no-autoupdate run --token ${CLOUDFLARE_TUNNEL_TOKEN:?CLOUDFLARE_TUNNEL_TOKEN is required for the production profile}
     restart: unless-stopped
     depends_on:
       - nginx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
-version: '3.8'
-
 services:
   # Next.js application
   nextjs:
     build:
       context: .
       dockerfile: Dockerfile
+    ports:
+      - "3000:3000"
     environment:
       - NODE_ENV=production
     restart: unless-stopped
@@ -22,6 +22,18 @@ services:
     depends_on:
       - nextjs
     restart: unless-stopped
+    networks:
+      - dazbeez-network
+    profiles:
+      - production
+
+  # Cloudflare Tunnel service
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    command: tunnel --no-autoupdate run --token ${CLOUDFLARE_TUNNEL_TOKEN}
+    restart: unless-stopped
+    depends_on:
+      - nginx
     networks:
       - dazbeez-network
     profiles:

--- a/scripts/check-cloudflare-tunnel.sh
+++ b/scripts/check-cloudflare-tunnel.sh
@@ -1,49 +1,55 @@
 #!/bin/bash
 
-# Default hostname
+set -euo pipefail
+
 HOSTNAME="${1:-dazbeez.com}"
+RESPONSE_FILE="$(mktemp)"
+trap 'rm -f "$RESPONSE_FILE"' EXIT
 
-# Perform HTTPS request to the hostname
 echo "Checking tunnel connectivity for $HOSTNAME..."
-RESPONSE=$(curl -s -w "%{http_code}" -o /tmp/response.html https://$HOSTNAME)
+if ! HTTP_CODE="$(curl -sS -L -o "$RESPONSE_FILE" -w "%{http_code}" "https://$HOSTNAME")"; then
+  echo "ERROR: Failed to reach https://$HOSTNAME"
+  echo "Check local network connectivity, DNS, and Cloudflare status before retrying."
+  exit 1
+fi
+CNAME_TARGET="$(dig +short CNAME "$HOSTNAME" | head -n 1 | sed 's/\.$//')"
 
-# Check if we got a 1033 error
-if [[ $RESPONSE == "1033" ]]; then
-    echo "ERROR: Cloudflare Tunnel returned HTTP 1033"
-    echo "This indicates the tunnel is not properly connected or the origin is unreachable."
-    
-    # Check DNS records for cfargotunnel.com target
-    echo "Checking DNS records for $HOSTNAME..."
-    DNS_RESULT=$(dig +short $HOSTNAME | grep -i cfargotunnel)
-    
-    if [[ -n "$DNS_RESULT" ]]; then
-        echo "DNS records show cfargotunnel.com target - tunnel configuration appears correct"
-    else
-        echo "WARNING: No cfargotunnel.com DNS records found"
-        echo "This may indicate tunnel misconfiguration or DNS propagation delay"
-    fi
-    
-    echo "ACTION REQUIRED: Check tunnel status and origin server connectivity"
-    exit 1
-elif [[ $RESPONSE == "200" ]]; then
-    echo "SUCCESS: Tunnel is functioning correctly"
-    echo "Origin server is reachable and tunnel is properly connected"
-    exit 0
+print_recovery_steps() {
+  echo "Recovery steps:"
+  echo "  1. cp .env.example .env"
+  echo "  2. Set CLOUDFLARE_TUNNEL_TOKEN in .env to the token from the dazbeez.com tunnel"
+  echo "  3. Run: docker compose --profile production up -d --build"
+  echo "  4. Confirm: docker compose --profile production ps"
+  echo "  5. Inspect logs if needed: docker compose --profile production logs cloudflared --tail=50"
+}
+
+if [[ -n "$CNAME_TARGET" ]]; then
+  echo "DNS CNAME target: $CNAME_TARGET"
 else
-    echo "INFO: HTTP response code $RESPONSE"
-    echo "Checking if this is a Cloudflare error page..."
-    
-    # Check if response contains Cloudflare error content
-    if grep -q "1033" /tmp/response.html 2>/dev/null; then
-        echo "ERROR: Cloudflare Tunnel returned HTTP 1033"
-        echo "This indicates the tunnel is not properly connected or the origin is unreachable."
-        exit 1
-    else
-        echo "INFO: Non-1033 error encountered - may be origin server issue"
-        echo "Tunnel may be connected but origin server not responding properly"
-        exit 2
-    fi
+  echo "DNS CNAME target: not exposed publicly (record may be proxied through Cloudflare)"
 fi
 
-# Cleanup
-rm -f /tmp/response.html
+if [[ "$HTTP_CODE" == "200" ]]; then
+  echo "SUCCESS: Tunnel is functioning correctly"
+  echo "Origin server is reachable and tunnel is properly connected"
+  exit 0
+fi
+
+if grep -Eqi "Error 1033|error code[:[:space:]]*1033" "$RESPONSE_FILE"; then
+  echo "ERROR: Cloudflare returned Error 1033 for $HOSTNAME"
+  echo "The tunnel is not connected to an active cloudflared origin."
+  print_recovery_steps
+  exit 1
+fi
+
+echo "INFO: Received HTTP $HTTP_CODE from https://$HOSTNAME"
+
+if [[ "$HTTP_CODE" == "530" ]] && grep -qi "cloudflare" "$RESPONSE_FILE"; then
+  echo "ERROR: Cloudflare is serving an origin/tunnel error page"
+  print_recovery_steps
+  exit 1
+fi
+
+echo "INFO: Tunnel did not return a 1033 page"
+echo "This is likely an origin application or proxy issue rather than a missing tunnel."
+exit 2

--- a/scripts/check-cloudflare-tunnel.sh
+++ b/scripts/check-cloudflare-tunnel.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Default hostname
+HOSTNAME="${1:-dazbeez.com}"
+
+# Perform HTTPS request to the hostname
+echo "Checking tunnel connectivity for $HOSTNAME..."
+RESPONSE=$(curl -s -w "%{http_code}" -o /tmp/response.html https://$HOSTNAME)
+
+# Check if we got a 1033 error
+if [[ $RESPONSE == "1033" ]]; then
+    echo "ERROR: Cloudflare Tunnel returned HTTP 1033"
+    echo "This indicates the tunnel is not properly connected or the origin is unreachable."
+    
+    # Check DNS records for cfargotunnel.com target
+    echo "Checking DNS records for $HOSTNAME..."
+    DNS_RESULT=$(dig +short $HOSTNAME | grep -i cfargotunnel)
+    
+    if [[ -n "$DNS_RESULT" ]]; then
+        echo "DNS records show cfargotunnel.com target - tunnel configuration appears correct"
+    else
+        echo "WARNING: No cfargotunnel.com DNS records found"
+        echo "This may indicate tunnel misconfiguration or DNS propagation delay"
+    fi
+    
+    echo "ACTION REQUIRED: Check tunnel status and origin server connectivity"
+    exit 1
+elif [[ $RESPONSE == "200" ]]; then
+    echo "SUCCESS: Tunnel is functioning correctly"
+    echo "Origin server is reachable and tunnel is properly connected"
+    exit 0
+else
+    echo "INFO: HTTP response code $RESPONSE"
+    echo "Checking if this is a Cloudflare error page..."
+    
+    # Check if response contains Cloudflare error content
+    if grep -q "1033" /tmp/response.html 2>/dev/null; then
+        echo "ERROR: Cloudflare Tunnel returned HTTP 1033"
+        echo "This indicates the tunnel is not properly connected or the origin is unreachable."
+        exit 1
+    else
+        echo "INFO: Non-1033 error encountered - may be origin server issue"
+        echo "Tunnel may be connected but origin server not responding properly"
+        exit 2
+    fi
+fi
+
+# Cleanup
+rm -f /tmp/response.html

--- a/scripts/check-domain-resolution.sh
+++ b/scripts/check-domain-resolution.sh
@@ -8,12 +8,13 @@
 # validation path for Cloudflare Tunnel deployments. For tunnel validation,
 # use ./scripts/check-cloudflare-tunnel.sh instead.
 
-set -e  # Exit on any error
+set -euo pipefail
 
 DOMAIN="dazbeez.com"
-EXPECTED_IP="$1"
+EXPECTED_IP="${1:-}"
 PORT="${2:-80}"
 SCHEME="${3:-http}"
+CNAME_TARGET="$(dig +short CNAME "$DOMAIN" | head -n 1 | sed 's/\.$//')"
 
 if [ "$PORT" = "80" ] && [ "$SCHEME" = "http" ]; then
   URL="$SCHEME://$DOMAIN"
@@ -43,7 +44,11 @@ fi
 
 echo "   DNS resolved $DOMAIN to $DNS_IP"
 
-if [ "$DNS_IP" != "$EXPECTED_IP" ]; then
+if [[ -n "$CNAME_TARGET" ]] && [[ "$CNAME_TARGET" == *"cfargotunnel.com" ]]; then
+  echo "   DNS uses Cloudflare Tunnel via $CNAME_TARGET"
+  echo "   Public DNS will not resolve directly to the local origin IP"
+  echo "   Use ./scripts/check-cloudflare-tunnel.sh for public tunnel verification"
+elif [ "$DNS_IP" != "$EXPECTED_IP" ]; then
   echo "WARNING: DNS resolves to $DNS_IP, but expected $EXPECTED_IP"
   echo "This may be expected if DNS is managed by a CDN or proxy."
 else

--- a/scripts/check-domain-resolution.sh
+++ b/scripts/check-domain-resolution.sh
@@ -1,20 +1,36 @@
 #!/bin/bash
 
-# Script to verify that dazbeez.com resolves to the specified host IP
-# Uses DNS lookup and HTTP request with Host header override via curl --resolve
+# Script to verify that dazbeez.com resolves to the specified host IP.
+# Uses DNS lookup plus curl --resolve so the request can be forced to a local
+# origin or reverse proxy without changing public DNS.
+#
+# NOTE: This script is intended for direct-origin/DNS testing, not as the primary
+# validation path for Cloudflare Tunnel deployments. For tunnel validation,
+# use ./scripts/check-cloudflare-tunnel.sh instead.
 
 set -e  # Exit on any error
 
 DOMAIN="dazbeez.com"
 EXPECTED_IP="$1"
+PORT="${2:-80}"
+SCHEME="${3:-http}"
+
+if [ "$PORT" = "80" ] && [ "$SCHEME" = "http" ]; then
+  URL="$SCHEME://$DOMAIN"
+elif [ "$PORT" = "443" ] && [ "$SCHEME" = "https" ]; then
+  URL="$SCHEME://$DOMAIN"
+else
+  URL="$SCHEME://$DOMAIN:$PORT"
+fi
 
 if [ -z "$EXPECTED_IP" ]; then
-  echo "Usage: $0 <expected_host_ip>"
+  echo "Usage: $0 <expected_host_ip> [port] [scheme]"
   echo "Example: $0 192.168.1.100"
+  echo "Example: $0 192.168.1.100 3000 http"
   exit 1
 fi
 
-echo "Verifying that $DOMAIN resolves to $EXPECTED_IP"
+echo "Verifying that $DOMAIN resolves to $EXPECTED_IP via $URL on port $PORT"
 
 # Step 1: Check DNS resolution
 echo "1. Checking DNS resolution..."
@@ -36,15 +52,13 @@ fi
 
 # Step 2: Perform HTTP request with Host header override
 echo "2. Testing HTTP access with Host override..."
-RESPONSE=$(curl -s --resolve "$DOMAIN:80:$EXPECTED_IP" "http://$DOMAIN/" -H "Host: $DOMAIN" --fail)
-
-if [ $? -eq 0 ]; then
-  echo "   HTTP request successful"
-  echo "   Response length: ${#RESPONSE} characters"
-else
-  echo "ERROR: HTTP request failed"
+if ! RESPONSE=$(curl -sS --location --resolve "$DOMAIN:$PORT:$EXPECTED_IP" "$URL/" --fail); then
+  echo "ERROR: HTTP request failed for $URL/ through $EXPECTED_IP:$PORT"
   exit 1
 fi
+
+echo "   HTTP request successful"
+echo "   Response length: ${#RESPONSE} characters"
 
 # Step 3: Verify response content (basic check)
 if [[ "$RESPONSE" == *"Dazbeez"* ]]; then


### PR DESCRIPTION
## Summary
Replace the repo’s one-off Cloudflare Tunnel guidance with a stable named-tunnel deployment path and tunnel-aware verification so dazbeez.com stops serving Cloudflare 1033 when the local origin is up.

## Issues
- Closes #6 — Add managed Cloudflare Tunnel service for dazbeez.com
- Closes #7 — Document required Cloudflare tunnel environment variables
- Closes #8 — Add Cloudflare Tunnel 1033 verification script
- Closes #9 — Replace misleading tunnel docs with named Cloudflare setup