### PR TITLE
feat(receipts): reconciliation hardening — collision resolution, signoff, stable identity, UX

### DIFF
--- a/app/(receipt-system)/receipts/reconcile/page.tsx
+++ b/app/(receipt-system)/receipts/reconcile/page.tsx
@@ -42,7 +42,7 @@ export default async function ReconcilePage({
       r.status !== "archived" &&
       r.status !== "exported" &&
       !r.deleted_at &&
-      r.transaction_date?.startsWith(month) &&
+      (!r.transaction_date || r.transaction_date.startsWith(month)) &&
       !linkedReceiptIds.has(r.id) &&
       !suggestedReceiptIds.has(r.id),
   );

--- a/app/(receipt-system)/receipts/reconcile/page.tsx
+++ b/app/(receipt-system)/receipts/reconcile/page.tsx
@@ -1,7 +1,12 @@
-import { listAmexLines, listReceiptRecords } from "@/lib/receipts/db";
+import {
+  listAmexLines,
+  listReceiptRecords,
+  getReconciliationForMonth,
+} from "@/lib/receipts/db";
 import { matchAmexToReceipts } from "@/lib/receipts/reconciliation";
 import { ReconciliationTable } from "@/components/receipts/reconciliation-table";
 import { assertReceiptsPageAccess } from "@/lib/receipts/auth-request";
+import type { AmexReconciliation } from "@/lib/receipts/types";
 
 export const dynamic = "force-dynamic";
 
@@ -15,12 +20,32 @@ export default async function ReconcilePage({
   const params = await searchParams;
   const month = String(params.month ?? new Date().toISOString().slice(0, 7));
 
-  const [amexLines, receipts] = await Promise.all([
+  const [amexLines, receipts, reconciliation] = await Promise.all([
     listAmexLines(month),
     listReceiptRecords({ paymentPath: "AMEX", limit: 200 }),
+    getReconciliationForMonth(month),
   ]);
 
-  const autoMatches = matchAmexToReceipts(amexLines, receipts);
+  const autoMatches = reconciliation?.status === "finalized"
+    ? [] // No auto-matching when finalized
+    : matchAmexToReceipts(amexLines, receipts);
+
+  const linkedReceiptIds = new Set(
+    amexLines
+      .map((l) => l.matched_receipt_id)
+      .filter((id): id is string => !!id),
+  );
+  const suggestedReceiptIds = new Set(autoMatches.map((m) => m.receiptId));
+  const orphanReceipts = receipts.filter(
+    (r) =>
+      r.payment_path === "AMEX" &&
+      r.status !== "archived" &&
+      r.status !== "exported" &&
+      !r.deleted_at &&
+      r.transaction_date?.startsWith(month) &&
+      !linkedReceiptIds.has(r.id) &&
+      !suggestedReceiptIds.has(r.id),
+  );
 
   return (
     <div className="space-y-6">
@@ -31,10 +56,36 @@ export default async function ReconcilePage({
         </p>
       </div>
 
+      {reconciliation?.status === "finalized" && (
+        <div className="rounded-2xl border border-green-200 bg-green-50 p-4">
+          <p className="text-sm font-semibold text-green-800">
+            Reconciliation signed off
+          </p>
+          <p className="mt-1 text-xs text-green-700">
+            Finalized by {reconciliation.finalized_by} at {reconciliation.finalized_at}
+            {" — "}{reconciliation.line_count} lines ({reconciliation.matched_count} matched, {reconciliation.no_receipt_count} no receipt)
+          </p>
+          {reconciliation.manifest_sha256 && (
+            <p className="mt-1 text-xs font-mono text-green-600">
+              SHA-256: {reconciliation.manifest_sha256}
+            </p>
+          )}
+          <a
+            href={`/api/receipts/reconcile/${month}/manifest`}
+            className="mt-2 inline-block text-xs font-medium text-amber-700 hover:text-amber-800 underline"
+          >
+            Download manifest CSV
+          </a>
+        </div>
+      )}
+
       <ReconciliationTable
         amexLines={amexLines}
         receipts={receipts}
         autoMatches={autoMatches}
+        orphanReceipts={orphanReceipts}
+        month={month}
+        finalized={reconciliation?.status === "finalized"}
       />
     </div>
   );

--- a/app/api/receipts/amex/import/route.ts
+++ b/app/api/receipts/amex/import/route.ts
@@ -21,6 +21,23 @@ import {
 } from "@/lib/receipts/storage";
 import { getReceiptsDb } from "@/lib/cloudflare-runtime";
 
+/*
+ * AMEX CSV Import — Dedup Contract
+ * ==================================
+ * AMEX line identity is stable across re-imports. The dedup key is:
+ *   (statement_month, amex_reference, cardholder_name)  — when amex_reference is present
+ *   (statement_month, transaction_date, amount_minor, merchant, cardholder_name)  — fallback
+ *
+ * On re-upload for the same month, INSERT … ON CONFLICT DO UPDATE preserves
+ * the row PK (id) and all reconciliation state (matched_receipt_id,
+ * match_status, receipt_status, expense_category_code, business_trip_status,
+ * category_status, receipt_missing_reason, business_trip_id) while refreshing
+ * CSV-sourced fields (dates, merchant, amount, raw_json, etc.).
+ *
+ * Prior artifact records are marked import_status='replaced' after a
+ * successful re-import.
+ */
+
 const MAX_CSV_BYTES = 5 * 1024 * 1024;
 
 export async function POST(request: Request) {
@@ -85,8 +102,9 @@ export async function POST(request: Request) {
           artifactId: existingBySha.id,
           statementMonth: existingBySha.statement_month,
           message: "This AMEX statement file has already been uploaded.",
-          imported: 0,
-          skipped: 0,
+          inserted: 0,
+          updated: 0,
+          unchanged: 0,
           transactionCount: existingBySha.transaction_count ?? 0,
           statementTotalCents: existingBySha.statement_total_amount_cents,
           cardName: existingBySha.card_name,
@@ -158,16 +176,12 @@ export async function POST(request: Request) {
           validationErrors,
           skippedLines,
           transactionCount: 0,
-          imported: 0,
-          skipped: 0,
+          inserted: 0,
+          updated: 0,
+          unchanged: 0,
         },
         { status: 422 },
       );
-    }
-
-    // ── Mark previous artifact replaced ────────────────────────────────────
-    if (previousArtifact) {
-      await markPreviousArtifactsReplaced(statementMonth, savedArtifactId);
     }
 
     // ── Import line items ───────────────────────────────────────────────────
@@ -178,9 +192,14 @@ export async function POST(request: Request) {
       sha256,
     );
 
-    const { imported, skipped } = await importAmexLines(importInputs, actor);
+    const { inserted, updated, unchanged } = await importAmexLines(importInputs, actor);
 
     await updateAmexArtifactStatus(savedArtifactId, "parsed");
+
+    // ── Mark previous artifact replaced (after successful import) ──────────
+    if (previousArtifact) {
+      await markPreviousArtifactsReplaced(statementMonth, savedArtifactId);
+    }
 
     // ── Business trip candidate detection ───────────────────────────────────
     let businessTripCandidatesCount = 0;
@@ -228,8 +247,9 @@ export async function POST(request: Request) {
         statementTotalCents: metadata.statementTotalCents,
         parsedTotalCents,
         transactionCount: lines.length,
-        imported,
-        skipped,
+        inserted,
+        updated,
+        unchanged,
         skippedLines,
         replaced: previousArtifact !== null,
         businessTripCandidates: businessTripCandidatesCount,

--- a/app/api/receipts/amex/lines/[id]/route.ts
+++ b/app/api/receipts/amex/lines/[id]/route.ts
@@ -126,6 +126,10 @@ export async function PATCH(request: Request, { params }: RouteContext) {
     if (error instanceof Error && error.message.startsWith("Unauthorized")) {
       return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
     }
+    // 409: month's reconciliation is finalized — edits blocked
+    if (error instanceof Error && error.message.includes("is finalized")) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
     console.error("[api/receipts/amex/lines/[id]] PATCH failed", error);
     return NextResponse.json(
       { error: error instanceof Error ? error.message : "Update failed." },

--- a/app/api/receipts/export/month/route.ts
+++ b/app/api/receipts/export/month/route.ts
@@ -5,6 +5,7 @@ import {
   listAttendees,
   createExport,
   finalizeExport,
+  getFinalizedReconciliationForMonth,
   listAmexLines,
 } from "@/lib/receipts/db";
 import {
@@ -72,8 +73,16 @@ export async function POST(request: Request) {
       };
     });
 
-    // Export blocking validation — check AMEX lines before finalizing
+    // Export blocking validation — check AMEX lines and reconciliation before finalizing
     if (body.finalize) {
+      const reconciliation = await getFinalizedReconciliationForMonth(month);
+      if (!reconciliation) {
+        return NextResponse.json(
+          { error: `Cannot finalize export: no finalized reconciliation for ${month}. Sign off the reconciliation first.`, blockers: [`No finalized reconciliation for ${month}`] },
+          { status: 422 },
+        );
+      }
+
       const amexLines = await listAmexLines(month);
       const blockers: string[] = [];
 
@@ -118,6 +127,11 @@ export async function POST(request: Request) {
     const encoder = new TextEncoder();
     await archiveBundle(archiveKey, encoder.encode(csv).buffer as ArrayBuffer);
 
+    // When finalizing, include reconciliation manifest reference in the export manifest
+    const reconciliation = body.finalize
+      ? await getFinalizedReconciliationForMonth(month)
+      : null;
+
     // Generate and upload manifest
     const manifest = buildManifestCsv(
       exportId,
@@ -126,6 +140,13 @@ export async function POST(request: Request) {
       sha256,
       exportRows.length,
       new Date().toISOString(),
+      reconciliation
+        ? {
+            id: reconciliation.id,
+            manifestR2Key: reconciliation.manifest_r2_key ?? "",
+            manifestSha256: reconciliation.manifest_sha256 ?? "",
+          }
+        : null,
     );
     await archiveManifest(manifestKey, encoder.encode(manifest).buffer as ArrayBuffer);
 

--- a/app/api/receipts/reconcile/[month]/manifest/route.ts
+++ b/app/api/receipts/reconcile/[month]/manifest/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+import { requireReceiptsActor } from "@/lib/receipts/auth";
+import { getFinalizedReconciliationForMonth } from "@/lib/receipts/db";
+import { getReceiptsArchiveBucket } from "@/lib/cloudflare-runtime";
+
+type RouteContext = { params: Promise<{ month: string }> };
+
+export async function GET(request: Request, { params }: RouteContext) {
+  try {
+    await requireReceiptsActor(request.headers);
+    const { month } = await params;
+
+    if (!/^\d{4}-\d{2}$/.test(month)) {
+      return NextResponse.json({ error: "Invalid month format." }, { status: 400 });
+    }
+
+    const reconciliation = await getFinalizedReconciliationForMonth(month);
+    if (!reconciliation || !reconciliation.manifest_r2_key) {
+      return NextResponse.json(
+        { error: "No finalized reconciliation found for this month." },
+        { status: 404 },
+      );
+    }
+
+    const bucket = getReceiptsArchiveBucket();
+    const object = await bucket.get(reconciliation.manifest_r2_key);
+    if (!object) {
+      return NextResponse.json(
+        { error: "Manifest file not found in storage." },
+        { status: 404 },
+      );
+    }
+
+    return new Response(object.body, {
+      headers: {
+        "Content-Type": "text/csv; charset=utf-8",
+        "Content-Disposition": `attachment; filename="reconciliation-${month}-manifest.csv"`,
+      },
+    });
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Unauthorized")) {
+      return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+    }
+    console.error("[api/receipts/reconcile/[month]/manifest] GET failed", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to download manifest." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/receipts/reconcile/finalize/route.ts
+++ b/app/api/receipts/reconcile/finalize/route.ts
@@ -103,6 +103,7 @@ export async function POST(request: Request) {
       amexLines,
       receipts,
       amexAttendees,
+      Object.fromEntries(receiptAttendeeMap),
     );
     const manifestSha256 = await hashCsvContent(manifestCsv);
 

--- a/app/api/receipts/reconcile/finalize/route.ts
+++ b/app/api/receipts/reconcile/finalize/route.ts
@@ -6,6 +6,7 @@ import {
   getFinalizedReconciliationForMonth,
   listAmexLineAttendeeNamesByMonth,
   listAmexLines,
+  listAttendees,
   listReceiptRecords,
 } from "@/lib/receipts/db";
 import { hashCsvContent } from "@/lib/receipts/export";
@@ -48,10 +49,14 @@ export async function POST(request: Request) {
     const amexAttendees = await listAmexLineAttendeeNamesByMonth(month);
     const receipts = await listReceiptRecords({ paymentPath: "AMEX", limit: 200 });
     const receiptAttendeeMap = new Map<string, string[]>();
-    for (const r of receipts) {
-      const { listAttendees } = await import("@/lib/receipts/db");
-      const att = await listAttendees(r.id);
-      if (att.length > 0) receiptAttendeeMap.set(r.id, att.map((a) => a.attendee_name));
+    const attendeeResults = await Promise.all(
+      receipts.map(async (r) => {
+        const att = await listAttendees(r.id);
+        return att.length > 0 ? [r.id, att.map((a) => a.attendee_name)] as const : null;
+      }),
+    );
+    for (const entry of attendeeResults) {
+      if (entry) receiptAttendeeMap.set(entry[0], entry[1]);
     }
 
     for (const line of amexLines) {

--- a/app/api/receipts/reconcile/finalize/route.ts
+++ b/app/api/receipts/reconcile/finalize/route.ts
@@ -1,0 +1,156 @@
+import { NextResponse } from "next/server";
+import { requireReceiptsActor } from "@/lib/receipts/auth";
+import {
+  createReconciliationDraft,
+  finalizeReconciliation,
+  getFinalizedReconciliationForMonth,
+  listAmexLineAttendeeNamesByMonth,
+  listAmexLines,
+  listReceiptRecords,
+} from "@/lib/receipts/db";
+import { hashCsvContent } from "@/lib/receipts/export";
+import { buildReconciliationManifestCsv } from "@/lib/receipts/reconciliation-signoff";
+import { archiveManifest } from "@/lib/receipts/storage";
+import { requiresAttendees } from "@/lib/receipts/categories";
+
+export async function POST(request: Request) {
+  try {
+    const actor = await requireReceiptsActor(request.headers);
+
+    const body = (await request.json()) as { month?: string };
+    const month = body.month?.trim();
+
+    if (!month || !/^\d{4}-\d{2}$/.test(month)) {
+      return NextResponse.json(
+        { error: "month must be in YYYY-MM format." },
+        { status: 400 },
+      );
+    }
+
+    const alreadyFinalized = await getFinalizedReconciliationForMonth(month);
+    if (alreadyFinalized) {
+      return NextResponse.json(
+        { error: `Reconciliation for ${month} is already finalized.` },
+        { status: 409 },
+      );
+    }
+
+    const amexLines = await listAmexLines(month);
+    if (amexLines.length === 0) {
+      return NextResponse.json(
+        { error: `No AMEX lines found for ${month}.` },
+        { status: 400 },
+      );
+    }
+
+    // Validate: all lines must be resolved
+    const blockers: string[] = [];
+    const amexAttendees = await listAmexLineAttendeeNamesByMonth(month);
+    const receipts = await listReceiptRecords({ paymentPath: "AMEX", limit: 200 });
+    const receiptAttendeeMap = new Map<string, string[]>();
+    for (const r of receipts) {
+      const { listAttendees } = await import("@/lib/receipts/db");
+      const att = await listAttendees(r.id);
+      if (att.length > 0) receiptAttendeeMap.set(r.id, att.map((a) => a.attendee_name));
+    }
+
+    for (const line of amexLines) {
+      const label = `${line.transaction_date} ${line.merchant}`;
+
+      if (line.match_status === "unmatched" || line.match_status === "matched") {
+        blockers.push(`AMEX ${label}: unresolved match status (${line.match_status})`);
+      }
+      if (!line.expense_category_code) {
+        blockers.push(`AMEX ${label}: missing expense category`);
+      }
+      if (
+        line.receipt_status === "matched" &&
+        (!line.matched_receipt_id || line.match_status !== "confirmed")
+      ) {
+        blockers.push(`AMEX ${label}: matched receipt is not confirmed`);
+      }
+      if (
+        line.receipt_status === "missing_receipt" ||
+        ((line.receipt_status === "no_receipt_required" ||
+          line.receipt_status === "receipt_not_available") &&
+          !line.receipt_missing_reason)
+      ) {
+        blockers.push(`AMEX ${label}: missing receipt requires a reason`);
+      }
+      if (requiresAttendees(line.expense_category_code)) {
+        const linkedReceiptAttendees = line.matched_receipt_id
+          ? receiptAttendeeMap.get(line.matched_receipt_id) ?? []
+          : [];
+        const directAmexAttendees = amexAttendees[line.id] ?? [];
+        if (linkedReceiptAttendees.length === 0 && directAmexAttendees.length === 0) {
+          blockers.push(`AMEX ${label}: requires attendees`);
+        }
+      }
+      if (line.business_trip_status === "candidate") {
+        blockers.push(`AMEX ${label}: unresolved business trip candidate`);
+      }
+    }
+
+    if (blockers.length > 0) {
+      return NextResponse.json(
+        { error: "Cannot sign off — resolve these issues first.", blockers },
+        { status: 400 },
+      );
+    }
+
+    // Build manifest CSV
+    const manifestCsv = buildReconciliationManifestCsv(
+      amexLines,
+      receipts,
+      amexAttendees,
+    );
+    const manifestSha256 = await hashCsvContent(manifestCsv);
+
+    const matchedCount = amexLines.filter((l) => l.match_status === "confirmed").length;
+    const noReceiptCount = amexLines.filter((l) => l.match_status === "no_receipt").length;
+
+    const reconciliationId = await createReconciliationDraft(
+      month,
+      amexLines.length,
+      matchedCount,
+      noReceiptCount,
+      actor,
+    );
+
+    const manifestR2Key = `reconciliations/${month}/${reconciliationId}-manifest.csv`;
+
+    // Upload manifest to archive bucket
+    const encoder = new TextEncoder();
+    await archiveManifest(manifestR2Key, encoder.encode(manifestCsv).buffer as ArrayBuffer);
+
+    await finalizeReconciliation(
+      reconciliationId,
+      manifestR2Key,
+      manifestSha256,
+      actor,
+    );
+
+    return NextResponse.json(
+      {
+        id: reconciliationId,
+        month,
+        manifestR2Key,
+        manifestSha256,
+        lineCount: amexLines.length,
+        matchedCount,
+        noReceiptCount,
+        finalized: true,
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Unauthorized")) {
+      return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+    }
+    console.error("[api/receipts/reconcile/finalize] failed", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Finalization failed." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/receipts/reconcile/finalize/route.ts
+++ b/app/api/receipts/reconcile/finalize/route.ts
@@ -3,6 +3,7 @@ import { requireReceiptsActor } from "@/lib/receipts/auth";
 import {
   createReconciliationDraft,
   finalizeReconciliation,
+  getAmexArtifactByMonth,
   getFinalizedReconciliationForMonth,
   listAmexLineAttendeeNamesByMonth,
   listAmexLines,
@@ -43,6 +44,8 @@ export async function POST(request: Request) {
         { status: 400 },
       );
     }
+
+    const activeArtifact = await getAmexArtifactByMonth(month);
 
     // Validate: all lines must be resolved
     const blockers: string[] = [];
@@ -104,13 +107,23 @@ export async function POST(request: Request) {
     }
 
     // Build manifest CSV
-    const manifestCsv = buildReconciliationManifestCsv(
+    let manifestCsv = buildReconciliationManifestCsv(
       amexLines,
       receipts,
       amexAttendees,
       Object.fromEntries(receiptAttendeeMap),
     );
     const manifestSha256 = await hashCsvContent(manifestCsv);
+
+    // Prepend header comments with self-hash and source artifact
+    const headerLines: string[] = [
+      `# manifest_sha256: ${manifestSha256}`,
+    ];
+    if (activeArtifact) {
+      headerLines.push(`# source_artifact_id: ${activeArtifact.id}`);
+      headerLines.push(`# source_artifact_sha256: ${activeArtifact.sha256_hash}`);
+    }
+    manifestCsv = headerLines.join("\n") + "\n" + manifestCsv;
 
     const matchedCount = amexLines.filter((l) => l.match_status === "confirmed").length;
     const noReceiptCount = amexLines.filter((l) => l.match_status === "no_receipt").length;
@@ -121,6 +134,7 @@ export async function POST(request: Request) {
       matchedCount,
       noReceiptCount,
       actor,
+      activeArtifact?.id ?? null,
     );
 
     const manifestR2Key = `reconciliations/${month}/${reconciliationId}-manifest.csv`;

--- a/app/api/receipts/reconcile/finalize/route.ts
+++ b/app/api/receipts/reconcile/finalize/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { requireReceiptsActor } from "@/lib/receipts/auth";
 import {
   createReconciliationDraft,
+  deleteDraftReconciliation,
   finalizeReconciliation,
   getAmexArtifactByMonth,
   getFinalizedReconciliationForMonth,
@@ -12,7 +13,7 @@ import {
 } from "@/lib/receipts/db";
 import { hashCsvContent } from "@/lib/receipts/export";
 import { buildReconciliationManifestCsv } from "@/lib/receipts/reconciliation-signoff";
-import { archiveManifest } from "@/lib/receipts/storage";
+import { archiveManifest, deleteArchiveObject } from "@/lib/receipts/storage";
 import { requiresAttendees } from "@/lib/receipts/categories";
 
 export async function POST(request: Request) {
@@ -139,16 +140,35 @@ export async function POST(request: Request) {
 
     const manifestR2Key = `reconciliations/${month}/${reconciliationId}-manifest.csv`;
 
-    // Upload manifest to archive bucket
-    const encoder = new TextEncoder();
-    await archiveManifest(manifestR2Key, encoder.encode(manifestCsv).buffer as ArrayBuffer);
+    try {
+      // Upload manifest to archive bucket
+      const encoder = new TextEncoder();
+      await archiveManifest(manifestR2Key, encoder.encode(manifestCsv).buffer as ArrayBuffer);
 
-    await finalizeReconciliation(
-      reconciliationId,
-      manifestR2Key,
-      manifestSha256,
-      actor,
-    );
+      await finalizeReconciliation(
+        reconciliationId,
+        manifestR2Key,
+        manifestSha256,
+        actor,
+      );
+    } catch (finalizeError) {
+      // Unique constraint violation means another request finalized first
+      if (
+        finalizeError instanceof Error &&
+        (finalizeError.message.includes("CONSTRAINT") ||
+          finalizeError.message.includes("UNIQUE"))
+      ) {
+        // Clean up draft row and uploaded manifest
+        await deleteDraftReconciliation(reconciliationId).catch(() => {});
+        await deleteArchiveObject(manifestR2Key).catch(() => {});
+
+        return NextResponse.json(
+          { error: `Reconciliation for ${month} was finalized by another request.` },
+          { status: 409 },
+        );
+      }
+      throw finalizeError;
+    }
 
     return NextResponse.json(
       {

--- a/app/api/receipts/reconcile/finalize/route.ts
+++ b/app/api/receipts/reconcile/finalize/route.ts
@@ -12,9 +12,8 @@ import {
   listReceiptRecords,
 } from "@/lib/receipts/db";
 import { hashCsvContent } from "@/lib/receipts/export";
-import { buildReconciliationManifestCsv } from "@/lib/receipts/reconciliation-signoff";
+import { buildReconciliationManifestCsv, validateAmexLinesForSignoff } from "@/lib/receipts/reconciliation-signoff";
 import { archiveManifest, deleteArchiveObject } from "@/lib/receipts/storage";
-import { requiresAttendees } from "@/lib/receipts/categories";
 
 export async function POST(request: Request) {
   try {
@@ -49,7 +48,6 @@ export async function POST(request: Request) {
     const activeArtifact = await getAmexArtifactByMonth(month);
 
     // Validate: all lines must be resolved
-    const blockers: string[] = [];
     const amexAttendees = await listAmexLineAttendeeNamesByMonth(month);
     const receipts = await listReceiptRecords({ paymentPath: "AMEX", limit: 200 });
     const receiptAttendeeMap = new Map<string, string[]>();
@@ -63,42 +61,7 @@ export async function POST(request: Request) {
       if (entry) receiptAttendeeMap.set(entry[0], entry[1]);
     }
 
-    for (const line of amexLines) {
-      const label = `${line.transaction_date} ${line.merchant}`;
-
-      if (line.match_status === "unmatched" || line.match_status === "matched") {
-        blockers.push(`AMEX ${label}: unresolved match status (${line.match_status})`);
-      }
-      if (!line.expense_category_code) {
-        blockers.push(`AMEX ${label}: missing expense category`);
-      }
-      if (
-        line.receipt_status === "matched" &&
-        (!line.matched_receipt_id || line.match_status !== "confirmed")
-      ) {
-        blockers.push(`AMEX ${label}: matched receipt is not confirmed`);
-      }
-      if (
-        line.receipt_status === "missing_receipt" ||
-        ((line.receipt_status === "no_receipt_required" ||
-          line.receipt_status === "receipt_not_available") &&
-          !line.receipt_missing_reason)
-      ) {
-        blockers.push(`AMEX ${label}: missing receipt requires a reason`);
-      }
-      if (requiresAttendees(line.expense_category_code)) {
-        const linkedReceiptAttendees = line.matched_receipt_id
-          ? receiptAttendeeMap.get(line.matched_receipt_id) ?? []
-          : [];
-        const directAmexAttendees = amexAttendees[line.id] ?? [];
-        if (linkedReceiptAttendees.length === 0 && directAmexAttendees.length === 0) {
-          blockers.push(`AMEX ${label}: requires attendees`);
-        }
-      }
-      if (line.business_trip_status === "candidate") {
-        blockers.push(`AMEX ${label}: unresolved business trip candidate`);
-      }
-    }
+    const blockers = validateAmexLinesForSignoff(amexLines, amexAttendees, receiptAttendeeMap);
 
     if (blockers.length > 0) {
       return NextResponse.json(

--- a/app/api/receipts/reconcile/route.ts
+++ b/app/api/receipts/reconcile/route.ts
@@ -31,10 +31,24 @@ export async function POST(request: Request) {
       );
     }
 
+    const status = body.matchStatus as AmexMatchStatus;
+    if ((status === "confirmed" || status === "matched") && !body.receiptId) {
+      return NextResponse.json(
+        { error: "receiptId is required for confirmed/matched" },
+        { status: 400 },
+      );
+    }
+    if ((status === "unmatched" || status === "no_receipt") && body.receiptId) {
+      return NextResponse.json(
+        { error: "receiptId must be null for unmatched/no_receipt" },
+        { status: 400 },
+      );
+    }
+
     await updateAmexReconciliation(
       body.amexLineId,
       body.receiptId ?? null,
-      body.matchStatus as AmexMatchStatus,
+      status,
       actor,
     );
 
@@ -42,6 +56,14 @@ export async function POST(request: Request) {
   } catch (error) {
     if (error instanceof Error && error.message.startsWith("Unauthorized")) {
       return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+    }
+    // 409: receipt already confirmed against a different AMEX line (race guard in db.ts)
+    if (error instanceof Error && error.message.startsWith("Receipt already confirmed against another AMEX line")) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
+    // 409: month's reconciliation is finalized — edits blocked
+    if (error instanceof Error && error.message.includes("is finalized")) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
     }
     console.error("[api/receipts/reconcile] failed", error);
     return NextResponse.json(

--- a/components/receipts/reconciliation-table.tsx
+++ b/components/receipts/reconciliation-table.tsx
@@ -549,6 +549,11 @@ export function ReconciliationTable({
                       <td className="px-4 py-3 text-gray-700">{line.transaction_date}</td>
                       <td className="px-4 py-3 font-medium text-gray-900">
                         {line.merchant}
+                        {line.re_review_needed === 1 && (
+                          <span className="ml-1.5 inline-block rounded-full bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold text-amber-700">
+                            Re-review
+                          </span>
+                        )}
                         {line.cardholder_name && (
                           <span className="ml-1 text-gray-400">({line.cardholder_name})</span>
                         )}

--- a/components/receipts/reconciliation-table.tsx
+++ b/components/receipts/reconciliation-table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import type { AmexStatementLine, ReceiptRecord } from "@/lib/receipts/types";
 import type { ReconciliationMatch } from "@/lib/receipts/types";
@@ -9,22 +9,37 @@ import {
   requiresAttendees as categoryRequiresAttendees,
   formatCategoryLabel,
 } from "@/lib/receipts/categories";
+import { normalizeDescription } from "@/lib/receipts/reconciliation";
 
 interface ReconciliationTableProps {
   amexLines: AmexStatementLine[];
   receipts: ReceiptRecord[];
   autoMatches: ReconciliationMatch[];
+  orphanReceipts: ReceiptRecord[];
+  month: string;
+  finalized?: boolean;
 }
 
 export function ReconciliationTable({
   amexLines,
   receipts,
   autoMatches,
+  orphanReceipts,
+  month,
+  finalized,
 }: ReconciliationTableProps) {
   const router = useRouter();
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [categoryBusy, setCategoryBusy] = useState<string | null>(null);
+  const [signoffBusy, setSignoffBusy] = useState(false);
+  const [confidenceThreshold, setConfidenceThreshold] = useState(0.9);
+  const [bulkProgress, setBulkProgress] = useState<{ current: number; total: number } | null>(null);
+  const [bulkResult, setBulkResult] = useState<{ confirmed: number; failed: number; errors: string[] } | null>(null);
+  const [focusIndex, setFocusIndex] = useState<number | null>(null);
+  const [showHelp, setShowHelp] = useState(false);
+  const cardRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const handlerRef = useRef<(e: KeyboardEvent) => void>(() => {});
 
   const matchMap = new Map<string, ReconciliationMatch>(
     autoMatches.map((m) => [m.amexLineId, m]),
@@ -34,13 +49,11 @@ export function ReconciliationTable({
     receipts.map((r) => [r.id, r]),
   );
 
-  async function reconcile(
+  async function reconcileFetch(
     amexLineId: string,
     receiptId: string | null,
     matchStatus: string,
-  ) {
-    setBusy(amexLineId);
-    setError(null);
+  ): Promise<{ ok: boolean; error?: string }> {
     try {
       const res = await fetch("/api/receipts/reconcile", {
         method: "POST",
@@ -48,13 +61,58 @@ export function ReconciliationTable({
         body: JSON.stringify({ amexLineId, receiptId, matchStatus }),
       });
       const json = (await res.json()) as { error?: string };
-      if (!res.ok) { setError(json.error ?? "Failed."); return; }
-      router.refresh();
+      if (!res.ok) return { ok: false, error: json.error ?? "Failed." };
+      return { ok: true };
     } catch {
-      setError("Network error.");
-    } finally {
-      setBusy(null);
+      return { ok: false, error: "Network error." };
     }
+  }
+
+  async function reconcile(
+    amexLineId: string,
+    receiptId: string | null,
+    matchStatus: string,
+  ) {
+    setBusy(amexLineId);
+    setError(null);
+    setBulkResult(null);
+    const result = await reconcileFetch(amexLineId, receiptId, matchStatus);
+    if (!result.ok) {
+      setError(result.error ?? "Failed.");
+    } else {
+      router.refresh();
+    }
+    setBusy(null);
+  }
+
+  async function bulkConfirm() {
+    const matches = autoMatches.filter((m) => m.confidenceScore >= confidenceThreshold);
+    if (matches.length === 0) return;
+
+    setBulkProgress({ current: 0, total: matches.length });
+    setBulkResult(null);
+    setError(null);
+
+    let confirmed = 0;
+    let failed = 0;
+    const errors: string[] = [];
+
+    for (let i = 0; i < matches.length; i++) {
+      const match = matches[i]!;
+      setBulkProgress({ current: i + 1, total: matches.length });
+
+      const result = await reconcileFetch(match.amexLineId, match.receiptId, "confirmed");
+      if (result.ok) {
+        confirmed++;
+      } else {
+        failed++;
+        errors.push(`Line ${match.amexLineId}: ${result.error}`);
+      }
+    }
+
+    setBulkProgress(null);
+    setBulkResult({ confirmed, failed, errors });
+    router.refresh();
   }
 
   async function updateCategory(lineId: string, expenseCategoryCode: string) {
@@ -98,11 +156,91 @@ export function ReconciliationTable({
     }
   }
 
+  async function signoff() {
+    setSignoffBusy(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/receipts/reconcile/finalize", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ month }),
+      });
+      const json = (await res.json()) as { error?: string; blockers?: string[] };
+      if (!res.ok) {
+        if (json.blockers && json.blockers.length > 0) {
+          setError(`${json.error ?? "Blocked"}: ${json.blockers.join("; ")}`);
+        } else {
+          setError(json.error ?? "Sign-off failed.");
+        }
+        return;
+      }
+      router.refresh();
+    } catch {
+      setError("Network error during sign-off.");
+    } finally {
+      setSignoffBusy(false);
+    }
+  }
+
   const unmatched = amexLines.filter(
     (l) => l.match_status === "unmatched" || l.match_status === "matched",
   );
   const confirmed = amexLines.filter((l) => l.match_status === "confirmed");
   const noReceipt = amexLines.filter((l) => l.match_status === "no_receipt");
+  const highConfidenceMatches = autoMatches.filter(
+    (m) => m.confidenceScore >= confidenceThreshold,
+  );
+
+  // Keyboard navigation over Pending cards
+  const unmatchedCount = unmatched.length;
+  handlerRef.current = (e: KeyboardEvent) => {
+    const tag = (e.target as HTMLElement).tagName;
+    if (tag === "INPUT" || tag === "SELECT" || tag === "TEXTAREA") return;
+    if ((e.target as HTMLElement).isContentEditable) return;
+    if (busy !== null || finalized) return;
+
+    if (e.key === "j" || e.key === "ArrowDown") {
+      e.preventDefault();
+      setFocusIndex((prev) =>
+        unmatchedCount === 0 ? null : prev === null ? 0 : Math.min(prev + 1, unmatchedCount - 1),
+      );
+    } else if (e.key === "k" || e.key === "ArrowUp") {
+      e.preventDefault();
+      setFocusIndex((prev) =>
+        unmatchedCount === 0 ? null : prev === null ? unmatchedCount - 1 : Math.max(prev - 1, 0),
+      );
+    } else if (e.key === "c") {
+      if (focusIndex === null) return;
+      const line = unmatched[focusIndex];
+      if (!line) return;
+      const m = matchMap.get(line.id);
+      const sr = m ? receiptMap.get(String(m.receiptId)) : null;
+      if (sr) reconcile(line.id, sr.id, "confirmed");
+    } else if (e.key === "n") {
+      if (focusIndex === null) return;
+      const line = unmatched[focusIndex];
+      if (!line) return;
+      reconcile(line.id, null, "no_receipt");
+      updateReceiptStatus(line.id, "no_receipt_required");
+    } else if (e.key === "?") {
+      setShowHelp((prev) => !prev);
+    }
+  };
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => handlerRef.current(e);
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
+
+  useEffect(() => {
+    if (focusIndex === null) return;
+    if (focusIndex >= unmatchedCount) {
+      setFocusIndex(unmatchedCount > 0 ? unmatchedCount - 1 : null);
+      return;
+    }
+    cardRefs.current[focusIndex]?.scrollIntoView({ behavior: "smooth", block: "nearest" });
+  }, [focusIndex, unmatchedCount]);
 
   function formatAmount(line: AmexStatementLine) {
     return line.currency === "JPY"
@@ -167,14 +305,68 @@ export function ReconciliationTable({
         </div>
       )}
 
+      {/* Bulk auto-confirm */}
+      {!finalized && highConfidenceMatches.length > 0 && (
+        <div className="flex flex-wrap items-center gap-3 rounded-xl border border-amber-200 bg-amber-50 px-3 py-2">
+          <button
+            disabled={busy !== null || bulkProgress !== null || signoffBusy}
+            onClick={bulkConfirm}
+            className="rounded-xl bg-amber-500 px-3 py-1.5 text-xs font-semibold text-white hover:bg-amber-600 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {bulkProgress
+              ? `Confirming ${bulkProgress.current} of ${bulkProgress.total}…`
+              : `Auto-confirm matches ≥ ${Math.round(confidenceThreshold * 100)}%`}
+          </button>
+          <select
+            value={confidenceThreshold}
+            onChange={(e) => {
+              setConfidenceThreshold(Number(e.target.value));
+              setBulkResult(null);
+            }}
+            disabled={bulkProgress !== null}
+            className="rounded-lg border border-amber-300 bg-white px-2 py-1 text-xs text-gray-700 focus:border-amber-500 focus:outline-none"
+          >
+            <option value={0.8}>80%</option>
+            <option value={0.9}>90%</option>
+            <option value={0.95}>95%</option>
+          </select>
+          <span className="text-xs text-amber-700">
+            {highConfidenceMatches.length} match{highConfidenceMatches.length !== 1 ? "es" : ""} above threshold
+          </span>
+        </div>
+      )}
+
+      {bulkResult && (
+        <div
+          className={`rounded-xl border px-3 py-2 text-sm ${
+            bulkResult.failed > 0
+              ? "border-amber-200 bg-amber-50 text-amber-700"
+              : "border-green-200 bg-green-50 text-green-700"
+          }`}
+        >
+          Confirmed {bulkResult.confirmed} match{bulkResult.confirmed !== 1 ? "es" : ""}.
+          {bulkResult.failed > 0 && ` ${bulkResult.failed} failed.`}
+          {bulkResult.errors.length > 0 && (
+            <ul className="mt-1 list-inside list-disc text-xs">
+              {bulkResult.errors.map((e, i) => (
+                <li key={i}>{e}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+
       {/* Pending reconciliation */}
       {unmatched.length > 0 && (
         <div>
-          <h3 className="mb-3 text-sm font-semibold text-gray-700">
-            Pending ({unmatched.length})
-          </h3>
+          <div className="mb-3 flex items-center gap-3">
+            <h3 className="text-sm font-semibold text-gray-700">
+              Pending ({unmatched.length})
+            </h3>
+            <span className="text-xs text-gray-400">Press ? for shortcuts</span>
+          </div>
           <div className="space-y-3">
-            {unmatched.map((line) => {
+            {unmatched.map((line, i) => {
               const autoMatch = matchMap.get(line.id);
               const suggestedReceipt = autoMatch
                 ? receiptMap.get(String(autoMatch.receiptId))
@@ -183,7 +375,10 @@ export function ReconciliationTable({
               return (
                 <div
                   key={line.id}
-                  className="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm"
+                  ref={(el) => { cardRefs.current[i] = el; }}
+                  className={`rounded-2xl border bg-white p-4 shadow-sm transition-shadow ${
+                    focusIndex === i ? "ring-2 ring-amber-500 border-amber-300" : "border-gray-200"
+                  }`}
                 >
                   <div className="flex flex-wrap items-start justify-between gap-3">
                     <div>
@@ -224,7 +419,51 @@ export function ReconciliationTable({
                       <p className="mt-1 text-xs text-gray-700">
                         {receiptLabel(suggestedReceipt)}
                       </p>
-                      <div className="mt-2 flex gap-2">
+                      {/* Delta badges */}
+                      {(() => {
+                        const badges: { key: string; label: string }[] = [];
+                        const rAmt = suggestedReceipt.amount_minor ?? 0;
+                        const lAmt = line.amount_minor;
+                        if (rAmt !== lAmt) {
+                          const diff = lAmt - rAmt;
+                          const sign = diff > 0 ? "+" : "";
+                          badges.push({
+                            key: "amt",
+                            label: line.currency === "JPY"
+                              ? `Δ ¥${Math.abs(diff).toLocaleString()}`
+                              : `Δ ${(Math.abs(diff) / 100).toFixed(2)} ${line.currency}`,
+                          });
+                        }
+                        if (line.merchant && suggestedReceipt.merchant &&
+                          normalizeDescription(line.merchant) !== normalizeDescription(suggestedReceipt.merchant)) {
+                          badges.push({ key: "merchant", label: "merchant differs" });
+                        }
+                        if (line.transaction_date && suggestedReceipt.transaction_date &&
+                          line.transaction_date !== suggestedReceipt.transaction_date) {
+                          const ms = Math.round(
+                            (new Date(line.transaction_date).getTime() -
+                              new Date(suggestedReceipt.transaction_date).getTime()) /
+                              86_400_000,
+                          );
+                          badges.push({ key: "date", label: `Δ ${Math.abs(ms)} day${Math.abs(ms) !== 1 ? "s" : ""}` });
+                        }
+                        return badges.length > 0 ? (
+                          <div className="mt-1 flex flex-wrap gap-1">
+                            {badges.map((b) => (
+                              <span key={b.key} className="rounded-full bg-amber-100 px-2 py-0.5 text-xs text-amber-700">
+                                {b.label}
+                              </span>
+                            ))}
+                          </div>
+                        ) : null;
+                      })()}
+                      {line.merchant && suggestedReceipt.merchant &&
+                        normalizeDescription(line.merchant) !== normalizeDescription(suggestedReceipt.merchant) && (
+                        <p className="mt-1 text-xs text-amber-700">
+                          Will rename receipt: {suggestedReceipt.merchant} → {line.merchant}
+                        </p>
+                      )}
+                      <div className="mt-2 flex items-center gap-2">
                         <button
                           disabled={busy === line.id}
                           onClick={() =>
@@ -234,6 +473,7 @@ export function ReconciliationTable({
                         >
                           Confirm match
                         </button>
+                        <span className="text-[10px] text-gray-400">AMEX merchant overrides receipt on confirm</span>
                         <button
                           disabled={busy === line.id}
                           onClick={() =>
@@ -373,10 +613,88 @@ export function ReconciliationTable({
         </div>
       )}
 
+      {/* Orphan receipts */}
+      {orphanReceipts.length > 0 && (
+        <div>
+          <h3 className="mb-3 text-sm font-semibold text-gray-700">
+            Orphan receipts ({orphanReceipts.length})
+          </h3>
+          <div className="space-y-3">
+            {orphanReceipts.map((r) => (
+              <div
+                key={r.id}
+                className="rounded-2xl border border-orange-200 bg-orange-50 p-4 shadow-sm"
+              >
+                <p className="text-sm text-gray-700">{receiptLabel(r)}</p>
+                {unmatched.length > 0 && (
+                  <div className="mt-2">
+                    <select
+                      className="block w-full rounded-xl border border-orange-300 bg-white px-3 py-2 text-xs text-gray-700 focus:border-amber-500 focus:outline-none"
+                      defaultValue=""
+                      onChange={(e) => {
+                        if (e.target.value) {
+                          reconcile(e.target.value, r.id, "confirmed");
+                        }
+                      }}
+                    >
+                      <option value="">— Manually link to AMEX line —</option>
+                      {unmatched.map((line) => (
+                        <option key={line.id} value={line.id}>
+                          {line.transaction_date} · {line.merchant} · {formatAmount(line)}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
       {unmatched.length === 0 && confirmed.length === 0 && noReceipt.length === 0 && (
         <p className="text-sm text-gray-500">
           No AMEX lines found. Import a statement CSV first.
         </p>
+      )}
+
+      {/* Sign-off */}
+      {!finalized && amexLines.length > 0 && (
+        <div className="flex items-center gap-3">
+          <button
+            disabled={signoffBusy || unmatched.length > 0}
+            onClick={signoff}
+            className="rounded-xl bg-green-600 px-4 py-2 text-sm font-semibold text-white hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed"
+            title={
+              unmatched.length > 0
+                ? `${unmatched.length} unresolved line(s) must be resolved before signing off`
+                : "Sign off reconciliation for this month"
+            }
+          >
+            {signoffBusy ? "Signing off…" : "Sign off reconciliation"}
+          </button>
+          {unmatched.length > 0 && (
+            <span className="text-xs text-gray-400">
+              {unmatched.length} unresolved line(s)
+            </span>
+          )}
+        </div>
+      )}
+      {/* Keyboard shortcuts help */}
+      {showHelp && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30" onClick={() => setShowHelp(false)}>
+          <div className="rounded-2xl bg-white p-6 shadow-xl" onClick={(e) => e.stopPropagation()}>
+            <h4 className="mb-3 font-semibold text-gray-900">Keyboard shortcuts</h4>
+            <dl className="space-y-1 text-sm">
+              <div className="flex gap-4"><dt className="w-12 font-mono text-amber-600">j / ↓</dt><dd className="text-gray-700">Next card</dd></div>
+              <div className="flex gap-4"><dt className="w-12 font-mono text-amber-600">k / ↑</dt><dd className="text-gray-700">Previous card</dd></div>
+              <div className="flex gap-4"><dt className="w-12 font-mono text-amber-600">c</dt><dd className="text-gray-700">Confirm suggested match</dd></div>
+              <div className="flex gap-4"><dt className="w-12 font-mono text-amber-600">n</dt><dd className="text-gray-700">Mark no receipt</dd></div>
+              <div className="flex gap-4"><dt className="w-12 font-mono text-amber-600">?</dt><dd className="text-gray-700">Toggle this help</dd></div>
+            </dl>
+            <button onClick={() => setShowHelp(false)} className="mt-4 rounded-lg bg-gray-100 px-3 py-1 text-xs text-gray-600 hover:bg-gray-200">Close</button>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/components/receipts/reconciliation-table.tsx
+++ b/components/receipts/reconciliation-table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import type { AmexStatementLine, ReceiptRecord } from "@/lib/receipts/types";
 import type { ReconciliationMatch } from "@/lib/receipts/types";
@@ -39,7 +39,9 @@ export function ReconciliationTable({
   const [focusIndex, setFocusIndex] = useState<number | null>(null);
   const [showHelp, setShowHelp] = useState(false);
   const cardRefs = useRef<(HTMLDivElement | null)[]>([]);
-  const handlerRef = useRef<(e: KeyboardEvent) => void>(() => {});
+
+  // Unified lock: any in-flight mutation disables all interactive controls
+  const locked = busy !== null || bulkProgress !== null || signoffBusy || !!finalized;
 
   const matchMap = new Map<string, ReconciliationMatch>(
     autoMatches.map((m) => [m.amexLineId, m]),
@@ -185,15 +187,15 @@ export function ReconciliationTable({
   const unmatched = amexLines.filter(
     (l) => l.match_status === "unmatched" || l.match_status === "matched",
   );
-  const confirmed = amexLines.filter((l) => l.match_status === "confirmed");
+  const confirmedLines = amexLines.filter((l) => l.match_status === "confirmed");
   const noReceipt = amexLines.filter((l) => l.match_status === "no_receipt");
   const highConfidenceMatches = autoMatches.filter(
     (m) => m.confidenceScore >= confidenceThreshold,
   );
 
-  // Keyboard navigation over Pending cards
+  // Keyboard navigation — useEffect with proper deps, no render-time ref writes
   const unmatchedCount = unmatched.length;
-  handlerRef.current = (e: KeyboardEvent) => {
+  const handleKeydown = useCallback((e: KeyboardEvent) => {
     const tag = (e.target as HTMLElement).tagName;
     if (tag === "INPUT" || tag === "SELECT" || tag === "TEXTAREA") return;
     if ((e.target as HTMLElement).isContentEditable) return;
@@ -225,13 +227,12 @@ export function ReconciliationTable({
     } else if (e.key === "?") {
       setShowHelp((prev) => !prev);
     }
-  };
+  }, [busy, finalized, focusIndex, unmatchedCount, unmatched, matchMap, receiptMap]);
 
   useEffect(() => {
-    const handler = (e: KeyboardEvent) => handlerRef.current(e);
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
-  }, []);
+    window.addEventListener("keydown", handleKeydown);
+    return () => window.removeEventListener("keydown", handleKeydown);
+  }, [handleKeydown]);
 
   useEffect(() => {
     if (focusIndex === null) return;
@@ -267,7 +268,7 @@ export function ReconciliationTable({
       <div className="mt-2 flex flex-wrap items-center gap-2">
         <select
           value={line.expense_category_code ?? ""}
-          disabled={categoryBusy === line.id}
+          disabled={locked || categoryBusy === line.id}
           onChange={(e) => updateCategory(line.id, e.target.value)}
           className={`rounded-lg border px-2 py-1 text-xs focus:border-amber-500 focus:outline-none ${
             !hasCategory
@@ -297,6 +298,13 @@ export function ReconciliationTable({
     );
   }
 
+  // Sort orphan receipts: dateless first
+  const sortedOrphanReceipts = [...orphanReceipts].sort((a, b) => {
+    if (!a.transaction_date && b.transaction_date) return -1;
+    if (a.transaction_date && !b.transaction_date) return 1;
+    return 0;
+  });
+
   return (
     <div className="space-y-6">
       {error && (
@@ -305,11 +313,18 @@ export function ReconciliationTable({
         </div>
       )}
 
+      {/* Finalized banner */}
+      {finalized && (
+        <div className="rounded-xl border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-600">
+          This reconciliation is signed off — edits are blocked.
+        </div>
+      )}
+
       {/* Bulk auto-confirm */}
       {!finalized && highConfidenceMatches.length > 0 && (
         <div className="flex flex-wrap items-center gap-3 rounded-xl border border-amber-200 bg-amber-50 px-3 py-2">
           <button
-            disabled={busy !== null || bulkProgress !== null || signoffBusy}
+            disabled={locked}
             onClick={bulkConfirm}
             className="rounded-xl bg-amber-500 px-3 py-1.5 text-xs font-semibold text-white hover:bg-amber-600 disabled:opacity-50 disabled:cursor-not-allowed"
           >
@@ -323,7 +338,7 @@ export function ReconciliationTable({
               setConfidenceThreshold(Number(e.target.value));
               setBulkResult(null);
             }}
-            disabled={bulkProgress !== null}
+            disabled={locked}
             className="rounded-lg border border-amber-300 bg-white px-2 py-1 text-xs text-gray-700 focus:border-amber-500 focus:outline-none"
           >
             <option value={0.8}>80%</option>
@@ -363,7 +378,7 @@ export function ReconciliationTable({
             <h3 className="text-sm font-semibold text-gray-700">
               Pending ({unmatched.length})
             </h3>
-            <span className="text-xs text-gray-400">Press ? for shortcuts</span>
+            {!finalized && <span className="text-xs text-gray-400">Press ? for shortcuts</span>}
           </div>
           <div className="space-y-3">
             {unmatched.map((line, i) => {
@@ -397,7 +412,7 @@ export function ReconciliationTable({
                     </div>
                     <div className="flex gap-2">
                       <button
-                        disabled={busy === line.id}
+                        disabled={locked || busy === line.id}
                         onClick={() => {
                           reconcile(line.id, null, "no_receipt");
                           updateReceiptStatus(line.id, "no_receipt_required");
@@ -426,12 +441,12 @@ export function ReconciliationTable({
                         const lAmt = line.amount_minor;
                         if (rAmt !== lAmt) {
                           const diff = lAmt - rAmt;
-                          const sign = diff > 0 ? "+" : "";
+                          const sign = diff > 0 ? "+" : "−";
                           badges.push({
                             key: "amt",
                             label: line.currency === "JPY"
-                              ? `Δ ¥${Math.abs(diff).toLocaleString()}`
-                              : `Δ ${(Math.abs(diff) / 100).toFixed(2)} ${line.currency}`,
+                              ? `Δ ${sign}¥${Math.abs(diff).toLocaleString()}`
+                              : `Δ ${sign}${(Math.abs(diff) / 100).toFixed(2)} ${line.currency}`,
                           });
                         }
                         if (line.merchant && suggestedReceipt.merchant &&
@@ -465,7 +480,7 @@ export function ReconciliationTable({
                       )}
                       <div className="mt-2 flex items-center gap-2">
                         <button
-                          disabled={busy === line.id}
+                          disabled={locked || busy === line.id}
                           onClick={() =>
                             reconcile(line.id, suggestedReceipt.id, "confirmed")
                           }
@@ -475,7 +490,7 @@ export function ReconciliationTable({
                         </button>
                         <span className="text-[10px] text-gray-400">AMEX merchant overrides receipt on confirm</span>
                         <button
-                          disabled={busy === line.id}
+                          disabled={locked || busy === line.id}
                           onClick={() =>
                             reconcile(line.id, suggestedReceipt.id, "matched")
                           }
@@ -490,8 +505,9 @@ export function ReconciliationTable({
                   {/* Manual receipt selector */}
                   <div className="mt-3">
                     <select
-                      className="block w-full rounded-xl border border-gray-300 px-3 py-2 text-xs text-gray-700 focus:border-amber-500 focus:outline-none"
+                      className="block w-full rounded-xl border border-gray-300 px-3 py-2 text-xs text-gray-700 focus:border-amber-500 focus:outline-none disabled:opacity-50"
                       defaultValue=""
+                      disabled={locked}
                       onChange={(e) => {
                         if (e.target.value) {
                           reconcile(line.id, e.target.value, "confirmed");
@@ -516,15 +532,15 @@ export function ReconciliationTable({
       )}
 
       {/* Confirmed */}
-      {confirmed.length > 0 && (
+      {confirmedLines.length > 0 && (
         <div>
           <h3 className="mb-3 text-sm font-semibold text-gray-700">
-            Confirmed ({confirmed.length})
+            Confirmed ({confirmedLines.length})
           </h3>
           <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
             <table className="min-w-full text-xs">
               <tbody className="divide-y divide-gray-100">
-                {confirmed.map((line) => {
+                {confirmedLines.map((line) => {
                   const r = line.matched_receipt_id
                     ? receiptMap.get(line.matched_receipt_id)
                     : null;
@@ -541,7 +557,7 @@ export function ReconciliationTable({
                       <td className="px-4 py-3">
                         <select
                           value={line.expense_category_code ?? ""}
-                          disabled={categoryBusy === line.id}
+                          disabled={locked || categoryBusy === line.id}
                           onChange={(e) =>
                             updateCategory(line.id, e.target.value)
                           }
@@ -586,7 +602,7 @@ export function ReconciliationTable({
                     <td className="px-4 py-3">
                       <select
                         value={line.expense_category_code ?? ""}
-                        disabled={categoryBusy === line.id}
+                        disabled={locked || categoryBusy === line.id}
                         onChange={(e) =>
                           updateCategory(line.id, e.target.value)
                         }
@@ -603,7 +619,7 @@ export function ReconciliationTable({
                       </select>
                     </td>
                     <td className="px-4 py-3">
-                      <NoReceiptReasonCell line={line} onUpdate={updateReceiptStatus} />
+                      <NoReceiptReasonCell line={line} onUpdate={updateReceiptStatus} disabled={locked} />
                     </td>
                   </tr>
                 ))}
@@ -614,23 +630,31 @@ export function ReconciliationTable({
       )}
 
       {/* Orphan receipts */}
-      {orphanReceipts.length > 0 && (
+      {sortedOrphanReceipts.length > 0 && (
         <div>
           <h3 className="mb-3 text-sm font-semibold text-gray-700">
-            Orphan receipts ({orphanReceipts.length})
+            Orphan receipts ({sortedOrphanReceipts.length})
           </h3>
           <div className="space-y-3">
-            {orphanReceipts.map((r) => (
+            {sortedOrphanReceipts.map((r) => (
               <div
                 key={r.id}
                 className="rounded-2xl border border-orange-200 bg-orange-50 p-4 shadow-sm"
               >
-                <p className="text-sm text-gray-700">{receiptLabel(r)}</p>
-                {unmatched.length > 0 && (
+                <div className="flex items-center gap-2">
+                  <p className="text-sm text-gray-700">{receiptLabel(r)}</p>
+                  {!r.transaction_date && (
+                    <span className="rounded-full bg-orange-200 px-2 py-0.5 text-xs text-orange-800">
+                      no date
+                    </span>
+                  )}
+                </div>
+                {!finalized && unmatched.length > 0 && (
                   <div className="mt-2">
                     <select
-                      className="block w-full rounded-xl border border-orange-300 bg-white px-3 py-2 text-xs text-gray-700 focus:border-amber-500 focus:outline-none"
+                      className="block w-full rounded-xl border border-orange-300 bg-white px-3 py-2 text-xs text-gray-700 focus:border-amber-500 focus:outline-none disabled:opacity-50"
                       defaultValue=""
+                      disabled={locked}
                       onChange={(e) => {
                         if (e.target.value) {
                           reconcile(e.target.value, r.id, "confirmed");
@@ -652,7 +676,7 @@ export function ReconciliationTable({
         </div>
       )}
 
-      {unmatched.length === 0 && confirmed.length === 0 && noReceipt.length === 0 && (
+      {unmatched.length === 0 && confirmedLines.length === 0 && noReceipt.length === 0 && (
         <p className="text-sm text-gray-500">
           No AMEX lines found. Import a statement CSV first.
         </p>
@@ -662,7 +686,7 @@ export function ReconciliationTable({
       {!finalized && amexLines.length > 0 && (
         <div className="flex items-center gap-3">
           <button
-            disabled={signoffBusy || unmatched.length > 0}
+            disabled={locked || unmatched.length > 0}
             onClick={signoff}
             className="rounded-xl bg-green-600 px-4 py-2 text-sm font-semibold text-white hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed"
             title={
@@ -703,16 +727,21 @@ export function ReconciliationTable({
 function NoReceiptReasonCell({
   line,
   onUpdate,
+  disabled,
 }: {
   line: AmexStatementLine;
   onUpdate: (id: string, status: string, reason?: string) => void;
+  disabled?: boolean;
 }) {
   const [reason, setReason] = useState(line.receipt_missing_reason ?? "");
   const [editing, setEditing] = useState(false);
 
   if (!editing) {
     return (
-      <span className="text-gray-400 hover:underline cursor-pointer" onClick={() => setEditing(true)}>
+      <span
+        className={`text-gray-400 ${disabled ? "" : "hover:underline cursor-pointer"}`}
+        onClick={() => { if (!disabled) setEditing(true); }}
+      >
         {line.receipt_missing_reason ?? "Add reason"}
       </span>
     );

--- a/db/receipts/0010_reconciliation_signoff.sql
+++ b/db/receipts/0010_reconciliation_signoff.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS amex_reconciliations (
+  id TEXT PRIMARY KEY,
+  statement_month TEXT NOT NULL,
+  statement_artifact_id TEXT REFERENCES amex_statement_artifacts(id),
+  status TEXT NOT NULL CHECK (status IN ('draft', 'finalized')),
+  manifest_r2_key TEXT,
+  manifest_sha256 TEXT,
+  line_count INTEGER NOT NULL,
+  matched_count INTEGER NOT NULL,
+  no_receipt_count INTEGER NOT NULL,
+  created_by TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  finalized_by TEXT,
+  finalized_at TEXT
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_amex_reconciliations_month_finalized
+  ON amex_reconciliations(statement_month) WHERE status = 'finalized';
+
+CREATE INDEX IF NOT EXISTS idx_amex_reconciliations_month
+  ON amex_reconciliations(statement_month);

--- a/db/receipts/0011_amex_dedup.sql
+++ b/db/receipts/0011_amex_dedup.sql
@@ -1,0 +1,32 @@
+-- 0011_amex_dedup.sql
+--
+-- Stable AMEX line identity across re-imports
+-- ============================================
+-- When an operator re-uploads a corrected CSV for a month, the import
+-- flow uses INSERT … ON CONFLICT DO UPDATE (upsert) instead of
+-- INSERT OR IGNORE.  This preserves the PK (id) and all reconciliation
+-- state (matched_receipt_id, match_status, receipt_status, etc.) while
+-- refreshing the CSV-sourced fields (dates, merchant, amount, raw_json).
+--
+-- Primary dedup key: (statement_month, amex_reference, cardholder_name)
+--   AMEX reference numbers are unique per transaction within a
+--   cardholder's statement, making this a reliable identity key.
+--
+-- Null-reference fallback: (statement_month, transaction_date,
+--   amount_minor, merchant, cardholder_name).
+--   AMEX Netアンサー CSVs always populate the Reference field for
+--   charge lines, so null references are exceedingly rare (typically
+--   header/footer rows filtered by the parser).  This fallback prevents
+--   accidental duplicates for any non-standard import.
+--   Note: if cardholder_name is also NULL, SQLite treats NULLs as
+--   distinct in unique indexes, so two charges at the same merchant
+--   on the same date for the same amount with unknown cardholders will
+--   still be treated as separate rows — the safe default.
+
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_amex_line_dedup
+  ON amex_statement_lines(statement_month, amex_reference, cardholder_name)
+  WHERE amex_reference IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_amex_line_null_ref
+  ON amex_statement_lines(statement_month, transaction_date, amount_minor, merchant, cardholder_name)
+  WHERE amex_reference IS NULL;

--- a/db/receipts/0012_re_review_flag.sql
+++ b/db/receipts/0012_re_review_flag.sql
@@ -1,0 +1,14 @@
+-- 0012_re_review_flag.sql
+--
+-- Adds a re_review_needed flag to amex_statement_lines.
+-- When a confirmed line's CSV-sourced fields (merchant, amount, date) change
+-- on re-import, the import logic sets this flag so the operator knows the
+-- reconciliation is stale and needs re-examination.
+
+ALTER TABLE amex_statement_lines
+  ADD COLUMN re_review_needed INTEGER NOT NULL DEFAULT 0
+  CHECK (re_review_needed IN (0, 1));
+
+CREATE INDEX IF NOT EXISTS idx_amex_lines_re_review
+  ON amex_statement_lines(statement_month, re_review_needed)
+  WHERE re_review_needed = 1;

--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -1284,6 +1284,7 @@ export async function createReconciliationDraft(
   matchedCount: number,
   noReceiptCount: number,
   actor: string,
+  artifactId: string | null,
 ): Promise<string> {
   const db = getReceiptsDb();
   const id = newUuid();
@@ -1292,10 +1293,10 @@ export async function createReconciliationDraft(
   await db
     .prepare(
       `INSERT INTO amex_reconciliations
-        (id, statement_month, status, line_count, matched_count, no_receipt_count, created_by, created_at)
-       VALUES (?, ?, 'draft', ?, ?, ?, ?, ?)`,
+        (id, statement_month, statement_artifact_id, status, line_count, matched_count, no_receipt_count, created_by, created_at)
+       VALUES (?, ?, ?, 'draft', ?, ?, ?, ?, ?)`,
     )
-    .bind(id, month, lineCount, matchedCount, noReceiptCount, actor, now)
+    .bind(id, month, artifactId, lineCount, matchedCount, noReceiptCount, actor, now)
     .run();
 
   return id;

--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -1290,6 +1290,12 @@ export async function createReconciliationDraft(
   const id = newUuid();
   const now = nowIso();
 
+  // Clear any stale draft rows left by a previous failed sign-off attempt.
+  await db
+    .prepare(`DELETE FROM amex_reconciliations WHERE statement_month = ? AND status = 'draft'`)
+    .bind(month)
+    .run();
+
   await db
     .prepare(
       `INSERT INTO amex_reconciliations

--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -436,7 +436,15 @@ export async function importAmexLines(
            source_file_sha256 = excluded.source_file_sha256,
            statement_artifact_id = excluded.statement_artifact_id,
            imported_at = excluded.imported_at,
-           raw_json = excluded.raw_json`,
+           raw_json = excluded.raw_json,
+           re_review_needed = CASE
+             WHEN match_status = 'confirmed'
+               AND (transaction_date IS NOT excluded.transaction_date
+                 OR merchant IS NOT excluded.merchant
+                 OR amount_minor IS NOT excluded.amount_minor)
+             THEN 1
+             ELSE re_review_needed
+           END`,
       )
       .bind(...binds)
       .run();

--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -1,8 +1,11 @@
 import { getReceiptsDb } from "@/lib/cloudflare-runtime";
 import { createAuditEntry } from "@/lib/receipts/audit";
 import { nowIso, newUuid, stringifyJson } from "@/lib/receipts/db-utils";
+import { shouldOverwriteMerchant } from "@/lib/receipts/reconciliation";
 import type {
   AmexMatchStatus,
+  AmexReceiptStatus,
+  AmexReconciliation,
   AmexStatementLine,
   AmexStatementArtifact,
   BusinessTripReport,
@@ -290,21 +293,85 @@ export async function listAttendees(
 export async function importAmexLines(
   rows: ImportAmexLineInput[],
   actor: string,
-): Promise<{ imported: number; skipped: number }> {
+): Promise<{ inserted: number; updated: number; unchanged: number }> {
   const db = getReceiptsDb();
   const now = nowIso();
-  let imported = 0;
+  const month = rows[0]?.statementMonth;
 
-  // Chunked multi-row INSERTs. Each row binds 19 params (the 20th column,
-  // match_status, is the SQL literal 'unmatched'). D1's hard limit is 100
-  // bind variables per statement, so 5 rows × 19 = 95 is the largest chunk
-  // that stays under the ceiling.
+  if (!month || rows.length === 0) {
+    return { inserted: 0, updated: 0, unchanged: 0 };
+  }
+
+  // ── Pre-query existing lines to classify inserted / updated / unchanged ──
+  const existingResult = await db
+    .prepare(
+      `SELECT amex_reference, cardholder_name, transaction_date, posting_date,
+              merchant, amount_minor, currency, memo, raw_json
+       FROM amex_statement_lines
+       WHERE statement_month = ?`,
+    )
+    .bind(month)
+    .all<{
+      amex_reference: string | null;
+      cardholder_name: string | null;
+      transaction_date: string;
+      posting_date: string | null;
+      merchant: string;
+      amount_minor: number;
+      currency: string;
+      memo: string | null;
+      raw_json: string;
+    }>();
+
+  const existingMap = new Map<
+    string,
+    (typeof existingResult.results)[number]
+  >();
+  for (const r of existingResult.results) {
+    if (r.amex_reference) {
+      existingMap.set(`${r.amex_reference}|${r.cardholder_name ?? ""}`, r);
+    }
+  }
+
+  let inserted = 0;
+  let updated = 0;
+  let unchanged = 0;
+
+  for (const row of rows) {
+    if (row.amexReference) {
+      const key = `${row.amexReference}|${row.cardholderName ?? ""}`;
+      const ex = existingMap.get(key);
+      if (!ex) {
+        inserted++;
+      } else if (
+        ex.transaction_date === row.transactionDate &&
+        (ex.posting_date ?? "") === (row.postingDate ?? "") &&
+        ex.merchant === row.merchant &&
+        ex.amount_minor === row.amountMinor &&
+        ex.currency === (row.currency ?? "JPY") &&
+        (ex.memo ?? "") === (row.memo ?? "") &&
+        ex.raw_json === row.rawJson
+      ) {
+        unchanged++;
+      } else {
+        updated++;
+      }
+    } else {
+      inserted++;
+    }
+  }
+
+  // ── Chunked INSERT … ON CONFLICT DO UPDATE (with amex_reference) ────────
+  const withRef = rows.filter((r) => !!r.amexReference);
+  const withoutRef = rows.filter((r) => !r.amexReference);
+  // Each row binds 19 params (match_status is the SQL literal 'unmatched').
+  // 19 × 5 = 95 < 100 (D1 bind-variable ceiling).
   const CHUNK_SIZE = 5;
   const rowPlaceholder =
     "(?, ?, ?, ?, ?, ?, ?, ?, 'unmatched', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
-  for (let i = 0; i < rows.length; i += CHUNK_SIZE) {
-    const chunk = rows.slice(i, i + CHUNK_SIZE);
+  for (let i = 0; i < withRef.length; i += CHUNK_SIZE) {
+    const chunk = withRef.slice(i, i + CHUNK_SIZE);
     const placeholders = chunk.map(() => rowPlaceholder).join(",");
     const binds: unknown[] = [];
     for (const row of chunk) {
@@ -330,7 +397,62 @@ export async function importAmexLines(
         now,
       );
     }
-    const result = await db
+    await db
+      .prepare(
+        `INSERT INTO amex_statement_lines
+          (id, statement_month, transaction_date, posting_date, merchant,
+           amount_minor, currency, amex_reference, match_status, raw_json,
+           statement_artifact_id, cardholder_name, cardholder_flag, payment_type,
+           prepayment_flag, memo, raw_csv_line_number, source_file_sha256,
+           imported_at, created_at)
+         VALUES ${placeholders}
+         ON CONFLICT (statement_month, amex_reference, cardholder_name) DO UPDATE SET
+           transaction_date = excluded.transaction_date,
+           posting_date = excluded.posting_date,
+           merchant = excluded.merchant,
+           amount_minor = excluded.amount_minor,
+           currency = excluded.currency,
+           cardholder_name = excluded.cardholder_name,
+           memo = excluded.memo,
+           raw_csv_line_number = excluded.raw_csv_line_number,
+           source_file_sha256 = excluded.source_file_sha256,
+           statement_artifact_id = excluded.statement_artifact_id,
+           imported_at = excluded.imported_at,
+           raw_json = excluded.raw_json`,
+      )
+      .bind(...binds)
+      .run();
+  }
+
+  // ── INSERT OR IGNORE for rows without amex_reference (rare edge case) ───
+  for (let i = 0; i < withoutRef.length; i += CHUNK_SIZE) {
+    const chunk = withoutRef.slice(i, i + CHUNK_SIZE);
+    const placeholders = chunk.map(() => rowPlaceholder).join(",");
+    const binds: unknown[] = [];
+    for (const row of chunk) {
+      binds.push(
+        newUuid(),
+        row.statementMonth,
+        row.transactionDate,
+        row.postingDate ?? null,
+        row.merchant,
+        row.amountMinor,
+        row.currency ?? "JPY",
+        row.amexReference ?? null,
+        row.rawJson,
+        row.statementArtifactId ?? null,
+        row.cardholderName ?? null,
+        row.cardholderFlag ?? null,
+        row.paymentType ?? null,
+        row.prepaymentFlag ?? null,
+        row.memo ?? null,
+        row.rawCsvLineNumber ?? null,
+        row.sourceFileSha256 ?? null,
+        now,
+        now,
+      );
+    }
+    await db
       .prepare(
         `INSERT OR IGNORE INTO amex_statement_lines
           (id, statement_month, transaction_date, posting_date, merchant,
@@ -342,20 +464,17 @@ export async function importAmexLines(
       )
       .bind(...binds)
       .run();
-    imported += result.meta.changes ?? 0;
   }
-
-  const skipped = rows.length - imported;
 
   await createAuditEntry(db, {
     actor,
     action: "amex.imported",
     objectType: "amex_import",
-    objectId: rows[0]?.statementMonth ?? "unknown",
-    newValueJson: stringifyJson({ imported, skipped }),
+    objectId: month,
+    newValueJson: stringifyJson({ inserted, updated, unchanged }),
   });
 
-  return { imported, skipped };
+  return { inserted, updated, unchanged };
 }
 
 export async function listAmexLines(
@@ -414,36 +533,133 @@ export async function updateAmexReconciliation(
   //      reconciled with no AMEX line claiming it.
   const previous = await db
     .prepare(
-      `SELECT matched_receipt_id, match_status
+      `SELECT matched_receipt_id, match_status, receipt_status,
+              merchant, transaction_date, statement_month
        FROM amex_statement_lines
        WHERE id = ?
        LIMIT 1`,
     )
     .bind(amexLineId)
-    .first<{ matched_receipt_id: string | null; match_status: AmexMatchStatus }>();
+    .first<{
+      matched_receipt_id: string | null;
+      match_status: AmexMatchStatus;
+      receipt_status: AmexReceiptStatus;
+      merchant: string | null;
+      transaction_date: string | null;
+      statement_month: string | null;
+    }>();
 
   const previousReceiptId = previous?.matched_receipt_id ?? null;
   const previousStatus: AmexMatchStatus = previous?.match_status ?? "unmatched";
+  const previousReceiptStatus: AmexReceiptStatus = previous?.receipt_status ?? "missing_receipt";
+  const amexMerchant = previous?.merchant ?? null;
+  const amexTransactionDate = previous?.transaction_date ?? null;
+  const statementMonth = previous?.statement_month;
+
+  // Block edits if the month's reconciliation is finalized.
+  if (statementMonth) {
+    await rejectIfFinalized(db, statementMonth);
+  }
+
+  // Derive receipt_status from the new match_status so the two fields stay in
+  // sync. The month-closing validator checks both — drift causes false blockers.
+  const noReceiptKeep = new Set<AmexReceiptStatus>(["no_receipt_required", "receipt_not_available"]);
+  let newReceiptStatus: AmexReceiptStatus;
+  switch (matchStatus) {
+    case "confirmed":
+    case "matched":
+      newReceiptStatus = "matched";
+      break;
+    case "no_receipt":
+      newReceiptStatus = noReceiptKeep.has(previousReceiptStatus) ? previousReceiptStatus : "no_receipt_required";
+      break;
+    case "unmatched":
+      newReceiptStatus = "missing_receipt";
+      break;
+  }
+
+  // Race guard: prevent two AMEX lines from confirming the same receipt.
+  if (matchStatus === "confirmed" && receiptId) {
+    const conflict = await db
+      .prepare(
+        `SELECT id FROM amex_statement_lines
+         WHERE matched_receipt_id = ? AND match_status = 'confirmed' AND id != ?
+         LIMIT 1`,
+      )
+      .bind(receiptId, amexLineId)
+      .first<{ id: string }>();
+    if (conflict) {
+      throw new Error(`Receipt already confirmed against another AMEX line: ${conflict.id}`);
+    }
+  }
 
   const statements = [
     db
       .prepare(
         `UPDATE amex_statement_lines
-         SET matched_receipt_id = ?, match_status = ?
+         SET matched_receipt_id = ?, match_status = ?, receipt_status = ?
          WHERE id = ?`,
       )
-      .bind(receiptId, matchStatus, amexLineId),
+      .bind(receiptId, matchStatus, newReceiptStatus, amexLineId),
   ];
 
-  // Promote the newly-linked receipt.
+  // Promote the newly-linked receipt and adopt AMEX values.
+  let receiptAdoptAudit: {
+    oldMerchant: string | null;
+    newMerchant: string | null;
+    filledDate: string | null;
+  } | null = null;
+
   if (receiptId && matchStatus === "confirmed") {
-    statements.push(
-      db
-        .prepare(
-          `UPDATE receipt_records SET status = 'reconciled', updated_at = ? WHERE id = ?`,
-        )
-        .bind(now, receiptId),
-    );
+    // Read the receipt's current merchant/transaction_date to decide whether
+    // the AMEX override is a no-op (and to populate the audit trail).
+    const receiptRow = await db
+      .prepare(
+        `SELECT merchant, transaction_date FROM receipt_records WHERE id = ? LIMIT 1`,
+      )
+      .bind(receiptId)
+      .first<{ merchant: string | null; transaction_date: string | null }>();
+
+    const receiptMerchant = receiptRow?.merchant ?? null;
+    const receiptDate = receiptRow?.transaction_date ?? null;
+
+    const merchantChanged = shouldOverwriteMerchant(amexMerchant, receiptMerchant);
+
+    const dateFill = !receiptDate && !!amexTransactionDate;
+
+    if (merchantChanged || dateFill) {
+      receiptAdoptAudit = {
+        oldMerchant: receiptMerchant,
+        newMerchant: merchantChanged ? amexMerchant : receiptMerchant,
+        filledDate: dateFill ? amexTransactionDate : null,
+      };
+      statements.push(
+        db
+          .prepare(
+            `UPDATE receipt_records
+             SET merchant = ?,
+                 transaction_date = COALESCE(transaction_date, ?),
+                 status = 'reconciled',
+                 updated_at = ?
+             WHERE id = ?`,
+          )
+          .bind(
+            merchantChanged ? amexMerchant : receiptMerchant,
+            amexTransactionDate,
+            now,
+            receiptId,
+          ),
+      );
+    } else {
+      // No merchant/date change — just promote status.
+      statements.push(
+        db
+          .prepare(
+            `UPDATE receipt_records SET status = 'reconciled', updated_at = ? WHERE id = ?`,
+          )
+          .bind(now, receiptId),
+      );
+    }
   }
 
   // Demote the previously-linked receipt if we're unwinding its confirmation
@@ -476,9 +692,30 @@ export async function updateAmexReconciliation(
     oldValueJson: stringifyJson({
       receiptId: previousReceiptId,
       matchStatus: previousStatus,
+      receiptStatus: previousReceiptStatus,
     }),
-    newValueJson: stringifyJson({ receiptId, matchStatus }),
+    newValueJson: stringifyJson({ receiptId, matchStatus, receiptStatus: newReceiptStatus }),
   });
+
+  // Second audit entry when AMEX values were adopted onto the receipt.
+  if (receiptAdoptAudit && receiptId) {
+    await createAuditEntry(db, {
+      actor,
+      action: "receipt.updated",
+      objectType: "receipt",
+      objectId: receiptId,
+      oldValueJson: stringifyJson({
+        merchant: receiptAdoptAudit.oldMerchant,
+        transactionDateFilled: false,
+      }),
+      newValueJson: stringifyJson({
+        merchant: receiptAdoptAudit.newMerchant,
+        transactionDateFilled: receiptAdoptAudit.filledDate !== null,
+        ...(receiptAdoptAudit.filledDate ? { transactionDate: receiptAdoptAudit.filledDate } : {}),
+        source: "amex_confirm_override",
+      }),
+    });
+  }
 }
 
 // ─── AMEX statement artifacts ────────────────────────────────────────────────
@@ -600,6 +837,15 @@ export async function updateAmexLineCategory(
   actor: string,
 ): Promise<void> {
   const db = getReceiptsDb();
+
+  // Block edits if the month's reconciliation is finalized.
+  const lineMonth = await db
+    .prepare(`SELECT statement_month FROM amex_statement_lines WHERE id = ? LIMIT 1`)
+    .bind(lineId)
+    .first<{ statement_month: string }>();
+  if (lineMonth?.statement_month) {
+    await rejectIfFinalized(db, lineMonth.statement_month);
+  }
 
   const sets: string[] = [];
   const binds: unknown[] = [];
@@ -962,5 +1208,102 @@ export async function finalizeExport(
     objectType: "export",
     objectId: exportId,
     newValueJson: stringifyJson({ archiveR2Key, archiveSha256 }),
+  });
+}
+
+// ─── Reconciliation signoff ────────────────────────────────────────────────
+
+async function rejectIfFinalized(db: D1Database, month: string): Promise<void> {
+  const finalized = await db
+    .prepare(
+      `SELECT id FROM amex_reconciliations WHERE statement_month = ? AND status = 'finalized' LIMIT 1`,
+    )
+    .bind(month)
+    .first<{ id: string }>();
+  if (finalized) {
+    throw new Error(`Reconciliation for ${month} is finalized`);
+  }
+}
+
+export async function getFinalizedReconciliationForMonth(
+  month: string,
+): Promise<AmexReconciliation | null> {
+  const db = getReceiptsDb();
+  return db
+    .prepare(
+      `SELECT * FROM amex_reconciliations WHERE statement_month = ? AND status = 'finalized' LIMIT 1`,
+    )
+    .bind(month)
+    .first<AmexReconciliation>();
+}
+
+export async function getReconciliationForMonth(
+  month: string,
+): Promise<AmexReconciliation | null> {
+  const db = getReceiptsDb();
+  return db
+    .prepare(
+      `SELECT * FROM amex_reconciliations WHERE statement_month = ? ORDER BY created_at DESC LIMIT 1`,
+    )
+    .bind(month)
+    .first<AmexReconciliation>();
+}
+
+export async function createReconciliationDraft(
+  month: string,
+  lineCount: number,
+  matchedCount: number,
+  noReceiptCount: number,
+  actor: string,
+): Promise<string> {
+  const db = getReceiptsDb();
+  const id = newUuid();
+  const now = nowIso();
+
+  await db
+    .prepare(
+      `INSERT INTO amex_reconciliations
+        (id, statement_month, status, line_count, matched_count, no_receipt_count, created_by, created_at)
+       VALUES (?, ?, 'draft', ?, ?, ?, ?, ?)`,
+    )
+    .bind(id, month, lineCount, matchedCount, noReceiptCount, actor, now)
+    .run();
+
+  return id;
+}
+
+export async function finalizeReconciliation(
+  reconciliationId: string,
+  manifestR2Key: string,
+  manifestSha256: string,
+  actor: string,
+): Promise<void> {
+  const db = getReceiptsDb();
+
+  const result = await db
+    .prepare(
+      `UPDATE amex_reconciliations
+       SET status = 'finalized',
+           manifest_r2_key = ?,
+           manifest_sha256 = ?,
+           finalized_by = ?,
+           finalized_at = ?
+       WHERE id = ? AND status = 'draft'`,
+    )
+    .bind(manifestR2Key, manifestSha256, actor, nowIso(), reconciliationId)
+    .run();
+
+  if ((result.meta.changes ?? 0) === 0) {
+    throw new Error(
+      `Reconciliation ${reconciliationId} could not be finalized — it may already be finalized or not found.`,
+    );
+  }
+
+  await createAuditEntry(db, {
+    actor,
+    action: "amex.reconciliation_signed_off",
+    objectType: "amex_reconciliation",
+    objectId: reconciliationId,
+    newValueJson: stringifyJson({ manifestR2Key, manifestSha256 }),
   });
 }

--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -1302,6 +1302,14 @@ export async function createReconciliationDraft(
   return id;
 }
 
+export async function deleteDraftReconciliation(id: string): Promise<void> {
+  const db = getReceiptsDb();
+  await db
+    .prepare(`DELETE FROM amex_reconciliations WHERE id = ? AND status = 'draft'`)
+    .bind(id)
+    .run();
+}
+
 export async function finalizeReconciliation(
   reconciliationId: string,
   manifestR2Key: string,

--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -329,7 +329,12 @@ export async function importAmexLines(
   >();
   for (const r of existingResult.results) {
     if (r.amex_reference) {
-      existingMap.set(`${r.amex_reference}|${r.cardholder_name ?? ""}`, r);
+      existingMap.set(`ref|${r.amex_reference}|${r.cardholder_name ?? ""}`, r);
+    } else {
+      existingMap.set(
+        `noref|${r.transaction_date}|${r.amount_minor}|${r.merchant}|${r.cardholder_name ?? ""}`,
+        r,
+      );
     }
   }
 
@@ -339,7 +344,7 @@ export async function importAmexLines(
 
   for (const row of rows) {
     if (row.amexReference) {
-      const key = `${row.amexReference}|${row.cardholderName ?? ""}`;
+      const key = `ref|${row.amexReference}|${row.cardholderName ?? ""}`;
       const ex = existingMap.get(key);
       if (!ex) {
         inserted++;
@@ -357,7 +362,20 @@ export async function importAmexLines(
         updated++;
       }
     } else {
-      inserted++;
+      const key = `noref|${row.transactionDate}|${row.amountMinor}|${row.merchant}|${row.cardholderName ?? ""}`;
+      const ex = existingMap.get(key);
+      if (!ex) {
+        inserted++;
+      } else if (
+        (ex.posting_date ?? "") === (row.postingDate ?? "") &&
+        ex.currency === (row.currency ?? "JPY") &&
+        (ex.memo ?? "") === (row.memo ?? "") &&
+        ex.raw_json === row.rawJson
+      ) {
+        unchanged++;
+      } else {
+        updated++;
+      }
     }
   }
 
@@ -424,7 +442,7 @@ export async function importAmexLines(
       .run();
   }
 
-  // ── INSERT OR IGNORE for rows without amex_reference (rare edge case) ───
+  // ── Upsert for rows without amex_reference (rare edge case) ───
   for (let i = 0; i < withoutRef.length; i += CHUNK_SIZE) {
     const chunk = withoutRef.slice(i, i + CHUNK_SIZE);
     const placeholders = chunk.map(() => rowPlaceholder).join(",");
@@ -454,13 +472,24 @@ export async function importAmexLines(
     }
     await db
       .prepare(
-        `INSERT OR IGNORE INTO amex_statement_lines
+        `INSERT INTO amex_statement_lines
           (id, statement_month, transaction_date, posting_date, merchant,
            amount_minor, currency, amex_reference, match_status, raw_json,
            statement_artifact_id, cardholder_name, cardholder_flag, payment_type,
            prepayment_flag, memo, raw_csv_line_number, source_file_sha256,
            imported_at, created_at)
-         VALUES ${placeholders}`,
+         VALUES ${placeholders}
+         ON CONFLICT (statement_month, transaction_date, amount_minor, merchant, cardholder_name)
+           WHERE amex_reference IS NULL
+         DO UPDATE SET
+           posting_date = excluded.posting_date,
+           currency = excluded.currency,
+           memo = excluded.memo,
+           raw_csv_line_number = excluded.raw_csv_line_number,
+           source_file_sha256 = excluded.source_file_sha256,
+           statement_artifact_id = excluded.statement_artifact_id,
+           imported_at = excluded.imported_at,
+           raw_json = excluded.raw_json`,
       )
       .bind(...binds)
       .run();

--- a/lib/receipts/export.ts
+++ b/lib/receipts/export.ts
@@ -90,6 +90,11 @@ export function buildManifestCsv(
   archiveSha256: string,
   rowCount: number,
   generatedAt: string,
+  reconciliation?: {
+    id: string;
+    manifestR2Key: string;
+    manifestSha256: string;
+  } | null,
 ): string {
   const lines = [
     "Field,Value",
@@ -100,5 +105,12 @@ export function buildManifestCsv(
     `RowCount,${rowCount}`,
     `GeneratedAt,${csvEscape(generatedAt)}`,
   ];
+  if (reconciliation) {
+    lines.push(
+      `ReconciliationId,${csvEscape(reconciliation.id)}`,
+      `ReconciliationManifestKey,${csvEscape(reconciliation.manifestR2Key)}`,
+      `ReconciliationManifestSha256,${csvEscape(reconciliation.manifestSha256)}`,
+    );
+  }
   return lines.join("\n");
 }

--- a/lib/receipts/month-closing.ts
+++ b/lib/receipts/month-closing.ts
@@ -6,6 +6,7 @@ import {
   listReceiptRecords,
 } from "@/lib/receipts/db";
 import type { ExportRow, ReceiptRecord } from "@/lib/receipts/types";
+import { validateAmexLinesForSignoff } from "@/lib/receipts/reconciliation-signoff";
 
 export interface MonthlyExportDraft {
   receipts: ReceiptRecord[];
@@ -70,40 +71,10 @@ export async function validateMonthReadyForExport(
 
   const amexLines = await listAmexLines(month);
   const amexAttendees = await listAmexLineAttendeeNamesByMonth(month);
-  for (const line of amexLines) {
-    const label = `${line.transaction_date} ${line.merchant}`;
-    if (!line.expense_category_code) {
-      blockers.push(`AMEX ${label}: missing expense category`);
-    }
-    if (
-      line.receipt_status === "matched" &&
-      (!line.matched_receipt_id || line.match_status !== "confirmed")
-    ) {
-      blockers.push(`AMEX ${label}: matched receipt is not confirmed`);
-    }
-    if (
-      line.receipt_status === "missing_receipt" ||
-      ((line.receipt_status === "no_receipt_required" ||
-        line.receipt_status === "receipt_not_available") &&
-        !line.receipt_missing_reason)
-    ) {
-      blockers.push(`AMEX ${label}: missing receipt requires a reason`);
-    }
-    if (requiresAttendees(line.expense_category_code)) {
-      const linkedReceiptAttendees = line.matched_receipt_id
-        ? currentDraft.attendeeMap.get(line.matched_receipt_id) ?? []
-        : [];
-      const directAmexAttendees = amexAttendees[line.id] ?? [];
-      if (linkedReceiptAttendees.length === 0 && directAmexAttendees.length === 0) {
-        blockers.push(
-          `AMEX ${label}: ${getCategoryByCode(line.expense_category_code ?? "")?.jaName ?? line.expense_category_code} requires attendees`,
-        );
-      }
-    }
-    if (line.business_trip_status === "candidate") {
-      blockers.push(`AMEX ${label}: unresolved business trip candidate`);
-    }
-  }
+
+  blockers.push(
+    ...validateAmexLinesForSignoff(amexLines, amexAttendees, currentDraft.attendeeMap),
+  );
 
   return blockers;
 }

--- a/lib/receipts/reconciliation-signoff.ts
+++ b/lib/receipts/reconciliation-signoff.ts
@@ -1,0 +1,68 @@
+import type { AmexStatementLine, ReceiptRecord } from "@/lib/receipts/types";
+
+function csvEscape(value: string | null | undefined): string {
+  if (value === null || value === undefined) return "";
+  const s = String(value);
+  if (s.includes(",") || s.includes('"') || s.includes("\n")) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}
+
+const MANIFEST_HEADERS = [
+  "line_id",
+  "transaction_date",
+  "merchant_amex",
+  "merchant_receipt",
+  "amount",
+  "currency",
+  "match_status",
+  "receipt_status",
+  "receipt_id",
+  "receipt_sha256",
+  "no_receipt_reason",
+  "expense_category_code",
+  "cardholder_name",
+  "source_file_sha256",
+];
+
+export function buildReconciliationManifestCsv(
+  lines: AmexStatementLine[],
+  receipts: ReceiptRecord[],
+  attendeeMap: Record<string, string[]>,
+): string {
+  const receiptMap = new Map(receipts.map((r) => [r.id, r]));
+
+  const rows: string[] = [MANIFEST_HEADERS.join(",")];
+
+  for (const line of lines) {
+    const receipt = line.matched_receipt_id
+      ? receiptMap.get(line.matched_receipt_id)
+      : null;
+
+    const amount = line.currency === "JPY"
+      ? String(line.amount_minor)
+      : (line.amount_minor / 100).toFixed(2);
+
+    rows.push(
+      [
+        csvEscape(line.id),
+        csvEscape(line.transaction_date),
+        csvEscape(line.merchant),
+        csvEscape(receipt?.merchant),
+        csvEscape(amount),
+        csvEscape(line.currency),
+        csvEscape(line.match_status),
+        csvEscape(line.receipt_status),
+        csvEscape(line.matched_receipt_id),
+        csvEscape(receipt?.original_sha256),
+        csvEscape(line.receipt_missing_reason),
+        csvEscape(line.expense_category_code),
+        csvEscape(line.cardholder_name),
+        csvEscape(line.source_file_sha256),
+      ].join(","),
+    );
+  }
+
+  return rows.join("\n");
+}

--- a/lib/receipts/reconciliation-signoff.ts
+++ b/lib/receipts/reconciliation-signoff.ts
@@ -1,4 +1,5 @@
 import type { AmexStatementLine, ReceiptRecord } from "@/lib/receipts/types";
+import { requiresAttendees } from "@/lib/receipts/categories";
 
 function csvEscape(value: string | null | undefined): string {
   if (value === null || value === undefined) return "";
@@ -75,4 +76,55 @@ export function buildReconciliationManifestCsv(
   }
 
   return rows.join("\n");
+}
+
+/**
+ * Validate that all AMEX lines are ready for sign-off/export.
+ * Returns an array of human-readable blocker strings (empty = ready).
+ */
+export function validateAmexLinesForSignoff(
+  amexLines: AmexStatementLine[],
+  amexAttendees: Record<string, string[]>,
+  receiptAttendeeMap: Map<string, string[]>,
+): string[] {
+  const blockers: string[] = [];
+
+  for (const line of amexLines) {
+    const label = `${line.transaction_date} ${line.merchant}`;
+
+    if (line.match_status === "unmatched" || line.match_status === "matched") {
+      blockers.push(`AMEX ${label}: unresolved match status (${line.match_status})`);
+    }
+    if (!line.expense_category_code) {
+      blockers.push(`AMEX ${label}: missing expense category`);
+    }
+    if (
+      line.receipt_status === "matched" &&
+      (!line.matched_receipt_id || line.match_status !== "confirmed")
+    ) {
+      blockers.push(`AMEX ${label}: matched receipt is not confirmed`);
+    }
+    if (
+      line.receipt_status === "missing_receipt" ||
+      ((line.receipt_status === "no_receipt_required" ||
+        line.receipt_status === "receipt_not_available") &&
+        !line.receipt_missing_reason)
+    ) {
+      blockers.push(`AMEX ${label}: missing receipt requires a reason`);
+    }
+    if (requiresAttendees(line.expense_category_code)) {
+      const linkedReceiptAttendees = line.matched_receipt_id
+        ? receiptAttendeeMap.get(line.matched_receipt_id) ?? []
+        : [];
+      const directAmexAttendees = amexAttendees[line.id] ?? [];
+      if (linkedReceiptAttendees.length === 0 && directAmexAttendees.length === 0) {
+        blockers.push(`AMEX ${label}: requires attendees`);
+      }
+    }
+    if (line.business_trip_status === "candidate") {
+      blockers.push(`AMEX ${label}: unresolved business trip candidate`);
+    }
+  }
+
+  return blockers;
 }

--- a/lib/receipts/reconciliation-signoff.ts
+++ b/lib/receipts/reconciliation-signoff.ts
@@ -24,12 +24,15 @@ const MANIFEST_HEADERS = [
   "expense_category_code",
   "cardholder_name",
   "source_file_sha256",
+  "attendees_amex",
+  "attendees_receipt",
 ];
 
 export function buildReconciliationManifestCsv(
   lines: AmexStatementLine[],
   receipts: ReceiptRecord[],
-  attendeeMap: Record<string, string[]>,
+  amexAttendeeMap: Record<string, string[]>,
+  receiptAttendeeMap: Record<string, string[]>,
 ): string {
   const receiptMap = new Map(receipts.map((r) => [r.id, r]));
 
@@ -43,6 +46,11 @@ export function buildReconciliationManifestCsv(
     const amount = line.currency === "JPY"
       ? String(line.amount_minor)
       : (line.amount_minor / 100).toFixed(2);
+
+    const amexAtts = amexAttendeeMap[line.id] ?? [];
+    const receiptAtts = receipt?.id
+      ? (receiptAttendeeMap[receipt.id] ?? [])
+      : [];
 
     rows.push(
       [
@@ -60,6 +68,8 @@ export function buildReconciliationManifestCsv(
         csvEscape(line.expense_category_code),
         csvEscape(line.cardholder_name),
         csvEscape(line.source_file_sha256),
+        csvEscape(amexAtts.join("; ")),
+        csvEscape(receiptAtts.join("; ")),
       ].join(","),
     );
   }

--- a/lib/receipts/reconciliation.ts
+++ b/lib/receipts/reconciliation.ts
@@ -42,14 +42,15 @@ export function matchAmexToReceipts(
       r.status !== "exported",
   );
 
-  const matches: ReconciliationMatch[] = [];
+  // Phase 1: compute best candidate per AMEX line
+  const candidates: Array<{ match: ReconciliationMatch; dateDelta: number }> = [];
 
   for (const line of amexLines) {
     if (line.match_status === "confirmed" || line.match_status === "no_receipt") {
       continue;
     }
 
-    let bestMatch: ReconciliationMatch | null = null;
+    let best: { match: ReconciliationMatch; dateDelta: number } | null = null;
 
     for (const receipt of eligibleReceipts) {
       if (receipt.payment_path !== "AMEX") continue;
@@ -66,6 +67,7 @@ export function matchAmexToReceipts(
 
       const reasons: string[] = [];
       let score = 0;
+      let dateDelta = Infinity;
 
       const amexMinor = line.amount_minor;
       const receiptMinor = receipt.amount_minor;
@@ -88,13 +90,13 @@ export function matchAmexToReceipts(
 
       // Date proximity
       if (receipt.transaction_date && line.transaction_date) {
-        const days = daysBetween(line.transaction_date, receipt.transaction_date);
-        if (days === 0) {
+        dateDelta = daysBetween(line.transaction_date, receipt.transaction_date);
+        if (dateDelta === 0) {
           score += 0.35;
           reasons.push("same date");
-        } else if (days <= 3) {
+        } else if (dateDelta <= 3) {
           score += 0.2;
-          reasons.push(`${days}-day window`);
+          reasons.push(`${dateDelta}-day window`);
         } else {
           continue; // Too far apart — skip
         }
@@ -108,20 +110,47 @@ export function matchAmexToReceipts(
         }
       }
 
-      if (score > 0 && (!bestMatch || score > bestMatch.confidenceScore)) {
-        bestMatch = {
-          amexLineId: line.id,
-          receiptId: receipt.id,
-          confidenceScore: Math.min(score, 1),
-          matchReasons: reasons,
+      if (score > 0 && (!best || score > best.match.confidenceScore)) {
+        best = {
+          match: {
+            amexLineId: line.id,
+            receiptId: receipt.id,
+            confidenceScore: Math.min(score, 1),
+            matchReasons: reasons,
+          },
+          dateDelta,
         };
       }
     }
 
-    if (bestMatch) {
-      matches.push(bestMatch);
+    if (best) {
+      candidates.push(best);
     }
   }
 
-  return matches;
+  // Phase 2: collision resolution — each receipt maps to at most one line and
+  // each line to at most one receipt. Greedy by descending confidence; ties
+  // broken by smaller date delta, then lexicographic line id.
+  candidates.sort((a, b) => {
+    const scoreDiff = b.match.confidenceScore - a.match.confidenceScore;
+    if (scoreDiff !== 0) return scoreDiff;
+    const deltaDiff = a.dateDelta - b.dateDelta;
+    if (deltaDiff !== 0) return deltaDiff;
+    return a.match.amexLineId.localeCompare(b.match.amexLineId);
+  });
+
+  const assignedReceipts = new Set<string>();
+  const assignedLines = new Set<string>();
+  const resolved: ReconciliationMatch[] = [];
+
+  for (const { match } of candidates) {
+    if (assignedReceipts.has(match.receiptId) || assignedLines.has(match.amexLineId)) {
+      continue;
+    }
+    assignedReceipts.add(match.receiptId);
+    assignedLines.add(match.amexLineId);
+    resolved.push(match);
+  }
+
+  return resolved;
 }

--- a/lib/receipts/reconciliation.ts
+++ b/lib/receipts/reconciliation.ts
@@ -7,9 +7,21 @@ import type {
 export function normalizeDescription(value: string): string {
   return value
     .toLowerCase()
-    .replace(/[^\w\s]/g, " ")
+    .replace(/[^\p{L}\p{N}\s]/gu, " ")
     .replace(/\s+/g, " ")
     .trim();
+}
+
+/**
+ * Returns true when the AMEX merchant should overwrite the receipt merchant.
+ * Both must be non-null and their normalized forms must differ.
+ */
+export function shouldOverwriteMerchant(
+  amexMerchant: string | null | undefined,
+  receiptMerchant: string | null | undefined,
+): boolean {
+  if (!amexMerchant || !receiptMerchant) return false;
+  return normalizeDescription(amexMerchant) !== normalizeDescription(receiptMerchant);
 }
 
 function daysBetween(dateA: string, dateB: string): number {
@@ -22,13 +34,41 @@ function descriptionContains(amexDesc: string, receiptMerchant: string): boolean
   const normalizedDesc = normalizeDescription(amexDesc);
   const normalizedMerchant = normalizeDescription(receiptMerchant);
 
-  if (!normalizedMerchant) return false;
+  if (!normalizedDesc || !normalizedMerchant) return false;
 
-  // Check if all words in the merchant name appear in the AMEX description
-  const merchantWords = normalizedMerchant.split(" ").filter((w) => w.length > 2);
-  if (merchantWords.length === 0) return false;
+  const descTokens = normalizedDesc.split(" ").filter((w) => w.length > 2);
+  const merchantTokens = normalizedMerchant.split(" ").filter((w) => w.length > 2);
 
-  return merchantWords.some((word) => normalizedDesc.includes(word));
+  if (descTokens.length === 0 || merchantTokens.length === 0) return false;
+
+  // Rule A: both sides have ≥2 significant tokens and share ≥2 of them.
+  if (descTokens.length >= 2 && merchantTokens.length >= 2) {
+    const merchantSet = new Set(merchantTokens);
+    if (descTokens.filter((t) => merchantSet.has(t)).length >= 2) return true;
+  }
+
+  // Rule B: one side has a single token (len ≥4) that is an exact token on
+  // the other side. Covers "AMAZON" ↔ "AMAZON MARKETPLACE" but rejects
+  // "STAR" ↔ "STARBUCKS" (not an exact token match).
+  if (merchantTokens.length === 1 && merchantTokens[0]!.length >= 4) {
+    if (descTokens.includes(merchantTokens[0]!)) return true;
+  }
+  if (descTokens.length === 1 && descTokens[0]!.length >= 4) {
+    if (merchantTokens.includes(descTokens[0]!)) return true;
+  }
+
+  // Rule C: both sides have exactly 1 token; the shorter (len ≥5) is a
+  // substring of the longer. Covers "セブンイレブン" ↔ "セブンイレブン渋谷"
+  // but rejects "STAR" ↔ "STARBUCKS" (shorter len=4 < 5).
+  if (descTokens.length === 1 && merchantTokens.length === 1) {
+    const [a] = descTokens;
+    const [m] = merchantTokens;
+    const shorter = a!.length <= m!.length ? a! : m!;
+    const longer = a!.length <= m!.length ? m! : a!;
+    if (shorter.length >= 5 && longer.includes(shorter)) return true;
+  }
+
+  return false;
 }
 
 export function matchAmexToReceipts(
@@ -88,18 +128,19 @@ export function matchAmexToReceipts(
         continue; // Amount mismatch too large — not a candidate
       }
 
-      // Date proximity
+      // Date proximity — linear gradient: max(0, 0.35 - 0.05 × days) for days ≤ 7
+      let dateCap = 1;
       if (receipt.transaction_date && line.transaction_date) {
         dateDelta = daysBetween(line.transaction_date, receipt.transaction_date);
-        if (dateDelta === 0) {
-          score += 0.35;
-          reasons.push("same date");
-        } else if (dateDelta <= 3) {
-          score += 0.2;
-          reasons.push(`${dateDelta}-day window`);
-        } else {
+        if (dateDelta > 7) {
           continue; // Too far apart — skip
         }
+        score += Math.max(0, 0.35 - 0.05 * dateDelta);
+        reasons.push(`${dateDelta}-day window`);
+      } else {
+        score -= 0.2;
+        reasons.push("no date on receipt");
+        dateCap = 0.5;
       }
 
       // Merchant name match
@@ -115,7 +156,7 @@ export function matchAmexToReceipts(
           match: {
             amexLineId: line.id,
             receiptId: receipt.id,
-            confidenceScore: Math.min(score, 1),
+            confidenceScore: Math.min(score, dateCap),
             matchReasons: reasons,
           },
           dateDelta,

--- a/lib/receipts/storage.ts
+++ b/lib/receipts/storage.ts
@@ -108,3 +108,8 @@ export async function computeSha256Hex(buffer: ArrayBuffer): Promise<string> {
   const hashArray = Array.from(new Uint8Array(hashBuffer));
   return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
 }
+
+export async function deleteArchiveObject(key: string): Promise<void> {
+  const bucket = getReceiptsArchiveBucket();
+  await bucket.delete(key);
+}

--- a/lib/receipts/types.ts
+++ b/lib/receipts/types.ts
@@ -176,6 +176,7 @@ export interface AmexStatementLine {
   business_trip_id: string | null;
   business_trip_status: AmexBusinessTripStatus;
   expense_category_code: string | null;
+  re_review_needed: 0 | 1;
   updated_at: string | null;
 }
 

--- a/lib/receipts/types.ts
+++ b/lib/receipts/types.ts
@@ -75,6 +75,8 @@ export type BusinessTripStatus =
 
 export type ExportStatus = "draft" | "finalized";
 
+export type AmexReconciliationStatus = "draft" | "finalized";
+
 export type AuditAction =
   | "receipt.uploaded"
   | "receipt.created"
@@ -93,6 +95,8 @@ export type AuditAction =
   | "amex.line_categorized"
   | "amex.reconciled"
   | "amex.business_trip_detected"
+  | "amex.reconciliation_signed_off"
+  | "amex.reconciliation_amended"
   | "export.created"
   | "export.finalized";
 
@@ -249,6 +253,22 @@ export interface ReceiptExport {
   archive_sha256: string | null;
   created_by: string;
   created_at: string;
+  finalized_at: string | null;
+}
+
+export interface AmexReconciliation {
+  id: string;
+  statement_month: string;
+  statement_artifact_id: string | null;
+  status: AmexReconciliationStatus;
+  manifest_r2_key: string | null;
+  manifest_sha256: string | null;
+  line_count: number;
+  matched_count: number;
+  no_receipt_count: number;
+  created_by: string;
+  created_at: string;
+  finalized_by: string | null;
   finalized_at: string | null;
 }
 

--- a/tests/receipts/manifest-csv.test.ts
+++ b/tests/receipts/manifest-csv.test.ts
@@ -33,6 +33,7 @@ function makeLine(overrides: Partial<AmexStatementLine> = {}): AmexStatementLine
     business_trip_id: null,
     business_trip_status: "not_applicable",
     expense_category_code: "office_supplies",
+    re_review_needed: 0,
     updated_at: null,
     ...overrides,
   };

--- a/tests/receipts/manifest-csv.test.ts
+++ b/tests/receipts/manifest-csv.test.ts
@@ -1,0 +1,130 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildReconciliationManifestCsv } from "@/lib/receipts/reconciliation-signoff";
+import type { AmexStatementLine, ReceiptRecord } from "@/lib/receipts/types";
+
+function makeLine(overrides: Partial<AmexStatementLine> = {}): AmexStatementLine {
+  return {
+    id: "line-1",
+    statement_month: "2024-01",
+    transaction_date: "2024-01-15",
+    posting_date: null,
+    merchant: "AMAZON",
+    amount_minor: 3800,
+    currency: "JPY",
+    amex_reference: "REF001",
+    matched_receipt_id: "r-1",
+    match_status: "confirmed",
+    raw_json: "{}",
+    created_at: "2024-01-15T00:00:00Z",
+    statement_artifact_id: null,
+    cardholder_name: null,
+    cardholder_flag: null,
+    payment_type: null,
+    prepayment_flag: null,
+    memo: null,
+    raw_csv_line_number: null,
+    source_file_sha256: null,
+    imported_at: null,
+    expense_category: "unknown",
+    category_status: "uncategorized",
+    receipt_status: "matched",
+    receipt_missing_reason: null,
+    business_trip_id: null,
+    business_trip_status: "not_applicable",
+    expense_category_code: "office_supplies",
+    updated_at: null,
+    ...overrides,
+  };
+}
+
+function makeReceipt(overrides: Partial<ReceiptRecord> = {}): ReceiptRecord {
+  return {
+    id: "r-1",
+    captured_at: "2024-01-15T10:00:00Z",
+    captured_by: "user@example.com",
+    source: "mobile_capture",
+    original_filename: "receipt.jpg",
+    payment_path: "AMEX",
+    expense_type: "misc",
+    transaction_date: "2024-01-15",
+    merchant: "Amazon",
+    amount_minor: 3800,
+    currency: "JPY",
+    tax_amount_minor: null,
+    business_purpose: null,
+    alcohol_present: 0,
+    attendees_required: 0,
+    status: "needs_review",
+    original_r2_key: "receipts/2024/01/r-1/file.jpg",
+    original_sha256: "sha256abc",
+    original_content_type: "image/jpeg",
+    original_size_bytes: 500_000,
+    processed_r2_key: null,
+    extraction_json: null,
+    legacy: 0,
+    exported_month: null,
+    expense_category_code: null,
+    deleted_at: null,
+    deleted_by: null,
+    delete_reason: null,
+    created_at: "2024-01-15T10:00:00Z",
+    updated_at: "2024-01-15T10:00:00Z",
+    ...overrides,
+  };
+}
+
+test("manifest CSV includes attendees_amex and attendees_receipt columns", () => {
+  const lines = [makeLine()];
+  const receipts = [makeReceipt()];
+  const amexAttendees = { "line-1": ["Alice", "Bob"] };
+  const receiptAttendees = { "r-1": ["Carol"] };
+
+  const csv = buildReconciliationManifestCsv(
+    lines,
+    receipts,
+    amexAttendees,
+    receiptAttendees,
+  );
+
+  const csvLines = csv.split("\n");
+  assert.equal(csvLines.length, 2, "header + 1 data row");
+  const headers = csvLines[0]!.split(",");
+  assert.ok(headers.includes("attendees_amex"), "missing attendees_amex header");
+  assert.ok(headers.includes("attendees_receipt"), "missing attendees_receipt header");
+
+  const amexAttIdx = headers.indexOf("attendees_amex");
+  const recAttIdx = headers.indexOf("attendees_receipt");
+  const dataCols = csvLines[1]!.split(",");
+  assert.equal(dataCols[amexAttIdx], "Alice; Bob");
+  assert.equal(dataCols[recAttIdx], "Carol");
+});
+
+test("manifest CSV: missing attendees render as empty", () => {
+  const lines = [makeLine({ matched_receipt_id: null })];
+  const receipts = [makeReceipt()];
+  const csv = buildReconciliationManifestCsv(lines, receipts, {}, {});
+
+  const csvLines = csv.split("\n");
+  const headers = csvLines[0]!.split(",");
+  const amexAttIdx = headers.indexOf("attendees_amex");
+  const recAttIdx = headers.indexOf("attendees_receipt");
+  const dataCols = csvLines[1]!.split(",");
+  assert.equal(dataCols[amexAttIdx], "");
+  assert.equal(dataCols[recAttIdx], "");
+});
+
+test("manifest CSV: attendees with commas are escaped", () => {
+  const lines = [makeLine()];
+  const receipts = [makeReceipt()];
+  const amexAttendees = { "line-1": ["Smith, Jr., John"] };
+
+  const csv = buildReconciliationManifestCsv(lines, receipts, amexAttendees, {});
+
+  // The raw CSV row must contain the escaped value
+  const dataRow = csv.split("\n")[1]!;
+  assert.ok(
+    dataRow.includes('"Smith, Jr., John"'),
+    "attendee with comma must be CSV-escaped",
+  );
+});

--- a/tests/receipts/merchant-override.test.ts
+++ b/tests/receipts/merchant-override.test.ts
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { shouldOverwriteMerchant } from "@/lib/receipts/reconciliation";
+
+// ─── shouldOverwriteMerchant ─────────────────────────────────────────────────
+
+test("both filled, same normalized form → false", () => {
+  assert.equal(shouldOverwriteMerchant("AMAZON", "Amazon"), false);
+});
+
+test("both filled, different forms → true", () => {
+  assert.equal(shouldOverwriteMerchant("AMAZON.CO.JP", "Amazon Marketplace"), true);
+});
+
+test("both filled, exact same string → false", () => {
+  assert.equal(shouldOverwriteMerchant("STARBUCKS", "STARBUCKS"), false);
+});
+
+test("amexMerchant null → false", () => {
+  assert.equal(shouldOverwriteMerchant(null, "Amazon"), false);
+});
+
+test("receiptMerchant null → false", () => {
+  assert.equal(shouldOverwriteMerchant("Amazon", null), false);
+});
+
+test("both null → false", () => {
+  assert.equal(shouldOverwriteMerchant(null, null), false);
+});
+
+test("empty string treated as null → false", () => {
+  assert.equal(shouldOverwriteMerchant("", "Amazon"), false);
+  assert.equal(shouldOverwriteMerchant("Amazon", ""), false);
+});

--- a/tests/receipts/reconciliation.test.ts
+++ b/tests/receipts/reconciliation.test.ts
@@ -35,6 +35,7 @@ function makeAmexLine(overrides: Partial<AmexStatementLine> = {}): AmexStatement
     business_trip_id: null,
     business_trip_status: "not_applicable",
     expense_category_code: null,
+    re_review_needed: 0,
     updated_at: null,
     ...overrides,
   };

--- a/tests/receipts/reconciliation.test.ts
+++ b/tests/receipts/reconciliation.test.ts
@@ -268,13 +268,13 @@ test("contested receipt goes to higher-confidence line; loser gets no suggestion
       id: "line-a",
       amount_minor: 380000,
       transaction_date: "2024-01-15",
-      merchant: null,
+      merchant: "",
     }),
     makeAmexLine({
       id: "line-b",
       amount_minor: 380000,
       transaction_date: "2024-01-13",
-      merchant: null,
+      merchant: "",
     }),
   ];
   const receipts = [
@@ -282,13 +282,13 @@ test("contested receipt goes to higher-confidence line; loser gets no suggestion
       id: "r-x",
       amount_minor: 380000,
       transaction_date: "2024-01-15",
-      merchant: null,
+      merchant: "",
     }),
     makeReceipt({
       id: "r-y",
       amount_minor: 381000,
       transaction_date: "2024-01-18",
-      merchant: null,
+      merchant: "",
     }),
   ];
   const matches = matchAmexToReceipts(lines, receipts);
@@ -325,8 +325,8 @@ test("2-day delta scores between 0-day and 6-day", () => {
     const base = "2024-01-15";
     const target = new Date(Date.UTC(2024, 0, 15 + days));
     const targetStr = target.toISOString().slice(0, 10);
-    const lines = [makeAmexLine({ transaction_date: base, merchant: null })];
-    const receipts = [makeReceipt({ transaction_date: targetStr, merchant: null })];
+    const lines = [makeAmexLine({ transaction_date: base, merchant: "" })];
+    const receipts = [makeReceipt({ transaction_date: targetStr, merchant: "" })];
     const matches = matchAmexToReceipts(lines, receipts);
     assert.equal(matches.length, 1, `expected a match at ${days} days`);
     return matches[0]!.confidenceScore;
@@ -341,7 +341,7 @@ test("2-day delta scores between 0-day and 6-day", () => {
 });
 
 test("8-day delta is rejected (> 7-day window)", () => {
-  const lines = [makeAmexLine({ transaction_date: "2024-01-15", merchant: null })];
+  const lines = [makeAmexLine({ transaction_date: "2024-01-15", merchant: "" })];
   const receipts = [makeReceipt({ transaction_date: "2024-01-23", merchant: null })];
   const matches = matchAmexToReceipts(lines, receipts);
   assert.equal(matches.length, 0, "8-day gap should fall outside the 7-day window");

--- a/tests/receipts/reconciliation.test.ts
+++ b/tests/receipts/reconciliation.test.ts
@@ -97,12 +97,12 @@ test("exact amount + same date produces high confidence match", () => {
   assert.equal(matches.length, 1);
   assert.ok(matches[0]!.confidenceScore >= 0.8, "expected high confidence for exact match");
   assert.ok(matches[0]!.matchReasons.includes("exact amount"));
-  assert.ok(matches[0]!.matchReasons.includes("same date"));
+  assert.ok(matches[0]!.matchReasons.includes("0-day window"));
 });
 
-test("no match when date is more than 3 days apart", () => {
+test("no match when date is more than 7 days apart", () => {
   const lines = [makeAmexLine({ transaction_date: "2024-01-15" })];
-  const receipts = [makeReceipt({ transaction_date: "2024-01-20" })];
+  const receipts = [makeReceipt({ transaction_date: "2024-01-24" })];
   const matches = matchAmexToReceipts(lines, receipts);
   assert.equal(matches.length, 0);
 });
@@ -296,4 +296,144 @@ test("contested receipt goes to higher-confidence line; loser gets no suggestion
   assert.equal(matches[0]!.amexLineId, "line-a");
   assert.equal(matches[0]!.receiptId, "r-x");
   assert.ok(matches[0]!.confidenceScore >= 0.8);
+});
+
+// ─── Null transaction_date handling ──────────────────────────────────────────
+
+test("null transaction_date + exact amount → match possible but capped at 0.5", () => {
+  const lines = [makeAmexLine({ transaction_date: "2024-01-15" })];
+  const receipts = [makeReceipt({ transaction_date: null, merchant: null })];
+  const matches = matchAmexToReceipts(lines, receipts);
+  assert.equal(matches.length, 1, "dateless receipt with matching amount should still be a candidate");
+  assert.ok(matches[0]!.confidenceScore <= 0.5, "confidence must be capped at 0.5 without a date");
+  assert.ok(matches[0]!.matchReasons.includes("no date on receipt"));
+});
+
+test("both dates present + same amount → unchanged high confidence", () => {
+  const lines = [makeAmexLine({ transaction_date: "2024-01-15" })];
+  const receipts = [makeReceipt({ transaction_date: "2024-01-15" })];
+  const matches = matchAmexToReceipts(lines, receipts);
+  assert.equal(matches.length, 1);
+  assert.ok(matches[0]!.confidenceScore >= 0.8, "full-date match should retain high confidence");
+  assert.ok(!matches[0]!.matchReasons.includes("no date on receipt"));
+});
+
+// ─── Date gradient scoring ───────────────────────────────────────────────────
+
+test("2-day delta scores between 0-day and 6-day", () => {
+  const scoreForDays = (days: number) => {
+    const base = "2024-01-15";
+    const target = new Date(Date.UTC(2024, 0, 15 + days));
+    const targetStr = target.toISOString().slice(0, 10);
+    const lines = [makeAmexLine({ transaction_date: base, merchant: null })];
+    const receipts = [makeReceipt({ transaction_date: targetStr, merchant: null })];
+    const matches = matchAmexToReceipts(lines, receipts);
+    assert.equal(matches.length, 1, `expected a match at ${days} days`);
+    return matches[0]!.confidenceScore;
+  };
+
+  const score0 = scoreForDays(0);
+  const score2 = scoreForDays(2);
+  const score6 = scoreForDays(6);
+
+  assert.ok(score0 > score2, `0-day score (${score0}) should exceed 2-day (${score2})`);
+  assert.ok(score2 > score6, `2-day score (${score2}) should exceed 6-day (${score6})`);
+});
+
+test("8-day delta is rejected (> 7-day window)", () => {
+  const lines = [makeAmexLine({ transaction_date: "2024-01-15", merchant: null })];
+  const receipts = [makeReceipt({ transaction_date: "2024-01-23", merchant: null })];
+  const matches = matchAmexToReceipts(lines, receipts);
+  assert.equal(matches.length, 0, "8-day gap should fall outside the 7-day window");
+});
+
+// ─── Unicode-aware normalizeDescription ───────────────────────────────────────
+
+test("normalizeDescription: preserves Japanese characters, strips punctuation", () => {
+  assert.equal(normalizeDescription("セブン-イレブン"), "セブン イレブン");
+});
+
+// ─── Tightened descriptionContains (merchant matching) ────────────────────────
+
+test("Japanese merchant: セブンイレブン渋谷 matches セブンイレブン", () => {
+  const lines = [
+    makeAmexLine({
+      merchant: "セブンイレブン渋谷",
+      amount_minor: 1500,
+      transaction_date: "2024-01-15",
+    }),
+  ];
+  const receipts = [
+    makeReceipt({
+      merchant: "セブンイレブン",
+      amount_minor: 1500,
+      transaction_date: "2024-01-15",
+    }),
+  ];
+  const matches = matchAmexToReceipts(lines, receipts);
+  assert.equal(matches.length, 1);
+  assert.ok(matches[0]!.matchReasons.includes("merchant match"));
+});
+
+test("single-token AMAZON matches multi-token AMAZON PRIME VIDEO", () => {
+  const lines = [
+    makeAmexLine({
+      merchant: "AMAZON PRIME VIDEO",
+      amount_minor: 1500,
+      transaction_date: "2024-01-15",
+    }),
+  ];
+  const receipts = [
+    makeReceipt({
+      merchant: "AMAZON",
+      amount_minor: 1500,
+      transaction_date: "2024-01-15",
+    }),
+  ];
+  const matches = matchAmexToReceipts(lines, receipts);
+  assert.equal(matches.length, 1);
+  assert.ok(matches[0]!.matchReasons.includes("merchant match"));
+});
+
+test("single-token AMAZON matches AMAZON MARKETPLACE", () => {
+  const lines = [
+    makeAmexLine({
+      merchant: "AMAZON MARKETPLACE",
+      amount_minor: 380000,
+      transaction_date: "2024-01-15",
+    }),
+  ];
+  const receipts = [
+    makeReceipt({
+      merchant: "AMAZON",
+      amount_minor: 380000,
+      transaction_date: "2024-01-15",
+    }),
+  ];
+  const matches = matchAmexToReceipts(lines, receipts);
+  assert.equal(matches.length, 1);
+  assert.ok(matches[0]!.matchReasons.includes("merchant match"));
+});
+
+test("STAR does not match STARBUCKS (substring too short for single-token rule)", () => {
+  // "STAR" (len 4) is a substring of "STARBUCKS" but not an exact token, and
+  // the substring-containment rule requires the shorter token to have len ≥ 5.
+  const lines = [
+    makeAmexLine({
+      merchant: "STARBUCKS",
+      amount_minor: 600,
+      transaction_date: "2024-01-15",
+    }),
+  ];
+  const receipts = [
+    makeReceipt({
+      merchant: "STAR",
+      amount_minor: 600,
+      transaction_date: "2024-01-15",
+    }),
+  ];
+  const matches = matchAmexToReceipts(lines, receipts);
+  // Match still occurs on amount+date, but merchant match must NOT be credited
+  assert.equal(matches.length, 1);
+  assert.ok(!matches[0]!.matchReasons.includes("merchant match"));
 });

--- a/tests/receipts/reconciliation.test.ts
+++ b/tests/receipts/reconciliation.test.ts
@@ -221,3 +221,79 @@ test("soft-deleted receipts are excluded from matching (defense-in-depth)", () =
   const matches = matchAmexToReceipts(lines, receipts);
   assert.equal(matches.length, 0, "soft-deleted receipts must not be matched");
 });
+
+// ─── Collision resolution ────────────────────────────────────────────────────
+
+test("collision: two lines competing for one receipt — only one match returned", () => {
+  const lines = [
+    makeAmexLine({ id: "line-a", amount_minor: 380000, transaction_date: "2024-01-15" }),
+    makeAmexLine({ id: "line-b", amount_minor: 380000, transaction_date: "2024-01-15" }),
+  ];
+  const receipts = [
+    makeReceipt({ id: "r-1", amount_minor: 380000, transaction_date: "2024-01-15" }),
+  ];
+  const matches = matchAmexToReceipts(lines, receipts);
+  assert.equal(matches.length, 1, "one receipt cannot satisfy two lines");
+  // Tied on score and dateDelta → lexicographic line id wins: "line-a" < "line-b"
+  assert.equal(matches[0]!.amexLineId, "line-a");
+  assert.equal(matches[0]!.receiptId, "r-1");
+});
+
+test("no collision: two lines with distinct receipts — both matched", () => {
+  const lines = [
+    makeAmexLine({ id: "line-a", amount_minor: 380000, transaction_date: "2024-01-15" }),
+    makeAmexLine({ id: "line-b", amount_minor: 200000, transaction_date: "2024-01-16" }),
+  ];
+  const receipts = [
+    makeReceipt({ id: "r-x", amount_minor: 380000, transaction_date: "2024-01-15" }),
+    makeReceipt({ id: "r-y", amount_minor: 200000, transaction_date: "2024-01-16" }),
+  ];
+  const matches = matchAmexToReceipts(lines, receipts);
+  assert.equal(matches.length, 2, "no collision — both lines should be matched");
+  const matchA = matches.find((m) => m.amexLineId === "line-a");
+  const matchB = matches.find((m) => m.amexLineId === "line-b");
+  assert.ok(matchA, "line-a should have a match");
+  assert.ok(matchB, "line-b should have a match");
+  assert.equal(matchA!.receiptId, "r-x");
+  assert.equal(matchB!.receiptId, "r-y");
+});
+
+test("contested receipt goes to higher-confidence line; loser gets no suggestion", () => {
+  // line-a (2024-01-15) ↔ receipt X (2024-01-15): exact amount + same date = 0.85
+  // line-b (2024-01-13) ↔ receipt X (2024-01-15): exact amount + 2-day window = 0.70
+  // line-a also matches receipt Y at lower score, but its best is still X.
+  // line-b cannot match receipt Y (date 5 days apart → rejected).
+  const lines = [
+    makeAmexLine({
+      id: "line-a",
+      amount_minor: 380000,
+      transaction_date: "2024-01-15",
+      merchant: null,
+    }),
+    makeAmexLine({
+      id: "line-b",
+      amount_minor: 380000,
+      transaction_date: "2024-01-13",
+      merchant: null,
+    }),
+  ];
+  const receipts = [
+    makeReceipt({
+      id: "r-x",
+      amount_minor: 380000,
+      transaction_date: "2024-01-15",
+      merchant: null,
+    }),
+    makeReceipt({
+      id: "r-y",
+      amount_minor: 381000,
+      transaction_date: "2024-01-18",
+      merchant: null,
+    }),
+  ];
+  const matches = matchAmexToReceipts(lines, receipts);
+  assert.equal(matches.length, 1, "receipt X goes to line-a; line-b unmatched");
+  assert.equal(matches[0]!.amexLineId, "line-a");
+  assert.equal(matches[0]!.receiptId, "r-x");
+  assert.ok(matches[0]!.confidenceScore >= 0.8);
+});


### PR DESCRIPTION
## Summary

- **Collision resolution**: two-phase matcher (per-line best candidate → greedy assign by descending confidence) so each receipt maps to at most one AMEX line
- **Scoring overhaul**: linear date gradient (0.35 − 0.05×days, 7-day window), null-date handling (cap 0.5, −0.2 penalty), Unicode-aware merchant normalization, three-rule description matching
- **Reconciliation signoff**: terminal auditable state with manifest CSV + SHA-256 in R2, `rejectIfFinalized` guard on all mutation paths, export requires finalized reconciliation
- **Stable AMEX line identity**: unique indexes on `(month, reference, cardholder)` + null-ref fallback; `INSERT … ON CONFLICT DO UPDATE` preserves PK and reconciliation state across CSV re-imports
- **UX**: bulk auto-confirm (80/90/95%), orphan receipts section, delta badges on suggestions, keyboard navigation (j/k/c/n/?) with help modal
- **Tests**: 28 reconciliation + 7 merchant-override tests passing

## Migrations (run on Mac M4)

- `db/receipts/0010_reconciliation_signoff.sql` — `amex_reconciliations` table
- `db/receipts/0011_amex_dedup.sql` — partial unique indexes for stable line identity

## Test plan

- [x] `npm run build` passes clean
- [x] `npx tsx --test tests/receipts/reconciliation.test.ts` — 28/28 pass
- [x] `npx tsx --test tests/receipts/merchant-override.test.ts` — 7/7 pass
- [ ] Run migrations 0010 + 0011 on Mac M4 against live D1
- [ ] End-to-end: import CSV → match → confirm → signoff → export with real bindings
- [ ] Verify re-import of corrected CSV preserves confirmed reconciliations
- [ ] Keyboard navigation smoke test in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)