### PR TITLE
fix(receipts): plumb re_review_needed via AMEX line join

### DIFF
--- a/app/(receipt-system)/receipts/review/[id]/page.tsx
+++ b/app/(receipt-system)/receipts/review/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import {
+  getAmexMatchFlagsByReceiptIds,
   getReceiptRecord,
   listAttendees,
   listReceiptRecords,
@@ -45,7 +46,17 @@ async function renderReceiptPage(params: Promise<{ id: string }>) {
   ]);
   if (!receipt) notFound();
 
-  const queueItems = buildQueueItems(all);
+  const amexFlags = await getAmexMatchFlagsByReceiptIds(
+    all.map((r) => r.id).concat(all.some((r) => r.id === id) ? [] : [id]),
+  );
+  const reReviewIds = new Set(
+    [...amexFlags.entries()]
+      .filter(([, f]) => f.reReviewNeeded)
+      .map(([rid]) => rid),
+  );
+  const activeFlags = amexFlags.get(id);
+
+  const queueItems = buildQueueItems(all, reReviewIds);
   const activeIndex = queueItems.findIndex((q) => q.id === id);
   const nextReceiptId = queueItems[activeIndex + 1]?.id ?? null;
   const prevReceiptId = queueItems[activeIndex - 1]?.id ?? null;
@@ -86,7 +97,8 @@ async function renderReceiptPage(params: Promise<{ id: string }>) {
           queueTotal={queueItems.length}
           nextReceiptId={nextReceiptId}
           prevReceiptId={prevReceiptId}
-          hasAmexMatch={false}
+          hasAmexMatch={activeFlags?.hasMatch ?? false}
+          reReviewNeeded={activeFlags?.reReviewNeeded ?? false}
         />
       }
     />

--- a/app/(receipt-system)/receipts/review/page.tsx
+++ b/app/(receipt-system)/receipts/review/page.tsx
@@ -1,6 +1,9 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
-import { listReceiptRecords } from "@/lib/receipts/db";
+import {
+  getAmexMatchFlagsByReceiptIds,
+  listReceiptRecords,
+} from "@/lib/receipts/db";
 import { assertReceiptsPageAccess } from "@/lib/receipts/auth-request";
 import { ReviewLayout } from "@/components/receipts/review/review-layout";
 import { QueueRail } from "@/components/receipts/review/queue-rail";
@@ -37,7 +40,13 @@ async function renderReviewPage(
 
   const receipts = await listReceiptRecords({ limit: 200 });
   const queue = filterQueue(receipts, filter);
-  const queueItems = buildQueueItems(queue);
+  const amexFlags = await getAmexMatchFlagsByReceiptIds(queue.map((r) => r.id));
+  const reReviewIds = new Set(
+    [...amexFlags.entries()]
+      .filter(([, f]) => f.reReviewNeeded)
+      .map(([rid]) => rid),
+  );
+  const queueItems = buildQueueItems(queue, reReviewIds);
   const needsAttention = queue.filter(
     (r) => r.status === "needs_review" || r.status === "captured",
   ).length;

--- a/components/receipts/review/form-pane.tsx
+++ b/components/receipts/review/form-pane.tsx
@@ -53,6 +53,7 @@ export interface FormPaneProps {
   nextReceiptId: string | null;
   prevReceiptId: string | null;
   hasAmexMatch: boolean;
+  reReviewNeeded: boolean;
 }
 
 type SaveState =
@@ -366,7 +367,7 @@ export function FormPane(props: FormPaneProps) {
               Auto-matched to AMEX
             </Pill>
           )}
