### PR TITLE
perf(receipts): batch D1 writes in AMEX import to fix Worker 1102 timeouts

### DIFF
--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -292,24 +292,24 @@ export async function importAmexLines(
   actor: string,
 ): Promise<{ imported: number; skipped: number }> {
   const db = getReceiptsDb();
-  let imported = 0;
-  let skipped = 0;
   const now = nowIso();
+  let imported = 0;
 
-  for (const row of rows) {
-    const id = newUuid();
-    const result = await db
-      .prepare(
-        `INSERT OR IGNORE INTO amex_statement_lines
-          (id, statement_month, transaction_date, posting_date, merchant,
-           amount_minor, currency, amex_reference, match_status, raw_json,
-           statement_artifact_id, cardholder_name, cardholder_flag, payment_type,
-           prepayment_flag, memo, raw_csv_line_number, source_file_sha256, imported_at,
-           created_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'unmatched', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      )
-      .bind(
-        id,
+  // Chunked multi-row INSERTs. Each row binds 19 params (the 20th column,
+  // match_status, is the SQL literal 'unmatched'), so a chunk of 50 sends ~950
+  // params per query — well under D1's per-query limits and ~50x cheaper
+  // than the previous one-INSERT-per-row loop that was tripping Worker 1102.
+  const CHUNK_SIZE = 50;
+  const rowPlaceholder =
+    "(?, ?, ?, ?, ?, ?, ?, ?, 'unmatched', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+
+  for (let i = 0; i < rows.length; i += CHUNK_SIZE) {
+    const chunk = rows.slice(i, i + CHUNK_SIZE);
+    const placeholders = chunk.map(() => rowPlaceholder).join(",");
+    const binds: unknown[] = [];
+    for (const row of chunk) {
+      binds.push(
+        newUuid(),
         row.statementMonth,
         row.transactionDate,
         row.postingDate ?? null,
@@ -328,15 +328,24 @@ export async function importAmexLines(
         row.sourceFileSha256 ?? null,
         now,
         now,
-      )
-      .run();
-
-    if ((result.meta.changes ?? 0) > 0) {
-      imported++;
-    } else {
-      skipped++;
+      );
     }
+    const result = await db
+      .prepare(
+        `INSERT OR IGNORE INTO amex_statement_lines
+          (id, statement_month, transaction_date, posting_date, merchant,
+           amount_minor, currency, amex_reference, match_status, raw_json,
+           statement_artifact_id, cardholder_name, cardholder_flag, payment_type,
+           prepayment_flag, memo, raw_csv_line_number, source_file_sha256,
+           imported_at, created_at)
+         VALUES ${placeholders}`,
+      )
+      .bind(...binds)
+      .run();
+    imported += result.meta.changes ?? 0;
   }
+
+  const skipped = rows.length - imported;
 
   await createAuditEntry(db, {
     actor,
@@ -666,44 +675,61 @@ export async function createBusinessTripReports(
 
   for (const candidate of candidates) {
     const tripId = newUuid();
-    await db
-      .prepare(
-        `INSERT INTO business_trip_reports
-          (id, cardholder_name, start_date, end_date, primary_location,
-           status, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, 'candidate', ?, ?)`,
-      )
-      .bind(
+
+    // One D1 batch per candidate: trip INSERT + bulk line-links INSERT +
+    // bulk line UPDATE. Previously this was 1 + 2N sequential awaits per
+    // candidate (e.g. 41 D1 calls for a 20-line trip), which compounded the
+    // import-route CPU budget on top of the row inserts.
+    const stmts = [
+      db
+        .prepare(
+          `INSERT INTO business_trip_reports
+            (id, cardholder_name, start_date, end_date, primary_location,
+             status, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, 'candidate', ?, ?)`,
+        )
+        .bind(
+          tripId,
+          candidate.cardholderName,
+          candidate.startDate,
+          candidate.endDate,
+          candidate.primaryLocation,
+          now,
+          now,
+        ),
+    ];
+
+    if (candidate.lineIds.length > 0) {
+      const linkPlaceholders = candidate.lineIds.map(() => "(?, ?, ?, ?)").join(",");
+      const linkBinds = candidate.lineIds.flatMap((lineId) => [
+        newUuid(),
         tripId,
-        candidate.cardholderName,
-        candidate.startDate,
-        candidate.endDate,
-        candidate.primaryLocation,
+        lineId,
         now,
-        now,
-      )
-      .run();
+      ]);
+      stmts.push(
+        db
+          .prepare(
+            `INSERT OR IGNORE INTO business_trip_report_lines
+              (id, business_trip_report_id, amex_statement_line_id, created_at)
+             VALUES ${linkPlaceholders}`,
+          )
+          .bind(...linkBinds),
+      );
 
-    // Link statement lines to this trip
-    for (const lineId of candidate.lineIds) {
-      await db
-        .prepare(
-          `INSERT OR IGNORE INTO business_trip_report_lines
-            (id, business_trip_report_id, amex_statement_line_id, created_at)
-           VALUES (?, ?, ?, ?)`,
-        )
-        .bind(newUuid(), tripId, lineId, now)
-        .run();
-
-      await db
-        .prepare(
-          `UPDATE amex_statement_lines
-           SET business_trip_id = ?, business_trip_status = 'candidate', updated_at = ?
-           WHERE id = ?`,
-        )
-        .bind(tripId, now, lineId)
-        .run();
+      const idPlaceholders = candidate.lineIds.map(() => "?").join(",");
+      stmts.push(
+        db
+          .prepare(
+            `UPDATE amex_statement_lines
+             SET business_trip_id = ?, business_trip_status = 'candidate', updated_at = ?
+             WHERE id IN (${idPlaceholders})`,
+          )
+          .bind(tripId, now, ...candidate.lineIds),
+      );
     }
+
+    await db.batch(stmts);
 
     await createAuditEntry(db, {
       actor,


### PR DESCRIPTION
## Summary

The AMEX import was hitting Cloudflare Worker 1102 ("exceeded resource limits") on submit, which the browser surfaced as a bare "Network error" because the fetch never received a response. Root cause: the route serializes one D1 round-trip per CSV row plus 1+2N per business trip.

Two hot-path fixes in `lib/receipts/db.ts`:

### `importAmexLines`
Chunked multi-row INSERT (50 rows / call, ~950 bound params per query). One D1 call per 50 lines instead of 50 individual calls. `INSERT OR IGNORE` semantics preserved; imported / skipped counts derived from `result.meta.changes`.

### `createBusinessTripReports`
Collapse the per-candidate sequence — 1 trip INSERT + N link INSERTs + N statement-line UPDATEs — into a single `db.batch([trip, linkBulk, updateBulkInClause])` per candidate. A 20-line trip drops from **41 sequential D1 calls to 1 batched round-trip**.

The trailing audit log entry is intentionally left out of the batch so a logging failure doesn't roll back the import.

### Order-of-magnitude impact

| Statement | Before | After |
|---|---|---|
| 200 lines, no trip | 201 D1 calls | 5 calls |
| 200 lines + 20-line trip | 242 D1 calls | 6 calls |
| 500 lines + two 30-line trips | 583 D1 calls | 13 calls |

## Out of scope (follow-up)

- **Auth deduplication.** The import route (and ~6 other receipts routes) does `assertReceiptsAccessFromHeaders` + `getReceiptsActor` — two D1 queries for what middleware already gated. Worth a single coordinated refactor across all receipts routes.
- **Atomicity between R2 upload and `createAmexArtifact`.** Either side can fail independently, leaving an orphaned blob or DB row pointing nowhere.
- **Skip-reason tracking in the parser.** Rows silently dropped via `continue` should surface their line numbers + reasons in `validationErrors`.
- **Legacy `parseAmexCsv` refund-sign bug** (uses `Math.abs()` — same bug we fixed in `parseAmexNetanswer` last PR but on the unused legacy path).

## Test plan

Unit tests around D1 batching require a SQLite test harness that doesn't exist in this repo yet (`better-sqlite3` / `sql.js` aren't installed). All existing tests pass (`npx tsx --test tests/receipts/amex-parser.test.ts` → 25 / 25). The Mac side needs to verify end-to-end:

- [ ] Run `npm run cf:dev` on the Mac with `RECEIPTS_DB` bound.
- [ ] Upload the SAISON_2603.csv that was producing the "Network error" — should now complete and reconcile.
- [ ] Re-upload the same file → 200 + duplicate flag (sha256 path).
- [ ] Upload a fresh file for an existing month → 409 + replace confirmation.
- [ ] Confirm a multi-day outside-Tokyo trip (if present) creates `business_trip_reports` rows and links them to the statement lines.
- [ ] Check D1 audit log shows one `amex.imported` entry per import (not N).

https://claude.ai/code/session_018Hmk6umzgR9AtC6Mq4BNPj

---
_Generated by [Claude Code](https://claude.ai/code/session_018Hmk6umzgR9AtC6Mq4BNPj)_