### PR TITLE
perf(receipts): resize images at browser, trim Vision round-trip (1102 fix)

### DIFF
--- a/app/api/receipts/[id]/extract/route.ts
+++ b/app/api/receipts/[id]/extract/route.ts
@@ -6,8 +6,9 @@ import { extractReceiptData } from "@/lib/receipts/extraction";
 import { createAuditEntry } from "@/lib/receipts/audit";
 import { nowIso, stringifyJson } from "@/lib/receipts/db-utils";
 import { getReceiptsDb } from "@/lib/cloudflare-runtime";
+import { MAX_RECEIPT_FILE_BYTES } from "@/lib/receipts/validation";
 
-const EXTRACTION_MAX_BYTES = 5 * 1024 * 1024; // 5 MB
+const EXTRACTION_MAX_BYTES = MAX_RECEIPT_FILE_BYTES;
 
 type RouteContext = { params: Promise<{ id: string }> };
 

--- a/components/receipts/receipt-drop-button.tsx
+++ b/components/receipts/receipt-drop-button.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRef, useState } from "react";
+import { maybeResizeImage } from "@/lib/receipts/client-image";
 
 export type PaymentChip = "AMEX" | "CASH" | null;
 
@@ -39,8 +40,12 @@ export function ReceiptDropButton({
     onError("");
 
     try {
+      // Downscale 3-12 MB phone photos to ~200-500 KB before upload. Keeps
+      // the worker's CPU budget under control during OCR extraction.
+      const uploadFile = await maybeResizeImage(file);
+
       const formData = new FormData();
-      formData.append("file", file);
+      formData.append("file", uploadFile);
       formData.append("source", "mobile_capture");
       if (paymentChip) formData.append("paymentPath", paymentChip);
 

--- a/lib/receipts/client-image.ts
+++ b/lib/receipts/client-image.ts
@@ -1,0 +1,128 @@
+// Browser-only image resize helper. Receipt photos straight off a phone are
+// 3–12 MB which inflates the upload, R2 storage, and (most importantly) the
+// base64-encoded body we POST to Google Vision during extraction. Shrinking
+// in the browser keeps the worker well under its CPU budget.
+//
+// All DOM access lives inside maybeResizeImage so a stray server import is
+// inert (the function simply isn't called server-side).
+
+const MAX_LONG_EDGE = 1600;
+const JPEG_QUALITY = 0.82;
+const MIN_RESIZE_BYTES = 500 * 1024;
+const MAX_CANVAS_PIXELS = 16_000_000; // iOS Safari hard cap (~4096 × 4096)
+
+const RESIZE_ELIGIBLE_MIME = new Set([
+  "image/jpeg",
+  "image/jpg",
+  "image/png",
+]);
+
+const RESIZE_ELIGIBLE_EXT = new Set([".jpg", ".jpeg", ".png"]);
+
+function isResizeEligible(file: File): boolean {
+  if (RESIZE_ELIGIBLE_MIME.has(file.type.toLowerCase())) return true;
+  // iOS Photos / some Androids hand back files with empty file.type.
+  // Fall back to extension so we still resize a JPEG that lost its MIME.
+  if (!file.type) {
+    const ext = file.name.toLowerCase().match(/\.[a-z0-9]+$/)?.[0];
+    if (ext && RESIZE_ELIGIBLE_EXT.has(ext)) return true;
+  }
+  return false;
+}
+
+async function decode(file: File): Promise<ImageBitmap | HTMLImageElement> {
+  if (typeof createImageBitmap === "function") {
+    return createImageBitmap(file, { imageOrientation: "from-image" });
+  }
+  // Fallback for browsers without createImageBitmap. The browser still bakes
+  // EXIF orientation into the <img> when drawn to canvas on all current
+  // engines (Chrome ≥ 81, Safari ≥ 13.4).
+  const url = URL.createObjectURL(file);
+  try {
+    const img = new Image();
+    await new Promise<void>((resolve, reject) => {
+      img.onload = () => resolve();
+      img.onerror = () => reject(new Error("decode failed"));
+      img.src = url;
+    });
+    return img;
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+function dimsOf(source: ImageBitmap | HTMLImageElement): { w: number; h: number } {
+  if (source instanceof HTMLImageElement) {
+    return { w: source.naturalWidth, h: source.naturalHeight };
+  }
+  return { w: source.width, h: source.height };
+}
+
+function targetDims(srcW: number, srcH: number): { w: number; h: number } {
+  const longEdge = Math.max(srcW, srcH);
+  let scale = MAX_LONG_EDGE / longEdge;
+  let w = Math.round(srcW * scale);
+  let h = Math.round(srcH * scale);
+  // Guard the iOS canvas-area cap. If the scaled image would still exceed
+  // 16 MP (only possible from gigantic sources), scale further so the
+  // destination canvas stays under the limit.
+  if (w * h > MAX_CANVAS_PIXELS) {
+    scale *= Math.sqrt(MAX_CANVAS_PIXELS / (w * h));
+    w = Math.round(srcW * scale);
+    h = Math.round(srcH * scale);
+  }
+  return { w, h };
+}
+
+function canvasToBlob(canvas: HTMLCanvasElement, type: string, q: number): Promise<Blob | null> {
+  return new Promise((resolve) => canvas.toBlob(resolve, type, q));
+}
+
+function replaceExtension(name: string, newExt: string): string {
+  const stem = name.replace(/\.[^.]+$/, "");
+  return (stem || name) + newExt;
+}
+
+export async function maybeResizeImage(file: File): Promise<File> {
+  if (!isResizeEligible(file)) return file;
+  if (file.size < MIN_RESIZE_BYTES) return file;
+
+  let bitmap: ImageBitmap | null = null;
+  try {
+    const decoded = await decode(file);
+    if (decoded instanceof ImageBitmap) bitmap = decoded;
+
+    const { w: srcW, h: srcH } = dimsOf(decoded);
+    if (Math.max(srcW, srcH) <= MAX_LONG_EDGE) return file;
+
+    const { w, h } = targetDims(srcW, srcH);
+
+    const canvas =
+      typeof OffscreenCanvas !== "undefined"
+        ? (new OffscreenCanvas(w, h) as unknown as HTMLCanvasElement)
+        : Object.assign(document.createElement("canvas"), { width: w, height: h });
+
+    const ctx = canvas.getContext("2d") as CanvasRenderingContext2D | null;
+    if (!ctx) return file;
+    ctx.drawImage(decoded as CanvasImageSource, 0, 0, w, h);
+
+    const blob =
+      "convertToBlob" in canvas
+        ? await (canvas as unknown as OffscreenCanvas).convertToBlob({
+            type: "image/jpeg",
+            quality: JPEG_QUALITY,
+          })
+        : await canvasToBlob(canvas, "image/jpeg", JPEG_QUALITY);
+
+    if (!blob || blob.size >= file.size) return file;
+
+    return new File([blob], replaceExtension(file.name, ".jpg"), {
+      type: "image/jpeg",
+      lastModified: file.lastModified,
+    });
+  } catch {
+    return file;
+  } finally {
+    bitmap?.close?.();
+  }
+}

--- a/lib/receipts/extraction.ts
+++ b/lib/receipts/extraction.ts
@@ -16,7 +16,6 @@ interface GoogleVisionError {
 interface GoogleVisionResponse {
   responses?: Array<{
     fullTextAnnotation?: { text?: string };
-    textAnnotations?: Array<{ description?: string }>;
     error?: GoogleVisionError;
   }>;
   error?: GoogleVisionError;
@@ -230,20 +229,33 @@ class GoogleVisionOcrExtractionProvider implements ExtractionProvider {
     }
 
     const apiKey = getGoogleCloudVisionApiKey();
+
+    // Build the body, then drop our local references to the image bytes and
+    // base64 string. The fetch+JSON.parse round-trip is hundreds of ms of
+    // network wait — without this, the original Uint8Array (~3-5 MB), the
+    // base64 string (~4-7 MB), and the JSON body (~4-7 MB) all stay pinned
+    // through the entire round-trip and through `response.json()`, which is
+    // exactly the heap pressure that trips Worker 1102 after a few requests.
+    let bodyImage: string | null = bytesToBase64(imageBytes);
+    const body = JSON.stringify({
+      requests: [
+        {
+          image: { content: bodyImage },
+          features: [{ type: "DOCUMENT_TEXT_DETECTION" }],
+          imageContext: { languageHints: ["ja", "en"] },
+        },
+      ],
+    });
+    bodyImage = null;
+    // The caller's Uint8Array is still alive in the route handler, but our
+    // local reference (and the base64 string above) are now free to collect.
+
     const response = await fetch(
       `https://vision.googleapis.com/v1/images:annotate?key=${encodeURIComponent(apiKey)}`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          requests: [
-            {
-              image: { content: bytesToBase64(imageBytes) },
-              features: [{ type: "DOCUMENT_TEXT_DETECTION" }],
-              imageContext: { languageHints: ["ja", "en"] },
-            },
-          ],
-        }),
+        body,
       },
     );
 
@@ -257,10 +269,10 @@ class GoogleVisionOcrExtractionProvider implements ExtractionProvider {
       throw new Error(annotation.error.message ?? "Google Vision OCR failed.");
     }
 
-    const rawText =
-      annotation?.fullTextAnnotation?.text ??
-      annotation?.textAnnotations?.[0]?.description ??
-      "";
+    // DOCUMENT_TEXT_DETECTION populates fullTextAnnotation.text whenever it
+    // returns anything at all — the per-word textAnnotations array is large
+    // and never needed for our parse.
+    const rawText = annotation?.fullTextAnnotation?.text ?? "";
     const parsed = parseReceiptOcrText(rawText);
 
     return {

--- a/lib/receipts/validation.ts
+++ b/lib/receipts/validation.ts
@@ -17,14 +17,18 @@ export const ALLOWED_RECEIPT_EXTENSIONS = [
   ".pdf",
 ];
 
-export const MAX_RECEIPT_FILE_BYTES = 10 * 1024 * 1024; // 10 MiB
+// 5 MiB cap on both upload and extraction. The Google Vision request body
+// is base64-encoded (≈ 1.33× the raw size) and JSON.stringified — anything
+// larger pins enough heap in the worker to trip 1102 during back-to-back
+// extractions. Clients should resize before upload (see client-image.ts).
+export const MAX_RECEIPT_FILE_BYTES = 5 * 1024 * 1024; // 5 MiB
 
 export const ALLOWED_CURRENCIES = ["JPY", "USD", "EUR", "GBP", "AUD", "CNY"];
 
 export function validateReceiptFile(file: File): string | null {
   if (file.size > MAX_RECEIPT_FILE_BYTES) {
     const mb = (file.size / (1024 * 1024)).toFixed(1);
-    return `File is too large (${mb} MB). Maximum allowed size is 10 MB.`;
+    return `File is too large (${mb} MB). Maximum allowed size is 5 MB.`;
   }
 
   const ext = `.${file.name.split(".").pop()?.toLowerCase() ?? ""}`;

--- a/tests/receipts/validation.test.ts
+++ b/tests/receipts/validation.test.ts
@@ -33,14 +33,14 @@ test("validateReceiptFile: unsupported MIME type is rejected", () => {
   assert.match(err!, /not allowed/i);
 });
 
-test("validateReceiptFile: file over 10 MiB is rejected", () => {
+test("validateReceiptFile: file over MAX_RECEIPT_FILE_BYTES is rejected", () => {
   const file = makeFile("big.jpg", "image/jpeg", MAX_RECEIPT_FILE_BYTES + 1);
   const err = validateReceiptFile(file);
   assert.ok(err !== null, "expected an error for oversized file");
   assert.match(err!, /too large/i);
 });
 
-test("validateReceiptFile: file exactly at 10 MiB limit passes", () => {
+test("validateReceiptFile: file at MAX_RECEIPT_FILE_BYTES limit passes", () => {
   const file = makeFile("max.jpg", "image/jpeg", MAX_RECEIPT_FILE_BYTES);
   assert.equal(validateReceiptFile(file), null);
 });


### PR DESCRIPTION
## Problem
After ~10 receipts in a review session the worker returned `1102: Worker exceeded resource limits` during AI extraction; photos then stopped loading. Modern phones produce 3-12 MB JPEGs, base64 inflates that ~33%, JSON.stringify wraps it, and Google Vision's response pinned everything in heap during the round-trip — each request individually was fine, but any larger-than-average image pushed CPU over.

## Changes
1. **`lib/receipts/client-image.ts` (new)** — `maybeResizeImage(file)` decodes via `createImageBitmap` with `imageOrientation: "from-image"` (EXIF baked in), downscales to a 1600 px long edge and re-encodes JPEG at q=0.82. Typical 4 MB phone JPEG → ~300 KB. HEIC/HEIF/PDF pass through; any decode failure returns the original file (never blocks upload). Caps target canvas at 16 MP for the iOS Safari limit.
2. **`ReceiptDropButton`** — calls `maybeResizeImage` before building FormData. Spinner already covers the 400-800 ms decode/encode on a 12 MP photo.
3. **`MAX_RECEIPT_FILE_BYTES`** 10 MiB → 5 MiB, matching `EXTRACTION_MAX_BYTES`. Extract route imports the constant — single source of truth.
4. **`GoogleVisionOcrExtractionProvider.extract`** — drops the unused `textAnnotations` fallback and nulls the base64 string before `fetch().json()` so the worker can reclaim ~5-8 MB of heap during the network round-trip.

## Deploy required
`git pull && npm run deploy` on the Mac.

## Test plan
- [x] `npm test` — all 96 tests pass
- [x] `npx tsc --noEmit` — clean
- [ ] Mac: deploy, then in a mobile-emulator (Chrome DevTools iPhone 14 preset) drop a 4 MB JPEG and confirm the `/api/receipts/upload` request body is ~200-500 KB in the Network panel
- [ ] Review 15+ receipts back-to-back in the live UI — no 1102, photos keep loading
- [ ] `wrangler tail` during the session — no "exceeded CPU" lines
- [ ] HEIC upload still works (passes through; hits the 5 MB gate cleanly if oversized)

## Out of scope
- HEIC client-side decode (would need `heic2any` ~70 KB)
- Backfill resizer for legacy oversized R2 objects (rare, do per-receipt re-upload if it comes up)
- GCS-URI mode for Vision (avoids base64 entirely but requires R2 signed URLs)

https://claude.ai/code/session_018Hmk6umzgR9AtC6Mq4BNPj

---
_Generated by [Claude Code](https://claude.ai/code/session_018Hmk6umzgR9AtC6Mq4BNPj)_