### PR TITLE
chore(receipts): tighten API input validation on AMEX routes

### DIFF
--- a/app/api/receipts/amex/import/route.ts
+++ b/app/api/receipts/amex/import/route.ts
@@ -44,6 +44,28 @@ export async function POST(request: Request) {
       );
     }
 
+    // Sanity-bound the statement month. The regex accepts 2099-12 / 1900-01
+    // etc. which would land junk months in D1 and corrupt UIs that group by
+    // month. Allow the current month plus one (Netアンサー sometimes posts the
+    // upcoming statement a few days before the closing date) and 5 years back.
+    {
+      const now = new Date();
+      const maxYearMonth = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 2).padStart(2, "0")}`;
+      const minYearMonth = `${now.getUTCFullYear() - 5}-01`;
+      // Normalize 13 → next-year-01 for the max comparison.
+      const maxNormalized = now.getUTCMonth() + 2 > 12
+        ? `${now.getUTCFullYear() + 1}-01`
+        : maxYearMonth;
+      if (statementMonth < minYearMonth || statementMonth > maxNormalized) {
+        return NextResponse.json(
+          {
+            error: `statementMonth ${statementMonth} is outside the accepted range (${minYearMonth} … ${maxNormalized}).`,
+          },
+          { status: 400 },
+        );
+      }
+    }
+
     if (file.size > MAX_CSV_BYTES) {
       return NextResponse.json(
         { error: "CSV file too large (max 5 MB)." },

--- a/app/api/receipts/amex/lines/[id]/route.ts
+++ b/app/api/receipts/amex/lines/[id]/route.ts
@@ -4,9 +4,43 @@ import { updateAmexLineCategory } from "@/lib/receipts/db";
 import { isCanonicalCode } from "@/lib/receipts/categories";
 import type {
   AmexCategoryStatus,
+  AmexExpenseCategory,
   AmexReceiptStatus,
   AmexBusinessTripStatus,
 } from "@/lib/receipts/types";
+
+const VALID_EXPENSE_CATEGORIES: AmexExpenseCategory[] = [
+  "meeting_no_alcohol",
+  "entertainment_alcohol",
+  "transportation",
+  "books",
+  "research",
+  "insurance",
+  "software",
+  "telecom",
+  "office_supplies",
+  "travel",
+  "business_trip",
+  "misc",
+  "unknown",
+];
+const VALID_CATEGORY_STATUSES: AmexCategoryStatus[] = [
+  "uncategorized",
+  "suggested",
+  "confirmed",
+];
+const VALID_RECEIPT_STATUSES: AmexReceiptStatus[] = [
+  "missing_receipt",
+  "matched",
+  "no_receipt_required",
+  "receipt_not_available",
+];
+const VALID_BUSINESS_TRIP_STATUSES: AmexBusinessTripStatus[] = [
+  "not_applicable",
+  "candidate",
+  "confirmed",
+  "excluded",
+];
 
 type RouteContext = { params: Promise<{ id: string }> };
 
@@ -33,10 +67,52 @@ export async function PATCH(request: Request, { params }: RouteContext) {
       );
     }
 
+    // Validate each enum field if provided — previously these were cast
+    // straight from arbitrary string body input into typed enums and
+    // forwarded to the DB, where invalid values could silently land.
+    if (
+      body.expenseCategory !== undefined &&
+      !VALID_EXPENSE_CATEGORIES.includes(body.expenseCategory as AmexExpenseCategory)
+    ) {
+      return NextResponse.json(
+        { error: `Invalid expenseCategory: ${body.expenseCategory}` },
+        { status: 400 },
+      );
+    }
+    if (
+      body.categoryStatus !== undefined &&
+      !VALID_CATEGORY_STATUSES.includes(body.categoryStatus as AmexCategoryStatus)
+    ) {
+      return NextResponse.json(
+        { error: `Invalid categoryStatus: ${body.categoryStatus}` },
+        { status: 400 },
+      );
+    }
+    if (
+      body.receiptStatus !== undefined &&
+      !VALID_RECEIPT_STATUSES.includes(body.receiptStatus as AmexReceiptStatus)
+    ) {
+      return NextResponse.json(
+        { error: `Invalid receiptStatus: ${body.receiptStatus}` },
+        { status: 400 },
+      );
+    }
+    if (
+      body.businessTripStatus !== undefined &&
+      !VALID_BUSINESS_TRIP_STATUSES.includes(
+        body.businessTripStatus as AmexBusinessTripStatus,
+      )
+    ) {
+      return NextResponse.json(
+        { error: `Invalid businessTripStatus: ${body.businessTripStatus}` },
+        { status: 400 },
+      );
+    }
+
     await updateAmexLineCategory(
       id,
       {
-        expenseCategory: body.expenseCategory as Parameters<typeof updateAmexLineCategory>[1]["expenseCategory"],
+        expenseCategory: body.expenseCategory as AmexExpenseCategory | undefined,
         expenseCategoryCode: body.expenseCategoryCode ?? undefined,
         categoryStatus: body.categoryStatus as AmexCategoryStatus | undefined,
         receiptStatus: body.receiptStatus as AmexReceiptStatus | undefined,


### PR DESCRIPTION
## Summary

Two route-level input-validation hardenings, surfaced by the receipts audit.

### `app/api/receipts/amex/lines/[id]/route.ts` — enum whitelist
Previously the PATCH handler cast `expenseCategory`, `categoryStatus`, `receiptStatus`, `businessTripStatus` straight from arbitrary string body input into typed enums and forwarded them to the DB. Invalid values landed silently in D1 (no `CHECK` constraint catches them). Now: explicit whitelist per field with the canonical members from `lib/receipts/types.ts`, returning 400 on rejection.

### `app/api/receipts/amex/import/route.ts` — statementMonth bounds
Regex-only validation on `statementMonth` allowed `2099-12`, `1900-01`, etc. Bound it to `[today − 5 years, today + 1 month]` so junk months can't pollute `statement_month` and break month-based UI groupings. The +1 month accommodates Netアンサー sometimes posting the upcoming statement a few days before the closing date.

## Test plan

- [x] `npx tsc --noEmit` → no errors in touched files.
- [x] `npx tsx --test tests/receipts/*.test.ts` → all pass.
- [ ] Mac: try PATCHing an AMEX line with `categoryStatus: "bogus"` → expect 400.
- [ ] Mac: import attempt with `statementMonth=2099-01` → expect 400.
- [ ] Mac: import normal current month → still works.

https://claude.ai/code/session_018Hmk6umzgR9AtC6Mq4BNPj

---
_Generated by [Claude Code](https://claude.ai/code/session_018Hmk6umzgR9AtC6Mq4BNPj)_