### PR TITLE
fix(receipts): stop boxing image bytes into a JS Array for AI extraction (1102 fix)

### DIFF
--- a/lib/receipts/extraction.ts
+++ b/lib/receipts/extraction.ts
@@ -101,7 +101,11 @@ class CloudflareAiExtractionProvider implements ExtractionProvider {
       "@cf/meta/llama-3.2-11b-vision-instruct",
       {
         prompt: EXTRACTION_PROMPT,
-        image: Array.from(imageBytes),
+        // Pass the Uint8Array directly. The previous Array.from(imageBytes)
+        // allocated 2-3 million boxed Number objects for typical receipt
+        // images and was burning the worker's CPU budget on every call,
+        // triggering 1102 errors after several extractions in a session.
+        image: imageBytes,
         max_tokens: 800,
         temperature: 0.1,
       },


### PR DESCRIPTION
## Problem
After ~10 receipts, AI extraction starts erroring, then photos stop loading, then the worker returns `1102: Worker exceeded resource limits`.

## Root cause
`lib/receipts/extraction.ts` was doing `image: Array.from(imageBytes)` when calling the Workers AI vision model. For a 2 MB JPEG that allocates **~2.1 million boxed Number objects** (32-48 MB of heap), and the binding then re-walks every element to serialize the request body. Combined with the vision-model inference cost, each extraction request was right at the edge of the worker's CPU budget — and any larger-than-average image pushed it over.

## Fix
Pass the `Uint8Array` directly. The Workers AI binding accepts typed arrays the same way it accepts `number[]` but without the boxing cost.

## Deploy required
`npm run deploy` on the Mac before retrying.

## Test plan
- [ ] Mac: `git pull && npm run deploy`
- [ ] Review 15+ receipts in one session — extraction should complete on each
- [ ] Confirm photos still load after extraction
- [ ] Check `wrangler tail` for any remaining 1102s

https://claude.ai/code/session_018Hmk6umzgR9AtC6Mq4BNPj

---
_Generated by [Claude Code](https://claude.ai/code/session_018Hmk6umzgR9AtC6Mq4BNPj)_