### PR TITLE
fix(receipts): correct bugs surfaced by branch review

### DIFF
--- a/app/(receipt-system)/receipts/amex/page.tsx
+++ b/app/(receipt-system)/receipts/amex/page.tsx
@@ -30,7 +30,7 @@ export default async function AmexPage({
     unmatched: lines.filter((l) => l.match_status === "unmatched").length,
     confirmed: lines.filter((l) => l.match_status === "confirmed").length,
     noReceipt: lines.filter((l) => l.match_status === "no_receipt").length,
-    uncategorized: lines.filter((l) => l.expense_category === "unknown").length,
+    uncategorized: lines.filter((l) => !l.expense_category_code).length,
   };
 
   const recentArtifacts = artifacts.slice(0, 6);

--- a/app/(receipt-system)/receipts/export/page.tsx
+++ b/app/(receipt-system)/receipts/export/page.tsx
@@ -24,10 +24,19 @@ import type {
 
 export const dynamic = "force-dynamic";
 
-export default async function ExportPage() {
+export default async function ExportPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
   await assertReceiptsPageAccess();
 
-  const month = new Date().toISOString().slice(0, 7);
+  const params = await searchParams;
+  const monthParam =
+    typeof params.month === "string" && /^\d{4}-\d{2}$/.test(params.month)
+      ? params.month
+      : null;
+  const month = monthParam ?? new Date().toISOString().slice(0, 7);
   const monthLabel = formatMonthLabel(month);
 
   const [exports, monthReceipts, monthLines, currentExport] = await Promise.all([

--- a/components/receipts/capture/use-receipt-upload.ts
+++ b/components/receipts/capture/use-receipt-upload.ts
@@ -148,15 +148,15 @@ async function runOcrAndPoll(
         const data = (await res.json()) as {
           receipt?: {
             merchant?: string | null;
-            amountMinor?: number | null;
+            amount_minor?: number | null;
             currency?: string | null;
-            transactionDate?: string | null;
-            expenseType?: string | null;
-            extractionJson?: string | null;
+            transaction_date?: string | null;
+            expense_type?: string | null;
+            extraction_json?: string | null;
           };
         };
         const r = data.receipt;
-        if (r && (r.merchant || r.amountMinor || r.extractionJson)) {
+        if (r && (r.merchant || r.amount_minor || r.extraction_json)) {
           setPhase({
             kind: "saved",
             receiptId,
@@ -165,10 +165,10 @@ async function runOcrAndPoll(
             capturedAt: started,
             extracted: {
               merchant: r.merchant ?? null,
-              amount: r.amountMinor ?? null,
+              amount: r.amount_minor ?? null,
               currency: r.currency ?? null,
-              transactionDate: r.transactionDate ?? null,
-              expenseType: r.expenseType ?? null,
+              transactionDate: r.transaction_date ?? null,
+              expenseType: r.expense_type ?? null,
             },
           });
           return;

--- a/components/receipts/export/export-screen.tsx
+++ b/components/receipts/export/export-screen.tsx
@@ -145,7 +145,6 @@ export function ExportScreen(props: ExportScreenProps) {
         busy={busy === "build"}
       />
       <Pipeline
-        reconciledCount={props.draftStats.rows}
         blockerCount={blockerCount}
         finalized={finalized}
         draftBuilt={draftBuilt}
@@ -286,7 +285,6 @@ function Pipeline({
   finalized,
   draftBuilt,
 }: {
-  reconciledCount: number;
   blockerCount: number;
   finalized: boolean;
   draftBuilt: boolean;
@@ -668,6 +666,7 @@ function FinalizePanel({
   finalized,
   draftBuilt,
   blockers,
+  warnings,
   confirmType,
   setConfirmType,
   onFinalize,
@@ -723,6 +722,12 @@ function FinalizePanel({
               <Bullet>Records signoff in audit log</Bullet>
               <Bullet>Marks AMEX statement as reconciled</Bullet>
             </ul>
+
+            {warnings > 0 && (
+              <div className="mt-3 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-[11.5px] text-amber-800">
+                {warnings} non-blocking warning{warnings === 1 ? "" : "s"} will ship as-is.
+              </div>
+            )}
 
             <div className="mt-5">
               <div className="mb-1.5 text-[11.5px] text-gray-500">

--- a/components/receipts/receipt-capture-form.tsx
+++ b/components/receipts/receipt-capture-form.tsx
@@ -13,7 +13,6 @@ import {
 } from "@/components/receipts/capture/capture-desktop";
 import type { PaymentPath } from "@/lib/receipts/types";
 
-// Back-compat alias; old callers may import PaymentChip from receipt-drop-button.
 export type PaymentChip = PaymentPath | null;
 
 export interface ReceiptCaptureFormProps {

--- a/components/receipts/reconcile/reconcile-screen.tsx
+++ b/components/receipts/reconcile/reconcile-screen.tsx
@@ -399,7 +399,6 @@ export function ReconcileScreen(props: ReconcileScreenProps) {
           setTab={setTab}
           counts={counts}
           orphanReceipts={props.orphanReceipts}
-          receiptMap={receiptMap}
         />
         <DetailPane
           active={active}
@@ -444,7 +443,6 @@ function LinesPane({
   setTab,
   counts,
   orphanReceipts,
-  receiptMap,
 }: {
   linesWithBand: Array<{
     line: AmexStatementLine;
@@ -464,13 +462,21 @@ function LinesPane({
     orphan: number;
   };
   orphanReceipts: ReceiptRecord[];
-  receiptMap: Map<string, ReceiptRecord>;
 }) {
   const groupReview = linesWithBand.filter(
-    (l) => l.band === "review" || l.band === "none",
+    (l) =>
+      (l.band === "review" || l.band === "none") &&
+      l.line.match_status !== "confirmed",
   );
-  const groupLikely = linesWithBand.filter((l) => l.band === "likely");
-  const groupObvious = linesWithBand.filter((l) => l.band === "obvious");
+  const groupLikely = linesWithBand.filter(
+    (l) => l.band === "likely" && l.line.match_status !== "confirmed",
+  );
+  const groupObvious = linesWithBand.filter(
+    (l) => l.band === "obvious" && l.line.match_status !== "confirmed",
+  );
+  const groupConfirmed = linesWithBand.filter(
+    (l) => l.line.match_status === "confirmed",
+  );
 
   return (
     <div className="flex h-full flex-col overflow-hidden border-r border-gray-200 bg-white">
@@ -548,6 +554,21 @@ function LinesPane({
                 onClick={() => setActiveId(l.line.id)}
               />
             ))}
+            {groupConfirmed.length > 0 && (
+              <SectionHeader
+                label="Confirmed"
+                count={groupConfirmed.length}
+                dot="bg-gray-300"
+              />
+            )}
+            {groupConfirmed.map((l) => (
+              <LineRow
+                key={l.line.id}
+                lwb={l}
+                active={activeId === l.line.id}
+                onClick={() => setActiveId(l.line.id)}
+              />
+            ))}
             {linesWithBand.length === 0 && (
               <div className="px-6 py-10 text-center text-sm text-gray-400">
                 No AMEX lines for this month. <br />
@@ -561,9 +582,7 @@ function LinesPane({
             )}
           </>
         )}
-        {tab === "orphans" && (
-          <OrphansList receipts={orphanReceipts} receiptMap={receiptMap} />
-        )}
+        {tab === "orphans" && <OrphansList receipts={orphanReceipts} />}
         {tab === "trips" && (
           <div className="px-6 py-10 text-center text-sm text-gray-400">
             Business trip detection runs at import time. No candidates for this
@@ -698,7 +717,6 @@ function OrphansList({
   receipts,
 }: {
   receipts: ReceiptRecord[];
-  receiptMap: Map<string, ReceiptRecord>;
 }) {
   if (receipts.length === 0) {
     return (

--- a/components/receipts/review/form-pane.tsx
+++ b/components/receipts/review/form-pane.tsx
@@ -137,9 +137,7 @@ export function FormPane(props: FormPaneProps) {
               attendees: attendees.map((a) => a.trim()).filter(Boolean),
               status: (markReviewed
                 ? "reviewed"
-                : receipt.status === "needs_review"
-                  ? receipt.status
-                  : receipt.status) as ReceiptStatus,
+                : receipt.status) as ReceiptStatus,
             }),
             signal: ctrl.signal,
           });
@@ -366,6 +364,11 @@ export function FormPane(props: FormPaneProps) {
           {props.hasAmexMatch && (
             <Pill tone="green" size="sm" dot>
               Auto-matched to AMEX
+            </Pill>
+          )}
+          {receipt.re_review_needed === 1 && (
+            <Pill tone="amber" size="sm" dot>
+              Re-review needed
             </Pill>
           )}
           <span className="flex-1" />

--- a/components/ui/btn.tsx
+++ b/components/ui/btn.tsx
@@ -41,11 +41,12 @@ export function Btn({
   className = "",
   children,
   disabled,
+  type,
   ...rest
 }: BtnProps) {
   return (
     <button
-      type={rest.type ?? "button"}
+      type={type ?? "button"}
       disabled={disabled}
       className={[
         "inline-flex items-center justify-center rounded-lg border font-semibold transition-colors",
@@ -60,7 +61,7 @@ export function Btn({
       {...rest}
     >
       {leftIcon}
-      <span>{children}</span>
+      {children != null && <span>{children}</span>}
       {rightIcon}
     </button>
   );

--- a/lib/receipts/queue-items.ts
+++ b/lib/receipts/queue-items.ts
@@ -11,7 +11,7 @@ export type QueueItem = {
   dateLabel: string;
   categoryLabel: string;
   status: ReceiptRecord["status"];
-  needs: "attendees" | "purpose" | null;
+  needs: "attendees" | "purpose" | "re-review" | null;
 };
 
 export function buildQueueItems(receipts: ReceiptRecord[]): QueueItem[] {
@@ -34,8 +34,9 @@ export function buildQueueItems(receipts: ReceiptRecord[]): QueueItem[] {
 function needsFlag(
   r: ReceiptRecord,
   code: string,
-): "attendees" | "purpose" | null {
+): "attendees" | "purpose" | "re-review" | null {
   if (r.status === "exported" || r.status === "archived") return null;
+  if (r.re_review_needed) return "re-review";
   if (categoryRequiresAttendees(code)) {
     if (!r.business_purpose) return "attendees";
   }

--- a/lib/receipts/use-viewport.ts
+++ b/lib/receipts/use-viewport.ts
@@ -3,10 +3,7 @@
 import { useEffect, useState } from "react";
 
 export function useIsMobile(breakpointPx = 768): boolean {
-  const [isMobile, setIsMobile] = useState<boolean>(() => {
-    if (typeof window === "undefined") return false;
-    return window.matchMedia(`(max-width: ${breakpointPx - 1}px)`).matches;
-  });
+  const [isMobile, setIsMobile] = useState<boolean>(false);
 
   useEffect(() => {
     if (typeof window === "undefined") return;


### PR DESCRIPTION
## Summary

Branch contains the receipts UI/UX redesign + follow-ups (originally merged into a working branch but not yet on `master`). I swept all 14 commits for correctness and fixed the real bugs I found. Style-only nits skipped.

### Correctness fixes
- **`use-receipt-upload.ts`** — capture polling read camelCase keys (`amountMinor`, `transactionDate`, `extractionJson`, `expenseType`) but the `GET /api/receipts/[id]` endpoint returns the snake_case `ReceiptRecord`. The "OCR done" branch never fired; mobile capture stayed in `running`/`timeout` even when extraction had finished.
- **`btn.tsx`** — `type={rest.type ?? "button"}` was written **before** `{...rest}`, so the spread overwrote `type` with `undefined` and every `Btn` inside a `<form>` silently defaulted to `submit`. Destructured `type` explicitly.
- **`use-viewport.ts`** — `useState` initializer touched `window.matchMedia`. Server rendered `false`; client could initialize `true`, producing a hydration mismatch on narrow viewports. Moved the detection fully into `useEffect`.
- **`amex/page.tsx`** — `Uncategorized` stat filtered on legacy `expense_category === "unknown"`. The rest of the new pipeline (reconcile blocker, export blocker, line UI) uses `expense_category_code`, so this stat under-counted. Switched to `!expense_category_code`.
- **`export/page.tsx`** — hardcoded `new Date().toISOString().slice(0,7)`. Reconcile + AMEX pages accept `?month=`; Export did not, so links to prior months silently routed to the current month. Now reads and validates `params.month`.
- **`reconcile-screen.tsx`** — `bandForLine` returned `"obvious"` for confirmed-no-match lines, putting them under the header *"Obvious matches · auto-confirm available"* even though they were already confirmed. Added a separate **Confirmed** section and filtered the other groups to exclude `match_status === "confirmed"`.

### Dead code / dead props
- **`form-pane.tsx`** — collapsed `markReviewed ? "reviewed" : receipt.status === "needs_review" ? receipt.status : receipt.status` (both inner branches return the same value).
- **`reconcile-screen.tsx`** — `OrphansList` (and the surrounding `LinesPane`) declared a `receiptMap` prop it never read; dropped.
- **`export-screen.tsx`** — `Pipeline` declared `reconciledCount` but only destructured the other three props; dropped at both call site and signature.

### Feature wiring
- **`re_review_needed` flag** (added in #39) was never surfaced in the redesigned UI. Now lights up an amber pill in the review form-pane header and adds a `needs re-review` badge in the queue rail.
- **`FinalizePanel.warnings`** was passed but ignored. Now renders an inline `"N non-blocking warnings will ship as-is."` note above the confirm input.

### Cleanup
- Removed stale `// Back-compat alias; old callers may import PaymentChip from receipt-drop-button.` comment (the referenced file no longer exists; no external callers found).

## Verification
- `npx tsc --noEmit` — clean
- `npx tsx --test tests/receipts/*.test.ts` — 126 / 126 pass (the existing `extraction.test.ts` failure is a pre-existing sandbox env issue: `@opennextjs/cloudflare` not installed; unrelated to this branch)

## Test plan
- [ ] On Mac with live bindings: capture a receipt and confirm the success card now shows extracted fields once OCR completes (instead of staying in `running`).
- [ ] Open a non-current month: `/receipts/export?month=2026-04` should load the April export view.
- [ ] Submit a form on `/receipts/review/[id]` and confirm the Save button doesn't trigger an accidental form submission.
- [ ] Verify a receipt with `re_review_needed=1` shows the amber pill in the review pane and the queue rail badge.
- [ ] On `/receipts/reconcile`, confirmed-no-match lines should now appear under a **Confirmed** group, not under *Obvious matches · auto-confirm available*.

https://claude.ai/code/session_018axZ7YQkPTdSaj1ryEQuG1

---
_Generated by [Claude Code](https://claude.ai/code/session_018axZ7YQkPTdSaj1ryEQuG1)_