### PR TITLE
fix(receipts): move buildQueueItems off the client boundary

### DIFF
--- a/app/(receipt-system)/receipts/review/[id]/page.tsx
+++ b/app/(receipt-system)/receipts/review/[id]/page.tsx
@@ -6,10 +6,8 @@ import {
 } from "@/lib/receipts/db";
 import { assertReceiptsPageAccess } from "@/lib/receipts/auth-request";
 import { ReviewLayout } from "@/components/receipts/review/review-layout";
-import {
-  QueueRail,
-  buildQueueItems,
-} from "@/components/receipts/review/queue-rail";
+import { QueueRail } from "@/components/receipts/review/queue-rail";
+import { buildQueueItems } from "@/lib/receipts/queue-items";
 import { ImagePane } from "@/components/receipts/review/image-pane";
 import { FormPane } from "@/components/receipts/review/form-pane";
 import {

--- a/app/(receipt-system)/receipts/review/page.tsx
+++ b/app/(receipt-system)/receipts/review/page.tsx
@@ -3,10 +3,8 @@ import { redirect } from "next/navigation";
 import { listReceiptRecords } from "@/lib/receipts/db";
 import { assertReceiptsPageAccess } from "@/lib/receipts/auth-request";
 import { ReviewLayout } from "@/components/receipts/review/review-layout";
-import {
-  QueueRail,
-  buildQueueItems,
-} from "@/components/receipts/review/queue-rail";
+import { QueueRail } from "@/components/receipts/review/queue-rail";
+import { buildQueueItems } from "@/lib/receipts/queue-items";
 import {
   InlineServerError,
   isNextInternalError,

--- a/components/receipts/review/queue-rail.tsx
+++ b/components/receipts/review/queue-rail.tsx
@@ -6,66 +6,7 @@ import { useEffect, useMemo, useRef } from "react";
 import { Kbd } from "@/components/ui/kbd";
 import { ReceiptThumb } from "@/components/receipts/ui/receipt-thumb";
 import { useKeyboardShortcuts } from "@/lib/receipts/keyboard";
-import {
-  requiresAttendees as categoryRequiresAttendees,
-  getCategoryByCode,
-} from "@/lib/receipts/categories";
-import type { ReceiptRecord } from "@/lib/receipts/types";
-
-export type QueueItem = {
-  id: string;
-  merchant: string;
-  amountLabel: string;
-  dateLabel: string;
-  categoryLabel: string;
-  status: ReceiptRecord["status"];
-  needs: "attendees" | "purpose" | null;
-};
-
-export function buildQueueItems(receipts: ReceiptRecord[]): QueueItem[] {
-  return receipts.map((r) => {
-    const code = r.expense_category_code ?? "";
-    const cat = getCategoryByCode(code);
-    const captured = r.captured_at ?? "";
-    return {
-      id: r.id,
-      merchant: r.merchant?.trim() || "Unnamed receipt",
-      amountLabel: formatAmount(r.amount_minor, r.currency),
-      dateLabel: formatDate(r.transaction_date ?? captured.slice(0, 10)),
-      categoryLabel: cat ? cat.enName : code ? code : "Uncategorized",
-      status: r.status,
-      needs: needsFlag(r, code),
-    };
-  });
-}
-
-function needsFlag(
-  r: ReceiptRecord,
-  code: string,
-): "attendees" | "purpose" | null {
-  if (r.status === "exported" || r.status === "archived") return null;
-  if (categoryRequiresAttendees(code)) {
-    // The full attendee list isn't passed here for performance; the queue rail
-    // uses extraction_json + receipt fields to display "needs attendees" as a
-    // best-effort hint. Detail page is the ground truth.
-    if (!r.business_purpose) return "attendees";
-  }
-  if (code === "meeting" && !r.business_purpose) return "purpose";
-  return null;
-}
-
-function formatAmount(amount: number | null, currency: string | null) {
-  if (amount == null) return "—";
-  if (!currency || currency === "JPY") return `¥${amount.toLocaleString()}`;
-  return `${currency} ${(amount / 100).toFixed(2)}`;
-}
-
-function formatDate(d: string) {
-  if (!d) return "—";
-  const date = new Date(d);
-  if (Number.isNaN(date.getTime())) return d.slice(0, 10);
-  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
-}
+import type { QueueItem } from "@/lib/receipts/queue-items";
 
 export function QueueRail({
   items,

--- a/lib/receipts/queue-items.ts
+++ b/lib/receipts/queue-items.ts
@@ -1,0 +1,57 @@
+import {
+  requiresAttendees as categoryRequiresAttendees,
+  getCategoryByCode,
+} from "@/lib/receipts/categories";
+import type { ReceiptRecord } from "@/lib/receipts/types";
+
+export type QueueItem = {
+  id: string;
+  merchant: string;
+  amountLabel: string;
+  dateLabel: string;
+  categoryLabel: string;
+  status: ReceiptRecord["status"];
+  needs: "attendees" | "purpose" | null;
+};
+
+export function buildQueueItems(receipts: ReceiptRecord[]): QueueItem[] {
+  return receipts.map((r) => {
+    const code = r.expense_category_code ?? "";
+    const cat = getCategoryByCode(code);
+    const captured = r.captured_at ?? "";
+    return {
+      id: r.id,
+      merchant: r.merchant?.trim() || "Unnamed receipt",
+      amountLabel: formatAmount(r.amount_minor, r.currency),
+      dateLabel: formatDate(r.transaction_date ?? captured.slice(0, 10)),
+      categoryLabel: cat ? cat.enName : code ? code : "Uncategorized",
+      status: r.status,
+      needs: needsFlag(r, code),
+    };
+  });
+}
+
+function needsFlag(
+  r: ReceiptRecord,
+  code: string,
+): "attendees" | "purpose" | null {
+  if (r.status === "exported" || r.status === "archived") return null;
+  if (categoryRequiresAttendees(code)) {
+    if (!r.business_purpose) return "attendees";
+  }
+  if (code === "meeting" && !r.business_purpose) return "purpose";
+  return null;
+}
+
+function formatAmount(amount: number | null, currency: string | null) {
+  if (amount == null) return "—";
+  if (!currency || currency === "JPY") return `¥${amount.toLocaleString()}`;
+  return `${currency} ${(amount / 100).toFixed(2)}`;
+}
+
+function formatDate(d: string) {
+  if (!d) return "—";
+  const date = new Date(d);
+  if (Number.isNaN(date.getTime())) return d.slice(0, 10);
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}


### PR DESCRIPTION
## Summary

Root cause of the `/receipts/review` server-render crash, surfaced by the new inline error page from #46:

> Error: Attempted to call `buildQueueItems()` from the server but `buildQueueItems` is on the client.

`buildQueueItems` was exported from `components/receipts/review/queue-rail.tsx`, which has `"use client"` at the top. In Next.js App Router, **any** non-component export from a client module is rewritten as a client reference — calling it from a server component throws.

## Fix

- Extract `buildQueueItems`, `QueueItem`, and the pure formatters (`needsFlag`, `formatAmount`, `formatDate`) into `lib/receipts/queue-items.ts` (no `"use client"` — pure functions, safe on both runtimes).
- `queue-rail.tsx` now just re-imports the `QueueItem` type and stays focused on the client component.
- Both server pages (`/receipts/review/page.tsx` and `/receipts/review/[id]/page.tsx`) import `buildQueueItems` from the new module; they still import `QueueRail` (the component) from `queue-rail.tsx`, which is the legitimate server-renders-client-component path.

## Test plan

- [ ] Mac: deploy, hit `/receipts/review` — should now render normally and redirect into the first item
- [ ] Hit `/receipts/review/<id>` directly — should render the 3-pane layout
- [ ] If anything still crashes, the inline error page from #46 will show the exact message

https://claude.ai/code/session_015zAgFrgjRe9JSgaZ7VhuoS

---
_Generated by [Claude Code](https://claude.ai/code/session_015zAgFrgjRe9JSgaZ7VhuoS)_