-          {receipt.re_review_needed === 1 && (
+          {props.reReviewNeeded && (
             <Pill tone="amber" size="sm" dot>
               Re-review needed
             </Pill>

--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -576,6 +576,39 @@ export async function listAmexLines(
   return result.results ?? [];
 }
 
+export interface AmexMatchFlags {
+  hasMatch: boolean;
+  reReviewNeeded: boolean;
+}
+
+export async function getAmexMatchFlagsByReceiptIds(
+  receiptIds: string[],
+): Promise<Map<string, AmexMatchFlags>> {
+  const flags = new Map<string, AmexMatchFlags>();
+  if (receiptIds.length === 0) return flags;
+
+  const db = getReceiptsDb();
+  const placeholders = receiptIds.map(() => "?").join(",");
+  const result = await db
+    .prepare(
+      `SELECT matched_receipt_id, re_review_needed
+       FROM amex_statement_lines
+       WHERE matched_receipt_id IN (${placeholders})`,
+    )
+    .bind(...receiptIds)
+    .all<{ matched_receipt_id: string; re_review_needed: 0 | 1 }>();
+
+  for (const row of result.results ?? []) {
+    const existing = flags.get(row.matched_receipt_id);
+    flags.set(row.matched_receipt_id, {
+      hasMatch: true,
+      reReviewNeeded:
+        (existing?.reReviewNeeded ?? false) || row.re_review_needed === 1,
+    });
+  }
+  return flags;
+}
+
 export async function listAmexLineAttendeeNamesByMonth(
   statementMonth: string,
 ): Promise<Record<string, string[]>> {

--- a/lib/receipts/queue-items.ts
+++ b/lib/receipts/queue-items.ts
@@ -14,7 +14,10 @@ export type QueueItem = {
   needs: "attendees" | "purpose" | "re-review" | null;
 };
 
-export function buildQueueItems(receipts: ReceiptRecord[]): QueueItem[] {
+export function buildQueueItems(
+  receipts: ReceiptRecord[],
+  reReviewIds: ReadonlySet<string> = new Set(),
+): QueueItem[] {
   return receipts.map((r) => {
     const code = r.expense_category_code ?? "";
     const cat = getCategoryByCode(code);
@@ -26,7 +29,7 @@ export function buildQueueItems(receipts: ReceiptRecord[]): QueueItem[] {
       dateLabel: formatDate(r.transaction_date ?? captured.slice(0, 10)),
       categoryLabel: cat ? cat.enName : code ? code : "Uncategorized",
       status: r.status,
-      needs: needsFlag(r, code),
+      needs: needsFlag(r, code, reReviewIds.has(r.id)),
     };
   });
 }
@@ -34,9 +37,10 @@ export function buildQueueItems(receipts: ReceiptRecord[]): QueueItem[] {
 function needsFlag(
   r: ReceiptRecord,
   code: string,
+  reReviewNeeded: boolean,
 ): "attendees" | "purpose" | "re-review" | null {
   if (r.status === "exported" || r.status === "archived") return null;
-  if (r.re_review_needed) return "re-review";
+  if (reReviewNeeded) return "re-review";
   if (categoryRequiresAttendees(code)) {
     if (!r.business_purpose) return "attendees";
   }


### PR DESCRIPTION
## Why

`re_review_needed` is a column on `amex_statement_lines`, not `receipts`. PR #48 mistakenly read it off `ReceiptRecord` in `lib/receipts/queue-items.ts:39` and `components/receipts/review/form-pane.tsx:369`. You caught both locally during the deploy and patched them, but the patch was never pushed — `master` still has the bad references. (Production was built locally with the patch applied, which is why the deploy succeeded.)

Confirmed on this branch's base (master `8ef71d0`):
```
$ npx tsc --noEmit
components/receipts/review/form-pane.tsx(369,20): error TS2339: Property 're_review_needed' does not exist on type 'ReceiptRecord'.
lib/receipts/queue-items.ts(39,9): error TS2339: Property 're_review_needed' does not exist on type 'ReceiptRecord'.
```

## What

Proper server-side plumbing instead of a property-existence hack:

- **`lib/receipts/db.ts`** — new `getAmexMatchFlagsByReceiptIds(ids)` returning `Map<receiptId, { hasMatch, reReviewNeeded }>` via a single `WHERE matched_receipt_id IN (…)` query against `amex_statement_lines`.
- **`/receipts/review/page.tsx`** — calls it after `listReceiptRecords`, builds a `reReviewIds: Set<string>`, hands it to `buildQueueItems`.
- **`/receipts/review/[id]/page.tsx`** — same; also pulls the active receipt's flags to feed `FormPane`.
- **`lib/receipts/queue-items.ts`** — `buildQueueItems(receipts, reReviewIds)`; `needsFlag` consumes the Set instead of reading the non-existent property. Backwards-compatible default `new Set()` so other callers (if any) still work.
- **`components/receipts/review/form-pane.tsx`** — `FormPaneProps` gains `reReviewNeeded: boolean`; the header pill reads the prop. Also fixes the previously-hardcoded `hasAmexMatch={false}` to the real value from the join.

## Verification

- `npx tsc --noEmit` — **clean** (the two TS2339 errors on master are gone)
- `npx tsx --test tests/receipts/*.test.ts` (excluding `extraction.test.ts` — sandbox env issue, unrelated) — **126 / 126 pass**

## Test plan

- [ ] On Mac: a receipt linked to an AMEX line with `re_review_needed=1` shows the amber pill in the review form-pane header **and** the "needs re-review" badge in the queue rail.
- [ ] A receipt linked to a clean AMEX line still shows the green "Auto-matched to AMEX" pill but not the amber re-review pill.
- [ ] An unmatched receipt shows neither pill.
- [ ] Confirm the join query is fast enough on a 200-receipt queue (single `IN (...)` query; should be sub-ms on D1).

## Migration / deploy

- No DB migration needed (the column already exists).
- Standard deploy: `npm run build:cf` → `npm run deploy` → smoke.

https://claude.ai/code/session_018axZ7YQkPTdSaj1ryEQuG1

---
_Generated by [Claude Code](https://claude.ai/code/session_018axZ7YQkPTdSaj1ryEQuG1)_