### PR TITLE
fix(receipts): chunk AMEX import to 5 rows — D1's bind limit is 100, not 500

### DIFF
--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -296,9 +296,10 @@ export async function importAmexLines(
   let imported = 0;
 
   // Chunked multi-row INSERTs. Each row binds 19 params (the 20th column,
-  // match_status, is the SQL literal 'unmatched'). D1's variable limit is
-  // empirically ~500; 20 rows × 19 params = 380, safely under that ceiling.
-  const CHUNK_SIZE = 20;
+  // match_status, is the SQL literal 'unmatched'). D1's hard limit is 100
+  // bind variables per statement, so 5 rows × 19 = 95 is the largest chunk
+  // that stays under the ceiling.
+  const CHUNK_SIZE = 5;
   const rowPlaceholder =
     "(?, ?, ?, ?, ?, ?, ?, ?, 'unmatched', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
@@ -726,10 +727,12 @@ export async function createBusinessTripReports(
   for (const candidate of candidates) {
     const tripId = newUuid();
 
-    // One D1 batch per candidate: trip INSERT + bulk line-links INSERT +
-    // bulk line UPDATE. Previously this was 1 + 2N sequential awaits per
-    // candidate (e.g. 41 D1 calls for a 20-line trip), which compounded the
-    // import-route CPU budget on top of the row inserts.
+    // One D1 batch per candidate: trip INSERT + chunked line-links INSERTs +
+    // chunked line UPDATEs. D1's 100-bind-variable per-statement limit means
+    // we can't put all line links in one statement (4 params each = 25 lines
+    // max), so we chunk both the inserts (20 lines × 4 = 80 binds) and the
+    // updates (2 + 20 ids = 22 binds).
+    const TRIP_CHUNK = 20;
     const stmts = [
       db
         .prepare(
@@ -749,9 +752,10 @@ export async function createBusinessTripReports(
         ),
     ];
 
-    if (candidate.lineIds.length > 0) {
-      const linkPlaceholders = candidate.lineIds.map(() => "(?, ?, ?, ?)").join(",");
-      const linkBinds = candidate.lineIds.flatMap((lineId) => [
+    for (let j = 0; j < candidate.lineIds.length; j += TRIP_CHUNK) {
+      const chunkIds = candidate.lineIds.slice(j, j + TRIP_CHUNK);
+      const linkPlaceholders = chunkIds.map(() => "(?, ?, ?, ?)").join(",");
+      const linkBinds = chunkIds.flatMap((lineId) => [
         newUuid(),
         tripId,
         lineId,
@@ -767,7 +771,7 @@ export async function createBusinessTripReports(
           .bind(...linkBinds),
       );
 
-      const idPlaceholders = candidate.lineIds.map(() => "?").join(",");
+      const idPlaceholders = chunkIds.map(() => "?").join(",");
       stmts.push(
         db
           .prepare(
@@ -775,7 +779,7 @@ export async function createBusinessTripReports(
              SET business_trip_id = ?, business_trip_status = 'candidate', updated_at = ?
              WHERE id IN (${idPlaceholders})`,
           )
-          .bind(tripId, now, ...candidate.lineIds),
+          .bind(tripId, now, ...chunkIds),
       );
     }
 


### PR DESCRIPTION
## Summary
Previous `CHUNK_SIZE=20` (PR #35) still failed with `D1_ERROR: too many SQL variables at offset 772`. The offset lands at row 6 of the multi-row INSERT, confirming D1's hard limit is **100 bind variables per statement**, not ~500 as I'd guessed.

- `importAmexLines`: CHUNK_SIZE 20 → 5. 5 × 19 = 95 binds per query, just under the 100 ceiling. Adds D1 round-trips for large statements but keeps every query legal.
- `createBusinessTripReports`: Chunk the `business_trip_report_lines` INSERT and per-trip `UPDATE` into batches of 20 line IDs (80 / 22 binds respectively). Previously a trip with >25 lines would hit the same limit.

## Deploy required
After merge, the Mac must `npm run deploy` for the worker to pick up the new chunk size — the error will persist until then.

## Test plan
- [ ] Mac: `git pull && npm run deploy`
- [ ] Re-upload SAISON_2603.csv (39 lines) — should succeed without the variable error
- [ ] Re-upload 2604 / 2605
- [ ] Confirm any auto-detected business trips also import

https://claude.ai/code/session_018Hmk6umzgR9AtC6Mq4BNPj

---
_Generated by [Claude Code](https://claude.ai/code/session_018Hmk6umzgR9AtC6Mq4BNPj)_