### PR TITLE
fix(receipts): reduce AMEX import chunk size to stay under D1 variable limit

### DIFF
--- a/db/receipts/scripts/wipe-amex.sql
+++ b/db/receipts/scripts/wipe-amex.sql
@@ -1,30 +1,31 @@
 -- Wipe ALL AMEX statement data so files can be re-imported with fresh code.
 -- Receipts (receipt_records) are NOT touched.
 --
--- Run on the Mac:
---   wrangler d1 execute RECEIPTS_DB --remote --file db/receipts/scripts/wipe-amex.sql
--- Or against local D1:
---   wrangler d1 execute RECEIPTS_DB --local  --file db/receipts/scripts/wipe-amex.sql
+-- Run on the Mac (one statement at a time to avoid multi-statement parser issues):
+--   wrangler d1 execute RECEIPTS_DB --remote --command "UPDATE receipt_records SET status = 'needs_review' WHERE status = 'reconciled' AND payment_path = 'AMEX'"
+--   wrangler d1 execute RECEIPTS_DB --remote --command "DELETE FROM business_trip_report_lines"
+--   wrangler d1 execute RECEIPTS_DB --remote --command "DELETE FROM business_trip_reports"
+--   wrangler d1 execute RECEIPTS_DB --remote --command "DELETE FROM amex_line_attendees"
+--   wrangler d1 execute RECEIPTS_DB --remote --command "DELETE FROM amex_statement_lines"
+--   wrangler d1 execute RECEIPTS_DB --remote --command "DELETE FROM amex_statement_artifacts"
+--   wrangler d1 execute RECEIPTS_DB --remote --command "DELETE FROM receipt_audit_log WHERE action IN ('amex.artifact_created','amex.business_trip_detected','amex.imported','amex.line_categorized','amex.reconciled')"
 
--- 1. Detach any receipts from AMEX lines (lines are about to be deleted)
 UPDATE receipt_records
-SET    status = 'needs_review',
-       updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+SET    status = 'needs_review'
 WHERE  status = 'reconciled'
   AND  payment_path = 'AMEX';
 
--- 2. AMEX-derived business trip data
 DELETE FROM business_trip_report_lines;
 DELETE FROM business_trip_reports;
-
--- 3. Per-line attendees (also CASCADE-deleted by step 4, but explicit for clarity)
 DELETE FROM amex_line_attendees;
-
--- 4. The statement lines themselves
 DELETE FROM amex_statement_lines;
-
--- 5. Upload artifacts (this clears the "already been uploaded" guard)
 DELETE FROM amex_statement_artifacts;
 
--- 6. Audit log entries for AMEX activity (optional — keeps the log focused on receipts)
-DELETE FROM receipt_audit_log WHERE action LIKE 'amex.%';
+DELETE FROM receipt_audit_log
+WHERE action IN (
+  'amex.artifact_created',
+  'amex.business_trip_detected',
+  'amex.imported',
+  'amex.line_categorized',
+  'amex.reconciled'
+);

--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -296,10 +296,9 @@ export async function importAmexLines(
   let imported = 0;
 
   // Chunked multi-row INSERTs. Each row binds 19 params (the 20th column,
-  // match_status, is the SQL literal 'unmatched'), so a chunk of 50 sends ~950
-  // params per query — well under D1's per-query limits and ~50x cheaper
-  // than the previous one-INSERT-per-row loop that was tripping Worker 1102.
-  const CHUNK_SIZE = 50;
+  // match_status, is the SQL literal 'unmatched'). D1's variable limit is
+  // empirically ~500; 20 rows × 19 params = 380, safely under that ceiling.
+  const CHUNK_SIZE = 20;
   const rowPlaceholder =
     "(?, ?, ?, ?, ?, ?, ?, ?, 'unmatched', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 


### PR DESCRIPTION
## Summary
- `CHUNK_SIZE` 50→20 in `importAmexLines`: 20 rows × 19 params = 380 variables/query, well under D1's empirical ~500-variable limit. The 2026-03 CSV (39 rows) was generating 741 variables in a single INSERT and throwing `D1_ERROR: too many SQL variables`.
- `wipe-amex.sql`: removed `strftime` (no `updated_at` touch needed), replaced `LIKE 'amex.%'` with explicit `IN (...)` to avoid `%` confusion in D1's multi-statement parser, added per-statement `--command` equivalents in the header as a fallback.

## Test plan
- [ ] Pull on Mac: `git pull`
- [ ] Wipe AMEX data — run each `--command` line from the file header individually (safest)
- [ ] Re-upload SAISON_2603.csv (39 lines) — should import without "too many SQL variables"
- [ ] Re-upload SAISON_2604.csv and SAISON_2605.csv
- [ ] Confirm reconciliation table shows all lines

https://claude.ai/code/session_018Hmk6umzgR9AtC6Mq4BNPj

---
_Generated by [Claude Code](https://claude.ai/code/session_018Hmk6umzgR9AtC6Mq4BNPj)_