### PR TITLE
Receipts + NFC card: BDD review + nine UX/DRY upgrades

### DIFF
--- a/app/(receipt-system)/receipts/export/page.tsx
+++ b/app/(receipt-system)/receipts/export/page.tsx
@@ -10,20 +10,20 @@ import {
 import {
   formatCategoryLabel,
   getCategoryByCode,
-  requiresAttendees,
 } from "@/lib/receipts/categories";
 import { assertReceiptsPageAccess } from "@/lib/receipts/auth-request";
 import {
   ExportScreen,
-  type Blocker,
   type CategoryBreakdownRow,
   type ManifestSampleRow,
 } from "@/components/receipts/export/export-screen";
-import type {
-  AmexStatementLine,
-  ReceiptRecord,
-} from "@/lib/receipts/types";
+import type { AmexStatementLine, ReceiptRecord } from "@/lib/receipts/types";
 import { MonthSwitcher, type MonthOption } from "@/components/receipts/month-switcher";
+import { formatMonth } from "@/lib/receipts/format";
+import {
+  computeExportBlockers,
+  computeExportWarnings,
+} from "@/lib/receipts/blockers";
 
 export const dynamic = "force-dynamic";
 
@@ -59,7 +59,7 @@ export default async function ExportPage({
     (availableMonths.length > 0
       ? availableMonths[availableMonths.length - 1]!.month
       : new Date().toISOString().slice(0, 7));
-  const monthLabel = formatMonthLabel(month);
+  const monthLabel = formatMonth(month);
 
   const [exports, monthReceipts, monthLines, currentExport] = await Promise.all([
     listExports(),
@@ -68,8 +68,8 @@ export default async function ExportPage({
     getExport(month),
   ]);
 
-  const blockers = computeBlockers(monthReceipts, monthLines);
-  const warnings = computeWarnings(monthLines);
+  const blockers = computeExportBlockers(monthReceipts, monthLines);
+  const warnings = computeExportWarnings(monthLines);
 
   const draftStats = computeDraftStats(monthReceipts, monthLines);
   const breakdown = computeBreakdown(monthReceipts, monthLines);
@@ -103,115 +103,6 @@ export default async function ExportPage({
       />
     </>
   );
-}
-
-function formatMonthLabel(month: string): string {
-  try {
-    const [y, m] = month.split("-").map(Number);
-    if (!y || !m) return month;
-    return new Date(y, m - 1, 1).toLocaleDateString("en-US", {
-      month: "long",
-      year: "numeric",
-    });
-  } catch {
-    return month;
-  }
-}
-
-function computeBlockers(
-  receipts: ReceiptRecord[],
-  lines: AmexStatementLine[],
-): Blocker[] {
-  const blockers: Blocker[] = [];
-
-  const uncategorized = lines.filter((l) => !l.expense_category_code).length;
-  if (uncategorized > 0) {
-    blockers.push({
-      severity: "blocker",
-      count: uncategorized,
-      label: "Uncategorized AMEX lines",
-      detail: "Pick an expense category for each line.",
-      href: "/receipts/reconcile",
-      ctaLabel: "Fix in Reconcile",
-    });
-  }
-
-  const unreviewed = receipts.filter(
-    (r) => r.status === "captured" || r.status === "needs_review",
-  ).length;
-  if (unreviewed > 0) {
-    blockers.push({
-      severity: "blocker",
-      count: unreviewed,
-      label: "Unreviewed receipts",
-      detail: "These receipts must be reviewed before sealing.",
-      href: "/receipts/review",
-      ctaLabel: "Fix in Review",
-    });
-  }
-
-  const attendeesMissing = lines.filter(
-    (l) => requiresAttendees(l.expense_category_code) && !l.matched_receipt_id,
-  ).length;
-  if (attendeesMissing > 0) {
-    blockers.push({
-      severity: "blocker",
-      count: attendeesMissing,
-      label: "Entertainment/meeting lines need attendees",
-      detail: "Link a receipt that has attendees recorded.",
-      href: "/receipts/reconcile",
-      ctaLabel: "Fix in Reconcile",
-    });
-  }
-
-  const missingReason = lines.filter(
-    (l) =>
-      l.receipt_status === "missing_receipt" && !l.receipt_missing_reason,
-  ).length;
-  if (missingReason > 0) {
-    blockers.push({
-      severity: "blocker",
-      count: missingReason,
-      label: 'Lines marked "missing receipt" without a reason',
-      detail: "Add a brief reason so audit can defend the claim.",
-      href: "/receipts/reconcile",
-      ctaLabel: "Fix in Reconcile",
-    });
-  }
-
-  return blockers;
-}
-
-function computeWarnings(lines: AmexStatementLine[]): Blocker[] {
-  const warnings: Blocker[] = [];
-
-  const tripCandidates = lines.filter(
-    (l) => l.business_trip_status === "candidate",
-  ).length;
-  if (tripCandidates > 0) {
-    warnings.push({
-      severity: "warn",
-      count: tripCandidates,
-      label: "Unresolved business-trip candidates",
-      detail: "Confirm or dismiss the trip cluster.",
-      href: "/receipts/reconcile",
-      ctaLabel: "Open trips",
-    });
-  }
-
-  const noReceipt = lines.filter((l) => l.match_status === "no_receipt").length;
-  if (noReceipt > 0) {
-    warnings.push({
-      severity: "warn",
-      count: noReceipt,
-      label: 'AMEX lines marked "no receipt expected"',
-      detail: "These ship as-is; not a blocker.",
-      href: null,
-      ctaLabel: "Acknowledge",
-    });
-  }
-
-  return warnings;
 }
 
 function computeDraftStats(

--- a/app/(receipt-system)/receipts/page.tsx
+++ b/app/(receipt-system)/receipts/page.tsx
@@ -12,6 +12,8 @@ import { AmexMissingStatementAlert } from "@/components/receipts/amex-missing-st
 import { Card } from "@/components/ui/card";
 import { Pill } from "@/components/ui/pill";
 import { ArrowRightIcon, CameraIcon } from "@/components/ui/icons";
+import { StatTile } from "@/components/receipts/ui/stat-tile";
+import { formatMonth } from "@/lib/receipts/format";
 
 export const dynamic = "force-dynamic";
 
@@ -212,44 +214,3 @@ export default async function ReceiptsDashboardPage() {
   );
 }
 
-function StatTile({
-  label,
-  value,
-  sub,
-  accent,
-}: {
-  label: string;
-  value: string;
-  sub: string;
-  accent?: boolean;
-}) {
-  return (
-    <Card>
-      <div className="text-[11px] font-bold uppercase tracking-[0.05em] text-gray-500">
-        {label}
-      </div>
-      <div
-        className={[
-          "mt-1.5 text-[26px] font-bold tabular-nums",
-          accent ? "text-amber-700" : "text-gray-900",
-        ].join(" ")}
-      >
-        {value}
-      </div>
-      <div className="mt-0.5 text-[12px] text-gray-500">{sub}</div>
-    </Card>
-  );
-}
-
-function formatMonth(month: string): string {
-  try {
-    const [y, m] = month.split("-").map(Number);
-    if (!y || !m) return month;
-    return new Date(y, m - 1, 1).toLocaleDateString("en-US", {
-      month: "long",
-      year: "numeric",
-    });
-  } catch {
-    return month;
-  }
-}

--- a/app/(receipt-system)/receipts/reconcile/page.tsx
+++ b/app/(receipt-system)/receipts/reconcile/page.tsx
@@ -13,6 +13,7 @@ import {
 import { ReconcileScreen } from "@/components/receipts/reconcile/reconcile-screen";
 import { assertReceiptsPageAccess } from "@/lib/receipts/auth-request";
 import type { MonthOption } from "@/components/receipts/month-switcher";
+import { formatMonth } from "@/lib/receipts/format";
 
 export const dynamic = "force-dynamic";
 
@@ -97,15 +98,3 @@ export default async function ReconcilePage({
   );
 }
 
-function formatMonth(month: string): string {
-  try {
-    const [y, m] = month.split("-").map(Number);
-    if (!y || !m) return month;
-    return new Date(y, m - 1, 1).toLocaleDateString("en-US", {
-      month: "long",
-      year: "numeric",
-    });
-  } catch {
-    return month;
-  }
-}

--- a/app/api/nfc/hit/route.ts
+++ b/app/api/nfc/hit/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+export const runtime = "edge";
+export const dynamic = "force-dynamic";
+
+/**
+ * Fire-and-forget endpoint hit by /nfc when a `src` query param is present.
+ * We don't have an analytics pipeline yet, so this just logs the tap
+ * source. Stays a no-op response so `navigator.sendBeacon` succeeds.
+ */
+export async function GET(req: NextRequest) {
+  const url = new URL(req.url);
+  const src = (url.searchParams.get("src") || "").slice(0, 64);
+  if (src) {
+    // Logged so it shows up in worker tail. Replace with a real analytics
+    // sink (D1 / Cloudflare Analytics) when we add tap reporting.
+    console.log(JSON.stringify({ evt: "nfc.hit", src }));
+  }
+  return new NextResponse(null, { status: 204 });
+}

--- a/app/api/vcard/route.ts
+++ b/app/api/vcard/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+
+export const runtime = "edge";
+
+const CRLF = "\r\n";
+
+/**
+ * Minimal vCard 3.0 contact for David Klan. Pointed at by the
+ * /business-card and /nfc pages so visitors can save the contact without
+ * leaving dazbeez.com. Keep this in sync with the canonical card hosted
+ * at hi.dazbeez.com.
+ */
+const VCARD = [
+  "BEGIN:VCARD",
+  "VERSION:3.0",
+  "N:Klan;David;;;",
+  "FN:David Klan",
+  "ORG:Dazbeez",
+  "TITLE:Founder — AI, Automation & Data",
+  "EMAIL;TYPE=INTERNET,PREF:david@dazbeez.com",
+  "URL:https://dazbeez.com",
+  "URL;TYPE=card:https://dazbeez.com/business-card",
+  "END:VCARD",
+].join(CRLF);
+
+export function GET() {
+  return new NextResponse(VCARD, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/vcard; charset=utf-8",
+      "Content-Disposition": 'attachment; filename="david-klan.vcf"',
+      "Cache-Control": "public, max-age=300",
+    },
+  });
+}

--- a/app/business-card/page.tsx
+++ b/app/business-card/page.tsx
@@ -144,12 +144,27 @@ export default function BusinessCardPage() {
               >
                 Open a live example
               </Link>
-              <Link
-                href="/case-studies/networking-card"
-                className="inline-flex items-center justify-center rounded-full border border-white/20 px-6 py-3 text-sm font-semibold text-white transition-colors hover:border-white/40"
+              <a
+                href="/api/vcard"
+                download="david-klan.vcf"
+                className="inline-flex items-center justify-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-semibold text-gray-900 transition-colors hover:bg-gray-100"
               >
-                How it was built
-              </Link>
+                <svg
+                  className="h-4 w-4"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M4 16v2a2 2 0 002 2h12a2 2 0 002-2v-2M7 10l5 5 5-5M12 15V3"
+                  />
+                </svg>
+                Save David&apos;s vCard
+              </a>
               <Link
                 href="/nfc"
                 className="inline-flex items-center justify-center rounded-full border border-white/20 px-6 py-3 text-sm font-semibold text-white transition-colors hover:border-white/40"
@@ -157,6 +172,16 @@ export default function BusinessCardPage() {
                 See the mobile demo
               </Link>
             </div>
+            <p className="mt-4 text-xs text-gray-400">
+              Want the technical write-up?{" "}
+              <Link
+                href="/case-studies/networking-card"
+                className="font-semibold text-amber-300 underline-offset-2 hover:underline"
+              >
+                Read how it was built
+              </Link>
+              .
+            </p>
           </div>
 
           <div className="w-full max-w-md lg:ml-auto">

--- a/app/nfc/nfc-content.tsx
+++ b/app/nfc/nfc-content.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useEffect, useSyncExternalStore } from "react";
 import { useSearchParams } from "next/navigation";
 import { HoneycombBackdrop } from "@/components/honeycomb-backdrop";
 
@@ -46,17 +46,21 @@ const secondaryActions: SecondaryAction[] = [
 
 const VCARD_HREF = "/api/vcard";
 
+const subscribeNoop = () => () => {};
+const getShareSupport = () =>
+  typeof navigator !== "undefined" && typeof navigator.share === "function";
+
 export function NFCContent() {
   const params = useSearchParams();
   const source = params.get("src") || "direct";
-  const [canShare, setCanShare] = useState(false);
-
-  useEffect(() => {
-    setCanShare(
-      typeof navigator !== "undefined" &&
-        typeof navigator.share === "function",
-    );
-  }, []);
+  // Hydration-safe client-only feature detection: server snapshot is always
+  // false (matches the initial markup), then the client snapshot reads the
+  // real value on the first client render without an effect-driven setState.
+  const canShare = useSyncExternalStore(
+    subscribeNoop,
+    getShareSupport,
+    () => false,
+  );
 
   useEffect(() => {
     if (source === "direct") return;

--- a/app/nfc/nfc-content.tsx
+++ b/app/nfc/nfc-content.tsx
@@ -1,73 +1,105 @@
 "use client";
 
 import Link from "next/link";
+import { useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { HoneycombBackdrop } from "@/components/honeycomb-backdrop";
 
-type QuickAction = {
+type PrimaryAction = {
   href: string;
   label: string;
   sublabel: string;
-  tone: "primary" | "neutral" | "secondary";
   icon: React.ReactNode;
 };
 
-const quickActions: QuickAction[] = [
-  {
-    href: "/contact",
-    label: "Book a consultation",
-    sublabel: "Reply within 24h",
-    tone: "primary",
-    icon: (
-      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-      </svg>
-    ),
-  },
-  {
-    href: "/services",
-    label: "Browse services",
-    sublabel: "AI · Automation · Data",
-    tone: "neutral",
-    icon: (
-      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
-      </svg>
-    ),
-  },
-  {
-    href: "/business-card",
-    label: "About this card",
-    sublabel: "How it works",
-    tone: "secondary",
-    icon: (
-      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M12 2a10 10 0 100 20 10 10 0 000-20z" />
-      </svg>
-    ),
-  },
+type SecondaryAction = {
+  href: string;
+  label: string;
+};
+
+const primaryAction: PrimaryAction = {
+  href: "/contact",
+  label: "Book a consultation",
+  sublabel: "Reply within 24h",
+  icon: (
+    <svg
+      className="h-6 w-6"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+      />
+    </svg>
+  ),
+};
+
+const secondaryActions: SecondaryAction[] = [
+  { href: "/services", label: "Browse services" },
+  { href: "/business-card", label: "About this card" },
 ];
 
-const toneClasses: Record<QuickAction["tone"], string> = {
-  primary: "bg-amber-500 hover:bg-amber-600 text-white",
-  neutral: "bg-gray-900 hover:bg-gray-800 text-white",
-  secondary: "bg-white hover:bg-gray-50 text-gray-900 border border-gray-200",
-};
+const VCARD_HREF = "/api/vcard";
 
 export function NFCContent() {
   const params = useSearchParams();
   const source = params.get("src") || "direct";
+  const [canShare, setCanShare] = useState(false);
+
+  useEffect(() => {
+    setCanShare(
+      typeof navigator !== "undefined" &&
+        typeof navigator.share === "function",
+    );
+  }, []);
+
+  useEffect(() => {
+    if (source === "direct") return;
+    // Fire-and-forget analytics; never block the UI on this.
+    const url = `/api/nfc/hit?src=${encodeURIComponent(source)}`;
+    try {
+      if (typeof navigator !== "undefined" && "sendBeacon" in navigator) {
+        navigator.sendBeacon(url);
+      } else {
+        void fetch(url, { method: "GET", keepalive: true }).catch(() => {});
+      }
+    } catch {
+      /* ignore */
+    }
+  }, [source]);
+
+  async function handleShare() {
+    try {
+      await navigator.share({
+        title: "Dazbeez — David Klan",
+        text: "AI · Automation · Data consulting",
+        url: typeof window !== "undefined" ? window.location.origin : "https://dazbeez.com",
+      });
+    } catch {
+      /* user cancelled or share unavailable */
+    }
+  }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900 flex items-center justify-center p-4 relative overflow-hidden">
+    <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900 p-4">
       <HoneycombBackdrop opacity={0.07} color="#FBBF24" />
-      <div className="max-w-sm w-full relative">
-        <div className="bg-white rounded-3xl shadow-2xl overflow-hidden">
-          <div className="relative overflow-hidden bg-gradient-to-r from-amber-400 to-amber-600 p-6 text-white text-center">
+      <div className="relative w-full max-w-sm">
+        <div className="overflow-hidden rounded-3xl bg-white shadow-2xl">
+          <div className="relative overflow-hidden bg-gradient-to-r from-amber-400 to-amber-600 p-6 text-center text-white">
             <HoneycombBackdrop opacity={0.18} color="#ffffff" />
             <div className="relative">
-              <div className="w-16 h-16 bg-white/20 rounded-2xl flex items-center justify-center mx-auto mb-3">
-                <svg viewBox="-32 -32 64 64" className="w-10 h-10" role="img" aria-label="Dazbeez honeycomb">
+              <div className="mx-auto mb-3 flex h-16 w-16 items-center justify-center rounded-2xl bg-white/20">
+                <svg
+                  viewBox="-32 -32 64 64"
+                  className="h-10 w-10"
+                  role="img"
+                  aria-label="Dazbeez honeycomb"
+                >
                   <polygon
                     points="0,-22 19,-11 19,11 0,22 -19,11 -19,-11"
                     fill="none"
@@ -82,64 +114,111 @@ export function NFCContent() {
                 </svg>
               </div>
               <h1 className="text-2xl font-bold">Dazbeez</h1>
-              <p className="text-amber-50 text-sm tracking-[0.18em] uppercase">
+              <p className="text-sm uppercase tracking-[0.18em] text-amber-50">
                 AI · Automation · Data
               </p>
             </div>
           </div>
 
           <div className="p-6">
-            <p className="text-gray-600 text-center mb-6 text-sm">
-              Tap one of the options below to get started.
-            </p>
+            <Link
+              href={primaryAction.href}
+              className="flex items-center gap-4 rounded-xl bg-amber-500 p-4 text-white transition-colors hover:bg-amber-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2"
+              aria-label={`${primaryAction.label} — ${primaryAction.sublabel}`}
+            >
+              <span aria-hidden="true" className="flex-shrink-0">
+                {primaryAction.icon}
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="block font-semibold leading-tight">
+                  {primaryAction.label}
+                </span>
+                <span className="mt-0.5 block text-xs opacity-80">
+                  {primaryAction.sublabel}
+                </span>
+              </span>
+              <svg
+                className="h-5 w-5 flex-shrink-0"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M9 5l7 7-7 7"
+                />
+              </svg>
+            </Link>
 
-            <div className="space-y-3 mb-6">
-              {quickActions.map((action) => (
+            <a
+              href={VCARD_HREF}
+              className="mt-3 flex items-center justify-center gap-2 rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm font-semibold text-gray-900 transition-colors hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2"
+            >
+              <svg
+                className="h-4 w-4"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M16 12V4M8 12V4m-4 8h16M4 20h16"
+                />
+              </svg>
+              Save David&apos;s contact (vCard)
+            </a>
+
+            <div className="mt-4 flex gap-2">
+              {secondaryActions.map((action) => (
                 <Link
                   key={action.href}
                   href={action.href}
-                  className={`${toneClasses[action.tone]} flex items-center gap-4 p-4 rounded-xl transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2`}
-                  aria-label={`${action.label} — ${action.sublabel}`}
+                  className="flex-1 rounded-lg border border-gray-200 px-3 py-2 text-center text-xs font-medium text-gray-600 transition-colors hover:border-gray-300 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
                 >
-                  <span aria-hidden="true" className="flex-shrink-0">
-                    {action.icon}
-                  </span>
-                  <span className="flex-1 min-w-0">
-                    <span className="block font-semibold leading-tight">
-                      {action.label}
-                    </span>
-                    <span className="block text-xs opacity-80 mt-0.5">
-                      {action.sublabel}
-                    </span>
-                  </span>
-                  <svg className="w-5 h-5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                  </svg>
+                  {action.label}
                 </Link>
               ))}
             </div>
 
-            <p className="text-center text-xs text-gray-400">
-              Scanned from: {source}
-            </p>
+            {canShare ? (
+              <button
+                type="button"
+                onClick={handleShare}
+                className="mt-3 flex w-full items-center justify-center gap-2 text-center text-xs font-medium text-gray-500 hover:text-gray-900"
+              >
+                <svg
+                  className="h-3.5 w-3.5"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"
+                  />
+                </svg>
+                Share this card
+              </button>
+            ) : null}
           </div>
 
-          <div className="bg-gray-100 p-4 text-center">
+          <div className="bg-gray-100 p-3 text-center">
             <Link
               href="/"
-              className="text-sm text-gray-600 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 rounded"
+              className="text-xs text-gray-500 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 rounded"
             >
               Visit full site →
             </Link>
           </div>
-        </div>
-
-        <div className="flex justify-center mt-6">
-          <div className="relative">
-            <div className="w-4 h-4 bg-amber-400 rounded-full motion-safe:animate-ping absolute" aria-hidden="true"></div>
-            <div className="w-4 h-4 bg-amber-500 rounded-full relative" aria-hidden="true"></div>
-          </div>
-          <p className="ml-3 text-white/60 text-sm">NFC detected</p>
         </div>
       </div>
     </div>

--- a/app/nfc/page.tsx
+++ b/app/nfc/page.tsx
@@ -3,17 +3,53 @@ import { Suspense } from "react";
 import { NFCContent } from "./nfc-content";
 
 export const metadata: Metadata = {
-  title: "NFC Quick Access — Dazbeez",
+  title: "Tap to reach David — Dazbeez",
   description:
-    "Open the Dazbeez NFC quick-access page to book a consultation, browse services, or learn how the card works.",
+    "Book a consultation, save David's contact, or browse Dazbeez services — straight from the NFC card.",
   alternates: {
     canonical: "/nfc",
   },
+  openGraph: {
+    title: "Tap to reach David — Dazbeez",
+    description:
+      "Book a consultation, save David's contact, or browse Dazbeez services — straight from the NFC card.",
+    url: "https://dazbeez.com/nfc",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Tap to reach David — Dazbeez",
+    description:
+      "Book a consultation, save David's contact, or browse Dazbeez services — straight from the NFC card.",
+  },
 };
+
+function NFCSkeleton() {
+  return (
+    <div
+      className="flex min-h-screen items-center justify-center bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900 p-4"
+      aria-hidden="true"
+    >
+      <div className="w-full max-w-sm">
+        <div className="overflow-hidden rounded-3xl bg-white shadow-2xl">
+          <div className="h-32 animate-pulse bg-gradient-to-r from-amber-400 to-amber-600" />
+          <div className="space-y-3 p-6">
+            <div className="h-14 animate-pulse rounded-xl bg-gray-200" />
+            <div className="h-11 animate-pulse rounded-xl bg-gray-100" />
+            <div className="flex gap-2">
+              <div className="h-8 flex-1 animate-pulse rounded-lg bg-gray-100" />
+              <div className="h-8 flex-1 animate-pulse rounded-lg bg-gray-100" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 export default function NFCPage() {
   return (
-    <Suspense fallback={null}>
+    <Suspense fallback={<NFCSkeleton />}>
       <NFCContent />
     </Suspense>
   );

--- a/components/receipts/device-list.tsx
+++ b/components/receipts/device-list.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState } from "react";
+import { useToast } from "@/components/ui/toaster";
+import { apiFetch } from "@/lib/use-api-error";
 
 export interface DeviceListItem {
   id: string;
@@ -21,38 +23,38 @@ function formatDate(value: string | null): string {
 export function DeviceList({ devices }: { devices: DeviceListItem[] }) {
   const [items, setItems] = useState(devices);
   const [busyId, setBusyId] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const { toast } = useToast();
 
-  async function revoke(id: string, isCurrent: boolean) {
+  async function revoke(id: string, label: string, isCurrent: boolean) {
     if (
       !confirm(
         isCurrent
           ? "Revoke this device? You'll be signed out and need to re-trust it via Cloudflare Access."
-          : "Revoke this device?",
+          : `Revoke "${label}"?`,
       )
     ) {
       return;
     }
-    setError(null);
     setBusyId(id);
-    try {
-      const res = await fetch(`/api/receipts/devices/${id}/revoke`, {
-        method: "POST",
+    const result = await apiFetch(`/api/receipts/devices/${id}/revoke`, {
+      method: "POST",
+    });
+    setBusyId(null);
+    if (!result.ok) {
+      toast({
+        tone: "error",
+        title: "Revoke failed",
+        body: result.error.message,
       });
-      if (!res.ok) {
-        const body = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(body.error ?? `Revoke failed (${res.status}).`);
-      }
-      if (isCurrent) {
-        window.location.assign("/receipts/enroll");
-        return;
-      }
-      setItems((prev) => prev.filter((d) => d.id !== id));
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Revoke failed.");
-    } finally {
-      setBusyId(null);
+      return;
     }
+    if (isCurrent) {
+      toast({ tone: "info", title: "Signing out…" });
+      window.location.assign("/receipts/enroll");
+      return;
+    }
+    setItems((prev) => prev.filter((d) => d.id !== id));
+    toast({ tone: "success", title: "Device revoked", body: label });
   }
 
   if (items.length === 0) {
@@ -65,11 +67,6 @@ export function DeviceList({ devices }: { devices: DeviceListItem[] }) {
 
   return (
     <div className="space-y-3">
-      {error ? (
-        <p className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-700">
-          {error}
-        </p>
-      ) : null}
       <ul className="divide-y divide-gray-100 overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
         {items.map((d) => (
           <li
@@ -99,7 +96,7 @@ export function DeviceList({ devices }: { devices: DeviceListItem[] }) {
             </div>
             <button
               type="button"
-              onClick={() => revoke(d.id, d.isCurrent)}
+              onClick={() => revoke(d.id, d.label, d.isCurrent)}
               disabled={busyId === d.id}
               className="self-start rounded-xl border border-red-200 bg-white px-3 py-1.5 text-sm font-medium text-red-700 transition-colors hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50 sm:self-auto"
             >

--- a/components/receipts/export/export-screen.tsx
+++ b/components/receipts/export/export-screen.tsx
@@ -12,15 +12,9 @@ import {
   LockIcon,
 } from "@/components/ui/icons";
 import type { ReceiptExport } from "@/lib/receipts/types";
+import type { Blocker } from "@/lib/receipts/blockers";
 
-export interface Blocker {
-  severity: "blocker" | "warn";
-  count: number;
-  label: string;
-  detail: string;
-  href: string | null;
-  ctaLabel: string;
-}
+export type { Blocker } from "@/lib/receipts/blockers";
 
 export interface CategoryBreakdownRow {
   code: string;

--- a/components/receipts/receipt-capture-form.tsx
+++ b/components/receipts/receipt-capture-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { useIsMobile } from "@/lib/receipts/use-viewport";
 import {
   useReceiptUpload,
@@ -25,25 +25,39 @@ const SESSION_QUEUE_KEY = "dazbeez.receipts.captureQueue.v1";
 /** Drop persisted queue entries older than this so the desktop doesn't keep
  *  showing yesterday's receipts after a coffee break. */
 const SESSION_QUEUE_TTL_MS = 1000 * 60 * 60 * 6;
+/** Stable empty array reference so useSyncExternalStore doesn't tear when
+ *  the server snapshot is read repeatedly. */
+const EMPTY_QUEUE: SessionUpload[] = [];
 
-function loadPersistedQueue(): SessionUpload[] {
-  if (typeof window === "undefined") return [];
+// useSyncExternalStore requires the snapshot getter to return a
+// referentially-stable value, so we memoise across renders. The cache is
+// invalidated on every successful persistQueue() write below.
+let cachedQueue: SessionUpload[] | null = null;
+
+function readPersistedQueueFresh(): SessionUpload[] {
+  if (typeof window === "undefined") return EMPTY_QUEUE;
   try {
     const raw = window.sessionStorage.getItem(SESSION_QUEUE_KEY);
-    if (!raw) return [];
+    if (!raw) return EMPTY_QUEUE;
     const parsed = JSON.parse(raw) as {
       savedAt?: number;
       items?: SessionUpload[];
     };
-    if (!parsed.items || !Array.isArray(parsed.items)) return [];
+    if (!parsed.items || !Array.isArray(parsed.items)) return EMPTY_QUEUE;
     if (!parsed.savedAt || Date.now() - parsed.savedAt > SESSION_QUEUE_TTL_MS)
-      return [];
+      return EMPTY_QUEUE;
     // Don't restore in-flight uploads — the upload was aborted when the page
     // unloaded, so the row would dangle forever.
-    return parsed.items.filter((u) => u.state !== "uploading");
+    const filtered = parsed.items.filter((u) => u.state !== "uploading");
+    return filtered.length === 0 ? EMPTY_QUEUE : filtered;
   } catch {
-    return [];
+    return EMPTY_QUEUE;
   }
+}
+
+function loadPersistedQueue(): SessionUpload[] {
+  if (cachedQueue == null) cachedQueue = readPersistedQueueFresh();
+  return cachedQueue;
 }
 
 function persistQueue(items: SessionUpload[]) {
@@ -53,10 +67,13 @@ function persistQueue(items: SessionUpload[]) {
       SESSION_QUEUE_KEY,
       JSON.stringify({ savedAt: Date.now(), items }),
     );
+    cachedQueue = items;
   } catch {
     /* quota or privacy mode — best-effort */
   }
 }
+
+const subscribeNoop = () => () => {};
 
 export function ReceiptCaptureForm({
   initialPayment = null,
@@ -65,16 +82,17 @@ export function ReceiptCaptureForm({
 }: ReceiptCaptureFormProps) {
   const isMobile = useIsMobile();
   const { phase, upload, reset, cancel } = useReceiptUpload();
-  const [sessionUploads, setSessionUploads] = useState<SessionUpload[]>([]);
+  // Seed the queue from sessionStorage on the very first client render
+  // (server snapshot is always empty so hydration matches the empty SSR
+  // markup; the client snapshot reads the persisted queue immediately,
+  // without an effect-driven setState).
+  const persisted = useSyncExternalStore(
+    subscribeNoop,
+    loadPersistedQueue,
+    () => EMPTY_QUEUE,
+  );
+  const [sessionUploads, setSessionUploads] = useState<SessionUpload[]>(persisted);
   const activeIdRef = useRef<string | null>(null);
-
-  // Restore queue from sessionStorage on mount (desktop only — mobile uploads
-  // immediately and doesn't keep a visible queue today).
-  useEffect(() => {
-    if (isMobile) return;
-    const restored = loadPersistedQueue();
-    if (restored.length > 0) setSessionUploads(restored);
-  }, [isMobile]);
 
   // Persist on every change so a hard reload doesn't lose the day's work.
   useEffect(() => {

--- a/components/receipts/receipt-capture-form.tsx
+++ b/components/receipts/receipt-capture-form.tsx
@@ -21,6 +21,43 @@ export interface ReceiptCaptureFormProps {
   todayCount?: number;
 }
 
+const SESSION_QUEUE_KEY = "dazbeez.receipts.captureQueue.v1";
+/** Drop persisted queue entries older than this so the desktop doesn't keep
+ *  showing yesterday's receipts after a coffee break. */
+const SESSION_QUEUE_TTL_MS = 1000 * 60 * 60 * 6;
+
+function loadPersistedQueue(): SessionUpload[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.sessionStorage.getItem(SESSION_QUEUE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as {
+      savedAt?: number;
+      items?: SessionUpload[];
+    };
+    if (!parsed.items || !Array.isArray(parsed.items)) return [];
+    if (!parsed.savedAt || Date.now() - parsed.savedAt > SESSION_QUEUE_TTL_MS)
+      return [];
+    // Don't restore in-flight uploads — the upload was aborted when the page
+    // unloaded, so the row would dangle forever.
+    return parsed.items.filter((u) => u.state !== "uploading");
+  } catch {
+    return [];
+  }
+}
+
+function persistQueue(items: SessionUpload[]) {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.setItem(
+      SESSION_QUEUE_KEY,
+      JSON.stringify({ savedAt: Date.now(), items }),
+    );
+  } catch {
+    /* quota or privacy mode — best-effort */
+  }
+}
+
 export function ReceiptCaptureForm({
   initialPayment = null,
   rapidMode = false,
@@ -30,6 +67,20 @@ export function ReceiptCaptureForm({
   const { phase, upload, reset, cancel } = useReceiptUpload();
   const [sessionUploads, setSessionUploads] = useState<SessionUpload[]>([]);
   const activeIdRef = useRef<string | null>(null);
+
+  // Restore queue from sessionStorage on mount (desktop only — mobile uploads
+  // immediately and doesn't keep a visible queue today).
+  useEffect(() => {
+    if (isMobile) return;
+    const restored = loadPersistedQueue();
+    if (restored.length > 0) setSessionUploads(restored);
+  }, [isMobile]);
+
+  // Persist on every change so a hard reload doesn't lose the day's work.
+  useEffect(() => {
+    if (isMobile) return;
+    persistQueue(sessionUploads);
+  }, [sessionUploads, isMobile]);
 
   const onPickFile = useCallback(
     async (file: File) => {

--- a/components/receipts/receipt-shell.tsx
+++ b/components/receipts/receipt-shell.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { BeeMark } from "@/components/receipts/ui/bee-mark";
+import { ToasterProvider } from "@/components/ui/toaster";
 
 const NAV = [
   { href: "/receipts", label: "Dashboard" },
@@ -25,6 +26,7 @@ export function ReceiptShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname() ?? "";
 
   return (
+    <ToasterProvider>
     <div className="flex min-h-screen flex-col bg-gray-50 text-gray-900">
       <header className="sticky top-0 z-10 flex items-center gap-6 border-b border-gray-200 bg-white px-4 py-3.5 sm:px-8">
         <Link
@@ -69,5 +71,6 @@ export function ReceiptShell({ children }: { children: React.ReactNode }) {
       </header>
       <div className="min-w-0 flex-1">{children}</div>
     </div>
+    </ToasterProvider>
   );
 }

--- a/components/receipts/reconcile/reconcile-screen.tsx
+++ b/components/receipts/reconcile/reconcile-screen.tsx
@@ -24,6 +24,7 @@ import {
   WarningIcon,
 } from "@/components/ui/icons";
 import { ReceiptThumb } from "@/components/receipts/ui/receipt-thumb";
+import { KeyboardHintBar } from "@/components/receipts/ui/keyboard-hint-bar";
 import { useKeyboardShortcuts } from "@/lib/receipts/keyboard";
 import {
   EXPENSE_CATEGORIES,
@@ -40,6 +41,12 @@ import type {
 } from "@/lib/receipts/types";
 import type { StatementWindow } from "@/lib/receipts/statement-window";
 import type { MonthOption } from "@/components/receipts/month-switcher";
+import {
+  BAND_DISPLAY,
+  bandForLine,
+  matchExplanation,
+  type ConfidenceBand,
+} from "@/lib/receipts/confidence";
 
 export interface ReconcileScreenProps {
   amexLines: AmexStatementLine[];
@@ -54,25 +61,6 @@ export interface ReconcileScreenProps {
   window: StatementWindow | null;
   receiptsInWindow: ReceiptRecord[];
 }
-
-type ConfidenceBand = "obvious" | "likely" | "review" | "none";
-
-const BAND_THRESHOLDS: Record<ConfidenceBand, [number, number]> = {
-  obvious: [0.92, 1],
-  likely: [0.7, 0.9199],
-  review: [0.01, 0.6999],
-  none: [0, 0],
-};
-
-const BAND_COLORS: Record<
-  ConfidenceBand,
-  { dot: string; label: string; tone: "green" | "amber" | "red" | "gray" }
-> = {
-  obvious: { dot: "bg-green-500", label: "Obvious", tone: "green" },
-  likely: { dot: "bg-amber-500", label: "Likely", tone: "amber" },
-  review: { dot: "bg-red-500", label: "Review", tone: "red" },
-  none: { dot: "bg-gray-300", label: "No match", tone: "gray" },
-};
 
 type Tab = "lines" | "orphans" | "trips";
 
@@ -452,6 +440,16 @@ export function ReconcileScreen(props: ReconcileScreenProps) {
         />
       </div>
 
+      <KeyboardHintBar
+        hints={[
+          ["j / k", "next · prev line"],
+          ["c", "confirm match"],
+          ["n", "no receipt expected"],
+          ["u", "unlink / unmatch"],
+        ]}
+        trailing={locked ? "Month is sealed — read-only" : undefined}
+      />
+
       {/* Finalize modal */}
       {showFinalizeModal && !locked && (
         <FinalizeModal
@@ -664,7 +662,7 @@ function LineRow({
   onClick: () => void;
 }) {
   const { line, band, match } = lwb;
-  const color = BAND_COLORS[band];
+  const color = BAND_DISPLAY[band];
   const receiptId = line.matched_receipt_id ?? match?.receiptId ?? null;
   const confirmed = line.match_status === "confirmed";
   const noReceipt = line.match_status === "no_receipt";
@@ -846,7 +844,7 @@ function DetailPane({
   const { line, band, match } = active;
   const receiptId = line.matched_receipt_id ?? match?.receiptId ?? null;
   const receipt = receiptId ? receiptMap.get(receiptId) ?? null : null;
-  const color = BAND_COLORS[band];
+  const color = BAND_DISPLAY[band];
   const busy = busyLineId === line.id;
   const showNoReceiptFields =
     line.match_status === "no_receipt" ||
@@ -1348,36 +1346,6 @@ function KV({
       </span>
     </div>
   );
-}
-
-function bandForLine(
-  line: AmexStatementLine,
-  match: ReconciliationMatch | undefined,
-): ConfidenceBand {
-  if (!match) {
-    if (line.match_status === "confirmed") return "obvious";
-    return "none";
-  }
-  const s = match.confidenceScore;
-  if (s >= BAND_THRESHOLDS.obvious[0]) return "obvious";
-  if (s >= BAND_THRESHOLDS.likely[0]) return "likely";
-  return "review";
-}
-
-function matchExplanation(
-  line: AmexStatementLine,
-  receipt: ReceiptRecord | null,
-): string {
-  if (!receipt) return "Pick a receipt or mark as no-receipt-expected.";
-  if (line.amount_minor !== (receipt.amount_minor ?? 0))
-    return "Amount differs — verify before confirming.";
-  if (
-    line.transaction_date &&
-    receipt.transaction_date &&
-    line.transaction_date !== receipt.transaction_date
-  )
-    return "Dates differ slightly — common for late captures.";
-  return "Linked match.";
 }
 
 function formatJpy(amount: number, currency: string | null): string {

--- a/components/receipts/review/form-pane.tsx
+++ b/components/receipts/review/form-pane.tsx
@@ -20,12 +20,13 @@ import {
 } from "@/lib/receipts/categories";
 import type {
   ExpenseType,
-  ExtractionResult,
   PaymentPath,
   ReceiptAttendee,
   ReceiptRecord,
   ReceiptStatus,
 } from "@/lib/receipts/types";
+import { SaveBadge, type SaveState } from "./save-badge";
+import { useExtraction } from "./use-extraction";
 
 const EXPENSE_TYPES: Array<{ value: ExpenseType; label: string }> = [
   { value: "UNKNOWN", label: "Unknown" },
@@ -56,12 +57,6 @@ export interface FormPaneProps {
   reReviewNeeded: boolean;
 }
 
-type SaveState =
-  | { kind: "idle" }
-  | { kind: "saving" }
-  | { kind: "saved"; at: number }
-  | { kind: "error"; message: string };
-
 export function FormPane(props: FormPaneProps) {
   const router = useRouter();
   const { receipt } = props;
@@ -87,10 +82,40 @@ export function FormPane(props: FormPaneProps) {
     props.initialAttendees.map((a) => a.attendee_name),
   );
   const [save, setSave] = useState<SaveState>({ kind: "idle" });
-  const [extractionBusy, setExtractionBusy] = useState(false);
-  const [extractionFeedback, setExtractionFeedback] = useState<string | null>(
-    null,
-  );
+
+  // ─── OCR extraction (delegated to the useExtraction hook) ───────────
+  const {
+    busy: extractionBusy,
+    feedback: extractionFeedback,
+    run: handleExtract,
+  } = useExtraction(receipt.id, (ex) => {
+    let filled = 0;
+    if (ex.transactionDate && !transactionDate) {
+      setTransactionDate(ex.transactionDate);
+      filled++;
+    }
+    if (ex.merchant && !merchant) {
+      setMerchant(ex.merchant);
+      filled++;
+    }
+    if (ex.currency && ex.currency !== currency && currency === "JPY") {
+      setCurrency(ex.currency);
+      filled++;
+    }
+    if (ex.amountMinor != null && !amountDisplay) {
+      setAmountDisplay(formatAmountInput(ex.amountMinor, ex.currency ?? currency));
+      filled++;
+    }
+    if (ex.expenseType && ex.expenseType !== "UNKNOWN" && expenseType === "UNKNOWN") {
+      setExpenseType(ex.expenseType);
+      filled++;
+    }
+    if (ex.businessPurpose && !businessPurpose) {
+      setBusinessPurpose(ex.businessPurpose);
+      filled++;
+    }
+    return filled;
+  });
 
   const needsAttendees = categoryRequiresAttendees(expenseCategoryCode);
   const category = getCategoryByCode(expenseCategoryCode);
@@ -272,62 +297,6 @@ export function FormPane(props: FormPaneProps) {
       if (input instanceof HTMLInputElement) input.focus();
     },
   });
-
-  // ─── extract helper (button in form) ────────────────────────────────
-  async function handleExtract() {
-    setExtractionBusy(true);
-    setExtractionFeedback(null);
-    try {
-      const res = await fetch(`/api/receipts/${receipt.id}/extract`, {
-        method: "POST",
-      });
-      const json = (await res.json()) as {
-        ok?: boolean;
-        extracted?: ExtractionResult;
-        error?: string;
-      };
-      if (!res.ok || !json.extracted) {
-        setExtractionFeedback(json.error ?? "Extraction failed.");
-        return;
-      }
-      const ex = json.extracted;
-      let filled = 0;
-      if (ex.transactionDate && !transactionDate) {
-        setTransactionDate(ex.transactionDate);
-        filled++;
-      }
-      if (ex.merchant && !merchant) {
-        setMerchant(ex.merchant);
-        filled++;
-      }
-      if (ex.currency && ex.currency !== currency && currency === "JPY") {
-        setCurrency(ex.currency);
-        filled++;
-      }
-      if (ex.amountMinor != null) {
-        const next = formatAmountInput(ex.amountMinor, ex.currency ?? currency);
-        if (!amountDisplay) {
-          setAmountDisplay(next);
-          filled++;
-        }
-      }
-      if (ex.expenseType && ex.expenseType !== "UNKNOWN" && expenseType === "UNKNOWN") {
-        setExpenseType(ex.expenseType);
-        filled++;
-      }
-      if (ex.businessPurpose && !businessPurpose) {
-        setBusinessPurpose(ex.businessPurpose);
-        filled++;
-      }
-      setExtractionFeedback(
-        filled === 0 ? "OCR ran — no new fields filled" : `${filled} field${filled === 1 ? "" : "s"} filled from OCR.`,
-      );
-    } catch {
-      setExtractionFeedback("Network error — extraction failed.");
-    } finally {
-      setExtractionBusy(false);
-    }
-  }
 
   async function handleDelete() {
     if (!window.confirm(`Soft-delete receipt ${receipt.id.slice(0, 8)}…?`))
@@ -562,53 +531,6 @@ export function FormPane(props: FormPaneProps) {
       </div>
     </div>
   );
-}
-
-function SaveBadge({ state }: { state: SaveState }) {
-  const ago = useElapsedSeconds(state.kind === "saved" ? state.at : null);
-
-  if (state.kind === "saving") {
-    return (
-      <span className="flex items-center gap-1.5 text-[11.5px] text-amber-700">
-        <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-amber-500" />
-        Saving…
-      </span>
-    );
-  }
-  if (state.kind === "saved") {
-    return (
-      <span className="flex items-center gap-1.5 text-[11.5px] text-green-700">
-        <span className="h-1.5 w-1.5 rounded-full bg-green-500" />
-        Saved · {ago}s ago
-      </span>
-    );
-  }
-  if (state.kind === "error") {
-    return (
-      <span className="flex items-center gap-1.5 text-[11.5px] text-red-600">
-        <span className="h-1.5 w-1.5 rounded-full bg-red-500" />
-        {state.message}
-      </span>
-    );
-  }
-  return null;
-}
-
-function useElapsedSeconds(at: number | null): number {
-  const [now, setNow] = useState<number | null>(at);
-  useEffect(() => {
-    if (at == null) return;
-    const tick = () => setNow(Date.now());
-    const start = setTimeout(tick, 0);
-    const interval = setInterval(tick, 1000);
-    return () => {
-      clearTimeout(start);
-      clearInterval(interval);
-    };
-  }, [at]);
-  return at == null || now == null
-    ? 0
-    : Math.max(1, Math.round((now - at) / 1000));
 }
 
 function formatAmountInput(amount: number | null, currency: string | null) {

--- a/components/receipts/review/review-layout.tsx
+++ b/components/receipts/review/review-layout.tsx
@@ -45,10 +45,17 @@ export function ReviewLayout({
         capturedThisMonth={capturedThisMonth}
         activeFilter={activeFilter ?? null}
       />
-      <div className="grid min-h-0 flex-1 grid-cols-[300px_minmax(0,1fr)_minmax(0,1fr)]">
-        {queueRail}
-        {imagePane}
-        {formPane}
+      {/* Phone: stack queue → image → form so each pane is full-width and
+          swipable. Tablet+: 2-column with image / form side-by-side and the
+          queue folded into a drawer above. Desktop: classic 3-column.       */}
+      <div className="grid min-h-0 flex-1 grid-cols-1 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] lg:grid-cols-[300px_minmax(0,1fr)_minmax(0,1fr)]">
+        <div className="md:col-span-2 lg:col-span-1 lg:row-span-1 max-h-[40vh] overflow-auto border-b border-gray-200 lg:max-h-none lg:border-b-0 lg:border-r">
+          {queueRail}
+        </div>
+        <div className="min-h-[50vh] lg:min-h-0">{imagePane}</div>
+        <div className="border-t border-gray-200 md:border-l md:border-t-0">
+          {formPane}
+        </div>
       </div>
       <KeyboardHintBar
         hints={REVIEW_HINTS}

--- a/components/receipts/review/save-badge.tsx
+++ b/components/receipts/review/save-badge.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export type SaveState =
+  | { kind: "idle" }
+  | { kind: "saving" }
+  | { kind: "saved"; at: number }
+  | { kind: "error"; message: string };
+
+/**
+ * Inline "Saving… / Saved Xs ago / error" indicator for the review form.
+ * Lives in its own file so form-pane stays focused on the receipt fields.
+ */
+export function SaveBadge({ state }: { state: SaveState }) {
+  const ago = useElapsedSeconds(state.kind === "saved" ? state.at : null);
+
+  if (state.kind === "saving") {
+    return (
+      <span className="flex items-center gap-1.5 text-[11.5px] text-amber-700">
+        <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-amber-500" />
+        Saving…
+      </span>
+    );
+  }
+  if (state.kind === "saved") {
+    return (
+      <span className="flex items-center gap-1.5 text-[11.5px] text-green-700">
+        <span className="h-1.5 w-1.5 rounded-full bg-green-500" />
+        Saved · {ago}s ago
+      </span>
+    );
+  }
+  if (state.kind === "error") {
+    return (
+      <span className="flex items-center gap-1.5 text-[11.5px] text-red-600">
+        <span className="h-1.5 w-1.5 rounded-full bg-red-500" />
+        {state.message}
+      </span>
+    );
+  }
+  return null;
+}
+
+function useElapsedSeconds(at: number | null): number {
+  const [now, setNow] = useState<number | null>(at);
+  useEffect(() => {
+    if (at == null) return;
+    const tick = () => setNow(Date.now());
+    const start = setTimeout(tick, 0);
+    const interval = setInterval(tick, 1000);
+    return () => {
+      clearTimeout(start);
+      clearInterval(interval);
+    };
+  }, [at]);
+  return at == null || now == null
+    ? 0
+    : Math.max(1, Math.round((now - at) / 1000));
+}

--- a/components/receipts/review/use-extraction.ts
+++ b/components/receipts/review/use-extraction.ts
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState } from "react";
+import type { ExtractionResult } from "@/lib/receipts/types";
+
+export type ExtractionApplyFn = (extracted: ExtractionResult) => number;
+
+export type UseExtractionResult = {
+  busy: boolean;
+  feedback: string | null;
+  run: () => Promise<void>;
+  setFeedback: (msg: string | null) => void;
+};
+
+/**
+ * Calls POST /api/receipts/:id/extract, then hands the result to a caller-
+ * supplied `apply` function which is responsible for merging the new
+ * fields into form state (returning the number of fields actually filled).
+ *
+ * Extracted from form-pane so the OCR retry/feedback UX has a single home.
+ */
+export function useExtraction(
+  receiptId: string,
+  apply: ExtractionApplyFn,
+): UseExtractionResult {
+  const [busy, setBusy] = useState(false);
+  const [feedback, setFeedback] = useState<string | null>(null);
+
+  async function run() {
+    setBusy(true);
+    setFeedback(null);
+    try {
+      const res = await fetch(`/api/receipts/${receiptId}/extract`, {
+        method: "POST",
+      });
+      const json = (await res.json()) as {
+        ok?: boolean;
+        extracted?: ExtractionResult;
+        error?: string;
+      };
+      if (!res.ok || !json.extracted) {
+        setFeedback(json.error ?? "Extraction failed.");
+        return;
+      }
+      const filled = apply(json.extracted);
+      setFeedback(
+        filled === 0
+          ? "OCR ran — no new fields filled"
+          : `${filled} field${filled === 1 ? "" : "s"} filled from OCR.`,
+      );
+    } catch {
+      setFeedback("Network error — extraction failed.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return { busy, feedback, run, setFeedback };
+}

--- a/components/receipts/ui/stat-tile.tsx
+++ b/components/receipts/ui/stat-tile.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from "react";
+import { Card } from "@/components/ui/card";
+
+export type StatTileProps = {
+  label: string;
+  value: ReactNode;
+  sub?: ReactNode;
+  /** Show the value in amber to signal something needs attention. */
+  accent?: boolean;
+};
+
+/**
+ * A small "metric" card used across the receipts dashboard, AMEX page,
+ * export and reconcile screens. Replaces the previously-duplicated
+ * `StatTile` / `Stat` definitions in each page.
+ */
+export function StatTile({ label, value, sub, accent }: StatTileProps) {
+  return (
+    <Card>
+      <div className="text-[11px] font-bold uppercase tracking-[0.05em] text-gray-500">
+        {label}
+      </div>
+      <div
+        className={[
+          "mt-1.5 text-[26px] font-bold tabular-nums",
+          accent ? "text-amber-700" : "text-gray-900",
+        ].join(" ")}
+      >
+        {value}
+      </div>
+      {sub ? <div className="mt-0.5 text-[12px] text-gray-500">{sub}</div> : null}
+    </Card>
+  );
+}

--- a/components/ui/toaster.tsx
+++ b/components/ui/toaster.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+
+export type ToastTone = "info" | "success" | "warn" | "error";
+
+export type Toast = {
+  id: string;
+  tone: ToastTone;
+  title: string;
+  body?: string;
+  /** Milliseconds before auto-dismiss. 0 = persistent. */
+  ttl?: number;
+};
+
+type ToastInput = Omit<Toast, "id"> & { id?: string };
+
+type ToasterContextValue = {
+  toast: (t: ToastInput) => string;
+  dismiss: (id: string) => void;
+};
+
+const ToasterContext = createContext<ToasterContextValue | null>(null);
+
+const TONE_CLASSES: Record<
+  ToastTone,
+  { bar: string; iconBg: string; icon: ReactNode }
+> = {
+  info: {
+    bar: "border-l-blue-400",
+    iconBg: "bg-blue-100 text-blue-700",
+    icon: "i",
+  },
+  success: {
+    bar: "border-l-green-500",
+    iconBg: "bg-green-100 text-green-700",
+    icon: "✓",
+  },
+  warn: {
+    bar: "border-l-amber-500",
+    iconBg: "bg-amber-100 text-amber-700",
+    icon: "!",
+  },
+  error: {
+    bar: "border-l-red-500",
+    iconBg: "bg-red-100 text-red-700",
+    icon: "✕",
+  },
+};
+
+export function ToasterProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  const timers = useRef(new Map<string, ReturnType<typeof setTimeout>>());
+
+  const dismiss = useCallback((id: string) => {
+    setToasts((list) => list.filter((t) => t.id !== id));
+    const handle = timers.current.get(id);
+    if (handle) {
+      clearTimeout(handle);
+      timers.current.delete(id);
+    }
+  }, []);
+
+  const toast = useCallback(
+    (input: ToastInput) => {
+      const id =
+        input.id ??
+        (typeof crypto !== "undefined" && crypto.randomUUID
+          ? crypto.randomUUID()
+          : `t-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+      const next: Toast = {
+        id,
+        tone: input.tone,
+        title: input.title,
+        body: input.body,
+        ttl: input.ttl ?? (input.tone === "error" ? 6000 : 3500),
+      };
+      setToasts((list) => [...list.filter((t) => t.id !== id), next]);
+      if (next.ttl && next.ttl > 0) {
+        timers.current.set(
+          id,
+          setTimeout(() => dismiss(id), next.ttl),
+        );
+      }
+      return id;
+    },
+    [dismiss],
+  );
+
+  useEffect(() => {
+    const t = timers.current;
+    return () => {
+      for (const handle of t.values()) clearTimeout(handle);
+      t.clear();
+    };
+  }, []);
+
+  const value = useMemo(() => ({ toast, dismiss }), [toast, dismiss]);
+
+  return (
+    <ToasterContext.Provider value={value}>
+      {children}
+      <div
+        aria-live="polite"
+        aria-atomic="false"
+        className="pointer-events-none fixed bottom-4 right-4 z-50 flex w-full max-w-sm flex-col gap-2"
+      >
+        {toasts.map((t) => {
+          const tone = TONE_CLASSES[t.tone];
+          return (
+            <div
+              key={t.id}
+              role={t.tone === "error" ? "alert" : "status"}
+              className={`pointer-events-auto flex items-start gap-3 rounded-xl border border-gray-200 border-l-4 bg-white p-3 shadow-lg ${tone.bar}`}
+            >
+              <span
+                aria-hidden="true"
+                className={`mt-0.5 flex h-6 w-6 flex-none items-center justify-center rounded-full text-sm font-bold ${tone.iconBg}`}
+              >
+                {tone.icon}
+              </span>
+              <div className="min-w-0 flex-1">
+                <div className="text-[13px] font-semibold text-gray-900">
+                  {t.title}
+                </div>
+                {t.body ? (
+                  <div className="mt-0.5 text-[12px] text-gray-600">{t.body}</div>
+                ) : null}
+              </div>
+              <button
+                type="button"
+                onClick={() => dismiss(t.id)}
+                className="text-gray-400 transition-colors hover:text-gray-700"
+                aria-label="Dismiss notification"
+              >
+                ×
+              </button>
+            </div>
+          );
+        })}
+      </div>
+    </ToasterContext.Provider>
+  );
+}
+
+/**
+ * Push toasts from any client component. Safe to call from a component that
+ * is mounted outside the provider — falls back to a no-op so legacy pages
+ * that haven't adopted the toaster don't throw.
+ */
+export function useToast(): ToasterContextValue {
+  const ctx = useContext(ToasterContext);
+  if (ctx) return ctx;
+  return {
+    toast: () => "",
+    dismiss: () => {},
+  };
+}

--- a/lib/receipts/blockers.ts
+++ b/lib/receipts/blockers.ts
@@ -1,0 +1,113 @@
+// Blocker / warning summarisation for the monthly export flow.
+// Hoisted out of app/(receipt-system)/receipts/export/page.tsx so the same
+// rules can power the dashboard "Export status" tile and the reconcile
+// screen's "Ready to seal?" summary without forking the logic.
+
+import { requiresAttendees } from "@/lib/receipts/categories";
+import type { AmexStatementLine, ReceiptRecord } from "@/lib/receipts/types";
+
+export type BlockerSeverity = "blocker" | "warn";
+
+export type Blocker = {
+  severity: BlockerSeverity;
+  count: number;
+  label: string;
+  detail: string;
+  href: string | null;
+  ctaLabel: string;
+};
+
+export function computeExportBlockers(
+  receipts: ReceiptRecord[],
+  lines: AmexStatementLine[],
+): Blocker[] {
+  const blockers: Blocker[] = [];
+
+  const uncategorized = lines.filter((l) => !l.expense_category_code).length;
+  if (uncategorized > 0) {
+    blockers.push({
+      severity: "blocker",
+      count: uncategorized,
+      label: "Uncategorized AMEX lines",
+      detail: "Pick an expense category for each line.",
+      href: "/receipts/reconcile",
+      ctaLabel: "Fix in Reconcile",
+    });
+  }
+
+  const unreviewed = receipts.filter(
+    (r) => r.status === "captured" || r.status === "needs_review",
+  ).length;
+  if (unreviewed > 0) {
+    blockers.push({
+      severity: "blocker",
+      count: unreviewed,
+      label: "Unreviewed receipts",
+      detail: "These receipts must be reviewed before sealing.",
+      href: "/receipts/review",
+      ctaLabel: "Fix in Review",
+    });
+  }
+
+  const attendeesMissing = lines.filter(
+    (l) => requiresAttendees(l.expense_category_code) && !l.matched_receipt_id,
+  ).length;
+  if (attendeesMissing > 0) {
+    blockers.push({
+      severity: "blocker",
+      count: attendeesMissing,
+      label: "Entertainment/meeting lines need attendees",
+      detail: "Link a receipt that has attendees recorded.",
+      href: "/receipts/reconcile",
+      ctaLabel: "Fix in Reconcile",
+    });
+  }
+
+  const missingReason = lines.filter(
+    (l) => l.receipt_status === "missing_receipt" && !l.receipt_missing_reason,
+  ).length;
+  if (missingReason > 0) {
+    blockers.push({
+      severity: "blocker",
+      count: missingReason,
+      label: 'Lines marked "missing receipt" without a reason',
+      detail: "Add a brief reason so audit can defend the claim.",
+      href: "/receipts/reconcile",
+      ctaLabel: "Fix in Reconcile",
+    });
+  }
+
+  return blockers;
+}
+
+export function computeExportWarnings(lines: AmexStatementLine[]): Blocker[] {
+  const warnings: Blocker[] = [];
+
+  const tripCandidates = lines.filter(
+    (l) => l.business_trip_status === "candidate",
+  ).length;
+  if (tripCandidates > 0) {
+    warnings.push({
+      severity: "warn",
+      count: tripCandidates,
+      label: "Unresolved business-trip candidates",
+      detail: "Confirm or dismiss the trip cluster.",
+      href: "/receipts/reconcile",
+      ctaLabel: "Open trips",
+    });
+  }
+
+  const noReceipt = lines.filter((l) => l.match_status === "no_receipt").length;
+  if (noReceipt > 0) {
+    warnings.push({
+      severity: "warn",
+      count: noReceipt,
+      label: 'AMEX lines marked "no receipt expected"',
+      detail: "These ship as-is; not a blocker.",
+      href: null,
+      ctaLabel: "Acknowledge",
+    });
+  }
+
+  return warnings;
+}

--- a/lib/receipts/confidence.ts
+++ b/lib/receipts/confidence.ts
@@ -1,0 +1,59 @@
+// Confidence bands for AMEX line ↔ receipt match suggestions.
+// Lifted out of reconcile-screen so thresholds, labels and colours have a
+// single home and can be referenced from blockers / dashboard summaries.
+
+import type { AmexStatementLine, ReceiptRecord } from "@/lib/receipts/types";
+
+export type ConfidenceBand = "obvious" | "likely" | "review" | "none";
+
+export const BAND_THRESHOLDS: Record<ConfidenceBand, [number, number]> = {
+  obvious: [0.92, 1],
+  likely: [0.7, 0.9199],
+  review: [0.01, 0.6999],
+  none: [0, 0],
+};
+
+export const BAND_DISPLAY: Record<
+  ConfidenceBand,
+  { dot: string; label: string; tone: "green" | "amber" | "red" | "gray" }
+> = {
+  obvious: { dot: "bg-green-500", label: "Obvious", tone: "green" },
+  likely: { dot: "bg-amber-500", label: "Likely", tone: "amber" },
+  review: { dot: "bg-red-500", label: "Review", tone: "red" },
+  none: { dot: "bg-gray-300", label: "No match", tone: "gray" },
+};
+
+/** Pick the band for a line given its (optional) best match score. */
+export function bandForLine(
+  line: AmexStatementLine,
+  match: { confidenceScore: number } | undefined,
+): ConfidenceBand {
+  if (!match) {
+    if (line.match_status === "confirmed") return "obvious";
+    return "none";
+  }
+  const s = match.confidenceScore;
+  if (s >= BAND_THRESHOLDS.obvious[0]) return "obvious";
+  if (s >= BAND_THRESHOLDS.likely[0]) return "likely";
+  return "review";
+}
+
+/**
+ * Human-readable explanation of why a line/receipt pair is or isn't a clean
+ * match. Used by the reconcile detail pane.
+ */
+export function matchExplanation(
+  line: AmexStatementLine,
+  receipt: ReceiptRecord | null,
+): string {
+  if (!receipt) return "Pick a receipt or mark as no-receipt-expected.";
+  if (line.amount_minor !== (receipt.amount_minor ?? 0))
+    return "Amount differs — verify before confirming.";
+  if (
+    line.transaction_date &&
+    receipt.transaction_date &&
+    line.transaction_date !== receipt.transaction_date
+  )
+    return "Dates differ slightly — common for late captures.";
+  return "Linked match.";
+}

--- a/lib/receipts/format.ts
+++ b/lib/receipts/format.ts
@@ -1,0 +1,49 @@
+// Shared formatters for the receipts module. Extracted from per-page
+// duplicates so dashboard, amex, export and reconcile render months and
+// amounts identically.
+
+/**
+ * Format a YYYY-MM string as "October 2026".
+ * Falls back to the raw input if the month string is malformed.
+ */
+export function formatMonth(month: string): string {
+  try {
+    const [y, m] = month.split("-").map(Number);
+    if (!y || !m) return month;
+    return new Date(y, m - 1, 1).toLocaleDateString("en-US", {
+      month: "long",
+      year: "numeric",
+    });
+  } catch {
+    return month;
+  }
+}
+
+/**
+ * Format a minor-unit amount as JPY ("¥1,234") when no currency is given
+ * or when the currency is JPY. Other currencies are rendered with two
+ * decimals and the ISO code.
+ */
+export function formatAmountMinor(
+  amountMinor: number,
+  currency: string | null = "JPY",
+): string {
+  if (!currency || currency === "JPY") return `¥${amountMinor.toLocaleString()}`;
+  return `${(amountMinor / 100).toFixed(2)} ${currency}`;
+}
+
+/**
+ * Pretty label for the payment path enum used throughout the receipts UI.
+ */
+export function formatPaymentPath(path: string | null | undefined): string {
+  switch (path) {
+    case "AMEX":
+      return "AMEX";
+    case "CASH":
+      return "Cash";
+    case "DIGITAL":
+      return "Digital";
+    default:
+      return path ?? "—";
+  }
+}

--- a/lib/receipts/month-lock.ts
+++ b/lib/receipts/month-lock.ts
@@ -1,0 +1,45 @@
+// A small value-object that bundles "is this month finalized?" with the
+// metadata UI surfaces need: a label, a reason for the lock, and a date.
+// Pages fetch the finalized flag server-side and pass this down so client
+// components can disable mutating controls upstream — instead of letting
+// the user click a button and discover the 409 in a toast.
+
+export type MonthLock = {
+  /** True when the month is finalized (no further edits allowed). */
+  locked: boolean;
+  /** ISO timestamp the reconciliation was sealed, if any. */
+  finalizedAt: string | null;
+  /** Short label suitable for a Pill or badge ("Sealed" / "Draft"). */
+  badge: "Sealed" | "Draft" | "Not built";
+  /** One-line reason to surface in tooltips and confirm dialogs. */
+  reason: string;
+};
+
+export function buildMonthLock(input: {
+  finalized: boolean;
+  finalizedAt?: string | null;
+  hasDraft?: boolean;
+}): MonthLock {
+  if (input.finalized) {
+    return {
+      locked: true,
+      finalizedAt: input.finalizedAt ?? null,
+      badge: "Sealed",
+      reason: "This month is finalized. Reopen reconciliation to edit.",
+    };
+  }
+  if (input.hasDraft) {
+    return {
+      locked: false,
+      finalizedAt: null,
+      badge: "Draft",
+      reason: "Reconciliation is in progress.",
+    };
+  }
+  return {
+    locked: false,
+    finalizedAt: null,
+    badge: "Not built",
+    reason: "Reconciliation hasn't been started for this month.",
+  };
+}

--- a/lib/use-api-error.ts
+++ b/lib/use-api-error.ts
@@ -1,0 +1,129 @@
+"use client";
+
+import { useCallback } from "react";
+import { useToast } from "@/components/ui/toaster";
+
+export type ApiErrorKind =
+  | "network"
+  | "auth"
+  | "forbidden"
+  | "not_found"
+  | "conflict"
+  | "validation"
+  | "server"
+  | "unknown";
+
+export type ApiError = {
+  kind: ApiErrorKind;
+  status: number | null;
+  message: string;
+  /** Original raw JSON body, when available. */
+  body?: unknown;
+};
+
+/**
+ * Classify a fetch Response (or thrown error) into a typed ApiError so
+ * UI code can branch on `.kind` instead of substring-matching `.message`.
+ */
+export async function classifyResponse(
+  res: Response | null,
+  err?: unknown,
+): Promise<ApiError> {
+  if (!res) {
+    return {
+      kind: "network",
+      status: null,
+      message:
+        err instanceof Error ? err.message : "Network error — please try again.",
+    };
+  }
+
+  let body: unknown;
+  let message: string | undefined;
+  try {
+    body = await res.clone().json();
+    if (body && typeof body === "object") {
+      const maybe = body as { error?: unknown; message?: unknown };
+      if (typeof maybe.error === "string") message = maybe.error;
+      else if (typeof maybe.message === "string") message = maybe.message;
+    }
+  } catch {
+    /* non-json body */
+  }
+
+  const fallback = message ?? `Request failed (HTTP ${res.status}).`;
+
+  if (res.status === 401)
+    return { kind: "auth", status: res.status, message: fallback, body };
+  if (res.status === 403)
+    return { kind: "forbidden", status: res.status, message: fallback, body };
+  if (res.status === 404)
+    return { kind: "not_found", status: res.status, message: fallback, body };
+  if (res.status === 409)
+    return { kind: "conflict", status: res.status, message: fallback, body };
+  if (res.status === 422)
+    return { kind: "validation", status: res.status, message: fallback, body };
+  if (res.status >= 500)
+    return { kind: "server", status: res.status, message: fallback, body };
+  return { kind: "unknown", status: res.status, message: fallback, body };
+}
+
+const TITLES: Record<ApiErrorKind, string> = {
+  network: "Network error",
+  auth: "Sign-in expired",
+  forbidden: "Not allowed",
+  not_found: "Not found",
+  conflict: "Conflict",
+  validation: "Validation failed",
+  server: "Server error",
+  unknown: "Request failed",
+};
+
+/**
+ * One-liner for reporting an ApiError to the toast surface from any
+ * client component. Returns a function so callers can keep their
+ * `try { await fetch(...) } catch (e) { reportApiError(e) }` shape.
+ */
+export function useApiError() {
+  const { toast } = useToast();
+  return useCallback(
+    (err: ApiError, opts?: { fallbackTitle?: string }) => {
+      toast({
+        tone: "error",
+        title: opts?.fallbackTitle ?? TITLES[err.kind],
+        body: err.message,
+      });
+    },
+    [toast],
+  );
+}
+
+/**
+ * Thin fetch wrapper that returns either `{ ok: true, data }` or
+ * `{ ok: false, error }`. Removes the boilerplate of manually parsing
+ * each response status. Use from client components only.
+ */
+export async function apiFetch<T = unknown>(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<{ ok: true; data: T } | { ok: false; error: ApiError }> {
+  let res: Response;
+  try {
+    res = await fetch(input, init);
+  } catch (err) {
+    return { ok: false, error: await classifyResponse(null, err) };
+  }
+  if (!res.ok) {
+    return { ok: false, error: await classifyResponse(res) };
+  }
+  let data: unknown = null;
+  const text = await res.text();
+  if (text) {
+    try {
+      data = JSON.parse(text);
+    } catch {
+      data = text;
+    }
+  }
+  return { ok: true, data: data as T };
+}


### PR DESCRIPTION
## Summary

Behavior-driven audit of `/receipts/*` and the NFC card pages
(`/business-card`, `/nfc`), then nine concrete upgrades that fall out of
that audit. No behavior changes for happy paths; all wins are about
de-duplication, error feedback, mobile UX, and the broken vCard promise.

## What changed

### Shared libs (DRY)
- `lib/receipts/format.ts` — `formatMonth` / `formatAmountMinor` /
  `formatPaymentPath` (previously duplicated in dashboard, export and
  reconcile pages).
- `lib/receipts/confidence.ts` — `BAND_THRESHOLDS`, `BAND_DISPLAY`,
  `bandForLine`, `matchExplanation` lifted out of `reconcile-screen`.
- `lib/receipts/blockers.ts` — export blocker/warning rules so the
  dashboard tile and reconcile summary can share the logic with the
  export page.
- `lib/receipts/month-lock.ts` — `MonthLock` value-object
  (`{ locked, badge, reason, finalizedAt }`) for finalized-month UI.
- `components/receipts/ui/stat-tile.tsx` — shared dashboard tile.

### Feedback layer
- `components/ui/toaster.tsx` — `<ToasterProvider>` + `useToast()`
  hook, mounted inside `ReceiptShell` so any client component under
  `/receipts/*` can call it. Renders bottom-right with `role=status` /
  `role=alert` per tone.
- `lib/use-api-error.ts` — `classifyResponse()` returns a typed
  `ApiError` (`network | auth | forbidden | not_found | conflict |
  validation | server | unknown`) plus an `apiFetch<T>()` wrapper.
  Adopted in `device-list.tsx` as a starter migration.

### Form-pane split
- `components/receipts/review/save-badge.tsx` — `<SaveBadge>` +
  `SaveState` type extracted.
- `components/receipts/review/use-extraction.ts` — OCR fetch + feedback
  copy moved into a hook; form-pane now only declares which fields to
  fill.
- `form-pane.tsx`: 618 → 540 LOC.

### Capture queue persistence
- Desktop capture queue persists to `sessionStorage` (6h TTL, in-flight
  rows dropped on restore). Implemented with `useSyncExternalStore` so
  initial state is hydration-safe and doesn't trigger React's
  set-state-in-effect rule.

### Mobile review layout
- `review-layout.tsx` swaps the hard-coded 3-col grid for
  `grid-cols-1 md:grid-cols-2 lg:grid-cols-[300px_1fr_1fr]` so the
  queue / image / form stack on phone, split 2-col on tablet, and only
  use the full 3-column desktop layout at `lg+`.
- Reconcile screen gets a `<KeyboardHintBar>` (was Review-only) so
  `j/k/c/n/u` shortcuts are discoverable.

### NFC card
- Drop the visible "Scanned from: …" debug string; replaced with a
  fire-and-forget `navigator.sendBeacon('/api/nfc/hit')` and a new
  `app/api/nfc/hit/route.ts` that logs the tap source.
- Demote secondary CTAs to thin link tiles so "Book a consultation"
  reads as the primary action.
- Add a real **"Save David's contact (vCard)"** button backed by a new
  `app/api/vcard/route.ts` that serves a proper `text/vcard` blob with
  `Content-Disposition: attachment`.
- Optional **"Share this card"** button using `navigator.share` when
  available (hydration-safe via `useSyncExternalStore`).
- Replace `<Suspense fallback={null}>` with a card skeleton so slow
  hydration doesn't flash a blank screen.
- Custom OG metadata for `/nfc`.
- `/business-card` now offers a direct vCard download CTA — closing
  the previously broken "download David's vCard" promise.

## Audit findings the PR does *not* address (left for follow-ups)

These came up in the BDD audit but felt risky to roll into the same PR
without a Mac + bindings to verify against:

- Further splitting `reconcile-screen.tsx` (still 1386 LOC) and
  `export-screen.tsx` (1054 LOC). The lib extracts (`blockers`,
  `confidence`) prepare the seams; the visual split is the next step.
- Migrating the remaining inline `setError` callsites in
  `amex-import-form`, `enroll-device-form`, `export-screen`, and
  `reconcile-screen` over to `useToast()` / `apiFetch()`.
- Adding `ReceiptThumb` alt-text + landmark roles in
  Review/Reconcile panes.
- Cursor pagination on `GET /api/receipts` (currently capped at 200).

## Test plan

- [x] `tsc --noEmit` passes (verified in the sandbox)
- [x] `eslint` passes on touched files (verified in the sandbox)
- [ ] On Mac: `npm run build:cf` passes
- [ ] On Mac: `npm run cf:dev`, then exercise the touched surfaces:
  - [ ] `/receipts` dashboard renders with shared `StatTile`
  - [ ] `/receipts/review` on a phone-sized viewport stacks 1-col;
        tablet shows 2-col; desktop shows 3-col
  - [ ] `/receipts/reconcile` shows the new keyboard hint bar; `j/k/c/n/u`
        still work
  - [ ] Revoke a non-current device → success toast appears,
        device disappears from the list
  - [ ] Refresh `/receipts/capture` on desktop with a queue → queue
        restores from sessionStorage (in-flight rows skipped)
  - [ ] `/nfc?src=card1` → no visible "Scanned from", `/api/nfc/hit`
        beacon fires, three buttons render with correct hierarchy,
        vCard downloads as `david-klan.vcf`
  - [ ] `/business-card` → "Save David's vCard" button downloads the
        vCard from `/api/vcard`
  - [ ] On a mobile browser, `/nfc` shows "Share this card" and the
        share sheet opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WxuDJmQXxuoZfa3W2rGreh)_