### PR TITLE
fix(seo): address Google Search Console index errors

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,46 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Page not found — Dazbeez",
+  description: "The page you were looking for doesn't exist or has moved. Browse services or get in touch.",
+  robots: { index: false, follow: false },
+};
+
+const destinations = [
+  { href: "/", label: "Home" },
+  { href: "/services", label: "Services" },
+  { href: "/about", label: "About" },
+  { href: "/contact", label: "Contact" },
+];
+
+export default function NotFound() {
+  return (
+    <div className="min-h-[60vh] py-20">
+      <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+        <p className="text-sm font-semibold uppercase tracking-[0.32em] text-amber-600 mb-3">
+          404
+        </p>
+        <h1 className="text-4xl md:text-5xl font-bold text-gray-900 mb-4 leading-tight">
+          We couldn&apos;t find that page.
+        </h1>
+        <p className="text-lg text-gray-600 mb-10">
+          The link may be outdated, or the page may have moved. Try one of the
+          destinations below, or head back home.
+        </p>
+
+        <div className="flex flex-wrap justify-center gap-3">
+          {destinations.map((d) => (
+            <Link
+              key={d.href}
+              href={d.href}
+              className="inline-flex items-center justify-center rounded-full border border-gray-300 px-6 py-3 text-sm font-semibold text-gray-900 transition-colors hover:border-amber-500 hover:text-amber-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2"
+            >
+              {d.label}
+            </Link>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -5,8 +5,9 @@ export default function robots(): MetadataRoute.Robots {
     rules: {
       userAgent: "*",
       allow: "/",
-      disallow: ["/admin/"],
+      disallow: ["/admin/", "/api/"],
     },
+    host: "https://dazbeez.com",
     sitemap: "https://dazbeez.com/sitemap.xml",
   };
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,6 +1,6 @@
 import { MetadataRoute } from "next";
 
-const LAST_MODIFIED = "2026-04-01";
+const LAST_MODIFIED = "2026-04-20";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   return [

--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,12 @@ const nextConfig: NextConfig = {
         destination: "/contact",
         permanent: true,
       },
+      {
+        source: "/:path*",
+        has: [{ type: "host", value: "www.dazbeez.com" }],
+        destination: "https://dazbeez.com/:path*",
+        permanent: true,
+      },
     ];
   },
   async headers() {
@@ -20,6 +26,18 @@ const nextConfig: NextConfig = {
           { key: "X-Frame-Options", value: "SAMEORIGIN" },
           { key: "X-Content-Type-Options", value: "nosniff" },
           { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+        ],
+      },
+      {
+        source: "/admin/:path*",
+        headers: [
+          { key: "X-Robots-Tag", value: "noindex, nofollow" },
+        ],
+      },
+      {
+        source: "/api/:path*",
+        headers: [
+          { key: "X-Robots-Tag", value: "noindex, nofollow" },
         ],
       },
     ];

--- a/proxy.ts
+++ b/proxy.ts
@@ -8,7 +8,10 @@ import {
 
 export function proxy(request: NextRequest) {
   if (!isAdminPageAuthConfigured()) {
-    return new NextResponse("Admin access is not configured.", { status: 503 });
+    return new NextResponse("Not Found", {
+      status: 404,
+      headers: { "X-Robots-Tag": "noindex, nofollow" },
+    });
   }
 
   if (isAdminPageAuthorized(request.headers)) {
@@ -17,7 +20,10 @@ export function proxy(request: NextRequest) {
 
   return new NextResponse("Authentication required.", {
     status: 401,
-    headers: getAdminPageAuthChallengeHeaders(),
+    headers: {
+      ...getAdminPageAuthChallengeHeaders(),
+      "X-Robots-Tag": "noindex, nofollow",
+    },
   });
 }
 


### PR DESCRIPTION
## Summary

Targeted fixes for the Google Search Console "Index" report categories. Each item below maps to a category from the report.

| GSC reason | Pages | What this PR does |
|---|---|---|
| Not found (404) | 24 | Adds a branded `app/not-found.tsx` so unknown URLs return a clean 404 with helpful navigation (Home / Services / About / Contact). Next still emits a real 404 status code, so Google can drop the stale URLs cleanly. |
| Alternate page with proper canonical tag | 7 | Adds a `308` redirect from `www.dazbeez.com/*` to `dazbeez.com/*` in `next.config.ts`. The two hostnames currently both serve the same content via Caddy, which is the most likely source of the duplicates. |
| Server error (5xx) | 6 | `proxy.ts` was returning **503** for `/admin/*` whenever `ADMIN_PAGE_USERNAME` / `ADMIN_PAGE_PASSWORD` weren't set — Google indexed that as a server error. Now it returns **404** when unconfigured (and the `401` challenge response also carries `X-Robots-Tag: noindex, nofollow`). |
| Blocked by robots.txt | 2 | Adds `/api/` to `disallow` so the contact API isn't crawled, and adds the `Host` directive to declare the canonical host. |
| Blocked due to other 4xx issue | 1 | Expected — `/admin` 401 challenge. Now also tagged `noindex, nofollow`. |
| Redirect error | 1 | Investigated; most plausible cause was a host-vs-canonical mismatch. The new www→apex redirect resolves that path. |
| Excluded by 'noindex' tag | 1 | Expected — `/admin`. Reinforced via the `X-Robots-Tag` header on `/admin/*` in `next.config.ts`. |
| Page with redirect | 1 | Expected — `/inquiry` → `/contact` 308. Left as-is. |
| Crawled - currently not indexed | 39 | This is a Google quality decision rather than a hard error, but bumping `sitemap.ts` `lastModified` (`2026-04-01` → `2026-04-20`) prompts re-crawl of the canonical URLs. |

### Files changed

- `app/not-found.tsx` (new) — branded 404 page, `robots: noindex, nofollow`.
- `next.config.ts` — www→apex redirect; `X-Robots-Tag` headers for `/admin/*` and `/api/*`.
- `app/robots.ts` — disallow `/api/`, declare `host`.
- `app/sitemap.ts` — bump `lastModified`.
- `proxy.ts` — return `404` (not `503`) when admin auth env is unset; add `X-Robots-Tag` to admin responses.

## Test plan

- [ ] `npm run build` succeeds locally.
- [ ] `curl -sI http://localhost:4488/admin` → `404` when `ADMIN_PAGE_USERNAME`/`PASSWORD` are unset; `401` (with `WWW-Authenticate` + `X-Robots-Tag`) when set.
- [ ] `curl -sI http://localhost:4488/api/contact` → response includes `X-Robots-Tag: noindex, nofollow`.
- [ ] `curl -sI -H 'Host: www.dazbeez.com' http://localhost:4488/services` → `308` to `https://dazbeez.com/services`.
- [ ] `curl -s http://localhost:4488/robots.txt` → contains `Disallow: /api/`.
- [ ] Visit a bogus URL (e.g. `/this-page-does-not-exist`) and confirm the new 404 page renders with a `404` status.
- [ ] After deploy, request re-indexing in Search Console for the affected categories.

https://claude.ai/code/session_011im2idRs3cvekx5HzpevYd