### PR TITLE
fix(receipts): surface real AMEX CSV import errors instead of "Network error"

### DIFF
--- a/components/receipts/amex-import-form.tsx
+++ b/components/receipts/amex-import-form.tsx
@@ -53,14 +53,38 @@ export function AmexImportForm() {
       formData.append("statementMonth", statementMonth);
       if (replaceConfirmed) formData.append("replaceConfirmed", "true");
 
-      const res = await fetch("/api/receipts/amex/import", {
-        method: "POST",
-        body: formData,
-      });
+      let res: Response;
+      try {
+        res = await fetch("/api/receipts/amex/import", {
+          method: "POST",
+          body: formData,
+        });
+      } catch {
+        setError("Network error — please try again.");
+        return;
+      }
 
-      const json = (await res.json()) as ImportResult;
+      let rawBody: string;
+      try {
+        rawBody = await res.text();
+      } catch {
+        setError("Network error while reading the server response — please try again.");
+        return;
+      }
+      let json: ImportResult | null = null;
+      try {
+        json = rawBody ? (JSON.parse(rawBody) as ImportResult) : null;
+      } catch {
+        const snippet = rawBody.trim().slice(0, 200);
+        setError(
+          `Server returned a non-JSON response (HTTP ${res.status}${res.statusText ? ` ${res.statusText}` : ""})${
+            snippet ? `: ${snippet}` : "."
+          }`,
+        );
+        return;
+      }
 
-      if (res.status === 409 && json.needsReplaceConfirm) {
+      if (res.status === 409 && json?.needsReplaceConfirm) {
         setPendingReplace({
           existingArtifactId: json.existingArtifactId ?? "",
           statementMonth: json.statementMonth,
@@ -68,21 +92,24 @@ export function AmexImportForm() {
         return;
       }
 
-      if (res.status === 422 && json.validationErrors) {
+      if (res.status === 422 && json?.validationErrors) {
         setError(json.validationErrors[0] ?? "Validation failed.");
         return;
       }
 
       if (!res.ok) {
-        setError(json.error ?? "Import failed.");
+        setError(json?.error ?? `Import failed (HTTP ${res.status}).`);
+        return;
+      }
+
+      if (!json) {
+        setError("Server returned an empty response.");
         return;
       }
 
       setResult(json);
       setPendingReplace(null);
       router.refresh();
-    } catch {
-      setError("Network error — please try again.");
     } finally {
       setSubmitting(false);
     }


### PR DESCRIPTION
## Summary

The AMEX CSV upload was showing a generic **"Network error — please try again."** even when the network was fine. The submit handler in `components/receipts/amex-import-form.tsx` wrapped both the `fetch()` call **and** `res.json()` in a single `catch`, so any non-JSON response body — Cloudflare Access HTML, a worker exception page, an empty 5xx body — threw at JSON.parse time and got mislabeled as a network failure, hiding the real cause.

## Changes

- Split error handling so:
  - A failed `fetch()` still shows "Network error — please try again."
  - A failed response stream read shows a distinct network-while-reading message.
  - A non-JSON body now surfaces the HTTP status + statusText and a short body snippet (e.g. `Server returned a non-JSON response (HTTP 502 Bad Gateway): <html>...`).
  - A non-OK JSON response falls back to `HTTP <status>` if the server omitted an error message.
- No API/route changes; this is a client-side error-surfacing fix.

## Test plan

- [ ] Upload a valid AMEX Netアンサー CSV and confirm success path is unchanged.
- [ ] Force an upstream non-JSON 5xx (e.g. transient Workers error) and confirm the toast now shows the HTTP status + body snippet rather than "Network error".
- [ ] Force a true offline scenario (devtools "Offline") and confirm "Network error — please try again." still appears.
- [ ] Re-upload the same file and confirm the 200 duplicate path still renders.
- [ ] Trigger the 409 replace confirmation flow and confirm it still works.

https://claude.ai/code/session_018Hmk6umzgR9AtC6Mq4BNPj

---
_Generated by [Claude Code](https://claude.ai/code/session_018Hmk6umzgR9AtC6Mq4BNPj)_