### PR TITLE
fix(receipts): make AMEX reconciliation update atomic and audit transitions

### DIFF
--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -378,30 +378,81 @@ export async function updateAmexReconciliation(
   actor: string,
 ): Promise<void> {
   const db = getReceiptsDb();
+  const now = nowIso();
 
-  await db
+  // Capture previous state for two reasons:
+  //   1. Audit log records the transition (oldValueJson), so a
+  //      confirmed → unmatched transition no longer silently orphans the
+  //      previously-matched receipt from the audit trail.
+  //   2. Demote logic below: when we unwind a confirmed match, the
+  //      previously-matched receipt was promoted to 'reconciled' — it
+  //      needs to go back to 'needs_review' so it doesn't sit stuck as
+  //      reconciled with no AMEX line claiming it.
+  const previous = await db
     .prepare(
-      `UPDATE amex_statement_lines
-       SET matched_receipt_id = ?, match_status = ?
-       WHERE id = ?`,
+      `SELECT matched_receipt_id, match_status
+       FROM amex_statement_lines
+       WHERE id = ?
+       LIMIT 1`,
     )
-    .bind(receiptId, matchStatus, amexLineId)
-    .run();
+    .bind(amexLineId)
+    .first<{ matched_receipt_id: string | null; match_status: AmexMatchStatus }>();
 
-  if (receiptId && matchStatus === "confirmed") {
-    await db
+  const previousReceiptId = previous?.matched_receipt_id ?? null;
+  const previousStatus: AmexMatchStatus = previous?.match_status ?? "unmatched";
+
+  const statements = [
+    db
       .prepare(
-        `UPDATE receipt_records SET status = 'reconciled', updated_at = ? WHERE id = ?`,
+        `UPDATE amex_statement_lines
+         SET matched_receipt_id = ?, match_status = ?
+         WHERE id = ?`,
       )
-      .bind(nowIso(), receiptId)
-      .run();
+      .bind(receiptId, matchStatus, amexLineId),
+  ];
+
+  // Promote the newly-linked receipt.
+  if (receiptId && matchStatus === "confirmed") {
+    statements.push(
+      db
+        .prepare(
+          `UPDATE receipt_records SET status = 'reconciled', updated_at = ? WHERE id = ?`,
+        )
+        .bind(now, receiptId),
+    );
   }
+
+  // Demote the previously-linked receipt if we're unwinding its confirmation
+  // (either dropping the link entirely or switching to a different receipt).
+  // Guard with `status = 'reconciled'` so we don't clobber a status another
+  // process may have advanced this receipt to in the meantime.
+  const wasConfirmed = previousStatus === "confirmed";
+  if (wasConfirmed && previousReceiptId && previousReceiptId !== receiptId) {
+    statements.push(
+      db
+        .prepare(
+          `UPDATE receipt_records
+           SET status = 'needs_review', updated_at = ?
+           WHERE id = ? AND status = 'reconciled'`,
+        )
+        .bind(now, previousReceiptId),
+    );
+  }
+
+  // Single batched round-trip so the AMEX line update, the new-receipt
+  // promotion, and the old-receipt demotion either all succeed or all fail.
+  // Previously these were three independent awaits with no rollback path.
+  await db.batch(statements);
 
   await createAuditEntry(db, {
     actor,
     action: "amex.reconciled",
     objectType: "amex_line",
     objectId: amexLineId,
+    oldValueJson: stringifyJson({
+      receiptId: previousReceiptId,
+      matchStatus: previousStatus,
+    }),
     newValueJson: stringifyJson({ receiptId, matchStatus }),
   });
 }


### PR DESCRIPTION
## Summary

`updateAmexReconciliation` previously did up to three independent awaited D1 writes with no rollback path:

1. `UPDATE amex_statement_lines.matched_receipt_id + match_status`
2. `UPDATE receipt_records.status = 'reconciled'` (when promoting)
3. `INSERT receipt_audit_log`

Two latent issues:

- **Partial commit on Worker death.** If the Worker died between (1) and (2), the AMEX line claimed it was confirmed against a receipt whose status was unchanged.
- **Orphaned receipts after un-confirm.** A `confirmed → unmatched` transition left the previously-matched receipt stuck as `status = 'reconciled'` with nothing claiming it, and the audit log captured only the new state so the trail offered no clue who that receipt had been linked to.

## Fix

- Read previous `(matched_receipt_id, match_status)` before the write so the audit `oldValueJson` reflects the transition.
- **Demote** the previously-confirmed receipt: when un-matching or switching to a different receipt, set the prior receipt back to `'needs_review'`. Guarded by `WHERE status = 'reconciled'` so we don't clobber a status some other process advanced.
- Run the line update + receipt promotion + receipt demotion as a single `db.batch([...])` so they're atomic at the D1 transaction layer.

## Test plan

- [x] `npx tsx --test tests/receipts/*.test.ts` → 90/90 pass.
- [x] `npx tsc --noEmit` → no new errors in touched files.
- [ ] Mac: confirm a match for receipt A → unmatch → expect receipt A's status to revert from `reconciled` to `needs_review`, and the audit log to show both old + new state.
- [ ] Mac: confirm a match for receipt A → switch to receipt B → expect A demoted back to `needs_review` and B promoted to `reconciled` atomically.

## Out of scope

- Schema-level unique constraint on `amex_statement_lines.matched_receipt_id` (currently nothing prevents two AMEX lines from pointing at the same receipt).
- Better handling when a receipt is linked to multiple AMEX lines — current demote logic doesn't account for that case (rare today because the matcher proposes 1:1).

https://claude.ai/code/session_018Hmk6umzgR9AtC6Mq4BNPj

---
_Generated by [Claude Code](https://claude.ai/code/session_018Hmk6umzgR9AtC6Mq4BNPj)_