### PR TITLE
chore(receipts): add SQL script to wipe AMEX statement data

### DIFF
--- a/db/receipts/scripts/wipe-amex.sql
+++ b/db/receipts/scripts/wipe-amex.sql
@@ -1,0 +1,30 @@
+-- Wipe ALL AMEX statement data so files can be re-imported with fresh code.
+-- Receipts (receipt_records) are NOT touched.
+--
+-- Run on the Mac:
+--   wrangler d1 execute RECEIPTS_DB --remote --file db/receipts/scripts/wipe-amex.sql
+-- Or against local D1:
+--   wrangler d1 execute RECEIPTS_DB --local  --file db/receipts/scripts/wipe-amex.sql
+
+-- 1. Detach any receipts from AMEX lines (lines are about to be deleted)
+UPDATE receipt_records
+SET    status = 'needs_review',
+       updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE  status = 'reconciled'
+  AND  payment_path = 'AMEX';
+
+-- 2. AMEX-derived business trip data
+DELETE FROM business_trip_report_lines;
+DELETE FROM business_trip_reports;
+
+-- 3. Per-line attendees (also CASCADE-deleted by step 4, but explicit for clarity)
+DELETE FROM amex_line_attendees;
+
+-- 4. The statement lines themselves
+DELETE FROM amex_statement_lines;
+
+-- 5. Upload artifacts (this clears the "already been uploaded" guard)
+DELETE FROM amex_statement_artifacts;
+
+-- 6. Audit log entries for AMEX activity (optional — keeps the log focused on receipts)
+DELETE FROM receipt_audit_log WHERE action LIKE 'amex.%';


### PR DESCRIPTION
## Summary
- Adds `db/receipts/scripts/wipe-amex.sql` so the operator can clear all imported AMEX data and re-upload statements with the current parser/import code.
- Wipes: `amex_statement_lines`, `amex_statement_artifacts` (the dedup guard), `amex_line_attendees`, `business_trip_reports`, `business_trip_report_lines`, and `amex.*` audit log entries.
- Preserves receipts: any `receipt_records` row that was reconciled against an AMEX line is flipped back to `needs_review` so it can be re-matched.

## How to run (Mac)
```bash
wrangler d1 execute RECEIPTS_DB --remote --file db/receipts/scripts/wipe-amex.sql
```

## Test plan
- [ ] Run script against `--local` D1, confirm AMEX tables empty and receipts preserved
- [ ] Re-upload SAISON_2603.csv and confirm "already uploaded" guard does not fire
- [ ] Run against `--remote` D1
- [ ] Re-import 2603, 2604, 2605 statements

https://claude.ai/code/session_018Hmk6umzgR9AtC6Mq4BNPj

---
_Generated by [Claude Code](https://claude.ai/code/session_018Hmk6umzgR9AtC6Mq4BNPj)_