### PR TITLE
fix(receipts): preserve sign on AMEX refund rows so statement totals reconcile

### DIFF
--- a/lib/receipts/validation.ts
+++ b/lib/receipts/validation.ts
@@ -365,19 +365,26 @@ export function parseAmexNetanswer(
     let memoField: string | null;
 
     if (fields.length > 7) {
-      // Comma-formatted amount — rejoin and strip
-      amountRaw = fields.slice(5, -1).join("").replace(/[^0-9]/g, "");
+      // Comma-formatted amount — rejoin
+      amountRaw = fields.slice(5, -1).join("");
       memoField = fields[fields.length - 1]?.trim() || null;
     } else {
-      amountRaw = (fields[5] ?? "").replace(/[^0-9]/g, "");
+      amountRaw = fields[5] ?? "";
       memoField = fields[6]?.trim() || null;
     }
 
     const memo = memoField;
 
-    if (!amountRaw) continue;
-    const amountCents = parseInt(amountRaw, 10);
-    if (isNaN(amountCents) || amountCents < 0) continue;
+    // Capture sign before stripping non-digits. Netアンサー uses ASCII "-" and
+    // sometimes the Japanese "△" / "▲" symbols to mark refunds; without this
+    // they would be silently imported as positive charges and break the
+    // statement-total reconciliation.
+    const isNegative = /[-−△▲]/.test(amountRaw);
+    const digits = amountRaw.replace(/[^0-9]/g, "");
+    if (!digits) continue;
+    const magnitude = parseInt(digits, 10);
+    if (isNaN(magnitude)) continue;
+    const amountCents = isNegative ? -magnitude : magnitude;
 
     lines.push({
       lineNumber: i + 1,

--- a/tests/receipts/amex-parser.test.ts
+++ b/tests/receipts/amex-parser.test.ts
@@ -358,6 +358,62 @@ test("parseAmexNetanswer: handles comma thousands separators in amounts", () => 
   assert.equal(result.validationErrors.length, 0);
 });
 
+test("parseAmexNetanswer: refunds (-) keep their sign so totals reconcile", () => {
+  const csv = [
+    "カード名称,TestCard",
+    "お支払日,2026/05/07",
+    "今回ご請求額,000900",
+    "",
+    "利用日,ご利用店名及び商品名,本人・家族区分,支払区分名称,締前入金区分,利用金額,備考",
+    ",ご利用者名:テスト 様,,,,,",
+    "2026/05/01,コンビニ,1,1回,,1000,",
+    "2026/05/02,返金,1,1回,,-100,",
+  ].join("\n");
+  const result = parseAmexNetanswer(toBuffer(csv), "2026-05");
+  assert.equal(result.lines.length, 2);
+  assert.equal(result.lines[0]!.amountCents, 1000);
+  assert.equal(result.lines[1]!.amountCents, -100);
+  assert.equal(result.parsedTotalCents, 900);
+  assert.equal(result.validationErrors.length, 0);
+});
+
+test("parseAmexNetanswer: refunds with comma thousands separators keep their sign", () => {
+  const csv = [
+    "カード名称,TestCard",
+    "お支払日,2026/05/07",
+    "今回ご請求額,008800",
+    "",
+    "利用日,ご利用店名及び商品名,本人・家族区分,支払区分名称,締前入金区分,利用金額,備考",
+    ",ご利用者名:テスト 様,,,,,",
+    "2026/05/01,コンビニ,1,1回,,10,000,",
+    "2026/05/02,返金,1,1回,,-1,200,",
+  ].join("\n");
+  const result = parseAmexNetanswer(toBuffer(csv), "2026-05");
+  assert.equal(result.lines.length, 2);
+  assert.equal(result.lines[0]!.amountCents, 10000);
+  assert.equal(result.lines[1]!.amountCents, -1200);
+  assert.equal(result.parsedTotalCents, 8800);
+  assert.equal(result.validationErrors.length, 0);
+});
+
+test("parseAmexNetanswer: △ (Japanese negative marker) is treated as a refund", () => {
+  const csv = [
+    "カード名称,TestCard",
+    "お支払日,2026/05/07",
+    "今回ご請求額,000900",
+    "",
+    "利用日,ご利用店名及び商品名,本人・家族区分,支払区分名称,締前入金区分,利用金額,備考",
+    ",ご利用者名:テスト 様,,,,,",
+    "2026/05/01,コンビニ,1,1回,,1000,",
+    "2026/05/02,返金,1,1回,,△100,",
+  ].join("\n");
+  const result = parseAmexNetanswer(toBuffer(csv), "2026-05");
+  assert.equal(result.lines.length, 2);
+  assert.equal(result.lines[1]!.amountCents, -100);
+  assert.equal(result.parsedTotalCents, 900);
+  assert.equal(result.validationErrors.length, 0);
+});
+
 test("parseAmexNetanswer: handles comma thousands separators in metadata total", () => {
   const csv = [
     "カード名称,TestCard",


### PR DESCRIPTION
## Summary

The AMEX import was rejecting valid statements with a "parsed total != statement total" mismatch. Root cause: the amount parser stripped non-digits with `.replace(/[^0-9]/g, "")`, which **silently swallowed the leading minus sign on refund rows**. A `-¥100` refund was imported as `+¥100`, so a single refund produced a `+¥200` discrepancy between the parsed total and the statement total. The downstream `if (amountCents < 0) continue` guard never fired because the sign had already been erased.

## Fix

In `lib/receipts/validation.ts`:
- Capture the sign **before** stripping digits — detect ASCII `-`, U+2212 `−`, and the Japanese `△` / `▲` markers (Netアンサー uses these for credits).
- Drop the `< 0` short-circuit so refunds are imported as negative-amount lines and the parsed total reconciles with the statement total.

The schema (`db/receipts/0001_init.sql:52`) defines `amount_minor INTEGER NOT NULL` with no positivity constraint, so negative values store cleanly.

## Tests

Added 3 new tests to `tests/receipts/amex-parser.test.ts`:
- `-` refund reconciles to statement total
- `-` refund with thousands-separator comma (e.g. `-1,200`) reconciles
- `△` refund reconciles to statement total

All 25 tests pass (`npx tsx --test tests/receipts/amex-parser.test.ts`).

## Test plan

- [ ] Re-upload the SAISON_2603.csv that was failing with the `¥681,240` vs `¥681,040` mismatch — should now reconcile and import.
- [ ] Confirm previously-working statements (no refunds) still import unchanged.
- [ ] In the line-items view, confirm refund rows display with a negative amount.
- [ ] Verify reconciliation/export logic handles negative amount_minor rows sensibly (downstream code may need follow-up — flagged here for awareness, not in scope of this fix).

https://claude.ai/code/session_018Hmk6umzgR9AtC6Mq4BNPj

---
_Generated by [Claude Code](https://claude.ai/code/session_018Hmk6umzgR9AtC6Mq4BNPj)_