### PR TITLE
docs(receipts): design handoff package for end-to-end UI/UX

### DIFF
--- a/docs/design-handoff/01-brief.md
+++ b/docs/design-handoff/01-brief.md
@@ -1,0 +1,48 @@
+# Brief — Receipts System UI/UX
+
+## What it is
+
+An internal expense-tracking module embedded in the Dazbeez marketing site, used by Dazbeez staff to:
+
+1. Capture business receipts (paper photos, digital records).
+2. Reconcile them against monthly AMEX statements imported from Netアンサー (Japanese AMEX online portal).
+3. Categorize expenses with attendees and business purpose where required by Japanese tax law.
+4. Export a finalized, immutable monthly bundle (CSV manifest + receipt archive) for accounting.
+
+It is **not** a public-facing product. Auth is Cloudflare Access JWT in production, with a trusted-device cookie path for repeated phone use, and Basic auth as a local-dev fallback.
+
+## Who uses it
+
+- **Primary user:** David (founder), capturing receipts on iPhone in the moment (restaurant, taxi, hotel) and reconciling on desktop monthly.
+- **Secondary user:** A bookkeeper / accountant role that may review and finalize exports. Not yet a real persona but design should leave room.
+- **Mobile vs desktop split:** Capture is ~95% phone. Review / reconcile / export is ~95% desktop. AMEX import is desktop-only (needs a CSV file).
+
+## Domain model in one paragraph
+
+A **receipt record** is one expense, created by uploading a photo to R2 and writing a row in D1. Google Cloud Vision OCRs the image and prefills merchant, date, amount, currency, and expense type. The user reviews and fills in payment path (AMEX/CASH/DIGITAL), expense category (14-item Japanese tax catalog), business purpose, and attendees (required for entertainment/meeting categories). Separately, monthly AMEX statements arrive as CSV; each statement line either matches an existing receipt (auto-matched by merchant fuzzy logic + date window) or flags a missing receipt. Reconciliation locks the month. Export generates a CSV + ZIP, stages to R2, and finalizes (immutable).
+
+## Success criteria for this UI/UX engagement
+
+1. **Capture takes under 10 seconds on phone** from app open to "saved" confirmation, including reasonable upload time.
+2. **Review feels like editing a form, not filling out a tax return** — sensible defaults, attendees autocomplete, image always visible alongside fields.
+3. **Reconciliation feels like email triage**, not spreadsheet work — fast confirm/skip/categorize keystrokes, batch operations where safe.
+4. **Export shows a single clear blocker count** before allowing finalize, with one-click navigation to fix each blocker.
+5. **The whole thing looks like Dazbeez** — bee theme (amber + charcoal), Inter font, rounded-xl/2xl, consistent with the marketing site in `docs/ui-ux.md`.
+
+## Hard constraints
+
+- **Framework:** Next.js 16.2.3 App Router. **No `getStaticProps`, no Pages Router patterns.** Read `node_modules/next/dist/docs/` if unsure — this is not the Next.js you know.
+- **Styling:** Tailwind CSS only. No CSS-in-JS, no styled-components.
+- **Server-first:** Default to server components. Add `"use client"` only where interactivity demands it (forms, drag-drop, live tables).
+- **Theme:** Inherit `app/globals.css` — `--bee-yellow #F59E0B`, `--bee-charcoal #111827`, focus ring already defined.
+- **Mobile-first:** Capture must work one-handed on iPhone. Use `<input type="file" capture="environment">` where the native camera is the right primitive.
+- **No new deps without justification.** No PDF lib, no chart lib, no UI framework (no shadcn/Radix/HeadlessUI in current bundle — check before adding).
+- **No live infrastructure access** during design work — see README.md "Working environment rules".
+
+## Out of scope for this engagement
+
+- Backend logic changes (matching algorithm, OCR, export format) — the plumbing works.
+- Auth flow changes — Cloudflare Access is owned by the Mac side.
+- New entity types (no projects, no clients, no budgets).
+- i18n — the catalog is bilingual JA/EN but the UI is English-only for now.
+- Accessibility audit beyond the basics (focus rings exist, semantic HTML, keyboard nav for the two complex screens).

