### PR TITLE
fix(receipts): atomic R2 conditional put in uploadOriginal

### DIFF
--- a/lib/receipts/storage.ts
+++ b/lib/receipts/storage.ts
@@ -19,17 +19,21 @@ export async function uploadOriginal(
 ): Promise<void> {
   const bucket = getReceiptsBucket();
 
-  // Never overwrite an existing original
-  const existing = await bucket.head(key);
-  if (existing !== null) {
+  // Conditional put — succeed only if no object exists at this key.
+  // Replaces the previous head() + put() pair, which had a TOCTOU window
+  // where two concurrent uploads could both observe "no object" and then
+  // both put, with the second silently winning. With onlyIf the precondition
+  // is evaluated atomically by R2 and the put returns null on conflict.
+  const result = await bucket.put(key, data, {
+    httpMetadata: { contentType },
+    onlyIf: { etagDoesNotMatch: "*" },
+  });
+
+  if (result === null) {
     throw new Error(
       `R2 key collision: refusing to overwrite existing object at key "${key}".`,
     );
   }
-
-  await bucket.put(key, data, {
-    httpMetadata: { contentType },
-  });
 }
 
 export async function getReceiptFile(


### PR DESCRIPTION
## Summary

`uploadOriginal` did a `head()` followed by `put()` to refuse overwrites of existing R2 objects. Two concurrent uploads racing on the same key could both observe "no object" between their respective `head()` calls and then both succeed in `put()`, with the second silently winning.

## Fix

Replace with R2's `onlyIf: { etagDoesNotMatch: "*" }` precondition so the existence check and the put are evaluated atomically by R2. On conflict `put()` returns `null` and we surface the same key-collision error.

The R2 key for receipts already includes a fresh `newUuid()` (see `generateR2Key`), so practical collisions are vanishingly unlikely — this is hardening, not a known-exploited bug.

## Test plan

- [x] `npx tsc --noEmit` → no errors in touched file.
- [ ] Mac: upload a receipt → still works.
- [ ] Mac: simulate two concurrent uploads with the same constructed key (manual test) → one succeeds, the other gets the key-collision error.

https://claude.ai/code/session_018Hmk6umzgR9AtC6Mq4BNPj

---
_Generated by [Claude Code](https://claude.ai/code/session_018Hmk6umzgR9AtC6Mq4BNPj)_