### PR TITLE
fix(receipts): guard null dates + surface real page errors

### DIFF
--- a/app/(receipt-system)/receipts/error.tsx
+++ b/app/(receipt-system)/receipts/error.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect } from "react";
+
+export default function ReceiptsError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("[receipts] page error", error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center px-6 py-12 text-center">
+      <div className="max-w-lg rounded-2xl border border-red-200 bg-red-50 p-6 text-left">
+        <div className="text-xs font-semibold uppercase tracking-[0.2em] text-red-700">
+          Receipts · page error
+        </div>
+        <div className="mt-2 text-lg font-semibold text-gray-900">
+          Something went wrong while loading this page.
+        </div>
+        <p className="mt-2 text-sm text-gray-600">
+          The receipts module hit an unexpected error. The detail below is the
+          actual exception — share it with David if it keeps happening.
+        </p>
+        <pre className="mt-3 max-h-48 overflow-auto rounded-lg bg-white p-3 font-mono text-[12px] text-red-700">
+{error.message || "Unknown error"}
+{error.digest ? `\n\ndigest: ${error.digest}` : ""}
+        </pre>
+        <div className="mt-4 flex gap-2">
+          <button
+            type="button"
+            onClick={reset}
+            className="rounded-lg bg-amber-500 px-4 py-2 text-sm font-semibold text-white hover:bg-amber-600"
+          >
+            Try again
+          </button>
+          <Link
+            href="/receipts"
+            className="rounded-lg border border-gray-200 bg-white px-4 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50"
+          >
+            Back to dashboard
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/receipts/review/form-pane.tsx
+++ b/components/receipts/review/form-pane.tsx
@@ -344,16 +344,16 @@ export function FormPane(props: FormPaneProps) {
   }
 
   const transactionLabel = useMemo(() => {
-    const date = receipt.transaction_date || receipt.captured_at.slice(0, 10);
-    try {
-      return new Date(date).toLocaleDateString("en-US", {
-        month: "short",
-        day: "numeric",
-        year: "numeric",
-      });
-    } catch {
-      return date;
-    }
+    const captured = receipt.captured_at ?? "";
+    const date = receipt.transaction_date || captured.slice(0, 10);
+    if (!date) return "—";
+    const parsed = new Date(date);
+    if (Number.isNaN(parsed.getTime())) return date;
+    return parsed.toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
   }, [receipt.transaction_date, receipt.captured_at]);
 
   return (

--- a/components/receipts/review/queue-rail.tsx
+++ b/components/receipts/review/queue-rail.tsx
@@ -26,11 +26,12 @@ export function buildQueueItems(receipts: ReceiptRecord[]): QueueItem[] {
   return receipts.map((r) => {
     const code = r.expense_category_code ?? "";
     const cat = getCategoryByCode(code);
+    const captured = r.captured_at ?? "";
     return {
       id: r.id,
       merchant: r.merchant?.trim() || "Unnamed receipt",
       amountLabel: formatAmount(r.amount_minor, r.currency),
-      dateLabel: formatDate(r.transaction_date ?? r.captured_at.slice(0, 10)),
+      dateLabel: formatDate(r.transaction_date ?? captured.slice(0, 10)),
       categoryLabel: cat ? cat.enName : code ? code : "Uncategorized",
       status: r.status,
       needs: needsFlag(r, code),
@@ -60,12 +61,10 @@ function formatAmount(amount: number | null, currency: string | null) {
 }
 
 function formatDate(d: string) {
-  try {
-    const date = new Date(d);
-    return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
-  } catch {
-    return d.slice(0, 10);
-  }
+  if (!d) return "—";
+  const date = new Date(d);
+  if (Number.isNaN(date.getTime())) return d.slice(0, 10);
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
 }
 
 export function QueueRail({


### PR DESCRIPTION
## Summary

Production hit a generic Cloudflare "page couldn't load" error on `/receipts/review` (clicking Review in the nav) with no visibility into what actually went wrong. Two changes to fix the immediate crash and surface future failures:

- **Null-safe date handling.** `buildQueueItems` and `FormPane`'s `transactionLabel` both called `receipt.captured_at.slice(0, 10)`. Older rows can have a missing `captured_at`/`transaction_date` and the bare `.slice` threw during SSR — that was the most likely source of the crash. Both call sites now coalesce to `""` first and validate `Date` parsing before formatting.
- **Route-level error boundary.** Added `app/(receipt-system)/receipts/error.tsx`. Future failures show the actual exception message + digest in the UI with **Try again** and **Back to dashboard** actions, instead of bouncing to the generic Cloudflare page.

## Test plan

- [ ] Mac: `npm run cf:dev`, hit `/receipts/review` — confirm it loads (or, if it still fails, the new error page now displays the real message)
- [ ] If the original crash recurs in production, the new `error.tsx` will surface the exception so we can fix the actual cause
- [ ] Confirm the redirect from `/receipts/review` → `/receipts/review/<first-id>` still works once data loads

---
_Generated by [Claude Code](https://claude.ai/code/session_015zAgFrgjRe9JSgaZ7VhuoS)_