### PR TITLE
feat(receipts): track skipped date-rows in AMEX parser; drop dead parseAmexCsv

### DIFF
--- a/app/api/receipts/amex/import/route.ts
+++ b/app/api/receipts/amex/import/route.ts
@@ -91,8 +91,14 @@ export async function POST(request: Request) {
     }
 
     // ── Parse CSV ───────────────────────────────────────────────────────────
-    const { metadata, lines, validationErrors, parsedTotalCents, rowCount } =
-      parseAmexNetanswer(buffer, statementMonth);
+    const {
+      metadata,
+      lines,
+      skippedLines,
+      validationErrors,
+      parsedTotalCents,
+      rowCount,
+    } = parseAmexNetanswer(buffer, statementMonth);
 
     const importStatus = validationErrors.length > 0 ? "failed" : "parsed";
 
@@ -129,6 +135,7 @@ export async function POST(request: Request) {
           statementMonth,
           importStatus: "failed",
           validationErrors,
+          skippedLines,
           transactionCount: 0,
           imported: 0,
           skipped: 0,
@@ -202,6 +209,7 @@ export async function POST(request: Request) {
         transactionCount: lines.length,
         imported,
         skipped,
+        skippedLines,
         replaced: previousArtifact !== null,
         businessTripCandidates: businessTripCandidatesCount,
       },

--- a/lib/receipts/validation.ts
+++ b/lib/receipts/validation.ts
@@ -101,72 +101,6 @@ export function parseCsvLine(line: string): string[] {
   return fields;
 }
 
-// ─── Legacy simple AMEX CSV parser (kept for backward compat) ─────────────
-
-export function parseAmexCsv(
-  text: string,
-  statementMonth: string,
-): ImportAmexLineInput[] {
-  const lines = text
-    .split(/\r?\n/)
-    .map((l) => l.trim())
-    .filter((l) => l.length > 0);
-
-  if (lines.length < 2) return [];
-
-  // Skip header row
-  const rows = lines.slice(1);
-  const results: ImportAmexLineInput[] = [];
-
-  for (const line of rows) {
-    const fields = parseCsvLine(line);
-    if (fields.length < 3) continue;
-
-    let transactionDateRaw: string;
-    let postDateRaw: string | undefined;
-    let merchantRaw: string;
-    let amountRaw: string;
-
-    const field0IsDate = parseAmexDate(fields[0] ?? "") !== null;
-    const field1IsDate = parseAmexDate(fields[1] ?? "") !== null;
-
-    if (field0IsDate && field1IsDate) {
-      transactionDateRaw = fields[0] ?? "";
-      postDateRaw = fields[1];
-      merchantRaw = fields[2] ?? "";
-      amountRaw = fields[3] ?? "";
-    } else {
-      transactionDateRaw = fields[0] ?? "";
-      merchantRaw = fields[1] ?? "";
-      amountRaw = fields[2] ?? "";
-    }
-
-    const transactionDate = parseAmexDate(transactionDateRaw);
-    if (!transactionDate) continue;
-
-    const postingDate = postDateRaw ? parseAmexDate(postDateRaw) ?? undefined : undefined;
-
-    const merchant = merchantRaw.trim();
-    if (!merchant) continue;
-
-    const amountFloat = parseFloat(amountRaw.replace(/[^0-9.-]/g, ""));
-    if (isNaN(amountFloat)) continue;
-
-    const amountMinor = Math.round(Math.abs(amountFloat) * 100);
-
-    results.push({
-      statementMonth,
-      transactionDate,
-      postingDate,
-      merchant,
-      amountMinor,
-      rawJson: JSON.stringify({ fields }),
-    });
-  }
-
-  return results;
-}
-
 // ─── Netアンサー CSV parser ────────────────────────────────────────────────
 
 export interface NetanswerMetadata {
@@ -190,9 +124,15 @@ export interface NetanswerParsedLine {
   rawFields: string[];
 }
 
+export interface SkippedLineInfo {
+  lineNumber: number;
+  reason: string;
+}
+
 export interface NetanswerParseResult {
   metadata: NetanswerMetadata;
   lines: NetanswerParsedLine[];
+  skippedLines: SkippedLineInfo[];
   validationErrors: string[];
   parsedTotalCents: number;
   rowCount: number;
@@ -298,6 +238,7 @@ export function parseAmexNetanswer(
   let currentCardholder: string | null = null;
   let currentCardholderFlag: string | null = null;
   const lines: NetanswerParsedLine[] = [];
+  const skippedLines: SkippedLineInfo[] = [];
   const validationErrors: string[] = [];
   let headerFound = false;
   let totalRowCount = 0;
@@ -347,12 +288,20 @@ export function parseAmexNetanswer(
     // Skip subtotal / total rows
     if (col1 === "【小計】" || col1 === "【合計】") continue;
 
-    // Transaction row: col0 matches date
+    // Transaction row: col0 matches date. A non-date col0 here means the row
+    // is not a transaction — silently skip (it's expected to hit header /
+    // metadata / blank rows that fell through the explicit handlers above).
     const txDate = parseAmexDate(col0);
     if (!txDate) continue;
 
+    // From here on the row is shaped like a transaction (date-led). If we
+    // bail out below we record the line + reason so the import surfaces
+    // partial data loss instead of silently dropping rows.
     const merchantName = col1;
-    if (!merchantName) continue;
+    if (!merchantName) {
+      skippedLines.push({ lineNumber: i + 1, reason: "missing merchant" });
+      continue;
+    }
 
     const txCardholderFlag = fields[2]?.trim() || null;
     const paymentType = fields[3]?.trim() || null;
@@ -381,9 +330,18 @@ export function parseAmexNetanswer(
     // statement-total reconciliation.
     const isNegative = /[-−△▲]/.test(amountRaw);
     const digits = amountRaw.replace(/[^0-9]/g, "");
-    if (!digits) continue;
+    if (!digits) {
+      skippedLines.push({ lineNumber: i + 1, reason: "missing amount" });
+      continue;
+    }
     const magnitude = parseInt(digits, 10);
-    if (isNaN(magnitude)) continue;
+    if (isNaN(magnitude)) {
+      skippedLines.push({
+        lineNumber: i + 1,
+        reason: `unparseable amount: ${amountRaw.slice(0, 30)}`,
+      });
+      continue;
+    }
     const amountCents = isNegative ? -magnitude : magnitude;
 
     lines.push({
@@ -427,6 +385,7 @@ export function parseAmexNetanswer(
   return {
     metadata,
     lines,
+    skippedLines,
     validationErrors,
     parsedTotalCents,
     rowCount: totalRowCount,

--- a/tests/receipts/amex-parser.test.ts
+++ b/tests/receipts/amex-parser.test.ts
@@ -358,6 +358,54 @@ test("parseAmexNetanswer: handles comma thousands separators in amounts", () => 
   assert.equal(result.validationErrors.length, 0);
 });
 
+test("parseAmexNetanswer: tracks skipped date-rows with missing merchant", () => {
+  const csv = [
+    "カード名称,TestCard",
+    "お支払日,2026/05/07",
+    "今回ご請求額,001000",
+    "",
+    "利用日,ご利用店名及び商品名,本人・家族区分,支払区分名称,締前入金区分,利用金額,備考",
+    ",ご利用者名:テスト 様,,,,,",
+    "2026/05/01,コンビニ,1,1回,,1000,",
+    "2026/05/02,,1,1回,,500,",
+  ].join("\n");
+  const result = parseAmexNetanswer(toBuffer(csv), "2026-05");
+  assert.equal(result.lines.length, 1);
+  assert.equal(result.skippedLines.length, 1);
+  assert.match(result.skippedLines[0]!.reason, /missing merchant/);
+});
+
+test("parseAmexNetanswer: tracks skipped date-rows with missing amount", () => {
+  const csv = [
+    "カード名称,TestCard",
+    "お支払日,2026/05/07",
+    "今回ご請求額,001000",
+    "",
+    "利用日,ご利用店名及び商品名,本人・家族区分,支払区分名称,締前入金区分,利用金額,備考",
+    ",ご利用者名:テスト 様,,,,,",
+    "2026/05/01,コンビニ,1,1回,,1000,",
+    "2026/05/02,スターバックス,1,1回,,,",
+  ].join("\n");
+  const result = parseAmexNetanswer(toBuffer(csv), "2026-05");
+  assert.equal(result.lines.length, 1);
+  assert.equal(result.skippedLines.length, 1);
+  assert.match(result.skippedLines[0]!.reason, /missing amount/);
+});
+
+test("parseAmexNetanswer: skippedLines is empty array for clean CSVs", () => {
+  const csv = [
+    "カード名称,TestCard",
+    "お支払日,2026/05/07",
+    "今回ご請求額,001000",
+    "",
+    "利用日,ご利用店名及び商品名,本人・家族区分,支払区分名称,締前入金区分,利用金額,備考",
+    ",ご利用者名:テスト 様,,,,,",
+    "2026/05/01,コンビニ,1,1回,,1000,",
+  ].join("\n");
+  const result = parseAmexNetanswer(toBuffer(csv), "2026-05");
+  assert.deepEqual(result.skippedLines, []);
+});
+
 test("parseAmexNetanswer: refunds (-) keep their sign so totals reconcile", () => {
   const csv = [
     "カード名称,TestCard",

--- a/tests/receipts/validation.test.ts
+++ b/tests/receipts/validation.test.ts
@@ -5,7 +5,6 @@ import {
   validateReceiptDate,
   validateAmountMinor,
   validateCurrency,
-  parseAmexCsv,
   MAX_RECEIPT_FILE_BYTES,
   ALLOWED_RECEIPT_MIME_TYPES,
 } from "@/lib/receipts/validation";
@@ -110,56 +109,3 @@ test("validateCurrency: unknown currency is rejected", () => {
   assert.equal(validateCurrency(""), false);
 });
 
-// ─── parseAmexCsv ────────────────────────────────────────────────────────────
-
-test("parseAmexCsv: parses single-date-column AMEX CSV", () => {
-  const csv = [
-    "Date,Description,Amount",
-    "01/15/2024,AMAZON.COM,3800",
-    "01/18/2024,STARBUCKS TOKYO,650",
-  ].join("\n");
-
-  const rows = parseAmexCsv(csv, "2024-01");
-  assert.equal(rows.length, 2);
-  assert.equal(rows[0]!.transactionDate, "2024-01-15");
-  assert.equal(rows[0]!.merchant, "AMAZON.COM");
-  assert.equal(rows[0]!.amountMinor, 380000);
-  assert.equal(rows[1]!.transactionDate, "2024-01-18");
-  assert.equal(rows[1]!.merchant, "STARBUCKS TOKYO");
-});
-
-test("parseAmexCsv: handles YYYY/MM/DD date format", () => {
-  const csv = [
-    "Date,Description,Amount",
-    "2024/01/20,CONVENIENCE STORE,320",
-  ].join("\n");
-
-  const rows = parseAmexCsv(csv, "2024-01");
-  assert.equal(rows.length, 1);
-  assert.equal(rows[0]!.transactionDate, "2024-01-20");
-});
-
-test("parseAmexCsv: skips header row and empty lines", () => {
-  const csv = [
-    "Transaction Date,Post Date,Description,Amount",
-    "",
-    "01/10/2024,01/12/2024,RESTAURANT ABC,4500",
-  ].join("\n");
-
-  const rows = parseAmexCsv(csv, "2024-01");
-  assert.equal(rows.length, 1);
-});
-
-test("parseAmexCsv: returns empty array for malformed CSV", () => {
-  assert.deepEqual(parseAmexCsv("", "2024-01"), []);
-  assert.deepEqual(parseAmexCsv("header only\n", "2024-01"), []);
-});
-
-test("parseAmexCsv: statementMonth is set on all rows", () => {
-  const csv = [
-    "Date,Description,Amount",
-    "02/01/2024,SHOP,1000",
-  ].join("\n");
-  const rows = parseAmexCsv(csv, "2024-02");
-  assert.equal(rows[0]!.statementMonth, "2024-02");
-});


### PR DESCRIPTION
## Summary

Two related cleanups in `lib/receipts/validation.ts`:

### 1. Surface skipped date-rows from the parser

`parseAmexNetanswer` previously dropped malformed transaction rows via bare `continue` (missing merchant, missing amount, unparseable amount). The statement-total reconciliation catches most cases, but a row whose missing amount happens to be zero would silently disappear with no warning.

`NetanswerParseResult` now includes `skippedLines: SkippedLineInfo[]` (each entry: `{ lineNumber, reason }`). The import route returns it through both the 200 (parsed) and 422 (validation-failed) responses so the client can show partial-data-loss diagnostics.

Only **date-led rows** that fail downstream parsing are recorded — non-transaction rows (metadata, headers, cardholder banners, subtotals) are still skipped silently because they're expected.

### 2. Delete dead `parseAmexCsv`

The legacy `parseAmexCsv` function and its 6 tests are removed. It was only referenced from its own tests — no production caller — and still contained the `Math.abs()` refund-sign bug that was fixed in `parseAmexNetanswer` last week. Easier to delete than to fix a path nobody calls.

## Test plan

- [x] `npx tsx --test tests/receipts/amex-parser.test.ts tests/receipts/validation.test.ts` → 43/43 pass (added 3 new skipped-line tests).
- [x] `npx tsc --noEmit` → no errors in touched files.
- [ ] Mac: upload a CSV containing a deliberately-blank-amount row → expect 200 with `skippedLines[]` populated, total still reconciles for the remaining rows.

## Out of scope (follow-up)

- Render `skippedLines` in `AmexImportForm` so users see the warning without inspecting the API response.
- Block import when `skippedLines.length > 0`? (Open question — current behavior accepts partial parse if totals reconcile, which feels right for forward compat with new Netアンサー row types.)

https://claude.ai/code/session_018Hmk6umzgR9AtC6Mq4BNPj

---
_Generated by [Claude Code](https://claude.ai/code/session_018Hmk6umzgR9AtC6Mq4BNPj)_