### PR TITLE
fix(receipts): inline server-render errors on /receipts/review

### DIFF
--- a/app/(receipt-system)/receipts/review/[id]/page.tsx
+++ b/app/(receipt-system)/receipts/review/[id]/page.tsx
@@ -12,6 +12,10 @@ import {
 } from "@/components/receipts/review/queue-rail";
 import { ImagePane } from "@/components/receipts/review/image-pane";
 import { FormPane } from "@/components/receipts/review/form-pane";
+import {
+  InlineServerError,
+  isNextInternalError,
+} from "@/components/receipts/review/inline-error";
 
 export const dynamic = "force-dynamic";
 
@@ -20,6 +24,19 @@ export default async function ReviewReceiptPage({
 }: {
   params: Promise<{ id: string }>;
 }) {
+  try {
+    return await renderReceiptPage(params);
+  } catch (err) {
+    if (isNextInternalError(err)) throw err;
+    const { id } = await params.catch(() => ({ id: "?" }));
+    console.error(`[receipts] /receipts/review/${id} render failed`, err);
+    return (
+      <InlineServerError where={`/receipts/review/${id}`} error={err} />
+    );
+  }
+}
+
+async function renderReceiptPage(params: Promise<{ id: string }>) {
   await assertReceiptsPageAccess();
 
   const { id } = await params;

--- a/app/(receipt-system)/receipts/review/page.tsx
+++ b/app/(receipt-system)/receipts/review/page.tsx
@@ -7,6 +7,10 @@ import {
   QueueRail,
   buildQueueItems,
 } from "@/components/receipts/review/queue-rail";
+import {
+  InlineServerError,
+  isNextInternalError,
+} from "@/components/receipts/review/inline-error";
 import type { ReceiptRecord } from "@/lib/receipts/types";
 
 export const dynamic = "force-dynamic";
@@ -16,6 +20,18 @@ export default async function ReviewPage({
 }: {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
+  try {
+    return await renderReviewPage(searchParams);
+  } catch (err) {
+    if (isNextInternalError(err)) throw err;
+    console.error("[receipts] /receipts/review render failed", err);
+    return <InlineServerError where="/receipts/review" error={err} />;
+  }
+}
+
+async function renderReviewPage(
+  searchParams: Promise<Record<string, string | string[] | undefined>>,
+) {
   await assertReceiptsPageAccess();
 
   const params = await searchParams;
@@ -28,7 +44,6 @@ export default async function ReviewPage({
     (r) => r.status === "needs_review" || r.status === "captured",
   ).length;
 
-  // If there's an obvious first item, go straight to it for a faster path.
   if (queueItems.length > 0 && filter === "") {
     redirect(`/receipts/review/${queueItems[0].id}`);
   }

--- a/components/receipts/review/inline-error.tsx
+++ b/components/receipts/review/inline-error.tsx
@@ -1,0 +1,52 @@
+import Link from "next/link";
+
+export function InlineServerError({
+  where,
+  error,
+}: {
+  where: string;
+  error: unknown;
+}) {
+  const err = error instanceof Error ? error : new Error(String(error));
+  const stack = err.stack ?? "(no stack)";
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center px-6 py-12 text-center">
+      <div className="max-w-2xl rounded-2xl border border-red-200 bg-red-50 p-6 text-left">
+        <div className="text-xs font-semibold uppercase tracking-[0.2em] text-red-700">
+          Receipts · server render error
+        </div>
+        <div className="mt-2 text-lg font-semibold text-gray-900">
+          {where} crashed while rendering on the server.
+        </div>
+        <p className="mt-2 text-sm text-gray-600">
+          Full exception below. Also logged to{" "}
+          <code className="font-mono">wrangler tail</code>.
+        </p>
+        <pre className="mt-3 max-h-96 overflow-auto rounded-lg bg-white p-3 font-mono text-[12px] text-red-700">
+          {err.name}: {err.message}
+          {"\n\n"}
+          {stack}
+        </pre>
+        <div className="mt-4 flex gap-2">
+          <Link
+            href="/receipts"
+            className="rounded-lg border border-gray-200 bg-white px-4 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50"
+          >
+            Back to dashboard
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function isNextInternalError(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const digest = (err as { digest?: unknown }).digest;
+  if (typeof digest !== "string") return false;
+  return (
+    digest === "NEXT_NOT_FOUND" ||
+    digest.startsWith("NEXT_REDIRECT") ||
+    digest.startsWith("NEXT_HTTP_ERROR_FALLBACK")
+  );
+}


### PR DESCRIPTION
## Summary

- Wrap both `/receipts/review` server components (`page.tsx` and `[id]/page.tsx`) in try/catch
- Re-throw Next.js internal signals (`NEXT_REDIRECT`, `NEXT_NOT_FOUND`, `NEXT_HTTP_ERROR_FALLBACK`) so `redirect()` and `notFound()` keep working
- On any other error: log full detail to `console.error` (visible via `wrangler tail`) and render `InlineServerError` showing the actual `error.name`, `error.message`, and stack trace inline in the browser

## Why

Production server-component crashes were only surfacing as opaque Next.js digests (e.g. `2649021896`), with the real exception redacted on the client and only retrievable from Worker logs. The browser dev console can't see it either — the digest is all Next.js exposes to the client in production. This bypasses Next's prod redaction for this module so the error is visible the moment it happens.

## Test plan

- [ ] Mac: deploy and hit `/receipts/review` — the new error page should show the actual exception text, not just a digest
- [ ] Confirm clicking a queue item still redirects normally (verifies `redirect()` re-throw path)
- [ ] Confirm hitting `/receipts/review/<bad-id>` still returns the standard 404 (verifies `notFound()` re-throw path)

https://claude.ai/code/session_015zAgFrgjRe9JSgaZ7VhuoS

---
_Generated by [Claude Code](https://claude.ai/code/session_015zAgFrgjRe9JSgaZ7VhuoS)_