### PR TITLE
Statement-window matching for AMEX reconciliation

### DIFF
--- a/app/(receipt-system)/receipts/reconcile/page.tsx
+++ b/app/(receipt-system)/receipts/reconcile/page.tsx
@@ -4,6 +4,7 @@ import {
   getReconciliationForMonth,
 } from "@/lib/receipts/db";
 import { matchAmexToReceipts } from "@/lib/receipts/reconciliation";
+import { deriveStatementWindow, isReceiptInWindow } from "@/lib/receipts/statement-window";
 import { ReconciliationTable } from "@/components/receipts/reconciliation-table";
 import { assertReceiptsPageAccess } from "@/lib/receipts/auth-request";
 import type { AmexReconciliation } from "@/lib/receipts/types";
@@ -26,9 +27,12 @@ export default async function ReconcilePage({
     getReconciliationForMonth(month),
   ]);
 
+  const window = deriveStatementWindow(amexLines, month);
+  const receiptsInWindow = receipts.filter((r) => isReceiptInWindow(r, window));
+
   const autoMatches = reconciliation?.status === "finalized"
     ? [] // No auto-matching when finalized
-    : matchAmexToReceipts(amexLines, receipts);
+    : matchAmexToReceipts(amexLines, receiptsInWindow);
 
   const linkedReceiptIds = new Set(
     amexLines
@@ -36,13 +40,13 @@ export default async function ReconcilePage({
       .filter((id): id is string => !!id),
   );
   const suggestedReceiptIds = new Set(autoMatches.map((m) => m.receiptId));
-  const orphanReceipts = receipts.filter(
+  const orphanReceipts = receiptsInWindow.filter(
     (r) =>
       r.payment_path === "AMEX" &&
       r.status !== "archived" &&
       r.status !== "exported" &&
+      r.status !== "reconciled" &&
       !r.deleted_at &&
-      (!r.transaction_date || r.transaction_date.startsWith(month)) &&
       !linkedReceiptIds.has(r.id) &&
       !suggestedReceiptIds.has(r.id),
   );
@@ -86,6 +90,8 @@ export default async function ReconcilePage({
         orphanReceipts={orphanReceipts}
         month={month}
         finalized={reconciliation?.status === "finalized"}
+        window={window}
+        receiptsInWindow={receiptsInWindow}
       />
     </div>
   );

--- a/components/receipts/reconciliation-table.tsx
+++ b/components/receipts/reconciliation-table.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import type { AmexStatementLine, ReceiptRecord } from "@/lib/receipts/types";
 import type { ReconciliationMatch } from "@/lib/receipts/types";
+import type { StatementWindow } from "@/lib/receipts/statement-window";
 import {
   EXPENSE_CATEGORIES,
   requiresAttendees as categoryRequiresAttendees,
@@ -18,6 +19,8 @@ interface ReconciliationTableProps {
   orphanReceipts: ReceiptRecord[];
   month: string;
   finalized?: boolean;
+  window?: StatementWindow;
+  receiptsInWindow?: ReceiptRecord[];
 }
 
 export function ReconciliationTable({
@@ -27,6 +30,8 @@ export function ReconciliationTable({
   orphanReceipts,
   month,
   finalized,
+  window: stmtWindow,
+  receiptsInWindow,
 }: ReconciliationTableProps) {
   const router = useRouter();
   const [busy, setBusy] = useState<string | null>(null);
@@ -305,6 +310,9 @@ export function ReconciliationTable({
     return 0;
   });
 
+  // Receipts available in the manual selector — scoped to window
+  const selectorReceipts = receiptsInWindow ?? receipts;
+
   return (
     <div className="space-y-6">
       {error && (
@@ -515,7 +523,7 @@ export function ReconciliationTable({
                       }}
                     >
                       <option value="">— Manually link a receipt —</option>
-                      {receipts
+                      {selectorReceipts
                         .filter((r) => r.payment_path === "AMEX")
                         .map((r) => (
                           <option key={r.id} value={r.id}>

--- a/components/receipts/reconciliation-table.tsx
+++ b/components/receipts/reconciliation-table.tsx
@@ -315,6 +315,13 @@ export function ReconciliationTable({
 
   return (
     <div className="space-y-6">
+      {stmtWindow && (
+        <p className="text-xs text-gray-500">
+          Statement window: {stmtWindow.start} → {stmtWindow.end}
+          {stmtWindow.source === "fallback" && " (estimated — no lines imported)"}
+        </p>
+      )}
+
       {error && (
         <div className="rounded-xl border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
           {error}

--- a/lib/receipts/reconciliation.ts
+++ b/lib/receipts/reconciliation.ts
@@ -79,7 +79,8 @@ export function matchAmexToReceipts(
     (r) =>
       r.deleted_at === null &&
       r.status !== "archived" &&
-      r.status !== "exported",
+      r.status !== "exported" &&
+      r.status !== "reconciled",
   );
 
   // Phase 1: compute best candidate per AMEX line

--- a/lib/receipts/statement-window.ts
+++ b/lib/receipts/statement-window.ts
@@ -1,0 +1,56 @@
+import type { AmexStatementLine, ReceiptRecord } from "./types";
+
+export interface StatementWindow {
+  start: string; // YYYY-MM-DD
+  end: string;   // YYYY-MM-DD
+}
+
+/**
+ * Derive a statement window from actual line transaction dates.
+ *
+ * When lines have valid dates, the window spans [min - slack, max + slack].
+ * When no valid dates exist, falls back to a calendar heuristic:
+ *   month-1 25th → month+3days (e.g. "2026-03" → 2026-02-25 … 2026-03-03).
+ */
+export function deriveStatementWindow(
+  lines: AmexStatementLine[],
+  statementMonth: string,
+  slackDays = 5,
+): StatementWindow {
+  const dates = lines
+    .map((l) => l.transaction_date)
+    .filter((d): d is string => !!d)
+    .sort();
+
+  if (dates.length > 0) {
+    const min = new Date(dates[0]!);
+    const max = new Date(dates[dates.length - 1]!);
+    min.setDate(min.getDate() - slackDays);
+    max.setDate(max.getDate() + slackDays);
+    return { start: iso(min), end: iso(max) };
+  }
+
+  // Calendar heuristic fallback
+  const [yearStr, monthStr] = statementMonth.split("-");
+  const year = Number(yearStr);
+  const month = Number(monthStr); // 1-based
+
+  const start = new Date(Date.UTC(year, month - 2, 25)); // previous month 25th
+  const end = new Date(Date.UTC(year, month - 1, 3));    // current month 3rd
+  return { start: iso(start), end: iso(end) };
+}
+
+function iso(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * True if the receipt has no date or its transaction_date falls within [start, end].
+ */
+export function isReceiptInWindow(
+  receipt: ReceiptRecord,
+  window: StatementWindow,
+): boolean {
+  if (!receipt.transaction_date) return true;
+  return receipt.transaction_date >= window.start && receipt.transaction_date <= window.end;
+}

--- a/lib/receipts/statement-window.ts
+++ b/lib/receipts/statement-window.ts
@@ -3,14 +3,24 @@ import type { AmexStatementLine, ReceiptRecord } from "./types";
 export interface StatementWindow {
   start: string; // YYYY-MM-DD
   end: string;   // YYYY-MM-DD
+  source: "lines" | "fallback";
 }
 
 /**
  * Derive a statement window from actual line transaction dates.
  *
- * When lines have valid dates, the window spans [min - slack, max + slack].
- * When no valid dates exist, falls back to a calendar heuristic:
- *   month-1 25th → month+3days (e.g. "2026-03" → 2026-02-25 … 2026-03-03).
+ * Saison/Netアンサー statements are labelled by the month they're due, but
+ * the transactions they contain post over the prior ~6 weeks. A March
+ * statement covers charges from roughly late December through early
+ * February — never March itself.
+ *
+ * When lines have valid dates, the window spans [min - slack, max + slack]
+ * (source: "lines").
+ *
+ * When no lines have dates (statement not yet uploaded, or parse failed),
+ * fall back to a calendar heuristic of (month-3, day 20) through
+ * (month-1, day 10) — e.g. "2026-03" → 2025-12-20 … 2026-02-10
+ * (source: "fallback").
  */
 export function deriveStatementWindow(
   lines: AmexStatementLine[],
@@ -27,17 +37,18 @@ export function deriveStatementWindow(
     const max = new Date(dates[dates.length - 1]!);
     min.setDate(min.getDate() - slackDays);
     max.setDate(max.getDate() + slackDays);
-    return { start: iso(min), end: iso(max) };
+    return { start: iso(min), end: iso(max), source: "lines" };
   }
 
-  // Calendar heuristic fallback
+  // Calendar heuristic fallback. Date.UTC normalizes negative month indices
+  // into prior years, so e.g. Date.UTC(2026, -1, 20) → 2025-12-20.
   const [yearStr, monthStr] = statementMonth.split("-");
   const year = Number(yearStr);
   const month = Number(monthStr); // 1-based
 
-  const start = new Date(Date.UTC(year, month - 2, 25)); // previous month 25th
-  const end = new Date(Date.UTC(year, month - 1, 3));    // current month 3rd
-  return { start: iso(start), end: iso(end) };
+  const start = new Date(Date.UTC(year, month - 4, 20));
+  const end = new Date(Date.UTC(year, month - 2, 10));
+  return { start: iso(start), end: iso(end), source: "fallback" };
 }
 
 function iso(d: Date): string {
@@ -49,7 +60,7 @@ function iso(d: Date): string {
  */
 export function isReceiptInWindow(
   receipt: ReceiptRecord,
-  window: StatementWindow,
+  window: { start: string; end: string },
 ): boolean {
   if (!receipt.transaction_date) return true;
   return receipt.transaction_date >= window.start && receipt.transaction_date <= window.end;

--- a/tests/receipts/reconciliation.test.ts
+++ b/tests/receipts/reconciliation.test.ts
@@ -216,6 +216,29 @@ test("refund line does not greedily match unrelated positive receipts", () => {
   assert.equal(matches.length, 0);
 });
 
+test("reconciled receipts are excluded from matching", () => {
+  const lines = [makeAmexLine()];
+  const receipts = [makeReceipt({ status: "reconciled" })];
+  const matches = matchAmexToReceipts(lines, receipts);
+  assert.equal(matches.length, 0, "reconciled receipts must not be matched");
+});
+
+test("needs_review and captured receipts remain eligible", () => {
+  const lines = [
+    makeAmexLine({ id: "line-a", transaction_date: "2024-01-15" }),
+  ];
+  const receipts = [
+    makeReceipt({ id: "r-needs", status: "needs_review", transaction_date: "2024-01-15" }),
+    makeReceipt({ id: "r-captured", status: "captured", transaction_date: "2024-01-15" }),
+  ];
+  const matches = matchAmexToReceipts(lines, receipts);
+  assert.equal(matches.length, 1, "one of the eligible receipts should match");
+  assert.ok(
+    matches[0]!.receiptId === "r-needs" || matches[0]!.receiptId === "r-captured",
+    "matched receipt should be either needs_review or captured",
+  );
+});
+
 test("soft-deleted receipts are excluded from matching (defense-in-depth)", () => {
   const lines = [makeAmexLine()];
   const receipts = [makeReceipt({ deleted_at: "2024-01-20T00:00:00Z" })];

--- a/tests/receipts/statement-window.test.ts
+++ b/tests/receipts/statement-window.test.ts
@@ -81,12 +81,17 @@ function makeReceipt(overrides: Partial<ReceiptRecord> = {}): ReceiptRecord {
 // ─── deriveStatementWindow ─────────────────────────────────────────────────
 
 test("fallback window when no lines have dates", () => {
-  const lines = [makeLine({ transaction_date: "" as unknown as string })];
-  // Force transaction_date to falsy
-  lines[0]!.transaction_date = "" as unknown as string;
   const w = deriveStatementWindow([], "2026-03");
-  assert.equal(w.start, "2026-02-25");
-  assert.equal(w.end, "2026-03-03");
+  assert.equal(w.start, "2025-12-20");
+  assert.equal(w.end, "2026-02-10");
+  assert.equal(w.source, "fallback");
+});
+
+test("fallback window crosses year boundary for January statement", () => {
+  const w = deriveStatementWindow([], "2026-01");
+  assert.equal(w.start, "2025-10-20");
+  assert.equal(w.end, "2025-12-10");
+  assert.equal(w.source, "fallback");
 });
 
 test("data-driven window from line dates with default slack=5", () => {
@@ -98,6 +103,7 @@ test("data-driven window from line dates with default slack=5", () => {
   const w = deriveStatementWindow(lines, "2026-03");
   assert.equal(w.start, "2026-01-23"); // 2026-01-28 - 5
   assert.equal(w.end, "2026-02-10");    // 2026-02-05 + 5
+  assert.equal(w.source, "lines");
 });
 
 test("data-driven window with mixed null dates ignores nulls", () => {
@@ -109,6 +115,7 @@ test("data-driven window with mixed null dates ignores nulls", () => {
   const w = deriveStatementWindow(lines, "2026-03", 3);
   assert.equal(w.start, "2026-01-29"); // 2026-02-01 - 3
   assert.equal(w.end, "2026-02-13");    // 2026-02-10 + 3
+  assert.equal(w.source, "lines");
 });
 
 // ─── isReceiptInWindow ────────────────────────────────────────────────────

--- a/tests/receipts/statement-window.test.ts
+++ b/tests/receipts/statement-window.test.ts
@@ -1,0 +1,140 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  deriveStatementWindow,
+  isReceiptInWindow,
+} from "@/lib/receipts/statement-window";
+import type { AmexStatementLine, ReceiptRecord } from "@/lib/receipts/types";
+
+function makeLine(overrides: Partial<AmexStatementLine> = {}): AmexStatementLine {
+  return {
+    id: "line-1",
+    statement_month: "2026-03",
+    transaction_date: "2026-02-01",
+    posting_date: null,
+    merchant: "TEST",
+    amount_minor: 1000,
+    currency: "JPY",
+    amex_reference: null,
+    matched_receipt_id: null,
+    match_status: "unmatched",
+    raw_json: "{}",
+    created_at: "2026-02-01T00:00:00Z",
+    statement_artifact_id: null,
+    cardholder_name: null,
+    cardholder_flag: null,
+    payment_type: null,
+    prepayment_flag: null,
+    memo: null,
+    raw_csv_line_number: null,
+    source_file_sha256: null,
+    imported_at: null,
+    expense_category: "unknown",
+    category_status: "uncategorized",
+    receipt_status: "missing_receipt",
+    receipt_missing_reason: null,
+    business_trip_id: null,
+    business_trip_status: "not_applicable",
+    expense_category_code: null,
+    re_review_needed: 0,
+    updated_at: null,
+    ...overrides,
+  };
+}
+
+function makeReceipt(overrides: Partial<ReceiptRecord> = {}): ReceiptRecord {
+  return {
+    id: "r-1",
+    captured_at: "2026-01-01T00:00:00Z",
+    captured_by: "test@example.com",
+    source: "mobile_capture",
+    original_filename: "receipt.jpg",
+    payment_path: "AMEX",
+    expense_type: "misc",
+    transaction_date: "2026-02-01",
+    merchant: "TEST",
+    amount_minor: 1000,
+    currency: "JPY",
+    tax_amount_minor: null,
+    business_purpose: null,
+    alcohol_present: 0,
+    attendees_required: 0,
+    status: "needs_review",
+    original_r2_key: "receipts/r-1/file.jpg",
+    original_sha256: "abc",
+    original_content_type: "image/jpeg",
+    original_size_bytes: 1000,
+    processed_r2_key: null,
+    extraction_json: null,
+    legacy: 0,
+    exported_month: null,
+    expense_category_code: null,
+    deleted_at: null,
+    deleted_by: null,
+    delete_reason: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+// ─── deriveStatementWindow ─────────────────────────────────────────────────
+
+test("fallback window when no lines have dates", () => {
+  const lines = [makeLine({ transaction_date: "" as unknown as string })];
+  // Force transaction_date to falsy
+  lines[0]!.transaction_date = "" as unknown as string;
+  const w = deriveStatementWindow([], "2026-03");
+  assert.equal(w.start, "2026-02-25");
+  assert.equal(w.end, "2026-03-03");
+});
+
+test("data-driven window from line dates with default slack=5", () => {
+  const lines = [
+    makeLine({ transaction_date: "2026-01-28" }),
+    makeLine({ transaction_date: "2026-02-05" }),
+    makeLine({ transaction_date: "2026-01-30" }),
+  ];
+  const w = deriveStatementWindow(lines, "2026-03");
+  assert.equal(w.start, "2026-01-23"); // 2026-01-28 - 5
+  assert.equal(w.end, "2026-02-10");    // 2026-02-05 + 5
+});
+
+test("data-driven window with mixed null dates ignores nulls", () => {
+  const lines = [
+    makeLine({ transaction_date: "2026-02-01" }),
+    makeLine({ transaction_date: "" as unknown as string }),
+    makeLine({ transaction_date: "2026-02-10" }),
+  ];
+  const w = deriveStatementWindow(lines, "2026-03", 3);
+  assert.equal(w.start, "2026-01-29"); // 2026-02-01 - 3
+  assert.equal(w.end, "2026-02-13");    // 2026-02-10 + 3
+});
+
+// ─── isReceiptInWindow ────────────────────────────────────────────────────
+
+test("isReceiptInWindow: dateless receipt always in window", () => {
+  const w = { start: "2026-01-25", end: "2026-02-10" };
+  assert.ok(isReceiptInWindow(makeReceipt({ transaction_date: null }), w));
+});
+
+test("isReceiptInWindow: date within window returns true", () => {
+  const w = { start: "2026-01-25", end: "2026-02-10" };
+  assert.ok(isReceiptInWindow(makeReceipt({ transaction_date: "2026-02-01" }), w));
+});
+
+test("isReceiptInWindow: date before window returns false", () => {
+  const w = { start: "2026-01-25", end: "2026-02-10" };
+  assert.ok(!isReceiptInWindow(makeReceipt({ transaction_date: "2026-01-20" }), w));
+});
+
+test("isReceiptInWindow: date after window returns false", () => {
+  const w = { start: "2026-01-25", end: "2026-02-10" };
+  assert.ok(!isReceiptInWindow(makeReceipt({ transaction_date: "2026-02-15" }), w));
+});
+
+test("isReceiptInWindow: exact boundary dates are inclusive", () => {
+  const w = { start: "2026-01-25", end: "2026-02-10" };
+  assert.ok(isReceiptInWindow(makeReceipt({ transaction_date: "2026-01-25" }), w));
+  assert.ok(isReceiptInWindow(makeReceipt({ transaction_date: "2026-02-10" }), w));
+});


### PR DESCRIPTION
## Summary

Match receipts to AMEX statements using a data-driven date window instead of
the calendar-month label. A "March" Saison statement covers charges from
roughly late December through early February — never March itself — so the
old `r.transaction_date.startsWith(month)` orphan filter silently hid every
in-window receipt.

- New `lib/receipts/statement-window.ts` with `deriveStatementWindow` and
  `isReceiptInWindow`. Window is derived from `min..max` of the imported
  line dates plus a configurable slack (default ±5 days); falls back to a
  calendar heuristic `(month-3, day 20) → (month-1, day 10)` when no
  dated lines exist. `source: "lines" | "fallback"` is surfaced so the UI
  can flag the estimated case.
- Reconcile page scopes both the matcher and the orphan list to receipts
  inside the window. The manual receipt selector in each pending card is
  also scoped.
- Matcher now excludes `status === "reconciled"` receipts, closing a
  cross-statement leak where a receipt confirmed against the March
  statement was still suggested on the April page.
- Reconciliation table renders the resolved window as a caption above the
  tables so the operator can sanity-check the range.

## Test plan

- [x] `npm test` — 129/129 pass (+11 new: statement-window + reconciled-exclusion)
- [x] `npx tsc --noEmit -p tsconfig.json` clean
- [ ] Manual: visit `/receipts/reconcile?month=2026-03` with March CSV imported, confirm caption shows window in Dec–Feb range
- [ ] Manual: visit `/receipts/reconcile?month=2026-06` with no statement, confirm caption shows "(estimated — no lines imported)"
- [ ] Manual: confirm a receipt on March statement, visit April page, verify the receipt is no longer suggested or shown as orphan
- [ ] Manual: dateless receipt appears as orphan on every month's page

https://claude.ai/code/session_01HWcVb7UpRAbcaZuX8BL64i

---
_Generated by [Claude Code](https://claude.ai/code/session_01HWcVb7UpRAbcaZuX8BL64i)_