### PR TITLE
chore(receipts): surface skipped CSV rows in UI; audit denied extractions

### DIFF
--- a/app/api/receipts/[id]/extract/route.ts
+++ b/app/api/receipts/[id]/extract/route.ts
@@ -18,11 +18,27 @@ export async function POST(request: Request, { params }: RouteContext) {
     const { id } = await params;
 
     const receipt = await getReceiptRecord(id);
+    const db = getReceiptsDb();
+
     if (!receipt) {
+      await createAuditEntry(db, {
+        actor,
+        action: "receipt.extraction_denied",
+        objectType: "receipt",
+        objectId: id,
+        newValueJson: stringifyJson({ reason: "not_found" }),
+      });
       return NextResponse.json({ error: "Receipt not found." }, { status: 404 });
     }
 
     if (receipt.status === "exported" || receipt.status === "archived") {
+      await createAuditEntry(db, {
+        actor,
+        action: "receipt.extraction_denied",
+        objectType: "receipt",
+        objectId: id,
+        newValueJson: stringifyJson({ reason: "locked", status: receipt.status }),
+      });
       return NextResponse.json(
         { error: `Receipt is ${receipt.status} and cannot be re-extracted.` },
         { status: 409 },
@@ -30,6 +46,17 @@ export async function POST(request: Request, { params }: RouteContext) {
     }
 
     if (receipt.original_size_bytes > EXTRACTION_MAX_BYTES) {
+      await createAuditEntry(db, {
+        actor,
+        action: "receipt.extraction_denied",
+        objectType: "receipt",
+        objectId: id,
+        newValueJson: stringifyJson({
+          reason: "file_too_large",
+          sizeBytes: receipt.original_size_bytes,
+          limitBytes: EXTRACTION_MAX_BYTES,
+        }),
+      });
       return NextResponse.json(
         {
           error:
@@ -38,8 +65,6 @@ export async function POST(request: Request, { params }: RouteContext) {
         { status: 413 },
       );
     }
-
-    const db = getReceiptsDb();
 
     await createAuditEntry(db, {
       actor,

--- a/components/receipts/amex-import-form.tsx
+++ b/components/receipts/amex-import-form.tsx
@@ -32,11 +32,17 @@ interface ImportResult {
   transactionCount?: number;
   imported?: number;
   skipped?: number;
+  skippedLines?: SkippedLineInfo[];
   replaced?: boolean;
   businessTripCandidates?: number;
   message?: string;
   validationErrors?: string[];
   error?: string;
+}
+
+interface SkippedLineInfo {
+  lineNumber: number;
+  reason: string;
 }
 
 export function AmexImportForm() {
@@ -292,6 +298,27 @@ function ImportResultSummary({ result }: { result: ImportResult }) {
           {result.businessTripCandidates} business trip candidate
           {result.businessTripCandidates !== 1 ? "s" : ""} detected.
         </p>
+      )}
+      {(result.skippedLines?.length ?? 0) > 0 && (
+        <div className="mt-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900">
+          <p className="font-semibold">
+            {result.skippedLines!.length} row
+            {result.skippedLines!.length !== 1 ? "s" : ""} could not be parsed
+            and were skipped:
+          </p>
+          <ul className="mt-1 list-disc pl-5">
+            {result.skippedLines!.slice(0, 5).map((s) => (
+              <li key={s.lineNumber}>
+                Line {s.lineNumber}: {s.reason}
+              </li>
+            ))}
+            {result.skippedLines!.length > 5 && (
+              <li className="italic opacity-70">
+                + {result.skippedLines!.length - 5} more
+              </li>
+            )}
+          </ul>
+        </div>
       )}
     </div>
   );

--- a/lib/receipts/types.ts
+++ b/lib/receipts/types.ts
@@ -82,6 +82,7 @@ export type AuditAction =
   | "receipt.extracted"
   | "receipt.extraction_requested"
   | "receipt.extraction_completed"
+  | "receipt.extraction_denied"
   | "receipt.extraction_failed"
   | "receipt.reconciled"
   | "receipt.exported"


### PR DESCRIPTION
## Summary

Two small UX / observability fixes.

### 1. Surface skipped CSV rows in the AMEX import form
`components/receipts/amex-import-form.tsx` now renders a warning panel under the import-success summary when the response includes a non-empty `skippedLines[]`. Shows up to 5 entries (e.g. `Line 47: missing amount`) plus a `+N more` tail. The field is optional so the component still renders cleanly against older servers that don't return it.

**Depends on #25** to actually populate the field from the API; until that lands the panel will simply never appear (graceful no-op).

### 2. Audit denied extraction attempts
`app/api/receipts/[id]/extract/route.ts` was returning silently on every early-rejection branch (404 / 409 locked / 413 too-large) with no audit trail, so a compliance review couldn't see denied attempts. Now writes a `receipt.extraction_denied` audit entry with a `reason` field before each early return. Added the matching member to the `AuditAction` enum in `lib/receipts/types.ts`.

## Test plan

- [x] `npx tsc --noEmit` → no errors in touched files.
- [x] `npx tsx --test tests/receipts/*.test.ts` → all pass.
- [ ] Mac: import a CSV with a deliberately-malformed transaction row → after #25 merges, expect to see the new amber warning panel under the success summary.
- [ ] Mac: POST `/api/receipts/<exported-id>/extract` → expect 409 + a `receipt.extraction_denied` row in `receipt_audit_log`.
- [ ] Mac: POST `/api/receipts/<nonexistent-id>/extract` → expect 404 + audit row with `reason: "not_found"`.

https://claude.ai/code/session_018Hmk6umzgR9AtC6Mq4BNPj

---
_Generated by [Claude Code](https://claude.ai/code/session_018Hmk6umzgR9AtC6Mq4BNPj)_