### PR TITLE
Month switcher + smart default for reconciliation page

### DIFF
--- a/app/(receipt-system)/receipts/amex/page.tsx
+++ b/app/(receipt-system)/receipts/amex/page.tsx
@@ -79,7 +79,7 @@ export default async function AmexPage({
           </dl>
           <div className="mt-4 text-center">
             <a
-              href="/receipts/reconcile"
+              href={`/receipts/reconcile?month=${month}`}
               className="text-sm text-amber-600 underline hover:text-amber-700"
             >
               Open reconciliation →

--- a/app/(receipt-system)/receipts/reconcile/page.tsx
+++ b/app/(receipt-system)/receipts/reconcile/page.tsx
@@ -2,12 +2,14 @@ import {
   listAmexLines,
   listReceiptRecords,
   getReconciliationForMonth,
+  listAmexLineCountsByMonth,
+  listReconciliationStatusByMonth,
 } from "@/lib/receipts/db";
 import { matchAmexToReceipts } from "@/lib/receipts/reconciliation";
 import { deriveStatementWindow, isReceiptInWindow } from "@/lib/receipts/statement-window";
 import { ReconciliationTable } from "@/components/receipts/reconciliation-table";
+import { MonthSwitcher, type MonthOption } from "@/components/receipts/month-switcher";
 import { assertReceiptsPageAccess } from "@/lib/receipts/auth-request";
-import type { AmexReconciliation } from "@/lib/receipts/types";
 
 export const dynamic = "force-dynamic";
 
@@ -19,7 +21,29 @@ export default async function ReconcilePage({
   await assertReceiptsPageAccess();
 
   const params = await searchParams;
-  const month = String(params.month ?? new Date().toISOString().slice(0, 7));
+  const requestedMonth = typeof params.month === "string" ? params.month : null;
+
+  const [lineCountsByMonth, reconciliationStatusByMonth] = await Promise.all([
+    listAmexLineCountsByMonth(),
+    listReconciliationStatusByMonth(),
+  ]);
+
+  const availableMonths: MonthOption[] = [...lineCountsByMonth.entries()]
+    .map(([month, counts]) => ({
+      month,
+      lineCount: counts.total,
+      unmatchedCount: counts.unmatched,
+      status: reconciliationStatusByMonth.get(month) ?? null,
+    }))
+    .sort((a, b) => a.month.localeCompare(b.month));
+
+  // Default to the latest month with lines if no explicit ?month=, falling back
+  // to today's calendar month only if nothing has been imported yet.
+  const month =
+    requestedMonth ??
+    (availableMonths.length > 0
+      ? availableMonths[availableMonths.length - 1]!.month
+      : new Date().toISOString().slice(0, 7));
 
   const [amexLines, receipts, reconciliation] = await Promise.all([
     listAmexLines(month),
@@ -51,48 +75,113 @@ export default async function ReconcilePage({
       !suggestedReceiptIds.has(r.id),
   );
 
+  const counts = {
+    total: amexLines.length,
+    confirmed: amexLines.filter((l) => l.match_status === "confirmed").length,
+    pending: amexLines.filter(
+      (l) => l.match_status === "unmatched" || l.match_status === "matched",
+    ).length,
+    noReceipt: amexLines.filter((l) => l.match_status === "no_receipt").length,
+    orphans: orphanReceipts.length,
+  };
+
   return (
     <div className="space-y-6">
       <div>
         <h2 className="text-2xl font-semibold text-gray-900">Reconciliation</h2>
         <p className="mt-1 text-sm text-gray-500">
-          Match AMEX statement lines to captured receipts for {month}.
+          Match AMEX statement lines to captured receipts.
         </p>
       </div>
 
-      {reconciliation?.status === "finalized" && (
-        <div className="rounded-2xl border border-green-200 bg-green-50 p-4">
-          <p className="text-sm font-semibold text-green-800">
-            Reconciliation signed off
+      <MonthSwitcher
+        months={availableMonths}
+        activeMonth={month}
+        basePath="/receipts/reconcile"
+      />
+
+      {amexLines.length === 0 ? (
+        <div className="rounded-2xl border border-gray-200 bg-white p-6 text-center shadow-sm">
+          <p className="text-sm text-gray-600">
+            No AMEX lines found for <span className="font-mono">{month}</span>.
           </p>
-          <p className="mt-1 text-xs text-green-700">
-            Finalized by {reconciliation.finalized_by} at {reconciliation.finalized_at}
-            {" — "}{reconciliation.line_count} lines ({reconciliation.matched_count} matched, {reconciliation.no_receipt_count} no receipt)
-          </p>
-          {reconciliation.manifest_sha256 && (
-            <p className="mt-1 text-xs font-mono text-green-600">
-              SHA-256: {reconciliation.manifest_sha256}
-            </p>
-          )}
           <a
-            href={`/api/receipts/reconcile/${month}/manifest`}
-            className="mt-2 inline-block text-xs font-medium text-amber-700 hover:text-amber-800 underline"
+            href="/receipts/amex"
+            className="mt-3 inline-block rounded-xl bg-amber-500 px-4 py-2 text-sm font-semibold text-white hover:bg-amber-600"
           >
-            Download manifest CSV
+            Import a statement CSV
           </a>
         </div>
-      )}
+      ) : (
+        <>
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-5">
+            <StatBox label="Total lines" value={counts.total} />
+            <StatBox label="Pending" value={counts.pending} warn={counts.pending > 0} />
+            <StatBox label="Confirmed" value={counts.confirmed} good={counts.confirmed > 0} />
+            <StatBox label="No receipt" value={counts.noReceipt} />
+            <StatBox label="Orphan receipts" value={counts.orphans} warn={counts.orphans > 0} />
+          </div>
 
-      <ReconciliationTable
-        amexLines={amexLines}
-        receipts={receipts}
-        autoMatches={autoMatches}
-        orphanReceipts={orphanReceipts}
-        month={month}
-        finalized={reconciliation?.status === "finalized"}
-        window={window}
-        receiptsInWindow={receiptsInWindow}
-      />
+          {reconciliation?.status === "finalized" && (
+            <div className="rounded-2xl border border-green-200 bg-green-50 p-4">
+              <p className="text-sm font-semibold text-green-800">
+                Reconciliation signed off
+              </p>
+              <p className="mt-1 text-xs text-green-700">
+                Finalized by {reconciliation.finalized_by} at {reconciliation.finalized_at}
+                {" — "}{reconciliation.line_count} lines ({reconciliation.matched_count} matched, {reconciliation.no_receipt_count} no receipt)
+              </p>
+              {reconciliation.manifest_sha256 && (
+                <p className="mt-1 text-xs font-mono text-green-600">
+                  SHA-256: {reconciliation.manifest_sha256}
+                </p>
+              )}
+              <a
+                href={`/api/receipts/reconcile/${month}/manifest`}
+                className="mt-2 inline-block text-xs font-medium text-amber-700 hover:text-amber-800 underline"
+              >
+                Download manifest CSV
+              </a>
+            </div>
+          )}
+
+          <ReconciliationTable
+            amexLines={amexLines}
+            receipts={receipts}
+            autoMatches={autoMatches}
+            orphanReceipts={orphanReceipts}
+            month={month}
+            finalized={reconciliation?.status === "finalized"}
+            window={window}
+            receiptsInWindow={receiptsInWindow}
+          />
+        </>
+      )}
+    </div>
+  );
+}
+
+function StatBox({
+  label,
+  value,
+  warn = false,
+  good = false,
+}: {
+  label: string;
+  value: number;
+  warn?: boolean;
+  good?: boolean;
+}) {
+  const valueClass =
+    warn && value > 0
+      ? "text-amber-600"
+      : good && value > 0
+        ? "text-green-700"
+        : "text-gray-900";
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-3 text-center shadow-sm">
+      <p className={`text-2xl font-bold ${valueClass}`}>{value}</p>
+      <p className="text-xs text-gray-500">{label}</p>
     </div>
   );
 }

--- a/components/receipts/month-switcher.tsx
+++ b/components/receipts/month-switcher.tsx
@@ -1,0 +1,162 @@
+import Link from "next/link";
+
+export interface MonthOption {
+  month: string;
+  lineCount: number;
+  unmatchedCount: number;
+  status: "draft" | "finalized" | null;
+}
+
+interface MonthSwitcherProps {
+  months: MonthOption[];
+  activeMonth: string;
+  basePath: string;
+}
+
+export function MonthSwitcher({ months, activeMonth, basePath }: MonthSwitcherProps) {
+  if (months.length === 0) {
+    return (
+      <div className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+        No AMEX statements imported yet.{" "}
+        <Link href="/receipts/amex" className="font-medium underline hover:text-amber-900">
+          Upload one
+        </Link>{" "}
+        to start reconciling.
+      </div>
+    );
+  }
+
+  const activeIndex = months.findIndex((m) => m.month === activeMonth);
+  const prevMonth = activeIndex > 0 ? months[activeIndex - 1]!.month : null;
+  const nextMonth =
+    activeIndex >= 0 && activeIndex < months.length - 1
+      ? months[activeIndex + 1]!.month
+      : null;
+
+  const isActiveInList = activeIndex >= 0;
+
+  return (
+    <div className="rounded-2xl border border-gray-200 bg-white p-3 shadow-sm">
+      <div className="flex items-center gap-2 overflow-x-auto">
+        <NavArrow
+          href={prevMonth ? `${basePath}?month=${prevMonth}` : null}
+          direction="prev"
+        />
+        <div className="flex flex-1 flex-wrap items-center gap-2">
+          {months.map((m) => (
+            <MonthPill
+              key={m.month}
+              option={m}
+              active={m.month === activeMonth}
+              basePath={basePath}
+            />
+          ))}
+          {!isActiveInList && (
+            <span className="rounded-xl border border-dashed border-gray-300 px-3 py-1.5 text-xs text-gray-500">
+              {activeMonth} (no statement)
+            </span>
+          )}
+        </div>
+        <NavArrow
+          href={nextMonth ? `${basePath}?month=${nextMonth}` : null}
+          direction="next"
+        />
+      </div>
+    </div>
+  );
+}
+
+function MonthPill({
+  option,
+  active,
+  basePath,
+}: {
+  option: MonthOption;
+  active: boolean;
+  basePath: string;
+}) {
+  const base =
+    "flex items-center gap-2 rounded-xl px-3 py-1.5 text-xs font-medium transition-colors whitespace-nowrap";
+  const style = active
+    ? "bg-amber-500 text-white hover:bg-amber-600"
+    : "bg-gray-50 text-gray-700 hover:bg-gray-100 border border-gray-200";
+
+  return (
+    <Link href={`${basePath}?month=${option.month}`} className={`${base} ${style}`}>
+      <span className="font-semibold">{option.month}</span>
+      <span className={active ? "text-amber-50" : "text-gray-500"}>
+        {option.lineCount} line{option.lineCount !== 1 ? "s" : ""}
+      </span>
+      <StatusDot status={option.status} unmatchedCount={option.unmatchedCount} active={active} />
+    </Link>
+  );
+}
+
+function StatusDot({
+  status,
+  unmatchedCount,
+  active,
+}: {
+  status: "draft" | "finalized" | null;
+  unmatchedCount: number;
+  active: boolean;
+}) {
+  if (status === "finalized") {
+    return (
+      <span
+        className={`inline-flex h-4 w-4 items-center justify-center rounded-full text-[10px] ${
+          active ? "bg-white text-amber-600" : "bg-green-100 text-green-700"
+        }`}
+        title="Signed off"
+      >
+        ✓
+      </span>
+    );
+  }
+  if (unmatchedCount > 0) {
+    return (
+      <span
+        className={`inline-flex h-4 min-w-[1rem] items-center justify-center rounded-full px-1 text-[10px] ${
+          active ? "bg-white text-amber-700" : "bg-amber-100 text-amber-700"
+        }`}
+        title={`${unmatchedCount} unresolved`}
+      >
+        {unmatchedCount}
+      </span>
+    );
+  }
+  return (
+    <span
+      className={`inline-block h-2 w-2 rounded-full ${
+        active ? "bg-white" : "bg-gray-300"
+      }`}
+      title="All lines resolved"
+    />
+  );
+}
+
+function NavArrow({
+  href,
+  direction,
+}: {
+  href: string | null;
+  direction: "prev" | "next";
+}) {
+  const symbol = direction === "prev" ? "‹" : "›";
+  if (!href) {
+    return (
+      <span className="rounded-lg px-2 py-1 text-gray-300" aria-hidden>
+        {symbol}
+      </span>
+    );
+  }
+  return (
+    <Link
+      href={href}
+      className="rounded-lg px-2 py-1 text-gray-500 hover:bg-gray-100 hover:text-gray-700"
+      aria-label={direction === "prev" ? "Previous month" : "Next month"}
+    >
+      {symbol}
+    </Link>
+  );
+}

--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -1286,6 +1286,65 @@ export async function getReconciliationForMonth(
     .first<AmexReconciliation>();
 }
 
+export async function listReconciliationStatusByMonth(): Promise<
+  Map<string, "draft" | "finalized">
+> {
+  const db = getReceiptsDb();
+  const result = await db
+    .prepare(
+      `SELECT statement_month, status FROM amex_reconciliations
+       WHERE status = 'finalized'
+       UNION
+       SELECT statement_month, MAX(status) AS status FROM amex_reconciliations
+       WHERE status = 'draft'
+       GROUP BY statement_month`,
+    )
+    .all<{ statement_month: string; status: "draft" | "finalized" }>();
+  const map = new Map<string, "draft" | "finalized">();
+  for (const r of result.results ?? []) {
+    const prev = map.get(r.statement_month);
+    if (prev === "finalized") continue;
+    map.set(r.statement_month, r.status);
+  }
+  return map;
+}
+
+export async function listAmexLineCountsByMonth(): Promise<
+  Map<string, { total: number; confirmed: number; unmatched: number; noReceipt: number }>
+> {
+  const db = getReceiptsDb();
+  const result = await db
+    .prepare(
+      `SELECT statement_month,
+              COUNT(*) AS total,
+              SUM(CASE WHEN match_status = 'confirmed' THEN 1 ELSE 0 END) AS confirmed,
+              SUM(CASE WHEN match_status IN ('unmatched','matched') THEN 1 ELSE 0 END) AS unmatched,
+              SUM(CASE WHEN match_status = 'no_receipt' THEN 1 ELSE 0 END) AS noReceipt
+       FROM amex_statement_lines
+       GROUP BY statement_month`,
+    )
+    .all<{
+      statement_month: string;
+      total: number;
+      confirmed: number;
+      unmatched: number;
+      noReceipt: number;
+    }>();
+  const map = new Map<
+    string,
+    { total: number; confirmed: number; unmatched: number; noReceipt: number }
+  >();
+  for (const r of result.results ?? []) {
+    map.set(r.statement_month, {
+      total: r.total,
+      confirmed: r.confirmed,
+      unmatched: r.unmatched,
+      noReceipt: r.noReceipt,
+    });
+  }
+  return map;
+}
+
 export async function createReconciliationDraft(
   month: string,
   lineCount: number,


### PR DESCRIPTION
## Summary

The reconcile page silently defaulted to today's calendar month with no way
to switch months in the UI. Operators with statements imported for prior
months saw an empty "No AMEX lines found" message and no path forward, even
though their data was right there. This PR adds month navigation plus the
operator stats the page was missing.

- **MonthSwitcher** (server component, no client JS) — pill row of every
  month that has imported lines, each showing line count, finalized
  checkmark, and an unmatched-line badge so you can see at a glance which
  months still need work. Prev/next arrows flank the row.
- **Smart default month** — lands on the latest month with lines instead of
  today's calendar month. Explicit `?month=` still wins.
- **Empty-state CTA** — when a month genuinely has no statement, link
  straight back to `/receipts/amex` to import one.
- **Stats strip** — total / pending / confirmed / no receipt / orphan
  counts above the reconciliation table.
- **AMEX page link fixed** — "Open reconciliation →" now carries the
  selected month instead of dropping it.

Two new DB helpers (`listAmexLineCountsByMonth`,
`listReconciliationStatusByMonth`) — single round-trip each, no N+1.

## Test plan

- [x] `npm test` — 129/129 pass
- [x] `npx tsc --noEmit -p tsconfig.json` clean
- [ ] Manual: visit `/receipts/reconcile` with 3 statements imported (Feb/Mar/Apr) and today = May. Verify it lands on Apr by default, switcher shows all three pills with counts, prev/next arrows navigate
- [ ] Manual: click `/receipts/amex` "Open reconciliation →" — confirm it lands on the month that page is showing
- [ ] Manual: sign off a month — verify the green checkmark appears on that pill in the switcher
- [ ] Manual: visit `/receipts/reconcile?month=2026-09` with no statement — empty-state shows the "Import a statement CSV" CTA

https://claude.ai/code/session_01HWcVb7UpRAbcaZuX8BL64i

---
_Generated by [Claude Code](https://claude.ai/code/session_01HWcVb7UpRAbcaZuX8BL64i)_