--- a/docs/design-handoff/02-current-state.md
+++ b/docs/design-handoff/02-current-state.md
@@ -1,0 +1,132 @@
+# Current State Inventory
+
+Reference document. Every route, API, lib module, component, and table that exists today. Don't read top-to-bottom — search for what you need.
+
+## Routes (`app/(receipt-system)/receipts/`)
+
+| Route | File | Server/Client | Current UX state |
+|---|---|---|---|
+| `/receipts` | `page.tsx` | SSR | Dashboard, 6 quick-link cards + missing-statement alert. Polished. |
+| `/receipts/capture` | `capture/page.tsx` | SSR shell, client form | Drag-drop form. Accepts `?payment=AMEX/CASH` and `?mode=rapid`. Works but desktop-biased. |
+| `/receipts/review` | `review/page.tsx` | SSR | Lists 50 most recent receipts. Basic table. Needs design. |
+| `/receipts/review/[id]` | `review/[id]/page.tsx` | SSR shell, client form | Big form + image viewer. Functional, rough. **The most-used screen after capture.** |
+| `/receipts/amex` | `amex/page.tsx` | SSR | CSV upload + statement stats + artifact history. Polished. |
+| `/receipts/reconcile` | `reconcile/page.tsx` | SSR shell, client table | Month picker + match table. **Most complex screen.** Data-heavy, functional. |
+| `/receipts/export` | `export/page.tsx` | SSR | Blocker checklist + generate/finalize panel. Functional. |
+| `/receipts/settings` | `settings/page.tsx` | SSR | Stub linking to devices. Placeholder. |
+| `/receipts/settings/devices` | `settings/devices/page.tsx` | SSR | Device list + revoke. Basic. |
+| `/receipts/enroll` | `enroll/page.tsx` | SSR | One-time device enrollment. Basic. |
+
+Layout: `app/(receipt-system)/receipts/layout.tsx` wraps all of the above in `<ReceiptShell>` (nav + auth guard).
+
+## API routes (`app/api/receipts/`)
+
+| Method + path | Purpose |
+|---|---|
+| `POST /api/receipts/upload` | Multipart upload → SHA256 dedup → R2 → D1 row. Returns `{ ok, receiptId, reviewUrl }`. |
+| `GET /api/receipts/[id]` | Fetch receipt + attendees. |
+| `PATCH /api/receipts/[id]` | Update fields + attendees (rewrites attendee list). Blocked when exported/archived. |
+| `DELETE /api/receipts/[id]` | Soft delete (sets `deleted_at`). |
+| `POST /api/receipts/[id]/extract` | Trigger Google Cloud Vision OCR. |
+| `GET /api/receipts/[id]/file` | Stream original from R2 (image viewer source). |
+| `POST /api/receipts/amex/import` | Parse Netアンサー CSV → batch-insert AMEX lines → detect business-trip candidates. |
+| `GET /api/receipts/amex/lines/[id]` | Fetch one AMEX line. |
+| `POST /api/receipts/reconcile` | Confirm or unlink one AMEX↔receipt match. |
+| `POST /api/receipts/reconcile/[month]/manifest` | Generate reconciliation CSV. |
+| `POST /api/receipts/reconcile/finalize` | Sign off month (locks edits). |
+| `POST /api/receipts/export/month` | Build monthly CSV + ZIP, stage to R2, create draft. |
+| `POST /api/receipts/export/[month]` | Finalize export (immutable after). |
+| `GET /api/receipts/export/[month]` | Fetch export record. |
+| `POST /api/receipts/devices/enroll` | Create trusted-device cookie. |
+| `DELETE /api/receipts/devices/[id]/revoke` | Revoke device. |
+| `POST /api/receipts/alerts/dismiss` | Snooze missing-statement alert (3 days). |
+
+## Lib modules (`lib/receipts/`)
+
+| Module | Role |
+|---|---|
+| `auth.ts` | Multipass auth: trusted-device HMAC → CF Access JWT → Basic auth. Exports `requireReceiptsActor`, `isReceiptsAuthorized`, `getReceiptsAuthChallengeHeaders`. |
+| `auth-request.ts` | `assertReceiptsPageAccess()` — page-level guard. |
+| `trusted-devices.ts` | Device cookie sign/verify, D1 revocation list. |
+| `db.ts` | ~60 CRUD functions. Receipts, attendees, AMEX lines, artifacts, exports, business trips, alerts. |
+| `db-utils.ts` | `newUuid`, `nowIso`, `stringifyJson`. |
+| `validation.ts` | File MIME/size, AMEX CSV parsing, business-trip detection. |
+| `categories.ts` | 14-item expense category catalog (JA/EN, attendee + trip rules). |
+| `extraction.ts` | Google Cloud Vision OCR. |
+| `storage.ts` | R2 upload/download + conditional put dedup. |
+| `client-image.ts` | Browser HEIC/HEIF → JPEG + max-2MP resize before upload. |
+| `reconciliation.ts` | Merchant fuzzy match + auto-match scoring. |
+| `statement-window.ts` | ±2-week date range for receipt↔AMEX matching. |
+| `export.ts` | Monthly CSV builder (14 columns). |
+| `month-closing.ts` | Month finalization. |
+| `reconciliation-signoff.ts` | Reconciliation sign-off. |
+| `audit.ts` | `createAuditEntry()` — all mutations logged. |
+| `attendee-directory.ts` | Predefined attendee names for autocomplete. |
+| `types.ts` | 440 lines of types — read first when building anything. |
+
+## Components (`components/receipts/`)
+
+| Component | Client? | Role |
+|---|---|---|
+| `receipt-shell.tsx` | client | Top nav, auth guard, breadcrumbs. |
+| `receipt-capture-form.tsx` | client | Wraps drop button + success/error states. |
+| `receipt-drop-button.tsx` | client | Drag-drop / file picker / base64 → `/upload`. |
+| `receipt-capture-success.tsx` | client | Success card + "Add another" (rapid mode). |
+| `receipt-review-form.tsx` | client | Big form with debounced PATCH per field + image sidebar. **Slow UX, ripe for redesign.** |
+| `attendee-editor.tsx` | client | Add/remove attendees with directory autocomplete. |
+| `receipt-review-table.tsx` | client | List 50 receipts. |
+| `receipt-image-viewer.tsx` | client | Loads image from `/api/receipts/[id]/file`. |
+| `amex-import-form.tsx` | client | CSV upload + month picker. |
+| `month-switcher.tsx` | client | Month dropdown. |
+| `reconciliation-table.tsx` | client | **Most complex component.** Per-line card with match status, category select, attendee editor, confidence display, bulk confirm. |
+| `monthly-export-panel.tsx` | client | Export history + generate/finalize. |
+| `device-list.tsx` | client | Device list + revoke. |
+| `enroll-device-form.tsx` | client | Device enrollment. |
+| `amex-missing-statement-alert.tsx` | client | Dismissible banner. |
+
+## Database tables (`db/receipts/0001_init.sql` through `0012_re_review_flag.sql`)
+
+| Table | What it stores |
+|---|---|
+| `receipt_records` | One row per receipt. Status: `captured → needs_review → reviewed → reconciled → exported → archived`. Payment paths: `AMEX / CASH / DIGITAL / UNKNOWN`. |
+| `receipt_attendees` | One row per attendee per receipt. `is_dazbeez_employee` bit. |
+| `amex_statement_lines` | One row per AMEX transaction. Match status: `unmatched / matched / confirmed / no_receipt`. |
+| `amex_statement_artifacts` | One row per imported CSV. Status: `pending / parsed / replaced / failed`. |
+| `receipt_exports` | One row per month. Status: `draft / finalized`. |
+| `business_trip_reports` | Auto-detected trip groupings. Status: `candidate / confirmed / rejected / exported`. |
+| `business_trip_report_lines` | Join table: trips ↔ AMEX lines. |
+| `amex_line_attendees` | Attendees on AMEX lines (when no matched receipt). |
+| `dashboard_alert_dismissals` | Snoozed alerts. |
+| `trusted_devices` | Phone enrollments. |
+| `expense_categories` | 14-item catalog (synced from `lib/receipts/categories.ts`). |
+| `receipt_audit_log` | All mutations. |
+
+## Tests (`tests/receipts/`)
+
+- `validation.test.ts`, `amex-parser.test.ts`, `extraction.test.ts`, `categories.test.ts`, `reconciliation.test.ts`, `statement-window.test.ts`, `merchant-override.test.ts`, `export.test.ts`, `manifest-csv.test.ts`.
+- All run with mocked bindings. `npm test` is the PC-side feedback loop.
+
+## Bindings & env (do not modify on PC)
+
+`wrangler.jsonc`:
+- `RECEIPTS_DB` (D1)
+- `RECEIPTS_BUCKET`, `RECEIPTS_ARCHIVE_BUCKET` (R2)
+- `AI` (Workers AI — bound but unused; potential local Vision fallback)
+
+`receipts-env.d.ts`:
+- `CF_ACCESS_TEAM`, `CF_ACCESS_AUD` (production auth)
+- `RECEIPTS_AUTH_USERNAME`, `RECEIPTS_AUTH_PASSWORD` (local Basic auth)
+- `RECEIPTS_DEVICE_SECRET` (trusted-device HMAC)
+
+## Theme tokens (from `app/globals.css`)
+
+```
+--bee-yellow:       #F59E0B   (amber-500, primary CTA, focus ring)
+--bee-yellow-light: #FBBF24   (amber-400, highlights)
+--bee-black:        #1F2937   (gray-800, secondary dark surfaces)
+--bee-charcoal:     #111827   (gray-900, primary dark surface)
+--background:       #FFFFFF
+--foreground:       #111827
+```
+
+Focus ring: `:focus-visible { outline: 2px solid var(--bee-yellow); outline-offset: 2px; }` — already applied globally, don't override.

