### PR TITLE
chore(receipts): clamp extracted currency to allowed set; add soft-delete indexes

### DIFF
--- a/db/receipts/0009_indexes.sql
+++ b/db/receipts/0009_indexes.sql
@@ -1,0 +1,10 @@
+-- Indexes that should have been added alongside earlier migrations but were
+-- missed. Every query against receipt_records filters on deleted_at IS NULL,
+-- and the reconciliation page also filters on payment_path; without these
+-- indexes the planner falls back to a full scan as the table grows.
+
+CREATE INDEX IF NOT EXISTS idx_receipts_deleted_at
+  ON receipt_records(deleted_at);
+
+CREATE INDEX IF NOT EXISTS idx_receipts_payment_path_deleted_at
+  ON receipt_records(payment_path, deleted_at);

--- a/lib/receipts/extraction.ts
+++ b/lib/receipts/extraction.ts
@@ -1,5 +1,6 @@
 import { getAiBinding } from "@/lib/cloudflare-runtime";
 import { isCanonicalCode, mapLegacyCategory, EXPENSE_CATEGORIES } from "@/lib/receipts/categories";
+import { ALLOWED_CURRENCIES } from "@/lib/receipts/validation";
 import type { ExtractionResult, ExpenseType } from "@/lib/receipts/types";
 
 // ─── Provider interface ───────────────────────────────────────────────────────
@@ -112,7 +113,17 @@ class CloudflareAiExtractionProvider implements ExtractionProvider {
         : (response as { response?: string }).response ?? "";
 
     const parsed = extractJsonBlock(rawText);
-    const currency = (parsed.currency as string | null) ?? "JPY";
+    // Normalize and clamp the LLM-reported currency to the allowed set so we
+    // can't end up storing junk like "XXX" or "yen" in the DB. parseAmountToMinor
+    // below depends on a JPY/non-JPY distinction, so an invalid currency would
+    // also misinterpret the amount magnitude.
+    const rawCurrency =
+      typeof parsed.currency === "string"
+        ? parsed.currency.toUpperCase().trim()
+        : "";
+    const currency = ALLOWED_CURRENCIES.includes(rawCurrency)
+      ? rawCurrency
+      : "JPY";
     const expenseType = normalizeExpenseType(parsed.expense_type);
 
     return {


### PR DESCRIPTION
## Summary

Two small follow-ups from the receipts review:

### 1. Validate extracted currency in `extractReceiptData`

`lib/receipts/extraction.ts` accepted whatever `currency` string the LLM returned (e.g. `"yen"`, `"XXX"`, `null`). `parseAmountToMinor` then branches on `currency === "JPY"` to decide whether the magnitude is already in minor units or needs ×100, so any unexpected currency silently mis-scaled the amount stored on the receipt.

Now: uppercase + trim the LLM value and clamp to `ALLOWED_CURRENCIES`, falling back to `"JPY"` if unrecognized.

### 2. Add missing soft-delete indexes

`db/receipts/0009_indexes.sql`:

- `idx_receipts_deleted_at` — every `receipt_records` read filters `deleted_at IS NULL`.
- `idx_receipts_payment_path_deleted_at` — the reconciliation page calls `listReceiptRecords({ paymentPath: "AMEX" })` which combines payment_path + soft-delete filtering.

Without these the planner falls back to a full scan as the table grows.

## Test plan

- [x] `npx tsc --noEmit` → no errors in touched files.
- [x] `npx tsx --test tests/receipts/*.test.ts` → all pass.
- [ ] **Mac**: apply migration `0009_indexes.sql` against the live D1 (`wrangler d1 migrations apply RECEIPTS_DB`).
- [ ] Mac: extract a receipt where the LLM returns a non-standard currency string → expect it to be stored as `JPY` rather than the raw value.

https://claude.ai/code/session_018Hmk6umzgR9AtC6Mq4BNPj

---
_Generated by [Claude Code](https://claude.ai/code/session_018Hmk6umzgR9AtC6Mq4BNPj)_