### PR TITLE
feat(receipts): auto-fill AMEX statement month from filename

### DIFF
--- a/components/receipts/amex-import-form.tsx
+++ b/components/receipts/amex-import-form.tsx
@@ -5,6 +5,18 @@ import { useRouter } from "next/navigation";
 
 const NETANSWER_URL = "https://www.saisoncard.co.jp/customer-support/netanswer/";
 
+// Netアンサー downloads are named like "SAISON_2603.csv" where 2603 = YYMM
+// (26 → 2026, 03 → March). Extracts "2026-03" so the user doesn't have to
+// retype the month every upload.
+function extractStatementMonthFromFilename(filename: string): string | null {
+  const match = filename.match(/_(\d{2})(\d{2})\.csv$/i);
+  if (!match) return null;
+  const yy = parseInt(match[1]!, 10);
+  const mm = parseInt(match[2]!, 10);
+  if (mm < 1 || mm > 12) return null;
+  return `20${match[1]}-${match[2]}`;
+}
+
 interface ImportResult {
   ok: boolean;
   duplicate?: boolean;
@@ -199,7 +211,14 @@ export function AmexImportForm() {
             <input
               type="file"
               accept=".csv,text/csv"
-              onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+              onChange={(e) => {
+                const selected = e.target.files?.[0] ?? null;
+                setFile(selected);
+                if (selected && !statementMonth) {
+                  const inferred = extractStatementMonthFromFilename(selected.name);
+                  if (inferred) setStatementMonth(inferred);
+                }
+              }}
               className="mt-2 block w-full rounded-xl border border-gray-300 px-3 py-2 text-sm focus:border-amber-500 focus:outline-none focus:ring-1 focus:ring-amber-500"
             />
           </div>


### PR DESCRIPTION
## Summary

Netアンサー downloads are always named `SAISON_YYMM.csv` (e.g. `SAISON_2603.csv` for March 2026). When the user picks a file, parse the trailing `_YYMM.csv` and pre-fill the statement-month input if it is still empty. The user can still type or override the value before submitting.

## Test plan

- [ ] Pick `SAISON_2603.csv` with the month field empty → field auto-fills to `2026-03`.
- [ ] Pick a file with a month already typed → existing value is preserved.
- [ ] Pick a file with a non-matching name (e.g. `bank-export.csv`) → field stays empty, no error.
- [ ] Pick a file with an invalid month (`SAISON_2613.csv`) → field stays empty.

## Follow-up (not in this PR)

Still tracking the "Network error" on submit. With my earlier surface-real-errors fix in place, "Network error" means `fetch()` itself threw — the Worker dropped the connection without returning an HTTP response. The most likely culprit is `importAmexLines` in `lib/receipts/db.ts:299`, which does a serial `await db.prepare(...).run()` per row — for a statement with ~100–200 transactions that's that many sequential D1 round-trips and plausibly exceeds the Worker CPU/time budget. Switching to `db.batch([...])` would collapse that to one round-trip. I'd like to send that as a separate PR once you've decided whether to ship it blind or test on the Mac first.

https://claude.ai/code/session_018Hmk6umzgR9AtC6Mq4BNPj

---
_Generated by [Claude Code](https://claude.ai/code/session_018Hmk6umzgR9AtC6Mq4BNPj)_