--- a/docs/design-handoff/03-flows-and-screens.md
+++ b/docs/design-handoff/03-flows-and-screens.md
@@ -1,0 +1,124 @@
+# End-to-End Flows & Screen-by-Screen Audit
+
+The five user journeys, what each one is, what the current UI does, and where it falls short. Use this to scope screen work.
+
+---
+
+## Flow 1 — Rapid phone capture (the high-frequency case)
+
+**User story:** "I just paid for dinner. Photograph the receipt before the server walks away. Done."
+
+**Current path:**
+1. User opens `/receipts/capture?mode=rapid` (bookmarked or via NFC).
+2. Drag-drop area on a desktop-shaped layout; on iPhone Safari, tapping it opens the system file picker (which offers camera).
+3. Browser-side HEIC→JPEG conversion + resize to ≤2MP (`lib/receipts/client-image.ts`).
+4. POST to `/api/receipts/upload`. Spinner during upload.
+5. Success: small card with link to review + "Add another" button.
+
+**What's weak:**
+- The drop area is a desktop pattern. On phone, the "tap to capture" affordance is not the dominant visual.
+- No explicit acknowledgment between "photo taken" and "upload finished" (already filed in `docs/receipt_review_feature_requests.md` — implement this).
+- The success state hides under the form; thumb has to scroll up. Should be a full-screen confirmation in rapid mode.
+- No undo / retake within the success state. If the photo was blurry the user has to delete-then-recapture.
+- Offline behavior is undefined. If the connection drops mid-upload, the user gets a generic error.
+
+**Design opportunity:** Treat phone capture as a single full-screen experience: huge tap-target, instant feedback, three-state machine (idle → uploading → saved), with retake and "add another" as primary actions on the saved state.
+
+---
+
+## Flow 2 — Review and finalize a single receipt (desktop, batches)
+
+**User story:** "It's Sunday. I have 23 receipts from last week to clean up. For each one, confirm what OCR got right, add what it missed, move on."
+
+**Current path:**
+1. `/receipts/review` lists the 50 most recent in a table.
+2. Click row → `/receipts/review/[id]`.
+3. Form on left, image viewer on right. Fields: payment path, expense type, category, transaction date, merchant, amount, currency, business purpose, attendees, alcohol-present flag.
+4. Each field PATCHes on debounce. Save state is implicit.
+5. No "next receipt" affordance — user must back-button to the list.
+
+**What's weak:**
+- One-receipt-at-a-time loop with back-and-forth navigation kills momentum.
+- Form is a vertical wall of inputs; no sense of progress or what's required vs optional.
+- Implicit save is anxiety-inducing — was that last edit saved?
+- Attendee editor is functional but doesn't surface the autocomplete directory clearly.
+- Image viewer doesn't support pinch-zoom, rotate, or "view original" for blurry text.
+- No keyboard shortcuts (j/k to next/prev, enter to confirm).
+- Category code → attendee requirement coupling is logical but invisible: pick "Entertainment" and the attendees section should snap into focus with a "required" cue.
+
+**Design opportunity:** Treat this like an email triage UI. Persistent list on the side or top, current receipt in focus, keyboard nav, explicit save indicator, smart focus order following category requirements.
+
+---
+
+## Flow 3 — Import AMEX statement (monthly, ~5 minutes)
+
+**User story:** "Once a month I download the Netアンサー CSV and load it so I can reconcile."
+
+**Current path:**
+1. Download CSV from Japanese AMEX portal manually.
+2. `/receipts/amex` → upload form + month picker.
+3. POST to `/api/receipts/amex/import`. CSV is parsed, deduped by `(month, amex_reference, cardholder)`, inserted. Prior artifacts for the same month are marked `replaced` (so re-uploads are safe).
+4. Page redraws with stats + artifact history table.
+
+**What's weak:**
+- The "what just happened?" feedback is a small stat block; for a 50-line statement it should be more obvious how many were new, replaced, or flagged as business-trip candidates.
+- No preview before commit. The user uploads and the import is immediate.
+- Validation errors come back as a list; there's no inline highlighting in the CSV.
+- No visible link to the new reconciliation work this import created.
+
+**Design opportunity:** Upload → preview (parsed rows in a scrollable table with deltas) → confirm → success state that links straight into `/receipts/reconcile?month=YYYY-MM`.
+
+---
+
+## Flow 4 — Reconcile a month (the dense screen)
+
+**User story:** "AMEX is loaded. For each line, either confirm the suggested receipt, pick a different one, or mark 'no receipt'. Then categorize. Then sign off."
+
+**Current path:**
+1. `/receipts/reconcile?month=YYYY-MM` with month switcher.
+2. `<ReconciliationTable>` shows each AMEX line as a card: merchant, amount, date, suggested receipt thumbnail, match confidence, category dropdown, attendee mini-editor, action buttons (confirm / unlink / no-receipt).
+3. Orphan receipts (no AMEX line matched) shown in a separate list at the bottom.
+4. Bulk-confirm action with a progress bar.
+5. "Finalize reconciliation" button locks the month.
+
+**What's weak:**
+- The card-per-line layout consumes vertical space; on a 27" monitor you see 4-5 lines at once. For a 50-line month this is a lot of scrolling.
+- Category dropdown + attendee editor inline per card is dense. Most lines need only a confirm click; the heavy editors should be progressive disclosure.
+- Match confidence is a number; doesn't communicate "you should look at this one" vs "obvious match".
+- Orphan receipts at the bottom are visually equal to matched lines but semantically different.
+- No keyboard navigation. This is the screen most in need of one.
+- Locked-month state isn't visually distinctive enough — it looks like editable state but with greyed buttons.
+
+**Design opportunity:** Two-column or table-based layout for high information density. Confidence as a visual cue (color + icon, not a number). Inline expand for the cases that need editing. Keyboard shortcuts. Clear locked-state styling.
+
+---
+
+## Flow 5 — Export and lock the month
+
+**User story:** "Reconciliation is done. I want one button that says 'send this to accounting' and one that says 'lock it'."
+
+**Current path:**
+1. `/receipts/export` shows blockers: unreviewed receipts, uncategorized AMEX, missing attendees, unresolved business trips. Each as a count with a link.
+2. Once blockers are zero, "Generate" button creates a draft export (CSV + ZIP staged to R2).
+3. Review the draft, download to verify, then "Finalize" makes it immutable.
+4. Export history shown below.
+
+**What's weak:**
+- Blocker list is a flat list. Some blockers (missing attendees) block; others (unresolved business trips) might be warnings. Hierarchy isn't visual.
+- No way to see what's in the draft before downloading — for a casual sanity check, a row count + total amount would be enough.
+- Finalize is one click with no confirmation modal. This is the only one-way action in the system.
+- Export history shows IDs and timestamps but no clear "what was in this export" summary.
+
+**Design opportunity:** Pipeline view (Draft → Review → Finalize → Done) with the current step highlighted. Blocker triage with severity. Confirmation modal on finalize. Per-export summary chip (line count, total amount).
+
+---
+
+## Cross-cutting screens
+
+### Dashboard `/receipts`
+
+Six quick-link cards, alert banner. Polished already. Could earn its keep by surfacing **this month's status at a glance** (X receipts captured, Y unreviewed, Z reconciled, finalized/not).
+
+### Settings & devices `/receipts/settings/*` and `/receipts/enroll`
+
+Placeholder territory. Devices list works but is utilitarian. Enrollment is a one-time flow that needs to feel trustworthy (it's giving a phone a long-lived cookie).

--- a/docs/design-handoff/04-open-questions.md
+++ b/docs/design-handoff/04-open-questions.md
@@ -1,0 +1,101 @@
+# Open Questions for Claude Design
+
+Each question is scoped so a single mock, written recommendation, or short Tailwind sketch is enough to answer it. Tackle them in order — early answers constrain later ones.
+
+---
+
+## A. Capture flow
+
+**A1. Phone capture as full-screen vs in-page?**
+Should `/receipts/capture` on mobile become a near-full-screen experience (dominant capture button, status fills the viewport) or stay an in-page form? The rapid mode (`?mode=rapid`) leans full-screen; the deliberate mode less so.
+
+**A2. Retake before commit, or always commit then delete?**
+Currently every photo creates a record. Should we add a client-side "preview → confirm" step on phone so misfires don't pollute the DB? Trade-off: extra tap vs cleanup load.
+
+**A3. Surface OCR preview at capture time?**
+Vision OCR runs server-side after upload. Should the capture success state show the extracted fields (merchant, amount, date) for instant verification, or save that for the review screen?
+
+---
+
+## B. Review flow
+
+**B1. List vs single-detail vs split-view?**
+For `/receipts/review`, three options:
+- (a) List page → click → detail page (current). Simple, slow.
+- (b) Split view: list on left, detail on right. Fast triage, more code.
+- (c) Single-detail with next/prev nav and a queue indicator. Email-style, very fast for batches.
+
+Pick one and justify.
+
+**B2. Save model: explicit save button, debounced auto-save with indicator, or per-field optimistic with badge?**
+Current implicit per-field debounce is anxiety-inducing. Recommend a clear pattern.
+
+**B3. Field grouping & progressive disclosure?**
+Receipt has ~12 editable fields. Group as: (1) Identification — merchant/date/amount/currency. (2) Classification — payment path, category, expense type. (3) Documentation — business purpose, attendees, alcohol. Or different grouping? Show all at once or progressive?
+
+**B4. Image viewer affordances?**
+What's the minimum viable image viewer — zoom, pan, rotate, fullscreen, side-by-side with form? It's the single thing most likely to make review feel professional.
+
+---
+
+## C. Reconciliation flow
+
+**C1. Table vs cards vs split view for `/receipts/reconcile`?**
+A 50-line month is the typical case. Cards (current) waste space. Plain table is dense but loses visual hierarchy. Split view (line list + detail panel) is the email pattern again. Recommend one with reasoning.
+
+**C2. Confidence display?**
+Match confidence is a 0–1 number. Render as: traffic-light icon, percentage bar, color-shaded row background, or a label like "obvious" / "likely" / "review"? Pick one.
+
+**C3. Bulk operations UX?**
+Bulk confirm exists but is hidden. Should there be a "confirm all matches above 90% confidence" macro? A select-multiple + bulk-categorize? What's the minimum to avoid feeling unsafe?
+
+**C4. Keyboard shortcuts — yes or no?**
+For a screen used monthly for ~30 minutes by a power user, keyboard nav (j/k, c=confirm, n=no-receipt, e=expand for edit) is high value. Worth designing if Claude Design will also implement.
+
+**C5. Orphan receipts placement?**
+Receipts with no matching AMEX line live at the bottom currently. Surface them: (a) where they are, (b) as a tab/section toggle, (c) interleaved by date with a different visual treatment?
+
+---
+
+## D. Export flow
+
+**D1. Pipeline visualization?**
+Should `/receipts/export` show a horizontal pipeline (Draft → Review → Finalize → Archived) with the current step lit, or keep the current scrolling-list layout?
+
+**D2. Finalize confirmation pattern?**
+Modal? Type-the-month-to-confirm? Two-step button? It's the only irreversible action in the system.
+
+**D3. Export summary chip per row?**
+For the history table, what info belongs on each row beyond month + status? Line count, total amount, finalized-by-actor, finalized-at?
+
+---
+
+## E. Cross-cutting
+
+**E1. Dashboard `/receipts` content?**
+Currently 6 navigation cards + alert. Should it also show "this month at a glance" (counts, status)? If yes, does that make the cards redundant?
+
+**E2. Empty states?**
+What does each screen look like with zero data? First-ever capture, first-ever AMEX import, first-ever export. The system is internal-only so this only matters early in the year for "no receipts yet this month" states — but still worth designing.
+
+**E3. Locked-month visual language?**
+After reconciliation sign-off and after export finalize, multiple screens shift to read-only. Is the pattern (a) global banner + disabled inputs, (b) full read-only mode with a separate "view-only" treatment, (c) edit-protected but visually identical with toast feedback on attempted edit?
+
+**E4. Error states across the app?**
+There's no consistent error pattern today. Banner at top of page? Toast? Inline below field? Pick one default plus one for destructive-action-failed.
+
+**E5. Trusted-device enrollment UX?**
+`/receipts/enroll` gives a phone a 1-year cookie. Should this feel like a "pair a device" flow (confirmation, name the device, success state explaining what just happened) or stay a simple form?
+
+**E6. Loading skeletons vs spinners vs progress bars?**
+Pick the default. Currently mixed.
+
+---
+
+## F. Implementation packaging
+
+**F1. PR sequence?**
+Propose 5-7 PR-sized chunks in dependency order. Likely shape: foundations (shell + tokens) → capture → review list/detail → reconcile → export → settings/devices → polish pass. Refine.
+
+**F2. Component reuse from the marketing site?**
+The marketing site has its own button, card, and layout idioms. Should the receipts module reuse them verbatim, fork them with receipt-specific variants, or share a primitives layer?

--- a/docs/design-handoff/README.md
+++ b/docs/design-handoff/README.md
@@ -1,0 +1,64 @@
+# Receipts System — Design Handoff Package
+
+**Audience:** Claude Design (sibling session working on UI/UX implementation)
+**Status:** Active — module is in production with working plumbing; UI/UX is functional but rough
+**Branch for design work:** `claude/receipts-system-ui-ux-DBp5W`
+
+---
+
+## Read these in order
+
+1. **[`01-brief.md`](./01-brief.md)** — What we're building, who uses it, what success looks like, scope of this engagement, hard constraints (tech stack, dev environment split, bee theme).
+2. **[`02-current-state.md`](./02-current-state.md)** — Full inventory of every route, API, lib module, component, and DB table that exists today. Reference, not narrative.
+3. **[`03-flows-and-screens.md`](./03-flows-and-screens.md)** — The five end-to-end user journeys (capture, review, AMEX import, reconcile, export) with current UX state and what's weak about each.
+4. **[`04-open-questions.md`](./04-open-questions.md)** — The design decisions we need Claude Design to drive. Each one is scoped enough to answer with mocks or a written recommendation.
+
+---
+
+## Companion docs already in the repo
+
+Don't duplicate these — link to them.
+
+- `docs/ui-ux.md` — Existing site-wide design system (bee colors, typography scale, component patterns). The receipts module must inherit this.
+- `docs/dazbeez-receipt-module-prd.md` — Original PRD for the module. Domain-level context.
+- `docs/receipt-module.md` — Architectural overview.
+- `docs/receipt_PRD_update.md` — More recent product updates.
+- `docs/receipt_review_feature_requests.md` — Specific UX requests already filed (capture acknowledgment, etc.) — these are concrete starting points.
+- `docs/amex_requirements.md` — AMEX reconciliation requirements.
+- `docs/expenseCat_Requirements.md` — Expense category catalog.
+
+---
+
+## What we want back from Claude Design
+
+In rough priority order:
+
+1. A **screen-by-screen visual design** for the 9 receipts routes, mobile-first, inheriting the bee theme. Tailwind class lists are fine — we don't need Figma.
+2. **Interaction patterns** for the two complex screens: review detail (`/receipts/review/[id]`) and reconciliation (`/receipts/reconcile`). These are where users spend real time.
+3. **A capture flow optimized for phone use** — single-hand, one-tap retry, clear upload state. The current form is a desktop drag-drop with a bolt-on mobile path.
+4. **Answers to the open questions in `04-open-questions.md`**, with rationale.
+5. **An implementation plan** broken into PR-sized chunks (capture polish → review polish → reconciliation polish → export polish → settings/devices polish).
+
+---
+
+## Working environment rules
+
+This work happens on the **PC** side of the split documented in `/AGENTS.md`:
+
+- Write code, run `npm run build`, run unit tests with mocked bindings.
+- **Do NOT** try to connect to D1, R2, or Cloudflare Access. The Mac handles all live infrastructure.
+- Use `lib/cloudflare-runtime.ts` as the pattern for any new binding-touching code.
+- `npm run dev` works for visual iteration with stubbed data — that is the primary feedback loop for UI work.
+
+---
+
+## Quick orientation commands
+
+```bash
+npm run dev                # local dev server (stubbed bindings)
+npm run build              # type-check + compile
+npm test                   # unit tests (mocked)
+ls app/\(receipt-system\)/receipts/   # all routes
+ls components/receipts/    # all components
+ls lib/receipts/           # all domain logic
+```


### PR DESCRIPTION
## Summary

A self-contained handoff package in `docs/design-handoff/` so a sibling Claude session ("Claude Design") can pick up the receipts UI/UX work cold and deliver an end-to-end visual design + interaction plan.

Five files, layered shallow-to-deep:

- **`README.md`** — entry point, reading order, working-environment rules (PC-only constraints), what we want back.
- **`01-brief.md`** — what the module is, who uses it, success criteria, hard constraints (Next.js 16 App Router, Tailwind, bee theme), out-of-scope.
- **`02-current-state.md`** — exhaustive inventory: 10 routes, 17 API endpoints, 18 lib modules, 15 components, 12 D1 tables, theme tokens.
- **`03-flows-and-screens.md`** — the five end-to-end flows (capture / review / AMEX import / reconcile / export), current UX state per screen, weaknesses, design opportunities.
- **`04-open-questions.md`** — ~20 scoped questions across capture, review, reconcile, export, cross-cutting, and PR sequencing — each answerable with a mock or short recommendation.

Cross-links existing docs (`ui-ux.md`, the receipts PRDs, `receipt_review_feature_requests.md`) rather than duplicating them.

## Test plan

- [ ] Sibling Claude Design session can read `docs/design-handoff/README.md` and produce a first screen mock without further context
- [ ] Open questions in `04-open-questions.md` align with David's priorities before design work starts

---
_Generated by [Claude Code](https://claude.ai/code/session_015zAgFrgjRe9JSgaZ7VhuoS)_