### PR TITLE
feat(receipts): Japanese tax-document preservation compliance layer

### DIFF
--- a/app/(receipt-system)/receipts/export/page.tsx
+++ b/app/(receipt-system)/receipts/export/page.tsx
@@ -24,6 +24,10 @@ import {
   computeExportBlockers,
   computeExportWarnings,
 } from "@/lib/receipts/blockers";
+import {
+  ACCOUNTANT_DISCLAIMER_EN,
+  ACCOUNTANT_DISCLAIMER_JA,
+} from "@/lib/receipts/settings";
 
 export const dynamic = "force-dynamic";
 
@@ -101,6 +105,11 @@ export default async function ExportPage({
         manifestSample={manifestSample}
         manifestSize={manifestSize}
       />
+      <div className="border-t border-amber-100 bg-amber-50 px-8 py-4 text-xs text-amber-900">
+        <p className="font-semibold">Accountant review boundary</p>
+        <p className="mt-1">{ACCOUNTANT_DISCLAIMER_EN}</p>
+        <p className="mt-2">{ACCOUNTANT_DISCLAIMER_JA}</p>
+      </div>
     </>
   );
 }

--- a/app/(receipt-system)/receipts/page.tsx
+++ b/app/(receipt-system)/receipts/page.tsx
@@ -14,6 +14,9 @@ import { Pill } from "@/components/ui/pill";
 import { ArrowRightIcon, CameraIcon } from "@/components/ui/icons";
 import { StatTile } from "@/components/receipts/ui/stat-tile";
 import { formatMonth } from "@/lib/receipts/format";
+import { ComplianceSummaryCards } from "@/components/receipts/ComplianceSummaryCards";
+import { summarizeOpenChecksForMonth } from "@/lib/receipts/compliance";
+import { getReceiptsDb } from "@/lib/cloudflare-runtime";
 
 export const dynamic = "force-dynamic";
 
@@ -78,10 +81,17 @@ export default async function ReceiptsDashboardPage() {
     /* alerts optional */
   }
 
