### PR TITLE
feat(receipts): wire backend blockers + pre-export checklist into the UI

### DIFF
--- a/app/(receipt-system)/receipts/export/page.tsx
+++ b/app/(receipt-system)/receipts/export/page.tsx
@@ -1,11 +1,44 @@
-import { listExports } from "@/lib/receipts/db";
+import Link from "next/link";
+import {
+  listExports,
+  listReceiptRecords,
+  listAmexLines,
+} from "@/lib/receipts/db";
+import { requiresAttendees } from "@/lib/receipts/categories";
 import { MonthlyExportPanel } from "@/components/receipts/monthly-export-panel";
 
 export const dynamic = "force-dynamic";
 
 export default async function ExportPage() {
   const currentMonth = new Date().toISOString().slice(0, 7);
-  const exports = await listExports();
+
+  const [exports, monthReceipts, monthLines] = await Promise.all([
+    listExports(),
+    listReceiptRecords({ month: currentMonth, limit: 1000 }),
+    listAmexLines(currentMonth),
+  ]);
+
+  // Pre-flight blockers — surface the same conditions the export route uses
+  // so the user sees them BEFORE clicking Generate, not after.
+  const unreviewed = monthReceipts.filter(
+    (r) => r.status === "captured" || r.status === "needs_review",
+  ).length;
+  const uncategorized = monthLines.filter(
+    (l) => !l.expense_category_code,
+  ).length;
+  const missingReason = monthLines.filter(
+    (l) => l.receipt_status === "missing_receipt" && !l.receipt_missing_reason,
+  ).length;
+  const attendeesMissing = monthLines.filter(
+    (l) =>
+      requiresAttendees(l.expense_category_code) && !l.matched_receipt_id,
+  ).length;
+  const tripCandidates = monthLines.filter(
+    (l) => l.business_trip_status === "candidate",
+  ).length;
+
+  const totalBlockers =
+    unreviewed + uncategorized + missingReason + attendeesMissing + tripCandidates;
 
   return (
     <div className="space-y-6">
@@ -16,6 +49,74 @@ export default async function ExportPage() {
           locked and cannot be overwritten.
         </p>
       </div>
+
+      {totalBlockers > 0 && (
+        <div className="rounded-2xl border border-amber-200 bg-amber-50 p-5 text-sm text-amber-900">
+          <p className="font-semibold">
+            {totalBlockers} {totalBlockers === 1 ? "item" : "items"} to resolve
+            before {currentMonth} can be finalized
+          </p>
+          <ul className="mt-2 space-y-1 text-xs">
+            {unreviewed > 0 && (
+              <li>
+                • {unreviewed} receipt{unreviewed !== 1 ? "s" : ""} not yet
+                reviewed —{" "}
+                <Link href="/receipts/review" className="font-semibold underline">
+                  Review →
+                </Link>
+              </li>
+            )}
+            {uncategorized > 0 && (
+              <li>
+                • {uncategorized} AMEX line{uncategorized !== 1 ? "s" : ""}{" "}
+                missing expense category —{" "}
+                <Link
+                  href="/receipts/reconcile"
+                  className="font-semibold underline"
+                >
+                  Reconcile →
+                </Link>
+              </li>
+            )}
+            {missingReason > 0 && (
+              <li>
+                • {missingReason} line{missingReason !== 1 ? "s" : ""} marked
+                "missing receipt" without a reason —{" "}
+                <Link
+                  href="/receipts/reconcile"
+                  className="font-semibold underline"
+                >
+                  Reconcile →
+                </Link>
+              </li>
+            )}
+            {attendeesMissing > 0 && (
+              <li>
+                • {attendeesMissing} entertainment/meeting line
+                {attendeesMissing !== 1 ? "s" : ""} need attendees recorded —{" "}
+                <Link
+                  href="/receipts/reconcile"
+                  className="font-semibold underline"
+                >
+                  Reconcile →
+                </Link>
+              </li>
+            )}
+            {tripCandidates > 0 && (
+              <li>
+                • {tripCandidates} unresolved business-trip candidate
+                {tripCandidates !== 1 ? "s" : ""} —{" "}
+                <Link
+                  href="/receipts/reconcile"
+                  className="font-semibold underline"
+                >
+                  Reconcile →
+                </Link>
+              </li>
+            )}
+          </ul>
+        </div>
+      )}
 
       <MonthlyExportPanel exports={exports} currentMonth={currentMonth} />
     </div>

--- a/components/receipts/monthly-export-panel.tsx
+++ b/components/receipts/monthly-export-panel.tsx
@@ -16,20 +16,30 @@ export function MonthlyExportPanel({
   const router = useRouter();
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [blockers, setBlockers] = useState<string[]>([]);
 
   const currentExport = exports.find((e) => e.export_month === currentMonth);
 
   async function handleGenerate() {
     setBusy("generate");
     setError(null);
+    setBlockers([]);
     try {
       const res = await fetch("/api/receipts/export/month", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ month: currentMonth }),
       });
-      const json = (await res.json()) as { error?: string; sha256?: string };
-      if (!res.ok) { setError(json.error ?? "Generation failed."); return; }
+      const json = (await res.json()) as {
+        error?: string;
+        blockers?: string[];
+        sha256?: string;
+      };
+      if (!res.ok) {
+        setError(json.error ?? "Generation failed.");
+        setBlockers(json.blockers ?? []);
+        return;
+      }
       router.refresh();
     } catch {
       setError("Network error.");
@@ -41,12 +51,17 @@ export function MonthlyExportPanel({
   async function handleFinalize(month: string) {
     setBusy(`finalize-${month}`);
     setError(null);
+    setBlockers([]);
     try {
       const res = await fetch(`/api/receipts/export/${month}`, {
         method: "POST",
       });
-      const json = (await res.json()) as { error?: string };
-      if (!res.ok) { setError(json.error ?? "Finalization failed."); return; }
+      const json = (await res.json()) as { error?: string; blockers?: string[] };
+      if (!res.ok) {
+        setError(json.error ?? "Finalization failed.");
+        setBlockers(json.blockers ?? []);
+        return;
+      }
       router.refresh();
     } catch {
       setError("Network error.");
@@ -58,8 +73,15 @@ export function MonthlyExportPanel({
   return (
     <div className="space-y-6">
       {error && (
-        <div className="rounded-xl border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
-          {error}
+        <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          <p className="font-semibold">{error}</p>
+          {blockers.length > 0 && (
+            <ul className="mt-2 list-disc space-y-0.5 pl-5 text-xs">
+              {blockers.map((b, i) => (
+                <li key={i}>{b}</li>
+              ))}
+            </ul>
+          )}
         </div>
       )}
 

--- a/components/receipts/reconciliation-table.tsx
+++ b/components/receipts/reconciliation-table.tsx
@@ -59,30 +59,42 @@ export function ReconciliationTable({
 
   async function updateCategory(lineId: string, expenseCategoryCode: string) {
     setCategoryBusy(lineId);
+    setError(null);
     try {
-      await fetch(`/api/receipts/amex/lines/${lineId}`, {
+      const res = await fetch(`/api/receipts/amex/lines/${lineId}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ expenseCategoryCode }),
       });
+      if (!res.ok) {
+        const json = (await res.json().catch(() => ({}))) as { error?: string };
+        setError(json.error ?? "Could not save category.");
+        return;
+      }
       router.refresh();
     } catch {
-      // silently fail — not critical
+      setError("Network error while saving category.");
     } finally {
       setCategoryBusy(null);
     }
   }
 
   async function updateReceiptStatus(lineId: string, receiptStatus: string, reason?: string) {
+    setError(null);
     try {
-      await fetch(`/api/receipts/amex/lines/${lineId}`, {
+      const res = await fetch(`/api/receipts/amex/lines/${lineId}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ receiptStatus, receiptMissingReason: reason ?? null }),
       });
+      if (!res.ok) {
+        const json = (await res.json().catch(() => ({}))) as { error?: string };
+        setError(json.error ?? "Could not save receipt status.");
+        return;
+      }
       router.refresh();
     } catch {
-      // silently fail
+      setError("Network error while saving receipt status.");
     }
   }
 


### PR DESCRIPTION
## Summary

The UI audit found one critical wiring gap and two smaller ones between the recently-hardened backend and the user-facing pages. Without these the end-to-end workflow (capture → review → match → confirm → export) still dead-ends.

### 1. Export blockers were hidden from the user

`monthly-export-panel.tsx` reads `error` from the export route's 422 response but silently discarded the `blockers: string[]` array. The user saw `"Export blocked — resolve these issues first."` with no list of what to fix. Now reads `blockers` too and renders it as a bullet list inside the error banner.

### 2. No pre-export checklist on `/receipts/export`

Users only discovered blockers after clicking Generate. The same conditions are now computed server-side at page render — unreviewed receipts, uncategorized AMEX lines, `missing_receipt` rows without reasons, lines whose category requires attendees with no linked receipt, and unresolved business-trip candidates. Each item deep-links to the right next page (`/receipts/review` or `/receipts/reconcile`).

### 3. Silent PATCH failures in the reconciliation table

Category and receipt-status PATCHes ignored the response. After PR #30 added enum whitelisting, a 400 from the server would be silently swallowed and the dropdown would appear to "save" while the value was rejected. Now reads `!res.ok` and surfaces the server's error message in the same error banner the row-level actions use.

## Files changed

- `components/receipts/monthly-export-panel.tsx`
- `app/(receipt-system)/receipts/export/page.tsx`
- `components/receipts/reconciliation-table.tsx`

## Test plan

- [x] `npx tsc --noEmit` → no errors in touched files.
- [x] `npx tsx --test tests/receipts/*.test.ts` → all pass.
- [ ] Mac: open `/receipts/export` for the current month with at least one uncategorized AMEX line → expect the amber checklist banner with "X AMEX lines missing expense category — Reconcile →".
- [ ] Mac: click Generate when blockers exist → expect the red banner to show both the summary error AND the bullet list of blockers from the API.
- [ ] Mac: in the reconciliation table, change a category in the dropdown → still saves; tamper with a request to send `categoryStatus: "bogus"` → expect the error to surface, not be swallowed.

https://claude.ai/code/session_018Hmk6umzgR9AtC6Mq4BNPj

---
_Generated by [Claude Code](https://claude.ai/code/session_018Hmk6umzgR9AtC6Mq4BNPj)_