-  const [monthReceipts, allLines, exports] = await Promise.all([
+  const [monthReceipts, allLines, exports, complianceSummary] = await Promise.all([
     listReceiptRecords({ month, limit: 1000 }),
     listAmexLineCountsByMonth(),
     listExports(),
+    summarizeOpenChecksForMonth(getReceiptsDb(), month).catch(() => ({
+      blockers: 0,
+      warnings: 0,
+      info: 0,
+      total: 0,
+      byType: {},
+    })),
   ]);
 
   const unreviewed = monthReceipts.filter(
@@ -149,6 +159,10 @@ export default async function ReceiptsDashboardPage() {
               : "Run reconcile + finalize"
           }
         />
+      </div>
+
+      <div className="mt-6">
+        <ComplianceSummaryCards month={month} summary={complianceSummary} />
       </div>
 
       <div className="mt-8 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">

--- a/app/(receipt-system)/receipts/review/[id]/page.tsx
+++ b/app/(receipt-system)/receipts/review/[id]/page.tsx
@@ -15,6 +15,9 @@ import {
   InlineServerError,
   isNextInternalError,
 } from "@/components/receipts/review/inline-error";
+import { CompliancePanel } from "@/components/receipts/CompliancePanel";
+import { listChecksForObject } from "@/lib/receipts/compliance";
+import { getReceiptsDb } from "@/lib/cloudflare-runtime";
 
 export const dynamic = "force-dynamic";
 
@@ -39,10 +42,11 @@ async function renderReceiptPage(params: Promise<{ id: string }>) {
   await assertReceiptsPageAccess();
 
   const { id } = await params;
-  const [receipt, attendees, all] = await Promise.all([
+  const [receipt, attendees, all, complianceChecks] = await Promise.all([
     getReceiptRecord(id),
     listAttendees(id),
     listReceiptRecords({ limit: 200 }),
+    listChecksForObject(getReceiptsDb(), "receipt", id),
   ]);
   if (!receipt) notFound();
 
@@ -90,16 +94,19 @@ async function renderReceiptPage(params: Promise<{ id: string }>) {
         />
       }
       formPane={
-        <FormPane
-          receipt={receipt}
-          initialAttendees={attendees}
-          queueIndex={Math.max(1, activeIndex + 1)}
-          queueTotal={queueItems.length}
-          nextReceiptId={nextReceiptId}
-          prevReceiptId={prevReceiptId}
-          hasAmexMatch={activeFlags?.hasMatch ?? false}
-          reReviewNeeded={activeFlags?.reReviewNeeded ?? false}
-        />
+        <div className="space-y-4">
+          <CompliancePanel checks={complianceChecks} />
+          <FormPane
+            receipt={receipt}
+            initialAttendees={attendees}
+            queueIndex={Math.max(1, activeIndex + 1)}
+            queueTotal={queueItems.length}
+            nextReceiptId={nextReceiptId}
+            prevReceiptId={prevReceiptId}
+            hasAmexMatch={activeFlags?.hasMatch ?? false}
+            reReviewNeeded={activeFlags?.reReviewNeeded ?? false}
+          />
+        </div>
       }
     />
   );

--- a/app/(receipt-system)/receipts/settings/compliance/page.tsx
+++ b/app/(receipt-system)/receipts/settings/compliance/page.tsx
@@ -1,0 +1,45 @@
+import { assertReceiptsPageAccess } from "@/lib/receipts/auth-request";
+import {
+  getComplianceSettings,
+  ACCOUNTANT_DISCLAIMER_EN,
+  ACCOUNTANT_DISCLAIMER_JA,
+} from "@/lib/receipts/settings";
+import { ComplianceSettingsForm } from "@/components/receipts/ComplianceSettingsForm";
+import Link from "next/link";
+
+export const dynamic = "force-dynamic";
+
+export default async function ComplianceSettingsPage() {
+  await assertReceiptsPageAccess();
+  const settings = await getComplianceSettings();
+
+  return (
+    <div className="space-y-6 px-8 py-8">
+      <div className="flex items-baseline justify-between">
+        <div>
+          <Link
+            href="/receipts/settings"
+            className="text-xs text-amber-700 hover:underline"
+          >
+            ← Settings
+          </Link>
+          <h2 className="mt-2 text-[26px] font-bold text-gray-900">
+            Compliance &amp; 税務 settings
+          </h2>
+          <p className="mt-1 text-sm text-gray-500">
+            Configure preservation, qualified-invoice, and attendee rules. These
+            apply to all receipts and exports.
+          </p>
+        </div>
+      </div>
+
+      <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+        <p className="font-semibold">Accountant review boundary</p>
+        <p className="mt-1">{ACCOUNTANT_DISCLAIMER_EN}</p>
+        <p className="mt-2 text-amber-800">{ACCOUNTANT_DISCLAIMER_JA}</p>
+      </div>
+
+      <ComplianceSettingsForm initial={settings} />
+    </div>
+  );
+}

--- a/app/(receipt-system)/receipts/settings/page.tsx
+++ b/app/(receipt-system)/receipts/settings/page.tsx
@@ -17,6 +17,23 @@ export default async function ReceiptsSettingsPage() {
       <ul className="divide-y divide-gray-100 overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
         <li>
           <Link
+            href="/receipts/settings/compliance"
+            className="flex items-center justify-between p-4 transition-colors hover:bg-amber-50"
+          >
+            <div>
+              <p className="text-sm font-semibold text-gray-900">
+                Compliance &amp; 税務 settings
+              </p>
+              <p className="mt-1 text-xs text-gray-500">
+                Retention horizon, attendee requirements, qualified-invoice
+                mode, paper-original policy.
+              </p>
+            </div>
+            <span className="text-sm text-amber-700">Configure →</span>
+          </Link>
+        </li>
+        <li>
+          <Link
             href="/receipts/settings/devices"
             className="flex items-center justify-between p-4 transition-colors hover:bg-amber-50"
           >

--- a/app/api/receipts/[id]/route.ts
+++ b/app/api/receipts/[id]/route.ts
@@ -8,6 +8,29 @@ import {
   validateReceiptDate,
 } from "@/lib/receipts/validation";
 import { isCanonicalCode } from "@/lib/receipts/categories";
+import { getReceiptsDb } from "@/lib/cloudflare-runtime";
+import {
+  runComplianceChecksForReceipt,
+  listChecksForObject,
+} from "@/lib/receipts/compliance";
+import { getComplianceSettings } from "@/lib/receipts/settings";
+import {
+  validateInvoiceRegistrationNumber,
+} from "@/lib/receipts/invoice";
+import type {
+  QualifiedInvoiceStatus,
+  SourceType,
+} from "@/lib/receipts/types";
+
+const VALID_SOURCE_TYPES: SourceType[] = [
+  "paper_scanned",
+  "electronic_receipt",
+  "digital_invoice",
+  "credit_card_statement",
+  "email_attachment",
+  "manual_upload",
+  "amex_csv",
+];
 
 type RouteContext = { params: Promise<{ id: string }> };
 
@@ -57,7 +80,8 @@ export async function GET(request: Request, { params }: RouteContext) {
     }
 
     const attendees = await listAttendees(id);
-    return NextResponse.json({ receipt, attendees }, { status: 200 });
+    const checks = await listChecksForObject(getReceiptsDb(), "receipt", id);
+    return NextResponse.json({ receipt, attendees, complianceChecks: checks }, { status: 200 });
   } catch (error) {
     if (error instanceof Error && error.message.startsWith("Unauthorized")) {
       return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
@@ -96,6 +120,11 @@ export async function PATCH(request: Request, { params }: RouteContext) {
       expenseCategoryCode?: string | null;
       status?: string;
       attendees?: string[];
+      // Compliance fields
+      sourceType?: string | null;
+      invoiceRegistrationNumber?: string | null;
+      counterpartyName?: string | null;
+      taxRate?: string | null;
     };
 
     if (
@@ -172,6 +201,44 @@ export async function PATCH(request: Request, { params }: RouteContext) {
     }
     const merchant = normalizeOptionalText(body.merchant, 200);
     const businessPurpose = normalizeOptionalText(body.businessPurpose, 500);
+    const counterpartyName = normalizeOptionalText(body.counterpartyName, 200);
+    const taxRate = normalizeOptionalText(body.taxRate, 16);
+
+    // Validate sourceType if provided.
+    let sourceType: SourceType | null | undefined = undefined;
+    if ("sourceType" in body) {
+      if (body.sourceType === null || body.sourceType === "") {
+        sourceType = null;
+      } else if (
+        typeof body.sourceType === "string" &&
+        VALID_SOURCE_TYPES.includes(body.sourceType as SourceType)
+      ) {
+        sourceType = body.sourceType as SourceType;
+      } else {
+        return NextResponse.json({ error: "Invalid sourceType." }, { status: 400 });
+      }
+    }
+
+    // Invoice number validation drives qualified_invoice_status.
+    let qualifiedInvoiceStatus: QualifiedInvoiceStatus | undefined;
+    let invoiceRegistrationNumber: string | null | undefined = undefined;
+    if ("invoiceRegistrationNumber" in body) {
+      const raw = body.invoiceRegistrationNumber;
+      if (raw === null || (typeof raw === "string" && raw.trim() === "")) {
+        invoiceRegistrationNumber = null;
+        qualifiedInvoiceStatus = "missing_registration_number";
+      } else if (typeof raw === "string") {
+        const v = validateInvoiceRegistrationNumber(raw);
+        if (v.registrationStatus === "format_invalid") {
+          return NextResponse.json(
+            { error: v.message ?? "Invalid invoiceRegistrationNumber." },
+            { status: 400 },
+          );
+        }
+        invoiceRegistrationNumber = v.normalizedNumber;
+        qualifiedInvoiceStatus = v.qualifiedInvoiceStatus;
+      }
+    }
 
     await updateReceiptRecord(
       id,
@@ -186,6 +253,11 @@ export async function PATCH(request: Request, { params }: RouteContext) {
         businessPurpose,
         expenseCategoryCode,
         status: body.status as ReceiptStatus | undefined,
+        sourceType,
+        invoiceRegistrationNumber,
+        counterpartyName,
+        taxRate,
+        qualifiedInvoiceStatus,
       },
       actor,
     );
@@ -195,6 +267,14 @@ export async function PATCH(request: Request, { params }: RouteContext) {
         .filter((name) => typeof name === "string" && name.trim())
         .map((name) => ({ attendeeName: name.trim().slice(0, 120) }));
       await createAttendees(id, attendeeInputs, actor);
+    }
+
+    // Re-run compliance checks so the review UI reflects the new state.
+    try {
+      const settings = await getComplianceSettings();
+      await runComplianceChecksForReceipt(getReceiptsDb(), id, settings);
+    } catch (checkError) {
+      console.error("[api/receipts/[id]] compliance check failed", checkError);
     }
 
     return NextResponse.json({ ok: true }, { status: 200 });

--- a/app/api/receipts/amex/import/route.ts
+++ b/app/api/receipts/amex/import/route.ts
@@ -21,6 +21,8 @@ import {
   computeSha256Hex,
 } from "@/lib/receipts/storage";
 import { getReceiptsDb } from "@/lib/cloudflare-runtime";
+import { createReceiptFile } from "@/lib/receipts/files";
+import { createAuditEntry } from "@/lib/receipts/audit";
 
 /*
  * AMEX CSV Import — Dedup Contract
@@ -173,6 +175,35 @@ export async function POST(request: Request) {
       validationErrors,
       importStatus,
     });
+
+    // File manifest row for the AMEX CSV — same preservation contract as a
+    // receipt original. Failure here is non-fatal: the artifact row already
+    // carries the hash and key.
+    try {
+      const db = getReceiptsDb();
+      await createReceiptFile(db, {
+        objectType: "amex_statement_artifact",
+        objectId: savedArtifactId,
+        role: "statement",
+        r2Bucket: "receipts",
+        r2Key,
+        originalFilename: file.name,
+        contentType: "text/csv",
+        fileSizeBytes: file.size,
+        sha256Hash: sha256,
+        uploadedBy: actor,
+        isOriginal: true,
+      });
+      await createAuditEntry(db, {
+        actor,
+        action: "amex_statement.uploaded",
+        objectType: "amex_statement_artifact",
+        objectId: savedArtifactId,
+        newValueJson: JSON.stringify({ statementMonth, sha256, fileSize: file.size }),
+      });
+    } catch (manifestErr) {
+      console.error("[amex/import] file manifest write failed", manifestErr);
+    }
 
     // ── Return validation errors without importing lines ────────────────────
     if (validationErrors.length > 0) {

--- a/app/api/receipts/compliance/[month]/route.ts
+++ b/app/api/receipts/compliance/[month]/route.ts
@@ -1,0 +1,75 @@
+import { NextResponse } from "next/server";
+import { requireReceiptsActor } from "@/lib/receipts/auth";
+import { getReceiptsDb } from "@/lib/cloudflare-runtime";
+import {
+  summarizeOpenChecksForMonth,
+  runComplianceChecksForReceipt,
+} from "@/lib/receipts/compliance";
+import {
+  getComplianceSettings,
+  ACCOUNTANT_DISCLAIMER_EN,
+  ACCOUNTANT_DISCLAIMER_JA,
+} from "@/lib/receipts/settings";
+import { listReceiptRecords, listAmexLines } from "@/lib/receipts/db";
+
+type RouteContext = { params: Promise<{ month: string }> };
+
+export async function GET(request: Request, { params }: RouteContext) {
+  try {
+    await requireReceiptsActor(request.headers);
+    const { month } = await params;
+
+    if (!/^\d{4}-\d{2}$/.test(month)) {
+      return NextResponse.json(
+        { error: "month must be in YYYY-MM format." },
+        { status: 400 },
+      );
+    }
+
+    const db = getReceiptsDb();
+    const settings = await getComplianceSettings();
+
+    // Refresh checks for every receipt in the month so the report reflects
+    // current state. This is idempotent.
+    const receipts = await listReceiptRecords({ month, limit: 1000 });
+    for (const r of receipts) {
+      try {
+        await runComplianceChecksForReceipt(db, r.id, settings);
+      } catch {
+        // Per-receipt check failure shouldn't block the report.
+      }
+    }
+
+    const summary = await summarizeOpenChecksForMonth(db, month);
+
+    const lines = await listAmexLines(month);
+    const missingReceipt = lines.filter(
+      (l) => l.receipt_status === "missing_receipt",
+    ).length;
+
+    return NextResponse.json(
+      {
+        month,
+        generatedAt: new Date().toISOString(),
+        receiptCount: receipts.length,
+        amexLineCount: lines.length,
+        missingReceiptLines: missingReceipt,
+        complianceSummary: summary,
+        disclaimer: {
+          en: ACCOUNTANT_DISCLAIMER_EN,
+          ja: ACCOUNTANT_DISCLAIMER_JA,
+        },
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Unauthorized")) {
+      return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+    }
+    console.error("[api/receipts/compliance/[month]] failed", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Compliance report failed." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/receipts/export/[month]/route.ts
+++ b/app/api/receipts/export/[month]/route.ts
@@ -1,6 +1,11 @@
 import { NextResponse } from "next/server";
 import { requireReceiptsActor } from "@/lib/receipts/auth";
-import { getExport, finalizeExport, getFinalizedReconciliationForMonth } from "@/lib/receipts/db";
+import {
+  getExport,
+  finalizeExport,
+  getFinalizedReconciliationForMonth,
+  createExportRevision,
+} from "@/lib/receipts/db";
 import { validateMonthReadyForExport } from "@/lib/receipts/month-closing";
 
 type RouteContext = { params: Promise<{ month: string }> };
@@ -29,6 +34,39 @@ export async function POST(request: Request, { params }: RouteContext) {
   try {
     const actor = await requireReceiptsActor(request.headers);
     const { month } = await params;
+
+    const url = new URL(request.url);
+    const isCorrection = url.searchParams.get("correction") === "true";
+
+    if (isCorrection) {
+      // Read correction reason from JSON body. Body is optional only when
+      // not a correction; for revisions the reason is required.
+      let reason = "";
+      try {
+        const body = (await request.json()) as { correctionReason?: string };
+        reason = body.correctionReason?.trim() ?? "";
+      } catch {
+        // No JSON body — fall through with empty reason which fails below.
+      }
+      if (!reason) {
+        return NextResponse.json(
+          { error: "correctionReason is required when creating a revision." },
+          { status: 400 },
+        );
+      }
+      try {
+        const revision = await createExportRevision(month, reason, actor);
+        return NextResponse.json(
+          { ok: true, ...revision, month },
+          { status: 201 },
+        );
+      } catch (err) {
+        return NextResponse.json(
+          { error: err instanceof Error ? err.message : "Revision failed." },
+          { status: 422 },
+        );
+      }
+    }
 
     const exportRecord = await getExport(month);
     if (!exportRecord) {
@@ -73,6 +111,7 @@ export async function POST(request: Request, { params }: RouteContext) {
       exportRecord.manifest_r2_key,
       exportRecord.archive_sha256,
       actor,
+      exportRecord.manifest_sha256 ?? undefined,
     );
 
     return NextResponse.json({ ok: true, month, finalized: true }, { status: 200 });

--- a/app/api/receipts/export/month/route.ts
+++ b/app/api/receipts/export/month/route.ts
@@ -15,10 +15,15 @@ import {
   buildArchiveKey,
   buildManifestKey,
   buildManifestCsv,
+  buildReadmeKey,
+  buildExportReadme,
 } from "@/lib/receipts/export";
 import { archiveBundle, archiveManifest } from "@/lib/receipts/storage";
 import { getCategoryByCode, requiresAttendees } from "@/lib/receipts/categories";
-import type { ExportRow } from "@/lib/receipts/types";
+import { getReceiptsDb, getReceiptsArchiveBucket } from "@/lib/cloudflare-runtime";
+import { getAmexArtifactByMonth } from "@/lib/receipts/db";
+import { retentionMetadata } from "@/lib/receipts/retention";
+import type { ExportRow, ReceiptFile } from "@/lib/receipts/types";
 
 export async function POST(request: Request) {
   try {
@@ -149,6 +154,30 @@ export async function POST(request: Request) {
       ? await getFinalizedReconciliationForMonth(month)
       : null;
 
+    // Gather all file-manifest entries for receipts included in this export
+    // plus the AMEX statement artifact. This builds the per-file SHA-256
+    // section of the manifest so an accountant can verify every artifact.
+    const db = getReceiptsDb();
+    const includedReceiptIds = receipts.map((r) => r.id);
+    const fileRows: ReceiptFile[] = [];
+    if (includedReceiptIds.length > 0) {
+      const CHUNK_SIZE = 90;
+      for (let i = 0; i < includedReceiptIds.length; i += CHUNK_SIZE) {
+        const chunk = includedReceiptIds.slice(i, i + CHUNK_SIZE);
+        const placeholders = chunk.map(() => "?").join(",");
+        const result = await db
+          .prepare(
+            `SELECT * FROM receipt_files
+             WHERE object_type = 'receipt' AND object_id IN (${placeholders})`,
+          )
+          .bind(...chunk)
+          .all<ReceiptFile>();
+        fileRows.push(...(result.results ?? []));
+      }
+    }
+    const amexArtifact = await getAmexArtifactByMonth(month);
+    const generatedAt = new Date().toISOString();
+
     // Generate and upload manifest
     const manifest = buildManifestCsv(
       exportId,
@@ -156,7 +185,7 @@ export async function POST(request: Request) {
       archiveKey,
       sha256,
       exportRows.length,
-      new Date().toISOString(),
+      generatedAt,
       reconciliation
         ? {
             id: reconciliation.id,
@@ -164,12 +193,51 @@ export async function POST(request: Request) {
             manifestSha256: reconciliation.manifest_sha256 ?? "",
           }
         : null,
+      {
+        files: fileRows,
+        amexArtifact: amexArtifact
+          ? {
+              r2Key: amexArtifact.r2_key,
+              sha256Hash: amexArtifact.sha256_hash,
+              originalFilename: amexArtifact.original_filename ?? "",
+            }
+          : null,
+      },
     );
-    await archiveManifest(manifestKey, encoder.encode(manifest).buffer as ArrayBuffer);
+    const manifestBytes = encoder.encode(manifest);
+    const manifestSha256 = await hashCsvContent(manifest);
+    await archiveManifest(manifestKey, manifestBytes.buffer as ArrayBuffer);
+
+    // README accompanies every bundle. Disclaimer text + revision context.
+    const readme = buildExportReadme({
+      exportId,
+      month,
+      rowCount: exportRows.length,
+      generatedAt,
+      exportRevision: 1,
+      archiveSha256: sha256,
+      manifestSha256,
+    });
+    const readmeKey = buildReadmeKey(month, exportId);
+    await getReceiptsArchiveBucket().put(
+      readmeKey,
+      encoder.encode(readme).buffer as ArrayBuffer,
+      {
+        httpMetadata: { contentType: "text/plain; charset=utf-8" },
+        customMetadata: retentionMetadata(),
+      },
+    );
 
     // Auto-finalize if requested
     if (body.finalize) {
-      await finalizeExport(exportId, archiveKey, manifestKey, sha256, actor);
+      await finalizeExport(
+        exportId,
+        archiveKey,
+        manifestKey,
+        sha256,
+        actor,
+        manifestSha256,
+      );
     }
 
     return NextResponse.json(
@@ -178,8 +246,10 @@ export async function POST(request: Request) {
         month,
         rowCount: exportRows.length,
         sha256,
+        manifestSha256,
         archiveKey,
         manifestKey,
+        readmeKey,
         finalized: body.finalize ?? false,
       },
       { status: 200 },

--- a/app/api/receipts/route.ts
+++ b/app/api/receipts/route.ts
@@ -2,6 +2,12 @@ import { NextResponse } from "next/server";
 import { requireReceiptsActor } from "@/lib/receipts/auth";
 import { listReceiptRecords } from "@/lib/receipts/db";
 
+function intOrUndef(value: string | null): number | undefined {
+  if (value === null || value === "") return undefined;
+  const n = Number.parseInt(value, 10);
+  return Number.isFinite(n) ? n : undefined;
+}
+
 export async function GET(request: Request) {
   try {
     await requireReceiptsActor(request.headers);
@@ -10,6 +16,14 @@ export async function GET(request: Request) {
     const status = url.searchParams.get("status") ?? undefined;
     const month = url.searchParams.get("month") ?? undefined;
     const paymentPath = url.searchParams.get("paymentPath") ?? undefined;
+    const sourceType = url.searchParams.get("sourceType") ?? undefined;
+    const qualifiedInvoiceStatus =
+      url.searchParams.get("qualifiedInvoiceStatus") ?? undefined;
+    const merchant = url.searchParams.get("merchant") ?? undefined;
+    const invoiceRegistrationNumber =
+      url.searchParams.get("invoiceRegistrationNumber") ?? undefined;
+    const minAmountMinor = intOrUndef(url.searchParams.get("minAmountMinor"));
+    const maxAmountMinor = intOrUndef(url.searchParams.get("maxAmountMinor"));
     const limit = Math.min(Number(url.searchParams.get("limit") ?? 100), 200);
     const offset = Number(url.searchParams.get("offset") ?? 0);
 
@@ -17,6 +31,12 @@ export async function GET(request: Request) {
       status,
       month,
       paymentPath,
+      sourceType,
+      qualifiedInvoiceStatus,
+      merchant,
+      invoiceRegistrationNumber,
+      minAmountMinor,
+      maxAmountMinor,
       limit,
       offset,
     });

--- a/app/api/receipts/settings/compliance/route.ts
+++ b/app/api/receipts/settings/compliance/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from "next/server";
+import { requireReceiptsActor } from "@/lib/receipts/auth";
+import {
+  getComplianceSettings,
+  updateComplianceSettings,
+} from "@/lib/receipts/settings";
+import { createAuditEntry } from "@/lib/receipts/audit";
+import { getReceiptsDb } from "@/lib/cloudflare-runtime";
+import type { ComplianceSettings } from "@/lib/receipts/types";
+
+export async function GET(request: Request) {
+  try {
+    await requireReceiptsActor(request.headers);
+    const settings = await getComplianceSettings();
+    return NextResponse.json({ settings }, { status: 200 });
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Unauthorized")) {
+      return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+    }
+    console.error("[api/receipts/settings/compliance] GET failed", error);
+    return NextResponse.json(
+      { error: "Failed to load settings." },
+      { status: 500 },
+    );
+  }
+}
+
+export async function PATCH(request: Request) {
+  try {
+    const actor = await requireReceiptsActor(request.headers);
+    const body = (await request.json()) as Partial<ComplianceSettings>;
+
+    if (
+      body.retention_years !== undefined &&
+      (typeof body.retention_years !== "number" ||
+        body.retention_years < 1 ||
+        body.retention_years > 100)
+    ) {
+      return NextResponse.json(
+        { error: "retention_years must be between 1 and 100." },
+        { status: 400 },
+      );
+    }
+    if (
+      body.statement_expected_day !== undefined &&
+      (typeof body.statement_expected_day !== "number" ||
+        body.statement_expected_day < 1 ||
+        body.statement_expected_day > 31)
+    ) {
+      return NextResponse.json(
+        { error: "statement_expected_day must be 1-31." },
+        { status: 400 },
+      );
+    }
+
+    const settings = await updateComplianceSettings(body, actor);
+
+    await createAuditEntry(getReceiptsDb(), {
+      actor,
+      action: "settings.updated",
+      objectType: "compliance_settings",
+      objectId: "global",
+      newValueJson: JSON.stringify(body),
+    });
+
+    return NextResponse.json({ settings }, { status: 200 });
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Unauthorized")) {
+      return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+    }
+    console.error("[api/receipts/settings/compliance] PATCH failed", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Save failed." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/receipts/upload/route.ts
+++ b/app/api/receipts/upload/route.ts
@@ -3,8 +3,9 @@ import { requireReceiptsActor } from "@/lib/receipts/auth";
 import { validateReceiptFile } from "@/lib/receipts/validation";
 import { generateR2Key, uploadOriginal } from "@/lib/receipts/storage";
 import { createReceiptRecord } from "@/lib/receipts/db";
-import { getReceiptsBucket } from "@/lib/cloudflare-runtime";
-import type { PaymentPath } from "@/lib/receipts/types";
+import { createReceiptFile } from "@/lib/receipts/files";
+import { getReceiptsBucket, getReceiptsDb } from "@/lib/cloudflare-runtime";
+import type { PaymentPath, SourceType } from "@/lib/receipts/types";
 
 async function sha256Hex(data: ArrayBuffer): Promise<string> {
   const hash = await crypto.subtle.digest("SHA-256", data);
@@ -14,6 +15,30 @@ async function sha256Hex(data: ArrayBuffer): Promise<string> {
 }
 
 const VALID_PAYMENT_PATHS: PaymentPath[] = ["AMEX", "CASH", "DIGITAL", "UNKNOWN"];
+const VALID_SOURCE_TYPES: SourceType[] = [
+  "paper_scanned",
+  "electronic_receipt",
+  "digital_invoice",
+  "credit_card_statement",
+  "email_attachment",
+  "manual_upload",
+  "amex_csv",
+];
+
+function deriveSourceType(
+  formValue: string | undefined,
+  source: string,
+  contentType: string,
+): SourceType {
+  if (formValue && VALID_SOURCE_TYPES.includes(formValue as SourceType)) {
+    return formValue as SourceType;
+  }
+  // Heuristic fallback: mobile camera capture → paper scan; PDF →
+  // electronic receipt; anything else → manual upload.
+  if (source === "mobile_capture") return "paper_scanned";
+  if (contentType === "application/pdf") return "electronic_receipt";
+  return "manual_upload";
+}
 
 export async function POST(request: Request) {
   try {
@@ -40,6 +65,12 @@ export async function POST(request: Request) {
 
     const expenseType = formData.get("expenseType")?.toString() || undefined;
     const source = formData.get("source")?.toString() || "mobile_capture";
+    const contentType = file.type || "application/octet-stream";
+    const sourceType = deriveSourceType(
+      formData.get("sourceType")?.toString(),
+      source,
+      contentType,
+    );
 
     const bytes = await file.arrayBuffer();
     const sha256 = await sha256Hex(bytes);
@@ -47,7 +78,7 @@ export async function POST(request: Request) {
     const tempId = crypto.randomUUID();
     const r2Key = generateR2Key(tempId, file.name, new Date().toISOString());
 
-    await uploadOriginal(r2Key, bytes, file.type || "application/octet-stream");
+    await uploadOriginal(r2Key, bytes, contentType);
 
     let receiptId: string;
     try {
@@ -55,12 +86,13 @@ export async function POST(request: Request) {
         {
           capturedBy: actor,
           source,
+          sourceType,
           originalFilename: file.name,
           paymentPath,
           expenseType: expenseType as import("@/lib/receipts/types").ExpenseType | undefined,
           originalR2Key: r2Key,
           originalSha256: sha256,
-          originalContentType: file.type || "application/octet-stream",
+          originalContentType: contentType,
           originalSizeBytes: file.size,
         },
         actor,
@@ -74,11 +106,34 @@ export async function POST(request: Request) {
       throw dbError;
     }
 
+    // Manifest row for the original file. Failure to write the manifest row
+    // does not roll back the upload — the receipt_records row already has the
+    // hash + R2 key; the manifest row is additive metadata that downstream
+    // compliance reports use.
+    try {
+      await createReceiptFile(getReceiptsDb(), {
+        objectType: "receipt",
+        objectId: receiptId,
+        role: "original",
+        r2Bucket: "receipts",
+        r2Key,
+        originalFilename: file.name,
+        contentType,
+        fileSizeBytes: file.size,
+        sha256Hash: sha256,
+        uploadedBy: actor,
+        isOriginal: true,
+      });
+    } catch (fileError) {
+      console.error("[receipts/upload] file manifest write failed", fileError);
+    }
+
     return NextResponse.json(
       {
         ok: true,
         receiptId,
         status: "needs_review",
+        sourceType,
         reviewUrl: `/receipts/review/${receiptId}`,
       },
       { status: 201 },

--- a/components/receipts/CompliancePanel.tsx
+++ b/components/receipts/CompliancePanel.tsx
@@ -1,0 +1,89 @@
+import type { ComplianceCheck } from "@/lib/receipts/types";
+
+const SEVERITY_STYLE: Record<string, string> = {
+  blocker: "bg-red-50 text-red-900 border-red-200",
+  warning: "bg-amber-50 text-amber-900 border-amber-200",
+  info: "bg-gray-50 text-gray-700 border-gray-200",
+};
+
+const SEVERITY_LABEL: Record<string, string> = {
+  blocker: "BLOCKER",
+  warning: "WARNING",
+  info: "INFO",
+};
+
+type Props = {
+  checks: ComplianceCheck[];
+};
+
+export function CompliancePanel({ checks }: Props) {
+  const open = checks.filter((c) => c.status === "open");
+  const resolved = checks.filter((c) => c.status === "resolved");
+
+  const blockerCount = open.filter((c) => c.severity === "blocker").length;
+  const warningCount = open.filter((c) => c.severity === "warning").length;
+
+  return (
+    <section className="rounded-2xl border border-gray-200 bg-white shadow-sm">
+      <header className="border-b border-gray-100 px-5 py-4">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-gray-900">
+            Compliance status
+          </h3>
+          <div className="flex gap-2 text-xs">
+            <span className="rounded-full bg-red-100 px-2 py-0.5 font-semibold text-red-800">
+              {blockerCount} blocker{blockerCount === 1 ? "" : "s"}
+            </span>
+            <span className="rounded-full bg-amber-100 px-2 py-0.5 font-semibold text-amber-900">
+              {warningCount} warning{warningCount === 1 ? "" : "s"}
+            </span>
+          </div>
+        </div>
+        <p className="mt-1 text-xs text-gray-500">
+          Preparation materials for accountant review. Dazbeez does not provide
+          tax advice or make final tax determinations.
+        </p>
+      </header>
+
+      {open.length === 0 ? (
+        <div className="px-5 py-6 text-sm text-gray-500">
+          No open compliance issues for this receipt.
+        </div>
+      ) : (
+        <ul className="divide-y divide-gray-100">
+          {open.map((c) => (
+            <li
+              key={c.id}
+              className={`border-l-4 px-5 py-3 text-sm ${SEVERITY_STYLE[c.severity] ?? SEVERITY_STYLE.info}`}
+            >
+              <div className="flex items-baseline gap-2">
+                <span className="text-[10px] font-bold tracking-wider">
+                  {SEVERITY_LABEL[c.severity] ?? c.severity.toUpperCase()}
+                </span>
+                <span className="font-mono text-[11px] text-gray-600">
+                  {c.check_type}
+                </span>
+              </div>
+              <p className="mt-1">{c.message}</p>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {resolved.length > 0 ? (
+        <details className="border-t border-gray-100 px-5 py-3 text-xs text-gray-500">
+          <summary className="cursor-pointer select-none">
+            {resolved.length} resolved check{resolved.length === 1 ? "" : "s"}
+          </summary>
+          <ul className="mt-2 space-y-1">
+            {resolved.map((c) => (
+              <li key={c.id} className="font-mono text-[11px]">
+                ✓ {c.check_type}
+              </li>
+            ))}
+          </ul>
+        </details>
+      ) : null}
+    </section>
+  );
+}

--- a/components/receipts/ComplianceSettingsForm.tsx
+++ b/components/receipts/ComplianceSettingsForm.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import type { ComplianceSettings } from "@/lib/receipts/types";
+
+type Props = { initial: ComplianceSettings };
+
+const LABELS: Record<keyof ComplianceSettings, string> = {
+  business_name: "Business name (事業者名)",
+  taxpayer_type: "Taxpayer type",
+  retention_years: "Retention years",
+  require_attendees_for_meeting: "Require attendees for 会議費 (meetings)",
+  require_attendees_for_entertainment: "Require attendees for 交際費 (entertainment)",
+  invoice_number_requirement_mode: "Qualified-invoice number enforcement",
+  export_block_on_warnings: "Block export when warnings are present",
+  paper_original_discard_policy: "Paper original discard policy",
+  statement_expected_day: "AMEX statement expected day",
+};
+
+export function ComplianceSettingsForm({ initial }: Props) {
+  const [settings, setSettings] = useState<ComplianceSettings>(initial);
+  const [savedAt, setSavedAt] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  function update<K extends keyof ComplianceSettings>(
+    key: K,
+    value: ComplianceSettings[K],
+  ) {
+    setSettings((s) => ({ ...s, [key]: value }));
+  }
+
+  async function save() {
+    setError(null);
+    startTransition(async () => {
+      const res = await fetch("/api/receipts/settings/compliance", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(settings),
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({}))) as { error?: string };
+        setError(data.error ?? `Save failed (${res.status}).`);
+        return;
+      }
+      const data = (await res.json()) as { settings: ComplianceSettings };
+      setSettings(data.settings);
+      setSavedAt(new Date().toLocaleTimeString());
+    });
+  }
+
+  return (
+    <div className="space-y-5 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+      <Row label={LABELS.business_name}>
+        <input
+          type="text"
+          value={settings.business_name}
+          onChange={(e) => update("business_name", e.target.value)}
+          className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+          maxLength={120}
+        />
+      </Row>
+
+      <Row label={LABELS.taxpayer_type}>
+        <select
+          value={settings.taxpayer_type}
+          onChange={(e) => update("taxpayer_type", e.target.value)}
+          className="rounded-md border border-gray-300 px-3 py-2 text-sm"
+        >
+          <option value="kojin">個人事業主 (sole proprietor)</option>
+          <option value="hojin">法人 (corporation)</option>
+          <option value="other">その他 / other</option>
+        </select>
+      </Row>
+
+      <Row label={LABELS.retention_years} hint="7 years is the typical minimum; some categories require 10.">
+        <input
+          type="number"
+          min={1}
+          max={20}
+          value={settings.retention_years}
+          onChange={(e) =>
+            update("retention_years", Number.parseInt(e.target.value, 10) || 1)
+          }
+          className="w-24 rounded-md border border-gray-300 px-3 py-2 text-sm"
+        />
+      </Row>
+
+      <Row label={LABELS.require_attendees_for_meeting}>
+        <Toggle
+          checked={settings.require_attendees_for_meeting}
+          onChange={(v) => update("require_attendees_for_meeting", v)}
+        />
+      </Row>
+
+      <Row label={LABELS.require_attendees_for_entertainment}>
+        <Toggle
+          checked={settings.require_attendees_for_entertainment}
+          onChange={(v) => update("require_attendees_for_entertainment", v)}
+        />
+      </Row>
+
+      <Row
+        label={LABELS.invoice_number_requirement_mode}
+        hint="warning = surface as warning; blocker = block export; disabled = ignore."
+      >
+        <select
+          value={settings.invoice_number_requirement_mode}
+          onChange={(e) =>
+            update(
+              "invoice_number_requirement_mode",
+              e.target.value as ComplianceSettings["invoice_number_requirement_mode"],
+            )
+          }
+          className="rounded-md border border-gray-300 px-3 py-2 text-sm"
+        >
+          <option value="warning">warning (recommended)</option>
+          <option value="blocker">blocker</option>
+          <option value="disabled">disabled</option>
+        </select>
+      </Row>
+
+      <Row label={LABELS.export_block_on_warnings}>
+        <Toggle
+          checked={settings.export_block_on_warnings}
+          onChange={(v) => update("export_block_on_warnings", v)}
+        />
+      </Row>
+
+      <Row
+        label={LABELS.paper_original_discard_policy}
+        hint="Dazbeez does not authorize discarding paper originals. Confirm with your accountant first."
+      >
+        <select
+          value={settings.paper_original_discard_policy}
+          onChange={(e) =>
+            update(
+              "paper_original_discard_policy",
+              e.target.value as ComplianceSettings["paper_original_discard_policy"],
+            )
+          }
+          className="rounded-md border border-gray-300 px-3 py-2 text-sm"
+        >
+          <option value="retain_until_accountant_confirms">
+            Retain until accountant confirms (recommended)
+          </option>
+          <option value="retain_indefinitely">Retain indefinitely</option>
+          <option value="permit_discard_after_scan">
+            Permit discard after scan (only with accountant policy)
+          </option>
+        </select>
+      </Row>
+
+      <Row label={LABELS.statement_expected_day}>
+        <input
+          type="number"
+          min={1}
+          max={31}
+          value={settings.statement_expected_day}
+          onChange={(e) =>
+            update(
+              "statement_expected_day",
+              Number.parseInt(e.target.value, 10) || 1,
+            )
+          }
+          className="w-24 rounded-md border border-gray-300 px-3 py-2 text-sm"
+        />
+      </Row>
+
+      <div className="flex items-center justify-between border-t border-gray-100 pt-4">
+        <div className="text-xs text-gray-500">
+          {error ? (
+            <span className="text-red-600">{error}</span>
+          ) : savedAt ? (
+            <span>Saved at {savedAt}</span>
+          ) : (
+            <span>Changes are saved when you click Save.</span>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={save}
+          disabled={pending}
+          className="rounded-md bg-amber-500 px-4 py-2 text-sm font-semibold text-white hover:bg-amber-600 disabled:opacity-60"
+        >
+          {pending ? "Saving…" : "Save"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function Row({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+      <div className="sm:max-w-md">
+        <div className="text-sm font-medium text-gray-900">{label}</div>
+        {hint ? <div className="text-xs text-gray-500">{hint}</div> : null}
+      </div>
+      <div>{children}</div>
+    </div>
+  );
+}
+
+function Toggle({
+  checked,
+  onChange,
+}: {
+  checked: boolean;
+  onChange: (v: boolean) => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onChange(!checked)}
+      className={`inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+        checked ? "bg-amber-500" : "bg-gray-300"
+      }`}
+      aria-pressed={checked}
+    >
+      <span
+        className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+          checked ? "translate-x-6" : "translate-x-1"
+        }`}
+      />
+    </button>
+  );
+}

--- a/components/receipts/ComplianceSummaryCards.tsx
+++ b/components/receipts/ComplianceSummaryCards.tsx
@@ -1,0 +1,88 @@
+import type { ComplianceSummary } from "@/lib/receipts/compliance";
+
+type Props = {
+  month: string;
+  summary: ComplianceSummary;
+};
+
+const TYPE_LABELS: Record<string, string> = {
+  missing_transaction_date: "Missing transaction date",
+  missing_amount: "Missing amount",
+  missing_counterparty: "Missing counterparty",
+  missing_category: "Missing category",
+  missing_receipt: "Missing receipt",
+  missing_attendees: "Missing attendees",
+  missing_invoice_registration_number: "Missing invoice number",
+  invoice_registration_invalid: "Invalid invoice number",
+  missing_tax_rate: "Missing tax rate",
+  missing_tax_amount: "Missing tax amount",
+  electronic_transaction_missing_original: "Electronic transaction warning",
+  scanner_preservation_metadata_incomplete: "Scanner preservation incomplete",
+  export_blocker: "Export blocker",
+};
+
+export function ComplianceSummaryCards({ month, summary }: Props) {
+  const topTypes = Object.entries(summary.byType)
+    .sort(([, a], [, b]) => b - a)
+    .slice(0, 4);
+
+  return (
+    <section className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
+      <header className="mb-4 flex items-baseline justify-between">
+        <div>
+          <h3 className="text-sm font-semibold text-gray-900">
+            Compliance summary
+          </h3>
+          <p className="text-xs text-gray-500">For receipts in {month}</p>
+        </div>
+        <a
+          href={`/api/receipts/compliance/${month}`}
+          className="text-xs text-amber-700 hover:underline"
+        >
+          View JSON →
+        </a>
+      </header>
+
+      <div className="grid grid-cols-3 gap-3">
+        <Card label="Blockers" count={summary.blockers} tone="red" />
+        <Card label="Warnings" count={summary.warnings} tone="amber" />
+        <Card label="Info" count={summary.info} tone="gray" />
+      </div>
+
+      {topTypes.length > 0 ? (
+        <ul className="mt-4 space-y-1 text-xs text-gray-700">
+          {topTypes.map(([type, count]) => (
+            <li key={type} className="flex justify-between">
+              <span>{TYPE_LABELS[type] ?? type}</span>
+              <span className="font-mono">{count}</span>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="mt-4 text-xs text-gray-500">No open issues for this month.</p>
+      )}
+    </section>
+  );
+}
+
+function Card({
+  label,
+  count,
+  tone,
+}: {
+  label: string;
+  count: number;
+  tone: "red" | "amber" | "gray";
+}) {
+  const palette = {
+    red: "bg-red-50 text-red-900",
+    amber: "bg-amber-50 text-amber-900",
+    gray: "bg-gray-50 text-gray-700",
+  }[tone];
+  return (
+    <div className={`rounded-xl px-3 py-2 ${palette}`}>
+      <div className="text-xs">{label}</div>
+      <div className="text-2xl font-bold">{count}</div>
+    </div>
+  );
+}

--- a/db/receipts/0014_compliance.sql
+++ b/db/receipts/0014_compliance.sql
@@ -1,0 +1,125 @@
+-- 0014_compliance.sql
+--
+-- Japanese tax-document preservation compliance layer.
+-- Adds:
+--   - source_type / preservation_status / qualified invoice / search metadata
+--     fields on receipt_records
+--   - receipt_files file manifest (one original + N derivatives per object)
+--   - receipt_compliance_checks (engine output, persisted)
+--   - receipt_settings key/value store for compliance configuration
+--   - export_revision / supersedes_export_id / correction_reason / finalized_by
+--     / finalization_hash / manifest_sha256 on receipt_exports
+--   - additional search indexes
+--
+-- All changes are additive. Enum-like columns (source_type, preservation_status,
+-- qualified_invoice_status, invoice_registration_status) are enforced in the
+-- application layer (lib/receipts/compliance.ts) because SQLite cannot ALTER
+-- an existing column to add a CHECK constraint.
+
+-- ── receipt_records: compliance metadata ─────────────────────────────────────
+ALTER TABLE receipt_records ADD COLUMN source_type TEXT;
+ALTER TABLE receipt_records ADD COLUMN preservation_status TEXT;
+ALTER TABLE receipt_records ADD COLUMN confirmed_at TEXT;
+ALTER TABLE receipt_records ADD COLUMN confirmed_by TEXT;
+ALTER TABLE receipt_records ADD COLUMN invoice_registration_number TEXT;
+ALTER TABLE receipt_records ADD COLUMN invoice_registration_status TEXT;
+ALTER TABLE receipt_records ADD COLUMN qualified_invoice_status TEXT NOT NULL DEFAULT 'not_checked';
+ALTER TABLE receipt_records ADD COLUMN tax_rate TEXT;
+ALTER TABLE receipt_records ADD COLUMN counterparty_name TEXT;
+ALTER TABLE receipt_records ADD COLUMN search_text TEXT;
+ALTER TABLE receipt_records ADD COLUMN compliance_warnings_json TEXT;
+
+-- ── File manifest ────────────────────────────────────────────────────────────
+-- One original + N derivatives per receipt; also tracks AMEX statement
+-- artifacts and export bundles under different object_type values.
+CREATE TABLE IF NOT EXISTS receipt_files (
+  id TEXT PRIMARY KEY,
+  object_type TEXT NOT NULL,
+  object_id TEXT NOT NULL,
+  role TEXT NOT NULL,
+  r2_bucket TEXT NOT NULL,
+  r2_key TEXT NOT NULL UNIQUE,
+  original_filename TEXT NOT NULL,
+  content_type TEXT NOT NULL,
+  file_size_bytes INTEGER NOT NULL,
+  sha256_hash TEXT NOT NULL,
+  uploaded_by TEXT NOT NULL,
+  uploaded_at TEXT NOT NULL,
+  is_original INTEGER NOT NULL DEFAULT 0 CHECK (is_original IN (0, 1)),
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_receipt_files_object ON receipt_files(object_type, object_id);
+CREATE INDEX IF NOT EXISTS idx_receipt_files_sha ON receipt_files(sha256_hash);
+
+-- ── Compliance checks ────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS receipt_compliance_checks (
+  id TEXT PRIMARY KEY,
+  object_type TEXT NOT NULL,
+  object_id TEXT NOT NULL,
+  check_type TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('open', 'resolved', 'ignored_with_reason')),
+  severity TEXT NOT NULL CHECK (severity IN ('info', 'warning', 'blocker')),
+  message TEXT NOT NULL,
+  details_json TEXT,
+  checked_at TEXT NOT NULL,
+  resolved_at TEXT,
+  resolved_by TEXT,
+  created_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_compliance_object ON receipt_compliance_checks(object_type, object_id, status);
+CREATE INDEX IF NOT EXISTS idx_compliance_open ON receipt_compliance_checks(check_type, status);
+
+-- ── Compliance settings (key/value store) ────────────────────────────────────
+CREATE TABLE IF NOT EXISTS receipt_settings (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  updated_by TEXT NOT NULL
+);
+
+INSERT OR IGNORE INTO receipt_settings (key, value, updated_at, updated_by) VALUES
+  ('business_name',                       '',        strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), 'system'),
+  ('taxpayer_type',                       'kojin',   strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), 'system'),
+  ('retention_years',                     '7',       strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), 'system'),
+  ('require_attendees_for_meeting',       'true',    strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), 'system'),
+  ('require_attendees_for_entertainment', 'true',    strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), 'system'),
+  ('invoice_number_requirement_mode',     'warning', strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), 'system'),
+  ('export_block_on_warnings',            'false',   strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), 'system'),
+  ('paper_original_discard_policy',       'retain_until_accountant_confirms', strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), 'system'),
+  ('statement_expected_day',              '18',      strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), 'system');
+
+-- ── receipt_exports: revisioning + manifest hash ─────────────────────────────
+ALTER TABLE receipt_exports ADD COLUMN export_revision INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE receipt_exports ADD COLUMN supersedes_export_id TEXT;
+ALTER TABLE receipt_exports ADD COLUMN correction_reason TEXT;
+ALTER TABLE receipt_exports ADD COLUMN finalized_by TEXT;
+ALTER TABLE receipt_exports ADD COLUMN finalization_hash TEXT;
+ALTER TABLE receipt_exports ADD COLUMN manifest_sha256 TEXT;
+
+-- ── Search indexes ───────────────────────────────────────────────────────────
+CREATE INDEX IF NOT EXISTS idx_receipts_amount ON receipt_records(amount_minor);
+CREATE INDEX IF NOT EXISTS idx_receipts_merchant ON receipt_records(merchant);
+CREATE INDEX IF NOT EXISTS idx_receipts_source_type ON receipt_records(source_type);
+CREATE INDEX IF NOT EXISTS idx_receipts_invoice_no ON receipt_records(invoice_registration_number);
+CREATE INDEX IF NOT EXISTS idx_receipts_counterparty ON receipt_records(counterparty_name);
+CREATE INDEX IF NOT EXISTS idx_amex_amount ON amex_statement_lines(amount_minor);
+CREATE INDEX IF NOT EXISTS idx_amex_merchant ON amex_statement_lines(merchant);
+
+-- ── Backfill ─────────────────────────────────────────────────────────────────
+-- Existing receipts predate the source_type / preservation_status concept.
+-- Treat them as manual uploads with preservation status derived from status.
+UPDATE receipt_records
+SET source_type = 'manual_upload'
+WHERE source_type IS NULL;
+
+UPDATE receipt_records
+SET preservation_status = CASE
+  WHEN status = 'archived' THEN 'archived'
+  WHEN status = 'exported' THEN 'exported'
+  WHEN status = 'reconciled' THEN 'reviewed'
+  WHEN status = 'reviewed' THEN 'reviewed'
+  WHEN status = 'captured' THEN 'needs_metadata'
+  ELSE 'needs_review'
+END
+WHERE preservation_status IS NULL;

--- a/lib/receipts/compliance.ts
+++ b/lib/receipts/compliance.ts
@@ -1,0 +1,349 @@
+// Compliance check engine. The pure `computeReceiptChecks` is exercised by
+// tests; `runComplianceChecks` persists the engine output into
+// `receipt_compliance_checks`, diffing against the prior row set so that
+// fixes are reflected without an explicit "resolve" click.
+
+import { requiresAttendees } from "@/lib/receipts/categories";
+import { newUuid, nowIso, stringifyJson } from "@/lib/receipts/db-utils";
+import { listFilesForObject } from "@/lib/receipts/files";
+import { validateInvoiceRegistrationNumber } from "@/lib/receipts/invoice";
+import type {
+  ComplianceCheck,
+  ComplianceCheckSeverity,
+  ComplianceCheckType,
+  ComplianceSettings,
+  ComputedCheck,
+  ReceiptAttendee,
+  ReceiptFile,
+  ReceiptRecord,
+  SourceType,
+} from "@/lib/receipts/types";
+
+const ELECTRONIC_SOURCE_TYPES: ReadonlySet<SourceType> = new Set([
+  "electronic_receipt",
+  "digital_invoice",
+  "email_attachment",
+  "credit_card_statement",
+  "amex_csv",
+]);
+
+const PAPER_SOURCE_TYPES: ReadonlySet<SourceType> = new Set([
+  "paper_scanned",
+]);
+
+export interface ComputeReceiptChecksInput {
+  receipt: ReceiptRecord;
+  attendees: ReceiptAttendee[];
+  files: ReceiptFile[];
+  settings: ComplianceSettings;
+}
+
+/**
+ * Pure check engine. No I/O. Returns the set of checks that *should* be
+ * "open" for the given receipt. Tests exercise this function directly.
+ */
+export function computeReceiptChecks(
+  input: ComputeReceiptChecksInput,
+): ComputedCheck[] {
+  const { receipt, attendees, files, settings } = input;
+  const checks: ComputedCheck[] = [];
+
+  if (!receipt.transaction_date) {
+    checks.push({
+      checkType: "missing_transaction_date",
+      severity: "blocker",
+      message: "Transaction date is missing.",
+    });
+  }
+
+  if (receipt.amount_minor === null || receipt.amount_minor === undefined) {
+    checks.push({
+      checkType: "missing_amount",
+      severity: "blocker",
+      message: "Amount is missing.",
+    });
+  }
+
+  const hasCounterparty =
+    !!(receipt.counterparty_name && receipt.counterparty_name.trim()) ||
+    !!(receipt.merchant && receipt.merchant.trim());
+  if (!hasCounterparty) {
+    checks.push({
+      checkType: "missing_counterparty",
+      severity: "warning",
+      message: "Counterparty / merchant name is missing.",
+    });
+  }
+
+  if (!receipt.expense_category_code) {
+    checks.push({
+      checkType: "missing_category",
+      severity: "blocker",
+      message: "Expense category is missing.",
+    });
+  }
+
+  const originals = files.filter((f) => f.is_original === 1);
+  if (originals.length === 0) {
+    checks.push({
+      checkType: "missing_receipt",
+      severity: "blocker",
+      message: "Original receipt file is missing.",
+    });
+  }
+
+  // Attendees: required for meeting and entertainment expenses unless the
+  // operator has disabled the requirement.
+  const code = receipt.expense_category_code ?? "";
+  const requiresAttendeesForCategory =
+    (code === "meeting" && settings.require_attendees_for_meeting) ||
+    (code === "entertainment" && settings.require_attendees_for_entertainment) ||
+    requiresAttendees(code);
+  if (requiresAttendeesForCategory && attendees.length === 0) {
+    checks.push({
+      checkType: "missing_attendees",
+      severity: "blocker",
+      message: "Attendees are required for this expense category.",
+    });
+  }
+
+  // Qualified invoice (インボイス制度) checks
+  const invoiceMode = settings.invoice_number_requirement_mode;
+  if (invoiceMode !== "disabled") {
+    const severity: ComplianceCheckSeverity =
+      invoiceMode === "blocker" ? "blocker" : "warning";
+    const number = receipt.invoice_registration_number;
+    const validation = validateInvoiceRegistrationNumber(number);
+    if (!number || number.trim() === "") {
+      checks.push({
+        checkType: "missing_invoice_registration_number",
+        severity,
+        message:
+          "Qualified-invoice registration number (T+13 digits) is missing.",
+      });
+    } else if (validation.registrationStatus === "format_invalid") {
+      checks.push({
+        checkType: "invoice_registration_invalid",
+        severity,
+        message: validation.message ?? "Registration number format is invalid.",
+        details: { number },
+      });
+    }
+  }
+
+  // Tax rate / consumption tax amount — warning only; some receipts
+  // legitimately omit them (small-amount, non-taxable).
+  if (!receipt.tax_rate) {
+    checks.push({
+      checkType: "missing_tax_rate",
+      severity: "warning",
+      message: "Tax rate is missing (typically 10% or 8% reduced).",
+    });
+  }
+  if (
+    receipt.tax_amount_minor === null ||
+    receipt.tax_amount_minor === undefined
+  ) {
+    checks.push({
+      checkType: "missing_tax_amount",
+      severity: "warning",
+      message: "Consumption tax amount is missing.",
+    });
+  }
+
+  // Electronic transaction preservation: if the source type is electronic,
+  // the original digital file (PDF / email / download) must be preserved.
+  // We treat image-only originals as a screenshot proxy and warn.
+  const sourceType = receipt.source_type as SourceType | null | undefined;
+  if (sourceType && ELECTRONIC_SOURCE_TYPES.has(sourceType)) {
+    const original = originals[0];
+    const looksLikeScreenshot =
+      !!original && original.content_type.startsWith("image/");
+    if (looksLikeScreenshot) {
+      checks.push({
+        checkType: "electronic_transaction_missing_original",
+        severity: "warning",
+        message:
+          "This appears to be an electronic transaction. Preserve the original PDF/email/download where available.",
+      });
+    }
+  }
+
+  // Scanner preservation metadata (paper scans)
+  if (sourceType && PAPER_SOURCE_TYPES.has(sourceType)) {
+    const original = originals[0];
+    const missingMetadata =
+      !original ||
+      !original.sha256_hash ||
+      !original.file_size_bytes ||
+      !original.content_type;
+    if (missingMetadata) {
+      checks.push({
+        checkType: "scanner_preservation_metadata_incomplete",
+        severity: "warning",
+        message:
+          "Scanner preservation metadata (hash / size / content type) is incomplete.",
+      });
+    }
+  }
+
+  return checks;
+}
+
+/**
+ * Persist the result of `computeReceiptChecks` to receipt_compliance_checks.
+ *
+ * Open checks that no longer apply are marked `resolved`. New checks insert
+ * new rows. Existing open checks with the same `(object_type, object_id,
+ * check_type)` are left untouched so their `checked_at` and `id` stay
+ * stable across runs.
+ */
+export async function persistReceiptChecks(
+  db: D1Database,
+  receiptId: string,
+  computed: ComputedCheck[],
+): Promise<void> {
+  const existing = await db
+    .prepare(
+      `SELECT id, check_type, status FROM receipt_compliance_checks
+       WHERE object_type = 'receipt' AND object_id = ?`,
+    )
+    .bind(receiptId)
+    .all<{ id: string; check_type: string; status: string }>();
+
+  const existingOpen = new Map<string, { id: string }>();
+  for (const row of existing.results ?? []) {
+    if (row.status === "open") existingOpen.set(row.check_type, { id: row.id });
+  }
+
+  const wantedTypes = new Set(computed.map((c) => c.checkType));
+  const now = nowIso();
+
+  // Resolve previously-open checks that no longer apply.
+  for (const [checkType, row] of existingOpen) {
+    if (!wantedTypes.has(checkType as ComplianceCheckType)) {
+      await db
+        .prepare(
+          `UPDATE receipt_compliance_checks
+           SET status = 'resolved', resolved_at = ?, resolved_by = 'system'
+           WHERE id = ?`,
+        )
+        .bind(now, row.id)
+        .run();
+    }
+  }
+
+  // Insert any newly-triggered checks.
+  for (const check of computed) {
+    if (existingOpen.has(check.checkType)) continue;
+    await db
+      .prepare(
+        `INSERT INTO receipt_compliance_checks
+          (id, object_type, object_id, check_type, status, severity, message,
+           details_json, checked_at, created_at)
+         VALUES (?, 'receipt', ?, ?, 'open', ?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        newUuid(),
+        receiptId,
+        check.checkType,
+        check.severity,
+        check.message,
+        check.details ? stringifyJson(check.details) : null,
+        now,
+        now,
+      )
+      .run();
+  }
+}
+
+export async function listChecksForObject(
+  db: D1Database,
+  objectType: string,
+  objectId: string,
+): Promise<ComplianceCheck[]> {
+  const result = await db
+    .prepare(
+      `SELECT * FROM receipt_compliance_checks
+       WHERE object_type = ? AND object_id = ?
+       ORDER BY status ASC, severity DESC, checked_at DESC`,
+    )
+    .bind(objectType, objectId)
+    .all<ComplianceCheck>();
+  return result.results ?? [];
+}
+
+export interface ComplianceSummary {
+  blockers: number;
+  warnings: number;
+  info: number;
+  total: number;
+  byType: Record<string, number>;
+}
+
+export async function summarizeOpenChecksForMonth(
+  db: D1Database,
+  month: string,
+): Promise<ComplianceSummary> {
+  const result = await db
+    .prepare(
+      `SELECT rcc.severity, rcc.check_type
+       FROM receipt_compliance_checks rcc
+       JOIN receipt_records rr ON rr.id = rcc.object_id
+       WHERE rcc.object_type = 'receipt'
+         AND rcc.status = 'open'
+         AND (rr.transaction_date LIKE ? OR rr.exported_month = ?)
+         AND rr.deleted_at IS NULL`,
+    )
+    .bind(`${month}%`, month)
+    .all<{ severity: ComplianceCheckSeverity; check_type: string }>();
+
+  const summary: ComplianceSummary = {
+    blockers: 0,
+    warnings: 0,
+    info: 0,
+    total: 0,
+    byType: {},
+  };
+  for (const row of result.results ?? []) {
+    summary.total++;
+    if (row.severity === "blocker") summary.blockers++;
+    else if (row.severity === "warning") summary.warnings++;
+    else summary.info++;
+    summary.byType[row.check_type] = (summary.byType[row.check_type] ?? 0) + 1;
+  }
+  return summary;
+}
+
+/**
+ * High-level helper: load the receipt + attendees + files + settings, run
+ * the engine, persist results, and return the computed checks.
+ */
+export async function runComplianceChecksForReceipt(
+  db: D1Database,
+  receiptId: string,
+  settings: ComplianceSettings,
+): Promise<ComputedCheck[]> {
+  const receipt = await db
+    .prepare(`SELECT * FROM receipt_records WHERE id = ? LIMIT 1`)
+    .bind(receiptId)
+    .first<ReceiptRecord>();
+  if (!receipt) return [];
+
+  const attendeesResult = await db
+    .prepare(`SELECT * FROM receipt_attendees WHERE receipt_id = ?`)
+    .bind(receiptId)
+    .all<ReceiptAttendee>();
+
+  const files = await listFilesForObject("receipt", receiptId);
+
+  const computed = computeReceiptChecks({
+    receipt,
+    attendees: attendeesResult.results ?? [],
+    files,
+    settings,
+  });
+
+  await persistReceiptChecks(db, receiptId, computed);
+  return computed;
+}

--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -37,6 +37,8 @@ export async function createReceiptRecord(
   const paymentPath = input.paymentPath ?? "UNKNOWN";
   const expenseType = input.expenseType ?? "UNKNOWN";
 
+  const sourceType = input.sourceType ?? "manual_upload";
+
   await db
     .prepare(
       `INSERT INTO receipt_records
@@ -45,8 +47,10 @@ export async function createReceiptRecord(
          transaction_date, merchant, amount_minor, currency, tax_amount_minor,
          business_purpose, alcohol_present, attendees_required, status,
          original_r2_key, original_sha256, original_content_type, original_size_bytes,
-         legacy, retention_until, legal_hold, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, 1, ?, ?)`,
+         legacy, retention_until, legal_hold,
+         source_type, preservation_status, qualified_invoice_status,
+         created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, 1, ?, 'needs_review', 'not_checked', ?, ?)`,
     )
     .bind(
       id,
@@ -73,6 +77,7 @@ export async function createReceiptRecord(
       input.originalContentType,
       input.originalSizeBytes,
       retentionUntilIso(now),
+      sourceType,
       now,
       now,
     )
@@ -131,6 +136,11 @@ export async function updateReceiptRecord(
   if ("extractionJson" in input) { sets.push("extraction_json = ?"); binds.push(input.extractionJson ?? null); }
   if ("exportedMonth" in input) { sets.push("exported_month = ?"); binds.push(input.exportedMonth ?? null); }
   if ("expenseCategoryCode" in input) { sets.push("expense_category_code = ?"); binds.push(input.expenseCategoryCode ?? null); }
+  if ("sourceType" in input) { sets.push("source_type = ?"); binds.push(input.sourceType ?? null); }
+  if ("invoiceRegistrationNumber" in input) { sets.push("invoice_registration_number = ?"); binds.push(input.invoiceRegistrationNumber ?? null); }
+  if ("counterpartyName" in input) { sets.push("counterparty_name = ?"); binds.push(input.counterpartyName ?? null); }
+  if ("taxRate" in input) { sets.push("tax_rate = ?"); binds.push(input.taxRate ?? null); }
+  if ("qualifiedInvoiceStatus" in input) { sets.push("qualified_invoice_status = ?"); binds.push(input.qualifiedInvoiceStatus ?? "not_checked"); }
 
   if (sets.length === 0) return;
 
@@ -178,6 +188,12 @@ export interface ListReceiptsFilter {
   status?: string;
   month?: string;
   paymentPath?: string;
+  sourceType?: string;
+  qualifiedInvoiceStatus?: string;
+  merchant?: string;
+  minAmountMinor?: number;
+  maxAmountMinor?: number;
+  invoiceRegistrationNumber?: string;
   limit?: number;
   offset?: number;
 }
@@ -200,6 +216,30 @@ export async function listReceiptRecords(
   if (filter?.month) {
     conditions.push("transaction_date LIKE ?");
     binds.push(`${filter.month}%`);
+  }
+  if (filter?.sourceType) {
+    conditions.push("source_type = ?");
+    binds.push(filter.sourceType);
+  }
+  if (filter?.qualifiedInvoiceStatus) {
+    conditions.push("qualified_invoice_status = ?");
+    binds.push(filter.qualifiedInvoiceStatus);
+  }
+  if (filter?.merchant) {
+    conditions.push("(merchant LIKE ? OR counterparty_name LIKE ?)");
+    binds.push(`%${filter.merchant}%`, `%${filter.merchant}%`);
+  }
+  if (filter?.minAmountMinor !== undefined) {
+    conditions.push("amount_minor >= ?");
+    binds.push(filter.minAmountMinor);
+  }
+  if (filter?.maxAmountMinor !== undefined) {
+    conditions.push("amount_minor <= ?");
+    binds.push(filter.maxAmountMinor);
+  }
+  if (filter?.invoiceRegistrationNumber) {
+    conditions.push("invoice_registration_number = ?");
+    binds.push(filter.invoiceRegistrationNumber);
   }
 
   const where = `WHERE ${conditions.join(" AND ")}`;
@@ -1243,19 +1283,30 @@ export async function createExport(
 ): Promise<string> {
   const db = getReceiptsDb();
 
-  const existing = await db
+  // Prefer reusing a pending draft. If there's no draft but a finalized
+  // export already exists for the month, callers must explicitly request a
+  // revision via createExportRevision().
+  const draft = await db
     .prepare(
-      `SELECT id, status FROM receipt_exports WHERE export_month = ? LIMIT 1`,
+      `SELECT id FROM receipt_exports
+       WHERE export_month = ? AND status = 'draft'
+       ORDER BY COALESCE(export_revision, 1) DESC LIMIT 1`,
     )
     .bind(month)
-    .first<{ id: string; status: string }>();
+    .first<{ id: string }>();
+  if (draft) return draft.id;
 
-  if (existing?.status === "finalized") {
-    throw new Error(`Export for ${month} is already finalized.`);
-  }
-
-  if (existing) {
-    return existing.id;
+  const finalized = await db
+    .prepare(
+      `SELECT id FROM receipt_exports
+       WHERE export_month = ? AND status = 'finalized' LIMIT 1`,
+    )
+    .bind(month)
+    .first<{ id: string }>();
+  if (finalized) {
+    throw new Error(
+      `Export for ${month} is already finalized. POST /api/receipts/export/${month}?correction=true to create a revision.`,
+    );
   }
 
   const id = newUuid();
@@ -1283,8 +1334,15 @@ export async function createExport(
 
 export async function getExport(month: string): Promise<ReceiptExport | null> {
   const db = getReceiptsDb();
+  // Return the highest-revision row for this month. Drafts and finalized
+  // exports coexist in the table once revisions are introduced.
   return db
-    .prepare(`SELECT * FROM receipt_exports WHERE export_month = ? LIMIT 1`)
+    .prepare(
+      `SELECT * FROM receipt_exports
+       WHERE export_month = ?
+       ORDER BY COALESCE(export_revision, 1) DESC, created_at DESC
+       LIMIT 1`,
+    )
     .bind(month)
     .first<ReceiptExport>();
 }
@@ -1303,8 +1361,10 @@ export async function finalizeExport(
   manifestR2Key: string,
   archiveSha256: string,
   actor: string,
+  manifestSha256?: string,
 ): Promise<void> {
   const db = getReceiptsDb();
+  const now = nowIso();
 
   const result = await db
     .prepare(
@@ -1313,10 +1373,22 @@ export async function finalizeExport(
            archive_r2_key = ?,
            manifest_r2_key = ?,
            archive_sha256 = ?,
+           manifest_sha256 = ?,
+           finalization_hash = ?,
+           finalized_by = ?,
            finalized_at = ?
        WHERE id = ? AND status = 'draft'`,
     )
-    .bind(archiveR2Key, manifestR2Key, archiveSha256, nowIso(), exportId)
+    .bind(
+      archiveR2Key,
+      manifestR2Key,
+      archiveSha256,
+      manifestSha256 ?? null,
+      manifestSha256 ?? archiveSha256,
+      actor,
+      now,
+      exportId,
+    )
     .run();
 
   if ((result.meta.changes ?? 0) === 0) {
@@ -1330,8 +1402,74 @@ export async function finalizeExport(
     action: "export.finalized",
     objectType: "export",
     objectId: exportId,
-    newValueJson: stringifyJson({ archiveR2Key, archiveSha256 }),
+    newValueJson: stringifyJson({
+      archiveR2Key,
+      archiveSha256,
+      manifestSha256: manifestSha256 ?? null,
+    }),
   });
+}
+
+/**
+ * Create a new revision of a previously-finalized export. The prior export
+ * row and its R2 archive are untouched — preservation principle.
+ */
+export async function createExportRevision(
+  month: string,
+  correctionReason: string,
+  actor: string,
+): Promise<{ exportId: string; revision: number; supersedesExportId: string }> {
+  const db = getReceiptsDb();
+  const now = nowIso();
+
+  const prior = await db
+    .prepare(
+      `SELECT id, export_revision FROM receipt_exports
+       WHERE export_month = ? AND status = 'finalized'
+       ORDER BY COALESCE(export_revision, 1) DESC LIMIT 1`,
+    )
+    .bind(month)
+    .first<{ id: string; export_revision: number | null }>();
+
+  if (!prior) {
+    throw new Error(
+      `Cannot create a revision: no finalized export exists for ${month}.`,
+    );
+  }
+
+  const newRevision = (prior.export_revision ?? 1) + 1;
+  const id = newUuid();
+
+  await db
+    .prepare(
+      `INSERT INTO receipt_exports
+        (id, export_month, status, created_by, created_at,
+         export_revision, supersedes_export_id, correction_reason,
+         retention_until, legal_hold)
+       VALUES (?, ?, 'draft', ?, ?, ?, ?, ?, ?, 1)`,
+    )
+    .bind(
+      id,
+      month,
+      actor,
+      now,
+      newRevision,
+      prior.id,
+      correctionReason,
+      retentionUntilIso(now),
+    )
+    .run();
+
+  await createAuditEntry(db, {
+    actor,
+    action: "export.revision_created",
+    objectType: "export",
+    objectId: id,
+    oldValueJson: stringifyJson({ supersedes: prior.id, revision: prior.export_revision ?? 1 }),
+    newValueJson: stringifyJson({ revision: newRevision, correctionReason, month }),
+  });
+
+  return { exportId: id, revision: newRevision, supersedesExportId: prior.id };
 }
 
 // ─── Reconciliation signoff ────────────────────────────────────────────────

--- a/lib/receipts/export.ts
+++ b/lib/receipts/export.ts
@@ -1,4 +1,8 @@
-import type { ExportRow } from "@/lib/receipts/types";
+import type { ExportRow, ReceiptFile } from "@/lib/receipts/types";
+import {
+  ACCOUNTANT_DISCLAIMER_EN,
+  ACCOUNTANT_DISCLAIMER_JA,
+} from "@/lib/receipts/settings";
 
 function csvEscape(value: string | null | undefined): string {
   if (value === null || value === undefined) return "";
@@ -95,6 +99,13 @@ export function buildManifestCsv(
     manifestR2Key: string;
     manifestSha256: string;
   } | null,
+  options?: {
+    files?: ReceiptFile[];
+    amexArtifact?: { r2Key: string; sha256Hash: string; originalFilename: string } | null;
+    exportRevision?: number;
+    supersedesExportId?: string | null;
+    correctionReason?: string | null;
+  },
 ): string {
   const lines = [
     "Field,Value",
@@ -105,6 +116,15 @@ export function buildManifestCsv(
     `RowCount,${rowCount}`,
     `GeneratedAt,${csvEscape(generatedAt)}`,
   ];
+  if (options?.exportRevision !== undefined) {
+    lines.push(`ExportRevision,${options.exportRevision}`);
+  }
+  if (options?.supersedesExportId) {
+    lines.push(`SupersedesExportId,${csvEscape(options.supersedesExportId)}`);
+  }
+  if (options?.correctionReason) {
+    lines.push(`CorrectionReason,${csvEscape(options.correctionReason)}`);
+  }
   if (reconciliation) {
     lines.push(
       `ReconciliationId,${csvEscape(reconciliation.id)}`,
@@ -112,5 +132,75 @@ export function buildManifestCsv(
       `ReconciliationManifestSha256,${csvEscape(reconciliation.manifestSha256)}`,
     );
   }
+  if (options?.amexArtifact) {
+    lines.push(
+      `AmexArtifactKey,${csvEscape(options.amexArtifact.r2Key)}`,
+      `AmexArtifactSha256,${csvEscape(options.amexArtifact.sha256Hash)}`,
+      `AmexArtifactFilename,${csvEscape(options.amexArtifact.originalFilename)}`,
+    );
+  }
+
+  // Per-file hash table follows the metadata section.
+  if (options?.files && options.files.length > 0) {
+    lines.push("");
+    lines.push("ObjectType,ObjectId,Role,R2Bucket,R2Key,OriginalFilename,ContentType,FileSizeBytes,SHA256,UploadedBy,UploadedAt");
+    for (const f of options.files) {
+      lines.push(
+        [
+          csvEscape(f.object_type),
+          csvEscape(f.object_id),
+          csvEscape(f.role),
+          csvEscape(f.r2_bucket),
+          csvEscape(f.r2_key),
+          csvEscape(f.original_filename),
+          csvEscape(f.content_type),
+          String(f.file_size_bytes),
+          csvEscape(f.sha256_hash),
+          csvEscape(f.uploaded_by),
+          csvEscape(f.uploaded_at),
+        ].join(","),
+      );
+    }
+  }
+
   return lines.join("\n");
+}
+
+export function buildReadmeKey(month: string, exportId: string): string {
+  return `exports/${month}/${exportId}-README.txt`;
+}
+
+export function buildExportReadme(opts: {
+  exportId: string;
+  month: string;
+  rowCount: number;
+  generatedAt: string;
+  exportRevision: number;
+  supersedesExportId?: string | null;
+  correctionReason?: string | null;
+  archiveSha256: string;
+  manifestSha256?: string | null;
+}): string {
+  const revisionLine =
+    opts.exportRevision > 1
+      ? `Revision: ${opts.exportRevision} (supersedes ${opts.supersedesExportId ?? "?"})\nCorrection reason: ${opts.correctionReason ?? ""}`
+      : `Revision: 1 (initial)`;
+  return [
+    `Dazbeez monthly export — ${opts.month}`,
+    `Export ID: ${opts.exportId}`,
+    `Generated at: ${opts.generatedAt}`,
+    `Row count: ${opts.rowCount}`,
+    revisionLine,
+    `Archive SHA-256: ${opts.archiveSha256}`,
+    `Manifest SHA-256: ${opts.manifestSha256 ?? "(pending)"}`,
+    "",
+    "── Accountant review ──────────────────────────────────────",
+    ACCOUNTANT_DISCLAIMER_EN,
+    "",
+    ACCOUNTANT_DISCLAIMER_JA,
+    "",
+    "── Files included ─────────────────────────────────────────",
+    "See the manifest CSV for SHA-256 hashes of every receipt original,",
+    "derivative, and the AMEX statement CSV included in this export.",
+  ].join("\n");
 }

--- a/lib/receipts/files.ts
+++ b/lib/receipts/files.ts
@@ -1,0 +1,78 @@
+import { getReceiptsDb } from "@/lib/cloudflare-runtime";
+import { newUuid, nowIso } from "@/lib/receipts/db-utils";
+import type { ReceiptFile, ReceiptFileRole } from "@/lib/receipts/types";
+
+export interface CreateReceiptFileInput {
+  objectType: "receipt" | "amex_statement_artifact" | "export";
+  objectId: string;
+  role: ReceiptFileRole;
+  r2Bucket: "receipts" | "archive";
+  r2Key: string;
+  originalFilename: string;
+  contentType: string;
+  fileSizeBytes: number;
+  sha256Hash: string;
+  uploadedBy: string;
+  isOriginal: boolean;
+}
+
+export async function createReceiptFile(
+  db: D1Database,
+  input: CreateReceiptFileInput,
+): Promise<string> {
+  const id = newUuid();
+  const now = nowIso();
+  await db
+    .prepare(
+      `INSERT INTO receipt_files
+        (id, object_type, object_id, role, r2_bucket, r2_key,
+         original_filename, content_type, file_size_bytes, sha256_hash,
+         uploaded_by, uploaded_at, is_original, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .bind(
+      id,
+      input.objectType,
+      input.objectId,
+      input.role,
+      input.r2Bucket,
+      input.r2Key,
+      input.originalFilename,
+      input.contentType,
+      input.fileSizeBytes,
+      input.sha256Hash,
+      input.uploadedBy,
+      now,
+      input.isOriginal ? 1 : 0,
+      now,
+      now,
+    )
+    .run();
+  return id;
+}
+
+export async function listFilesForObject(
+  objectType: string,
+  objectId: string,
+): Promise<ReceiptFile[]> {
+  const db = getReceiptsDb();
+  const result = await db
+    .prepare(
+      `SELECT * FROM receipt_files
+       WHERE object_type = ? AND object_id = ?
+       ORDER BY is_original DESC, created_at ASC`,
+    )
+    .bind(objectType, objectId)
+    .all<ReceiptFile>();
+  return result.results ?? [];
+}
+
+export async function findFileBySha256(
+  sha256: string,
+): Promise<ReceiptFile | null> {
+  const db = getReceiptsDb();
+  return db
+    .prepare(`SELECT * FROM receipt_files WHERE sha256_hash = ? LIMIT 1`)
+    .bind(sha256)
+    .first<ReceiptFile>();
+}

--- a/lib/receipts/invoice.ts
+++ b/lib/receipts/invoice.ts
@@ -1,0 +1,87 @@
+// 適格請求書発行事業者の登録番号 (Qualified Invoice Issuer Registration Number)
+//
+// Format: literal "T" + 13 digits. National Tax Agency (NTA) issues these
+// numbers. Real-time lookup against NTA is intentionally NOT performed here
+// (network round-trip from the upload path is undesirable and the public
+// API has rate limits); format validation is treated as sufficient for the
+// preservation layer. A future worker can periodically batch-confirm.
+
+import type {
+  InvoiceRegistrationStatus,
+  QualifiedInvoiceStatus,
+} from "@/lib/receipts/types";
+
+const REGISTRATION_NUMBER_PATTERN = /^T\d{13}$/;
+
+export interface NormalizedRegistrationNumber {
+  normalized: string;
+  formatValid: boolean;
+}
+
+/** Strip whitespace, hyphens, and normalize Japanese fullwidth digits. */
+export function normalizeRegistrationNumber(
+  raw: string | null | undefined,
+): NormalizedRegistrationNumber {
+  if (!raw) return { normalized: "", formatValid: false };
+  // NFKC handles fullwidth → halfwidth digit/Latin conversion.
+  const normalized = raw
+    .normalize("NFKC")
+    .replace(/[\s\-‐‒–—―ー−]/g, "")
+    .toUpperCase();
+  return {
+    normalized,
+    formatValid: REGISTRATION_NUMBER_PATTERN.test(normalized),
+  };
+}
+
+export function isValidRegistrationNumberFormat(
+  raw: string | null | undefined,
+): boolean {
+  return normalizeRegistrationNumber(raw).formatValid;
+}
+
+export interface InvoiceValidationResult {
+  registrationStatus: InvoiceRegistrationStatus;
+  qualifiedInvoiceStatus: QualifiedInvoiceStatus;
+  normalizedNumber: string | null;
+  message: string | null;
+}
+
+/**
+ * Validate a registration number purely on format. Returns the persisted
+ * statuses to write back to receipt_records. Network lookup against the
+ * NTA registry is left as a future hook — see file header.
+ */
+export function validateInvoiceRegistrationNumber(
+  raw: string | null | undefined,
+  opts?: { counterpartyKnownUnregistered?: boolean },
+): InvoiceValidationResult {
+  if (!raw || raw.trim() === "") {
+    return {
+      registrationStatus: "unchecked",
+      qualifiedInvoiceStatus: opts?.counterpartyKnownUnregistered
+        ? "unregistered_counterparty"
+        : "missing_registration_number",
+      normalizedNumber: null,
+      message: null,
+    };
+  }
+
+  const { normalized, formatValid } = normalizeRegistrationNumber(raw);
+  if (!formatValid) {
+    return {
+      registrationStatus: "format_invalid",
+      qualifiedInvoiceStatus: "invalid",
+      normalizedNumber: normalized || null,
+      message:
+        'Registration number must match "T" followed by 13 digits (e.g. T1234567890123).',
+    };
+  }
+
+  return {
+    registrationStatus: "format_valid",
+    qualifiedInvoiceStatus: "valid",
+    normalizedNumber: normalized,
+    message: null,
+  };
+}

--- a/lib/receipts/settings.ts
+++ b/lib/receipts/settings.ts
@@ -1,0 +1,125 @@
+import { getReceiptsDb } from "@/lib/cloudflare-runtime";
+import { nowIso } from "@/lib/receipts/db-utils";
+import type {
+  ComplianceSettings,
+  InvoiceNumberRequirementMode,
+  PaperOriginalDiscardPolicy,
+} from "@/lib/receipts/types";
+
+export const COMPLIANCE_DEFAULTS: ComplianceSettings = {
+  business_name: "",
+  taxpayer_type: "kojin",
+  retention_years: 7,
+  require_attendees_for_meeting: true,
+  require_attendees_for_entertainment: true,
+  invoice_number_requirement_mode: "warning",
+  export_block_on_warnings: false,
+  paper_original_discard_policy: "retain_until_accountant_confirms",
+  statement_expected_day: 18,
+};
+
+const INVOICE_MODES: ReadonlySet<InvoiceNumberRequirementMode> = new Set([
+  "disabled",
+  "warning",
+  "blocker",
+]);
+
+const DISCARD_POLICIES: ReadonlySet<PaperOriginalDiscardPolicy> = new Set([
+  "retain_until_accountant_confirms",
+  "retain_indefinitely",
+  "permit_discard_after_scan",
+]);
+
+function parseBool(v: string | undefined, fallback: boolean): boolean {
+  if (v === undefined) return fallback;
+  return v === "true" || v === "1";
+}
+
+function parseInt10(v: string | undefined, fallback: number): number {
+  if (v === undefined) return fallback;
+  const n = Number.parseInt(v, 10);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+export function parseComplianceSettings(
+  rows: Array<{ key: string; value: string }>,
+): ComplianceSettings {
+  const map = new Map(rows.map((r) => [r.key, r.value]));
+  const invoiceMode = map.get("invoice_number_requirement_mode");
+  const discardPolicy = map.get("paper_original_discard_policy");
+  return {
+    business_name: map.get("business_name") ?? COMPLIANCE_DEFAULTS.business_name,
+    taxpayer_type: map.get("taxpayer_type") ?? COMPLIANCE_DEFAULTS.taxpayer_type,
+    retention_years: parseInt10(
+      map.get("retention_years"),
+      COMPLIANCE_DEFAULTS.retention_years,
+    ),
+    require_attendees_for_meeting: parseBool(
+      map.get("require_attendees_for_meeting"),
+      COMPLIANCE_DEFAULTS.require_attendees_for_meeting,
+    ),
+    require_attendees_for_entertainment: parseBool(
+      map.get("require_attendees_for_entertainment"),
+      COMPLIANCE_DEFAULTS.require_attendees_for_entertainment,
+    ),
+    invoice_number_requirement_mode:
+      invoiceMode && INVOICE_MODES.has(invoiceMode as InvoiceNumberRequirementMode)
+        ? (invoiceMode as InvoiceNumberRequirementMode)
+        : COMPLIANCE_DEFAULTS.invoice_number_requirement_mode,
+    export_block_on_warnings: parseBool(
+      map.get("export_block_on_warnings"),
+      COMPLIANCE_DEFAULTS.export_block_on_warnings,
+    ),
+    paper_original_discard_policy:
+      discardPolicy && DISCARD_POLICIES.has(discardPolicy as PaperOriginalDiscardPolicy)
+        ? (discardPolicy as PaperOriginalDiscardPolicy)
+        : COMPLIANCE_DEFAULTS.paper_original_discard_policy,
+    statement_expected_day: parseInt10(
+      map.get("statement_expected_day"),
+      COMPLIANCE_DEFAULTS.statement_expected_day,
+    ),
+  };
+}
+
+export async function getComplianceSettings(): Promise<ComplianceSettings> {
+  const db = getReceiptsDb();
+  const result = await db
+    .prepare(`SELECT key, value FROM receipt_settings`)
+    .all<{ key: string; value: string }>();
+  return parseComplianceSettings(result.results ?? []);
+}
+
+export async function updateComplianceSettings(
+  updates: Partial<ComplianceSettings>,
+  actor: string,
+): Promise<ComplianceSettings> {
+  const db = getReceiptsDb();
+  const now = nowIso();
+  const entries = Object.entries(updates).filter(([, v]) => v !== undefined);
+  for (const [key, value] of entries) {
+    const stringValue =
+      typeof value === "boolean" ? (value ? "true" : "false") : String(value);
+    await db
+      .prepare(
+        `INSERT INTO receipt_settings (key, value, updated_at, updated_by)
+         VALUES (?, ?, ?, ?)
+         ON CONFLICT (key) DO UPDATE SET value = excluded.value,
+           updated_at = excluded.updated_at, updated_by = excluded.updated_by`,
+      )
+      .bind(key, stringValue, now, actor)
+      .run();
+  }
+  return getComplianceSettings();
+}
+
+// ─── Accountant review disclaimer ────────────────────────────────────────
+
+export const ACCOUNTANT_DISCLAIMER_EN =
+  "These records are preparation materials for accountant review. " +
+  "Dazbeez does not provide tax advice or make final tax determinations. " +
+  "Please confirm treatment with your tax accountant.";
+
+export const ACCOUNTANT_DISCLAIMER_JA =
+  "本資料は税理士による確認用の準備資料です。" +
+  "Dazbeez は税務上の助言や最終的な税務判断を提供するものではありません。" +
+  "最終的な取り扱いは税理士にご確認ください。";

--- a/lib/receipts/types.ts
+++ b/lib/receipts/types.ts
@@ -86,10 +86,16 @@ export type AuditAction =
   | "receipt.extraction_completed"
   | "receipt.extraction_denied"
   | "receipt.extraction_failed"
+  | "receipt.reviewed"
   | "receipt.reconciled"
   | "receipt.exported"
   | "receipt.archived"
   | "receipt.deleted"
+  | "receipt.restored"
+  | "receipt.finalized"
+  | "receipt.file_downloaded"
+  | "receipt.search_performed"
+  | "receipt.compliance_checked"
   | "amex.imported"
   | "amex.artifact_created"
   | "amex.line_categorized"
@@ -97,8 +103,82 @@ export type AuditAction =
   | "amex.business_trip_detected"
   | "amex.reconciliation_signed_off"
   | "amex.reconciliation_amended"
+  | "amex_statement.uploaded"
+  | "amex_statement.parsed"
+  | "amex_statement.import_failed"
+  | "amex_statement.line_updated"
+  | "amex_statement.line_reconciled"
   | "export.created"
-  | "export.finalized";
+  | "export.generated"
+  | "export.finalized"
+  | "export.revision_created"
+  | "archive.created"
+  | "settings.updated";
+
+// ─── Compliance: source / preservation / qualified-invoice ────────────────
+
+export type SourceType =
+  | "paper_scanned"
+  | "electronic_receipt"
+  | "digital_invoice"
+  | "credit_card_statement"
+  | "email_attachment"
+  | "manual_upload"
+  | "amex_csv";
+
+export type PreservationStatus =
+  | "captured"
+  | "needs_metadata"
+  | "needs_review"
+  | "reviewed"
+  | "exported"
+  | "archived"
+  | "superseded"
+  | "deleted";
+
+export type QualifiedInvoiceStatus =
+  | "not_checked"
+  | "not_applicable"
+  | "valid"
+  | "invalid"
+  | "missing_registration_number"
+  | "unregistered_counterparty"
+  | "needs_review";
+
+export type InvoiceRegistrationStatus =
+  | "unchecked"
+  | "format_valid"
+  | "format_invalid"
+  | "lookup_skipped"
+  | "lookup_confirmed"
+  | "lookup_failed";
+
+export type ComplianceCheckType =
+  | "missing_transaction_date"
+  | "missing_amount"
+  | "missing_counterparty"
+  | "missing_category"
+  | "missing_receipt"
+  | "missing_attendees"
+  | "missing_invoice_registration_number"
+  | "invoice_registration_invalid"
+  | "missing_tax_rate"
+  | "missing_tax_amount"
+  | "electronic_transaction_missing_original"
+  | "scanner_preservation_metadata_incomplete"
+  | "export_blocker";
+
+export type ComplianceCheckStatus = "open" | "resolved" | "ignored_with_reason";
+export type ComplianceCheckSeverity = "info" | "warning" | "blocker";
+
+export type ReceiptFileRole =
+  | "original"
+  | "processed"
+  | "back_side"
+  | "continuation"
+  | "related_invoice"
+  | "statement"
+  | "export_artifact";
 
 // ─── Database row shapes ───────────────────────────────────────────────────
 
@@ -133,6 +213,18 @@ export interface ReceiptRecord {
   delete_reason: string | null;
   retention_until?: string | null;
   legal_hold?: number;
+  // Compliance metadata (0014_compliance.sql)
+  source_type?: SourceType | null;
+  preservation_status?: PreservationStatus | null;
+  confirmed_at?: string | null;
+  confirmed_by?: string | null;
+  invoice_registration_number?: string | null;
+  invoice_registration_status?: InvoiceRegistrationStatus | null;
+  qualified_invoice_status?: QualifiedInvoiceStatus;
+  tax_rate?: string | null;
+  counterparty_name?: string | null;
+  search_text?: string | null;
+  compliance_warnings_json?: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -261,6 +353,74 @@ export interface ReceiptExport {
   finalized_at: string | null;
   retention_until?: string | null;
   legal_hold?: number;
+  // Revisioning + manifest hashing (0014_compliance.sql)
+  export_revision?: number;
+  supersedes_export_id?: string | null;
+  correction_reason?: string | null;
+  finalized_by?: string | null;
+  finalization_hash?: string | null;
+  manifest_sha256?: string | null;
+}
+
+// ─── Compliance row shapes ────────────────────────────────────────────────
+
+export interface ReceiptFile {
+  id: string;
+  object_type: string;
+  object_id: string;
+  role: ReceiptFileRole;
+  r2_bucket: string;
+  r2_key: string;
+  original_filename: string;
+  content_type: string;
+  file_size_bytes: number;
+  sha256_hash: string;
+  uploaded_by: string;
+  uploaded_at: string;
+  is_original: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ComplianceCheck {
+  id: string;
+  object_type: string;
+  object_id: string;
+  check_type: ComplianceCheckType;
+  status: ComplianceCheckStatus;
+  severity: ComplianceCheckSeverity;
+  message: string;
+  details_json: string | null;
+  checked_at: string;
+  resolved_at: string | null;
+  resolved_by: string | null;
+  created_at: string;
+}
+
+export interface ComputedCheck {
+  checkType: ComplianceCheckType;
+  severity: ComplianceCheckSeverity;
+  message: string;
+  details?: Record<string, unknown>;
+}
+
+export type InvoiceNumberRequirementMode = "disabled" | "warning" | "blocker";
+
+export type PaperOriginalDiscardPolicy =
+  | "retain_until_accountant_confirms"
+  | "retain_indefinitely"
+  | "permit_discard_after_scan";
+
+export interface ComplianceSettings {
+  business_name: string;
+  taxpayer_type: string;
+  retention_years: number;
+  require_attendees_for_meeting: boolean;
+  require_attendees_for_entertainment: boolean;
+  invoice_number_requirement_mode: InvoiceNumberRequirementMode;
+  export_block_on_warnings: boolean;
+  paper_original_discard_policy: PaperOriginalDiscardPolicy;
+  statement_expected_day: number;
 }
 
 export interface AmexReconciliation {
@@ -297,6 +457,7 @@ export interface ReceiptAuditEntry {
 export interface CreateReceiptInput {
   capturedBy: string;
   source?: string;
+  sourceType?: SourceType;
   originalFilename?: string;
   paymentPath?: PaymentPath;
   expenseType?: ExpenseType;
@@ -328,6 +489,12 @@ export interface UpdateReceiptInput {
   processedR2Key?: string | null;
   extractionJson?: string | null;
   exportedMonth?: string | null;
+  // Compliance fields (0014_compliance.sql)
+  sourceType?: SourceType | null;
+  invoiceRegistrationNumber?: string | null;
+  counterpartyName?: string | null;
+  taxRate?: string | null;
+  qualifiedInvoiceStatus?: QualifiedInvoiceStatus | null;
 }
 
 export interface CreateAttendeeInput {
@@ -398,6 +565,13 @@ export interface ExtractionResult {
   attendeeNames: string[];
   rawText: string;
   provider: string;
+  // Qualified-invoice (インボイス制度) extraction. Initial providers may
+  // leave these null; the review UI is the source of truth until populated.
+  invoiceRegistrationNumber?: string | null;
+  taxRate?: string | null;
+  taxAmountMinor?: number | null;
+  counterpartyName?: string | null;
+  qualifiedInvoiceStatus?: QualifiedInvoiceStatus | null;
 }
 
 // ─── Reconciliation ────────────────────────────────────────────────────────

--- a/tests/receipts/compliance-settings.test.ts
+++ b/tests/receipts/compliance-settings.test.ts
@@ -1,0 +1,68 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseComplianceSettings,
+  COMPLIANCE_DEFAULTS,
+} from "@/lib/receipts/settings";
+
+test("settings: empty rows produce all defaults", () => {
+  const settings = parseComplianceSettings([]);
+  assert.deepEqual(settings, COMPLIANCE_DEFAULTS);
+});
+
+test("settings: explicit values override defaults", () => {
+  const settings = parseComplianceSettings([
+    { key: "retention_years", value: "10" },
+    { key: "require_attendees_for_meeting", value: "false" },
+    { key: "invoice_number_requirement_mode", value: "blocker" },
+  ]);
+  assert.equal(settings.retention_years, 10);
+  assert.equal(settings.require_attendees_for_meeting, false);
+  assert.equal(settings.invoice_number_requirement_mode, "blocker");
+  // Untouched keys keep their defaults.
+  assert.equal(
+    settings.paper_original_discard_policy,
+    COMPLIANCE_DEFAULTS.paper_original_discard_policy,
+  );
+});
+
+test("settings: invalid enum value falls back to default", () => {
+  const settings = parseComplianceSettings([
+    { key: "invoice_number_requirement_mode", value: "yolo" },
+    { key: "paper_original_discard_policy", value: "burn_it" },
+  ]);
+  assert.equal(
+    settings.invoice_number_requirement_mode,
+    COMPLIANCE_DEFAULTS.invoice_number_requirement_mode,
+  );
+  assert.equal(
+    settings.paper_original_discard_policy,
+    COMPLIANCE_DEFAULTS.paper_original_discard_policy,
+  );
+});
+
+test("settings: malformed integer falls back to default", () => {
+  const settings = parseComplianceSettings([
+    { key: "retention_years", value: "not-a-number" },
+    { key: "statement_expected_day", value: "" },
+  ]);
+  assert.equal(
+    settings.retention_years,
+    COMPLIANCE_DEFAULTS.retention_years,
+  );
+  assert.equal(
+    settings.statement_expected_day,
+    COMPLIANCE_DEFAULTS.statement_expected_day,
+  );
+});
+
+test("settings: bool parsing accepts true/false/1/0", () => {
+  const settings = parseComplianceSettings([
+    { key: "require_attendees_for_meeting", value: "1" },
+    { key: "require_attendees_for_entertainment", value: "0" },
+    { key: "export_block_on_warnings", value: "true" },
+  ]);
+  assert.equal(settings.require_attendees_for_meeting, true);
+  assert.equal(settings.require_attendees_for_entertainment, false);
+  assert.equal(settings.export_block_on_warnings, true);
+});

--- a/tests/receipts/compliance.test.ts
+++ b/tests/receipts/compliance.test.ts
@@ -1,0 +1,241 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { computeReceiptChecks } from "@/lib/receipts/compliance";
+import { COMPLIANCE_DEFAULTS } from "@/lib/receipts/settings";
+import type {
+  ComplianceSettings,
+  ReceiptAttendee,
+  ReceiptFile,
+  ReceiptRecord,
+} from "@/lib/receipts/types";
+
+function baseReceipt(overrides: Partial<ReceiptRecord> = {}): ReceiptRecord {
+  const now = "2026-05-01T00:00:00Z";
+  return {
+    id: "rec_1",
+    captured_at: now,
+    captured_by: "test",
+    source: "mobile_capture",
+    original_filename: "scan.jpg",
+    payment_path: "CASH",
+    expense_type: "UNKNOWN",
+    transaction_date: "2026-05-01",
+    merchant: "Test Merchant",
+    amount_minor: 5000,
+    currency: "JPY",
+    tax_amount_minor: 500,
+    business_purpose: null,
+    alcohol_present: 0,
+    attendees_required: 0,
+    status: "needs_review",
+    original_r2_key: "receipts/2026/05/rec_1/foo.jpg",
+    original_sha256: "abc",
+    original_content_type: "image/jpeg",
+    original_size_bytes: 1024,
+    processed_r2_key: null,
+    extraction_json: null,
+    legacy: 0,
+    exported_month: null,
+    expense_category_code: "supplies",
+    deleted_at: null,
+    deleted_by: null,
+    delete_reason: null,
+    source_type: "paper_scanned",
+    preservation_status: "needs_review",
+    qualified_invoice_status: "not_checked",
+    invoice_registration_number: "T1234567890123",
+    invoice_registration_status: "format_valid",
+    counterparty_name: "Test Merchant K.K.",
+    tax_rate: "10%",
+    created_at: now,
+    updated_at: now,
+    ...overrides,
+  };
+}
+
+function originalFile(
+  overrides: Partial<ReceiptFile> = {},
+): ReceiptFile {
+  return {
+    id: "file_1",
+    object_type: "receipt",
+    object_id: "rec_1",
+    role: "original",
+    r2_bucket: "receipts",
+    r2_key: "receipts/2026/05/rec_1/foo.jpg",
+    original_filename: "scan.jpg",
+    content_type: "image/jpeg",
+    file_size_bytes: 1024,
+    sha256_hash: "abc",
+    uploaded_by: "test",
+    uploaded_at: "2026-05-01T00:00:00Z",
+    is_original: 1,
+    created_at: "2026-05-01T00:00:00Z",
+    updated_at: "2026-05-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+const SETTINGS: ComplianceSettings = { ...COMPLIANCE_DEFAULTS };
+
+test("compliance: fully populated receipt has no blockers", () => {
+  const checks = computeReceiptChecks({
+    receipt: baseReceipt(),
+    attendees: [],
+    files: [originalFile()],
+    settings: SETTINGS,
+  });
+  const blockers = checks.filter((c) => c.severity === "blocker");
+  assert.equal(blockers.length, 0);
+});
+
+test("compliance: missing transaction_date is a blocker", () => {
+  const checks = computeReceiptChecks({
+    receipt: baseReceipt({ transaction_date: null }),
+    attendees: [],
+    files: [originalFile()],
+    settings: SETTINGS,
+  });
+  assert.ok(checks.some((c) => c.checkType === "missing_transaction_date"));
+});
+
+test("compliance: missing amount is a blocker", () => {
+  const checks = computeReceiptChecks({
+    receipt: baseReceipt({ amount_minor: null }),
+    attendees: [],
+    files: [originalFile()],
+    settings: SETTINGS,
+  });
+  const c = checks.find((x) => x.checkType === "missing_amount");
+  assert.ok(c);
+  assert.equal(c!.severity, "blocker");
+});
+
+test("compliance: missing category is a blocker", () => {
+  const checks = computeReceiptChecks({
+    receipt: baseReceipt({ expense_category_code: null }),
+    attendees: [],
+    files: [originalFile()],
+    settings: SETTINGS,
+  });
+  assert.ok(checks.some((c) => c.checkType === "missing_category"));
+});
+
+test("compliance: meeting expense without attendees blocks", () => {
+  const checks = computeReceiptChecks({
+    receipt: baseReceipt({ expense_category_code: "meeting" }),
+    attendees: [],
+    files: [originalFile()],
+    settings: SETTINGS,
+  });
+  const c = checks.find((x) => x.checkType === "missing_attendees");
+  assert.ok(c);
+  assert.equal(c!.severity, "blocker");
+});
+
+test("compliance: meeting expense with attendees passes", () => {
+  const attendees: ReceiptAttendee[] = [
+    {
+      id: "a1",
+      receipt_id: "rec_1",
+      attendee_name: "Alice",
+      company: null,
+      relationship: null,
+      is_dazbeez_employee: 0,
+      notes: null,
+      created_at: "2026-05-01T00:00:00Z",
+    },
+  ];
+  const checks = computeReceiptChecks({
+    receipt: baseReceipt({ expense_category_code: "meeting" }),
+    attendees,
+    files: [originalFile()],
+    settings: SETTINGS,
+  });
+  assert.equal(
+    checks.find((c) => c.checkType === "missing_attendees"),
+    undefined,
+  );
+});
+
+test("compliance: missing invoice number warns when mode=warning", () => {
+  const checks = computeReceiptChecks({
+    receipt: baseReceipt({ invoice_registration_number: null }),
+    attendees: [],
+    files: [originalFile()],
+    settings: { ...SETTINGS, invoice_number_requirement_mode: "warning" },
+  });
+  const c = checks.find(
+    (x) => x.checkType === "missing_invoice_registration_number",
+  );
+  assert.ok(c);
+  assert.equal(c!.severity, "warning");
+});
+
+test("compliance: missing invoice number blocks when mode=blocker", () => {
+  const checks = computeReceiptChecks({
+    receipt: baseReceipt({ invoice_registration_number: null }),
+    attendees: [],
+    files: [originalFile()],
+    settings: { ...SETTINGS, invoice_number_requirement_mode: "blocker" },
+  });
+  const c = checks.find(
+    (x) => x.checkType === "missing_invoice_registration_number",
+  );
+  assert.ok(c);
+  assert.equal(c!.severity, "blocker");
+});
+
+test("compliance: invoice mode=disabled hides the check", () => {
+  const checks = computeReceiptChecks({
+    receipt: baseReceipt({ invoice_registration_number: null }),
+    attendees: [],
+    files: [originalFile()],
+    settings: { ...SETTINGS, invoice_number_requirement_mode: "disabled" },
+  });
+  assert.equal(
+    checks.find((c) => c.checkType === "missing_invoice_registration_number"),
+    undefined,
+  );
+});
+
+test("compliance: electronic receipt with only image warns about original", () => {
+  const checks = computeReceiptChecks({
+    receipt: baseReceipt({ source_type: "electronic_receipt" }),
+    attendees: [],
+    files: [originalFile({ content_type: "image/png" })],
+    settings: SETTINGS,
+  });
+  const c = checks.find(
+    (x) => x.checkType === "electronic_transaction_missing_original",
+  );
+  assert.ok(c);
+  assert.equal(c!.severity, "warning");
+});
+
+test("compliance: electronic receipt with PDF original does not warn", () => {
+  const checks = computeReceiptChecks({
+    receipt: baseReceipt({ source_type: "electronic_receipt" }),
+    attendees: [],
+    files: [originalFile({ content_type: "application/pdf" })],
+    settings: SETTINGS,
+  });
+  assert.equal(
+    checks.find(
+      (c) => c.checkType === "electronic_transaction_missing_original",
+    ),
+    undefined,
+  );
+});
+
+test("compliance: missing original file is a blocker", () => {
+  const checks = computeReceiptChecks({
+    receipt: baseReceipt(),
+    attendees: [],
+    files: [],
+    settings: SETTINGS,
+  });
+  const c = checks.find((x) => x.checkType === "missing_receipt");
+  assert.ok(c);
+  assert.equal(c!.severity, "blocker");
+});

--- a/tests/receipts/export-manifest.test.ts
+++ b/tests/receipts/export-manifest.test.ts
@@ -1,0 +1,145 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildManifestCsv,
+  buildExportReadme,
+} from "@/lib/receipts/export";
+import type { ReceiptFile } from "@/lib/receipts/types";
+
+function makeFile(overrides: Partial<ReceiptFile> = {}): ReceiptFile {
+  return {
+    id: "f1",
+    object_type: "receipt",
+    object_id: "rec_1",
+    role: "original",
+    r2_bucket: "receipts",
+    r2_key: "receipts/2026/05/rec_1/scan.jpg",
+    original_filename: "scan.jpg",
+    content_type: "image/jpeg",
+    file_size_bytes: 1024,
+    sha256_hash: "deadbeef",
+    uploaded_by: "test",
+    uploaded_at: "2026-05-01T00:00:00Z",
+    is_original: 1,
+    created_at: "2026-05-01T00:00:00Z",
+    updated_at: "2026-05-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+test("manifest: baseline fields are always present", () => {
+  const csv = buildManifestCsv(
+    "exp_1",
+    "2026-05",
+    "exports/2026-05/exp_1-receipts.csv",
+    "hashabc",
+    3,
+    "2026-05-19T12:00:00Z",
+  );
+  assert.match(csv, /^Field,Value/);
+  assert.match(csv, /ExportId,exp_1/);
+  assert.match(csv, /Month,2026-05/);
+  assert.match(csv, /SHA256,hashabc/);
+  assert.match(csv, /RowCount,3/);
+});
+
+test("manifest: revision fields appear when supplied", () => {
+  const csv = buildManifestCsv(
+    "exp_2",
+    "2026-05",
+    "key",
+    "hash",
+    1,
+    "2026-05-19T12:00:00Z",
+    null,
+    {
+      exportRevision: 2,
+      supersedesExportId: "exp_1",
+      correctionReason: "Reissued after late receipt",
+    },
+  );
+  assert.match(csv, /ExportRevision,2/);
+  assert.match(csv, /SupersedesExportId,exp_1/);
+  assert.match(csv, /CorrectionReason,Reissued after late receipt/);
+});
+
+test("manifest: file table includes one row per file with hash", () => {
+  const csv = buildManifestCsv(
+    "exp_1",
+    "2026-05",
+    "key",
+    "hash",
+    2,
+    "2026-05-19T12:00:00Z",
+    null,
+    {
+      files: [
+        makeFile({ id: "f1", sha256_hash: "aaa" }),
+        makeFile({
+          id: "f2",
+          object_id: "rec_2",
+          r2_key: "k2",
+          sha256_hash: "bbb",
+        }),
+      ],
+    },
+  );
+  assert.match(csv, /ObjectType,ObjectId,Role/);
+  assert.match(csv, /,aaa,/);
+  assert.match(csv, /,bbb,/);
+});
+
+test("manifest: amex artifact triple is emitted", () => {
+  const csv = buildManifestCsv(
+    "exp_1",
+    "2026-05",
+    "key",
+    "hash",
+    1,
+    "2026-05-19T12:00:00Z",
+    null,
+    {
+      amexArtifact: {
+        r2Key: "amex/2026-05/abc",
+        sha256Hash: "zzz",
+        originalFilename: "netanswer.csv",
+      },
+    },
+  );
+  assert.match(csv, /AmexArtifactKey,amex\/2026-05\/abc/);
+  assert.match(csv, /AmexArtifactSha256,zzz/);
+  assert.match(csv, /AmexArtifactFilename,netanswer\.csv/);
+});
+
+test("readme: contains accountant-review disclaimer", () => {
+  const readme = buildExportReadme({
+    exportId: "exp_1",
+    month: "2026-05",
+    rowCount: 5,
+    generatedAt: "2026-05-19T12:00:00Z",
+    exportRevision: 1,
+    archiveSha256: "hash",
+    manifestSha256: "mhash",
+  });
+  assert.match(readme, /accountant review/i);
+  assert.match(readme, /税理士/);
+  assert.match(readme, /SHA-256.*hash/);
+  assert.match(readme, /Revision: 1/);
+});
+
+test("readme: revision > 1 shows correction reason", () => {
+  const readme = buildExportReadme({
+    exportId: "exp_2",
+    month: "2026-05",
+    rowCount: 5,
+    generatedAt: "2026-05-19T12:00:00Z",
+    exportRevision: 2,
+    supersedesExportId: "exp_1",
+    correctionReason: "Receipt added late",
+    archiveSha256: "hash",
+    manifestSha256: "mhash",
+  });
+  assert.match(readme, /Revision: 2/);
+  assert.match(readme, /supersedes exp_1/);
+  assert.match(readme, /Receipt added late/);
+});

--- a/tests/receipts/invoice-validation.test.ts
+++ b/tests/receipts/invoice-validation.test.ts
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  isValidRegistrationNumberFormat,
+  normalizeRegistrationNumber,
+  validateInvoiceRegistrationNumber,
+} from "@/lib/receipts/invoice";
+
+test("invoice: T + 13 digits is valid", () => {
+  assert.equal(isValidRegistrationNumberFormat("T1234567890123"), true);
+});
+
+test("invoice: missing T prefix is invalid", () => {
+  assert.equal(isValidRegistrationNumberFormat("1234567890123"), false);
+});
+
+test("invoice: wrong digit count is invalid", () => {
+  assert.equal(isValidRegistrationNumberFormat("T12345"), false);
+  assert.equal(isValidRegistrationNumberFormat("T12345678901234"), false);
+});
+
+test("invoice: lowercase t is normalized to T", () => {
+  assert.equal(isValidRegistrationNumberFormat("t1234567890123"), true);
+});
+
+test("invoice: hyphens and whitespace are stripped", () => {
+  const result = normalizeRegistrationNumber("T1234-5678-90123");
+  assert.equal(result.normalized, "T1234567890123");
+  assert.equal(result.formatValid, true);
+});
+
+test("invoice: fullwidth digits normalize", () => {
+  // T followed by 13 fullwidth digits
+  const fullwidth = "T１２３４５６７８９０１２３";
+  const result = normalizeRegistrationNumber(fullwidth);
+  assert.equal(result.normalized, "T1234567890123");
+  assert.equal(result.formatValid, true);
+});
+
+test("invoice: empty input yields missing status", () => {
+  const result = validateInvoiceRegistrationNumber(null);
+  assert.equal(result.registrationStatus, "unchecked");
+  assert.equal(result.qualifiedInvoiceStatus, "missing_registration_number");
+});
+
+test("invoice: invalid format yields invalid status with message", () => {
+  const result = validateInvoiceRegistrationNumber("NOT-A-NUMBER");
+  assert.equal(result.registrationStatus, "format_invalid");
+  assert.equal(result.qualifiedInvoiceStatus, "invalid");
+  assert.match(result.message ?? "", /T.*13 digits/);
+});
+
+test("invoice: valid format yields valid status", () => {
+  const result = validateInvoiceRegistrationNumber("T9876543210123");
+  assert.equal(result.registrationStatus, "format_valid");
+  assert.equal(result.qualifiedInvoiceStatus, "valid");
+  assert.equal(result.normalizedNumber, "T9876543210123");
+});
+
+test("invoice: known unregistered counterparty changes missing status", () => {
+  const result = validateInvoiceRegistrationNumber("", {
+    counterpartyKnownUnregistered: true,
+  });
+  assert.equal(result.qualifiedInvoiceStatus, "unregistered_counterparty");
+});


### PR DESCRIPTION
## Summary

Adds a compliance layer to the receipts module aligned with 電子帳簿保存法
(Electronic Bookkeeping Preservation Act), インボイス制度 (Qualified Invoice
System), スキャナ保存 (scanner preservation), and 電子取引データ保存
(electronic transaction preservation). The module continues to be
**preparation materials for accountant review** — it does not provide tax
advice or make final determinations.

Scope boundary: this is a preservation/preparation layer that sits upstream
of freee / Money Forward / Yayoi. Disclaimers (EN + JA) appear in the
export README, export page, and compliance settings page; the change is
deliberately additive and does not couple the receipts module to `/admin`,
the CRM tables, or the networking-card app.

## What's in

**Schema (`db/receipts/0014_compliance.sql` — all additive):**

- `receipt_records` gains `source_type`, `preservation_status`,
  `confirmed_at/by`, `invoice_registration_number/status`,
  `qualified_invoice_status`, `tax_rate`, `counterparty_name`,
  `search_text`, `compliance_warnings_json`.
- New `receipt_files` table: one original + N derivatives per object, also
  tracks AMEX statement artifacts and export bundles.
- New `receipt_compliance_checks` table: persisted engine output with
  severity (`blocker`/`warning`/`info`) and resolution state.
- New `receipt_settings` key/value table, seeded with defaults
  (retention 7y, meeting+entertainment attendees required, invoice
  enforcement = warning, retain paper originals until accountant confirms).
- `receipt_exports` gains `export_revision`, `supersedes_export_id`,
  `correction_reason`, `finalized_by`, `finalization_hash`,
  `manifest_sha256`.
- Search indexes on amount, merchant, source type, counterparty, invoice
  number.

**Library:**

- `lib/receipts/invoice.ts` — `T+13` validation with NFKC normalization
  (handles hyphens, whitespace, fullwidth digits, lowercase `t`).
- `lib/receipts/compliance.ts` — pure check engine + persister. Resolves
  checks that no longer apply (diff-based) so the review panel reflects
  fixes without manual action. Checks for missing date / amount /
  counterparty / category / receipt / attendees / invoice number /
  tax rate / tax amount, electronic-transaction screenshot warning,
  and scanner-preservation metadata.
- `lib/receipts/files.ts` — file manifest CRUD.
- `lib/receipts/settings.ts` — typed reader/writer with defaults +
  bilingual accountant-review disclaimer constants.
- `lib/receipts/export.ts` — manifest CSV now includes per-file SHA-256
  rows, revision metadata, and a new README artifact with disclaimer.
- `lib/receipts/db.ts` — `createReceiptRecord` persists compliance fields,
  `finalizeExport` stores `manifest_sha256`, new `createExportRevision`
  never overwrites the prior finalized bundle, `listReceiptRecords` gains
  compliance + search filters.

**APIs:**

- `POST /api/receipts/upload` writes a `receipt_files` row with
  `role='original'` and derives `source_type`.
- `PATCH /api/receipts/[id]` validates invoice numbers and runs the check
  engine after every save; `GET` returns the open checks.
- `POST /api/receipts/amex/import` writes a manifest row with
  `role='statement'` for the CSV.
- `POST /api/receipts/export/month` emits a hash manifest covering every
  artifact + a README; computes and stores `manifest_sha256`.
- `POST /api/receipts/export/[month]?correction=true` creates a new
  revision pointing at the prior finalized export — the previous R2
  archive is **not** overwritten.
- `GET /api/receipts/compliance/[month]` — monthly compliance report.
- `GET`/`PATCH /api/receipts/settings/compliance`.

**UI:**

- `/receipts/settings/compliance` — retention, attendee rules, invoice
  mode, paper-original policy.
- Review page — `<CompliancePanel>` above the form with open + resolved
  checks.
- Dashboard — `<ComplianceSummaryCards>` with the per-month
  blocker/warning/info breakdown.
- Export page footer — bilingual accountant-review disclaimer.

**Tests (33 new, all passing):** engine, invoice format, settings
parsing, manifest CSV revision + file-table, README disclaimer.

## Cloud-session caveats

Per AGENTS.md, this branch was prepared in a cloud sandbox. The following
must run on the Mac before merge:

- `wrangler d1 migrations apply RECEIPTS_DB` (applies `0014_compliance.sql`).
- `npm run build:cf` and `npm run cf:dev` with real bindings.
- `bash scripts/check-deployment.sh <base-url>` smoke test.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 162 receipts tests pass (including 33 new)
- [x] `npm run lint` — clean
- [ ] Apply `0014_compliance.sql` against live D1 on Mac
- [ ] Upload a receipt → review page shows the compliance panel
- [ ] Save invoice number `T1234567890123` → `missing_invoice_registration_number` resolves
- [ ] Save invalid number → 400 with format message
- [ ] Try to delete an `exported` receipt → 409
- [ ] Finalize an export → manifest CSV contains per-file SHA-256 rows
- [ ] `POST /api/receipts/export/2026-05?correction=true` with
      `correctionReason` → new row with `export_revision=2`, prior row untouched
- [ ] `GET /api/receipts/compliance/2026-05` returns the expected JSON

## Non-goals (called out for reviewers)

- No NTA invoice-registration lookup yet — format validation only; a
  future worker can batch-confirm via the stub in `lib/receipts/invoice.ts`.
- No hard-delete admin override.
- No R2 object-lock / WORM claims — disclaimer text avoids them.
- Not a replacement for freee / Money Forward / Yayoi.

https://claude.ai/code/session_011yfmCew9WJtUz2e17Ww5pq

---
_Generated by [Claude Code](https://claude.ai/code/session_011yfmCew9WJtUz2e17Ww5pq)_