### PR TITLE
feat(capture-app): backend M1 + iOS scaffold

### DIFF
--- a/app/(receipt-system)/receipts/pair/page.tsx
+++ b/app/(receipt-system)/receipts/pair/page.tsx
@@ -1,0 +1,50 @@
+import type { Metadata } from "next";
+import { headers } from "next/headers";
+import { requireReceiptsActor } from "@/lib/receipts/auth";
+import { PairMobileDeviceForm } from "@/components/receipts/pair-mobile-device-form";
+
+export const metadata: Metadata = {
+  title: "Pair iPhone — Receipts",
+  robots: { index: false, follow: false },
+};
+
+interface PairingPageProps {
+  searchParams: Promise<{ code?: string }>;
+}
+
+export default async function PairMobileDevicePage({ searchParams }: PairingPageProps) {
+  const requestHeaders = await headers();
+  const actor = await requireReceiptsActor(requestHeaders);
+  const { code } = await searchParams;
+  const initialCode = code?.trim().toUpperCase() ?? "";
+
+  return (
+    <div className="space-y-6 px-8 py-8">
+      <div>
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-amber-600">
+          Mobile
+        </p>
+        <h1 className="mt-2 text-[26px] font-bold text-gray-900">
+          Pair an iPhone
+        </h1>
+        <p className="mt-1 text-sm text-gray-600">
+          Open Dazbeez Capture on your iPhone, tap{" "}
+          <span className="font-medium text-gray-900">Pair with Dazbeez</span>,
+          then enter the code shown on the phone here. Signed in as{" "}
+          <span className="font-medium text-gray-900">{actor}</span>.
+        </p>
+      </div>
+
+      <div className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+        <PairMobileDeviceForm initialCode={initialCode} />
+        <p className="mt-4 text-xs text-gray-500">
+          The bearer token is sent directly to the polling iPhone and is never
+          shown in this browser. Revoke a paired device anytime from{" "}
+          <a className="font-medium text-amber-700 hover:underline" href="/receipts/settings/devices">
+            Trusted devices
+          </a>.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/app/(receipt-system)/receipts/settings/devices/page.tsx
+++ b/app/(receipt-system)/receipts/settings/devices/page.tsx
@@ -40,6 +40,8 @@ export default async function DevicesPage() {
           createdAt: d.created_at,
           lastSeenAt: d.last_seen_at,
           isCurrent: currentDeviceId === d.id,
+          platform: d.platform,
+          appVersion: d.app_version,
         }))}
       />
     </div>

--- a/app/api/mobile/auth/check/route.ts
+++ b/app/api/mobile/auth/check/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+import { checkPairingCode } from "@/lib/receipts/mobile-pairing";
+
+// Public endpoint polled by the iPhone with the pairing code it received from
+// /start-pairing. Returns the bearer token exactly once after an operator
+// completes pairing behind Cloudflare Access.
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const code = url.searchParams.get("code");
+  if (!code) {
+    return NextResponse.json({ error: "code is required." }, { status: 400 });
+  }
+
+  try {
+    const result = await checkPairingCode(code);
+
+    switch (result.status) {
+      case "pending":
+        return NextResponse.json({ ready: false }, { status: 200 });
+      case "expired":
+        return NextResponse.json({ ready: false, expired: true }, { status: 200 });
+      case "not_found":
+        return NextResponse.json({ error: "Unknown or already-redeemed code." }, { status: 404 });
+      case "ready":
+        return NextResponse.json(
+          {
+            ready: true,
+            bearerToken: result.bearerToken,
+            deviceId: result.deviceId,
+          },
+          { status: 200 },
+        );
+    }
+  } catch (error) {
+    console.error("[api/mobile/auth/check] failed", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Check failed." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/mobile/auth/complete-pairing/route.ts
+++ b/app/api/mobile/auth/complete-pairing/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+import { requireReceiptsActor } from "@/lib/receipts/auth";
+import { completePairing } from "@/lib/receipts/mobile-pairing";
+
+// Cloudflare-Access-protected endpoint hit from the browser pairing page.
+// Consumes the pairing code and enrolls the mobile device. The bearer token
+// is NOT returned to the browser — it is stored on the pairing-codes row and
+// picked up by the polling iPhone via /check.
+export async function POST(request: Request) {
+  try {
+    const actor = await requireReceiptsActor(request.headers);
+
+    const body = (await request.json().catch(() => ({}))) as {
+      code?: string;
+      label?: string;
+      platform?: "ios" | "android";
+      appVersion?: string | null;
+    };
+
+    if (!body.code) {
+      return NextResponse.json({ error: "code is required." }, { status: 400 });
+    }
+    const platform = body.platform === "android" ? "android" : "ios";
+    const label = (body.label ?? "iPhone").slice(0, 80);
+    const appVersion = body.appVersion?.slice(0, 32) ?? null;
+    const userAgent = request.headers.get("user-agent")?.slice(0, 256) ?? null;
+
+    const { deviceId } = await completePairing({
+      code: body.code,
+      actor,
+      label,
+      userAgent,
+      platform,
+      appVersion,
+    });
+
+    return NextResponse.json({ ok: true, deviceId }, { status: 200 });
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Unauthorized")) {
+      return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+    }
+    if (
+      error instanceof Error &&
+      /Pairing code|Invalid pairing/.test(error.message)
+    ) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+    console.error("[api/mobile/auth/complete-pairing] failed", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Pairing failed." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/mobile/auth/revoke/route.ts
+++ b/app/api/mobile/auth/revoke/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+import { revokeDevice, verifyBearerDevice } from "@/lib/receipts/trusted-devices";
+
+// iPhone-initiated revoke. Uses the bearer token itself to identify the
+// device, so a stolen token cannot be used to revoke a different device.
+export async function POST(request: Request) {
+  try {
+    const device = await verifyBearerDevice(request.headers);
+    if (!device) {
+      return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+    }
+    await revokeDevice(device.deviceId, device.actor);
+    return NextResponse.json({ ok: true }, { status: 200 });
+  } catch (error) {
+    console.error("[api/mobile/auth/revoke] failed", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Revoke failed." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/mobile/auth/start-pairing/route.ts
+++ b/app/api/mobile/auth/start-pairing/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+import { createPairingCode } from "@/lib/receipts/mobile-pairing";
+
+// Public endpoint — the iPhone has no token yet at this stage. The bearer
+// token is only ever delivered through /check after the pairing code is
+// consumed by an operator behind Cloudflare Access.
+export async function POST() {
+  try {
+    const { code, expiresAt } = await createPairingCode();
+    return NextResponse.json({ code, expiresAt }, { status: 201 });
+  } catch (error) {
+    console.error("[api/mobile/auth/start-pairing] failed", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Pairing setup failed." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/mobile/business-cards/upload/route.ts
+++ b/app/api/mobile/business-cards/upload/route.ts
@@ -1,0 +1,104 @@
+import { NextResponse } from "next/server";
+import { createMobileBusinessCardCapture } from "@/lib/crm";
+import { extractBusinessCardDetails } from "@/lib/crm-provider";
+import { getImageSizeValidationError } from "@/lib/crm-upload-limits";
+import { requireMobileActor } from "@/lib/receipts/trusted-devices";
+
+export async function POST(request: Request) {
+  try {
+    const device = await requireMobileActor(request.headers, "business_card:create");
+
+    const formData = await request.formData();
+    const file = formData.get("file");
+    if (!(file instanceof File)) {
+      return NextResponse.json({ error: "A file is required." }, { status: 400 });
+    }
+
+    const sizeError = getImageSizeValidationError({
+      fileSize: file.size,
+      label: "Business card image",
+    });
+    if (sizeError) {
+      return NextResponse.json({ error: sizeError }, { status: 413 });
+    }
+
+    const clientCaptureId = formData.get("client_capture_id")?.toString().trim();
+    if (!clientCaptureId) {
+      return NextResponse.json(
+        { error: "client_capture_id is required." },
+        { status: 400 },
+      );
+    }
+    const rawBatchId = formData.get("batch_id")?.toString().trim();
+    const batchId = rawBatchId ? Number(rawBatchId) : null;
+    if (rawBatchId && (!Number.isInteger(batchId) || (batchId as number) < 1)) {
+      return NextResponse.json({ error: "batch_id must be a positive integer." }, { status: 400 });
+    }
+    const eventName = formData.get("event_name")?.toString().slice(0, 200) || null;
+    if (!batchId && !eventName) {
+      return NextResponse.json(
+        { error: "event_name is required when no batch_id is provided." },
+        { status: 400 },
+      );
+    }
+    const capturedAtClient =
+      formData.get("captured_at_client")?.toString().trim() || null;
+    const appVersion = formData.get("app_version")?.toString().slice(0, 32) || null;
+    const note = formData.get("note")?.toString().slice(0, 1000) || null;
+
+    const bytes = new Uint8Array(await file.arrayBuffer());
+
+    // Extract the card details inline. Mobile uploads send a clean cropped
+    // image from VisionKit, so we run extraction once per upload (no
+    // composite-then-crop step). The result lands in batch_cards via
+    // insertBatchCard.
+    const extracted = await extractBusinessCardDetails({
+      imageBytes: Array.from(bytes),
+      eventContext: eventName ?? null,
+    });
+
+    const result = await createMobileBusinessCardCapture({
+      actor: device.actor,
+      deviceId: device.deviceId,
+      clientCaptureId,
+      capturedAtClient,
+      appVersion,
+      note,
+      batchId,
+      eventName,
+      image: {
+        fileName: file.name || `${clientCaptureId}.jpg`,
+        mimeType: file.type || "image/jpeg",
+        bytes,
+        width: null,
+        height: null,
+        metadata: null,
+      },
+      extracted,
+    });
+
+    return NextResponse.json(
+      {
+        ok: true,
+        duplicate: result.duplicate,
+        batchId: result.batchId,
+        batchCardId: result.batchCardId,
+        businessCardImageId: result.businessCardImageId,
+        reviewUrl: `/admin/batches/${result.batchId}`,
+      },
+      { status: result.duplicate ? 200 : 201 },
+    );
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Unauthorized")) {
+      return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+    }
+    if (error instanceof Error && error.message.startsWith("Forbidden")) {
+      return NextResponse.json({ error: error.message }, { status: 403 });
+    }
+    console.error("[api/mobile/business-cards/upload] failed", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Upload failed." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/mobile/me/route.ts
+++ b/app/api/mobile/me/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { getReceiptsDb } from "@/lib/cloudflare-runtime";
+import { verifyBearerDevice } from "@/lib/receipts/trusted-devices";
+
+export async function GET(request: Request) {
+  const device = await verifyBearerDevice(request.headers);
+  if (!device) {
+    return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+  }
+
+  const db = getReceiptsDb();
+  const row = await db
+    .prepare(
+      `SELECT label, last_seen_at, created_at FROM trusted_devices WHERE id = ? LIMIT 1`,
+    )
+    .bind(device.deviceId)
+    .first<{ label: string; last_seen_at: string | null; created_at: string }>();
+
+  return NextResponse.json(
+    {
+      deviceId: device.deviceId,
+      actor: device.actor,
+      scopes: device.scopes,
+      platform: device.platform,
+      appVersion: device.appVersion,
+      label: row?.label ?? null,
+      lastSeenAt: row?.last_seen_at ?? null,
+      createdAt: row?.created_at ?? null,
+    },
+    { status: 200 },
+  );
+}

--- a/app/api/mobile/receipts/upload/route.ts
+++ b/app/api/mobile/receipts/upload/route.ts
@@ -1,0 +1,164 @@
+import { NextResponse } from "next/server";
+import { getReceiptsBucket, getReceiptsDb } from "@/lib/cloudflare-runtime";
+import { createReceiptFile } from "@/lib/receipts/files";
+import { generateR2Key, uploadOriginal } from "@/lib/receipts/storage";
+import { requireMobileActor } from "@/lib/receipts/trusted-devices";
+import { validateReceiptFile } from "@/lib/receipts/validation";
+import {
+  createMobileReceiptRecord,
+  findMobileReceiptByIdempotency,
+} from "@/lib/receipts/mobile-upload";
+import type { PaymentPath } from "@/lib/receipts/types";
+
+async function sha256Hex(data: ArrayBuffer): Promise<string> {
+  const hash = await crypto.subtle.digest("SHA-256", data);
+  return Array.from(new Uint8Array(hash))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+const VALID_PAYMENT_HINTS = new Set(["AMEX", "CASH"]);
+
+export async function POST(request: Request) {
+  try {
+    const device = await requireMobileActor(request.headers, "receipt:create");
+
+    const formData = await request.formData();
+    const file = formData.get("file");
+    if (!(file instanceof File)) {
+      return NextResponse.json({ error: "A file is required." }, { status: 400 });
+    }
+    const validationError = validateReceiptFile(file);
+    if (validationError) {
+      return NextResponse.json({ error: validationError }, { status: 400 });
+    }
+
+    const clientCaptureId = formData.get("client_capture_id")?.toString().trim();
+    if (!clientCaptureId) {
+      return NextResponse.json(
+        { error: "client_capture_id is required." },
+        { status: 400 },
+      );
+    }
+    const capturedAtClient =
+      formData.get("captured_at_client")?.toString().trim() || null;
+    const appVersion = formData.get("app_version")?.toString().slice(0, 32) || null;
+    const note = formData.get("note")?.toString().slice(0, 1000) || null;
+    const rawPaymentHint = formData.get("payment_hint")?.toString().toUpperCase();
+    const paymentPath: PaymentPath = VALID_PAYMENT_HINTS.has(rawPaymentHint ?? "")
+      ? (rawPaymentHint as PaymentPath)
+      : "UNKNOWN";
+
+    // Pre-R2 idempotency check. The browser route writes R2 before DB; the
+    // mobile route inverts that order because retries are normal with an
+    // offline queue and an R2 orphan on each retry would be expensive.
+    const existing = await findMobileReceiptByIdempotency(
+      device.deviceId,
+      clientCaptureId,
+    );
+    if (existing) {
+      return NextResponse.json(
+        {
+          ok: true,
+          duplicate: true,
+          receiptId: existing.id,
+          status: existing.status,
+          reviewUrl: `/receipts/review/${existing.id}`,
+        },
+        { status: 200 },
+      );
+    }
+
+    const bytes = await file.arrayBuffer();
+    const sha256 = await sha256Hex(bytes);
+    const contentType = file.type || "image/jpeg";
+    const tempId = crypto.randomUUID();
+    const r2Key = generateR2Key(tempId, file.name, new Date().toISOString());
+
+    await uploadOriginal(r2Key, bytes, contentType);
+
+    let receiptId: string;
+    try {
+      receiptId = await createMobileReceiptRecord({
+        actor: device.actor,
+        deviceId: device.deviceId,
+        clientCaptureId,
+        capturedAtClient,
+        appVersion,
+        note,
+        paymentPath,
+        originalFilename: file.name,
+        originalR2Key: r2Key,
+        originalSha256: sha256,
+        originalContentType: contentType,
+        originalSizeBytes: file.size,
+      });
+    } catch (dbError) {
+      // If the unique index races against a concurrent retry, surface the
+      // already-saved receipt instead of leaving an orphan.
+      const existingOnRace = await findMobileReceiptByIdempotency(
+        device.deviceId,
+        clientCaptureId,
+      );
+      try {
+        await getReceiptsBucket().delete(r2Key);
+      } catch {
+        // best-effort
+      }
+      if (existingOnRace) {
+        return NextResponse.json(
+          {
+            ok: true,
+            duplicate: true,
+            receiptId: existingOnRace.id,
+            status: existingOnRace.status,
+            reviewUrl: `/receipts/review/${existingOnRace.id}`,
+          },
+          { status: 200 },
+        );
+      }
+      throw dbError;
+    }
+
+    try {
+      await createReceiptFile(getReceiptsDb(), {
+        objectType: "receipt",
+        objectId: receiptId,
+        role: "original",
+        r2Bucket: "receipts",
+        r2Key,
+        originalFilename: file.name,
+        contentType,
+        fileSizeBytes: file.size,
+        sha256Hash: sha256,
+        uploadedBy: device.actor,
+        isOriginal: true,
+      });
+    } catch (fileError) {
+      console.error("[mobile/receipts/upload] file manifest write failed", fileError);
+    }
+
+    return NextResponse.json(
+      {
+        ok: true,
+        duplicate: false,
+        receiptId,
+        status: "needs_review",
+        reviewUrl: `/receipts/review/${receiptId}`,
+      },
+      { status: 201 },
+    );
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Unauthorized")) {
+      return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+    }
+    if (error instanceof Error && error.message.startsWith("Forbidden")) {
+      return NextResponse.json({ error: error.message }, { status: 403 });
+    }
+    console.error("[api/mobile/receipts/upload] failed", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Upload failed." },
+      { status: 500 },
+    );
+  }
+}

--- a/components/receipts/device-list.tsx
+++ b/components/receipts/device-list.tsx
@@ -11,6 +11,8 @@ export interface DeviceListItem {
   createdAt: string;
   lastSeenAt: string | null;
   isCurrent: boolean;
+  platform: string | null;
+  appVersion: string | null;
 }
 
 function formatDate(value: string | null): string {
@@ -74,13 +76,19 @@ export function DeviceList({ devices }: { devices: DeviceListItem[] }) {
             className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between"
           >
             <div className="min-w-0">
-              <div className="flex items-center gap-2">
+              <div className="flex flex-wrap items-center gap-2">
                 <p className="truncate text-sm font-semibold text-gray-900">
                   {d.label}
                 </p>
                 {d.isCurrent ? (
                   <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-amber-800">
                     This device
+                  </span>
+                ) : null}
+                {d.platform === "ios" || d.platform === "android" ? (
+                  <span className="rounded-full bg-gray-900 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-white">
+                    {d.platform === "ios" ? "iPhone" : "Android"}
+                    {d.appVersion ? ` · ${d.appVersion}` : ""}
                   </span>
                 ) : null}
               </div>

--- a/components/receipts/pair-mobile-device-form.tsx
+++ b/components/receipts/pair-mobile-device-form.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useState } from "react";
+import { useToast } from "@/components/ui/toaster";
+import { apiFetch } from "@/lib/use-api-error";
+
+interface Props {
+  initialCode: string;
+}
+
+export function PairMobileDeviceForm({ initialCode }: Props) {
+  const [code, setCode] = useState(initialCode);
+  const [label, setLabel] = useState("iPhone");
+  const [busy, setBusy] = useState(false);
+  const [pairedDeviceId, setPairedDeviceId] = useState<string | null>(null);
+  const { toast } = useToast();
+
+  async function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const trimmed = code.trim().toUpperCase();
+    if (!/^DAZ-[A-Z0-9]{4}$/.test(trimmed)) {
+      toast({
+        tone: "error",
+        title: "Invalid code",
+        body: "Codes look like DAZ-7K3M.",
+      });
+      return;
+    }
+    setBusy(true);
+    const result = await apiFetch<{ ok: true; deviceId: string }>(
+      "/api/mobile/auth/complete-pairing",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          code: trimmed,
+          label: label.trim() || "iPhone",
+          platform: "ios",
+        }),
+      },
+    );
+    setBusy(false);
+    if (!result.ok) {
+      toast({
+        tone: "error",
+        title: "Pairing failed",
+        body: result.error.message,
+      });
+      return;
+    }
+    setPairedDeviceId(result.data.deviceId);
+    toast({
+      tone: "success",
+      title: "iPhone paired",
+      body: "The token is now on the phone.",
+    });
+  }
+
+  if (pairedDeviceId) {
+    return (
+      <div className="space-y-2 text-sm text-gray-700">
+        <p className="font-semibold text-gray-900">iPhone paired successfully.</p>
+        <p>
+          The phone should show <span className="font-medium">Paired</span>{" "}
+          within a few seconds. The bearer token was delivered only to that
+          device — close this tab.
+        </p>
+        <p className="text-xs text-gray-500">Device id: {pairedDeviceId}</p>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-4">
+      <label className="block">
+        <span className="text-xs font-medium uppercase tracking-wide text-gray-600">
+          Pairing code shown on the iPhone
+        </span>
+        <input
+          type="text"
+          value={code}
+          onChange={(event) => setCode(event.target.value.toUpperCase())}
+          placeholder="DAZ-7K3M"
+          autoComplete="off"
+          spellCheck={false}
+          className="mt-1 w-full rounded-xl border border-gray-300 px-3 py-2 font-mono text-lg tracking-widest uppercase shadow-sm focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-200"
+          maxLength={8}
+        />
+      </label>
+      <label className="block">
+        <span className="text-xs font-medium uppercase tracking-wide text-gray-600">
+          Device label (visible in the trusted-devices list)
+        </span>
+        <input
+          type="text"
+          value={label}
+          onChange={(event) => setLabel(event.target.value)}
+          placeholder="iPhone 16 Pro"
+          maxLength={80}
+          className="mt-1 w-full rounded-xl border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-200"
+        />
+      </label>
+      <button
+        type="submit"
+        disabled={busy}
+        className="rounded-xl bg-amber-500 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-amber-600 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {busy ? "Pairing…" : "Pair this iPhone"}
+      </button>
+    </form>
+  );
+}

--- a/db/receipts/0015_mobile_devices.sql
+++ b/db/receipts/0015_mobile_devices.sql
@@ -1,0 +1,30 @@
+-- Receipt Module: mobile device pairing + idempotency
+-- Run: npx wrangler d1 migrations apply RECEIPTS_DB [--local]
+
+ALTER TABLE trusted_devices ADD COLUMN platform TEXT;          -- 'web' | 'ios'
+ALTER TABLE trusted_devices ADD COLUMN app_version TEXT;
+ALTER TABLE trusted_devices ADD COLUMN scopes_json TEXT;
+
+CREATE TABLE IF NOT EXISTS mobile_pairing_codes (
+  code TEXT PRIMARY KEY,
+  created_at TEXT NOT NULL,
+  expires_at TEXT NOT NULL,
+  consumed_device_id TEXT,
+  consumed_at TEXT,
+  -- Bearer token is delivered exactly once to the polling iPhone, then
+  -- cleared. The browser-side complete-pairing call writes it; the
+  -- iPhone-side /check read clears it.
+  bearer_token TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_mobile_pairing_codes_expires
+  ON mobile_pairing_codes(expires_at);
+
+ALTER TABLE receipt_records ADD COLUMN device_id TEXT;
+ALTER TABLE receipt_records ADD COLUMN client_capture_id TEXT;
+ALTER TABLE receipt_records ADD COLUMN captured_at_client TEXT;
+ALTER TABLE receipt_records ADD COLUMN upload_origin TEXT;     -- 'web' | 'mobile'
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_receipt_mobile_idempotency
+  ON receipt_records(device_id, client_capture_id)
+  WHERE device_id IS NOT NULL AND client_capture_id IS NOT NULL;

--- a/ios/DazbeezCapture/.gitignore
+++ b/ios/DazbeezCapture/.gitignore
@@ -1,0 +1,15 @@
+# Xcode build artifacts (generated locally on the Mac, never committed)
+build/
+DerivedData/
+*.xcuserstate
+xcuserdata/
+*.xcscmblueprint
+*.xccheckout
+.DS_Store
+
+# Swift Package Manager
+.swiftpm/
+Package.resolved
+
+# Xcode project file is generated locally on the Mac (see README.md)
+DazbeezCapture.xcodeproj/

--- a/ios/DazbeezCapture/App/AppEnvironment.swift
+++ b/ios/DazbeezCapture/App/AppEnvironment.swift
@@ -1,0 +1,78 @@
+import Foundation
+import SwiftUI
+
+/// Single source of truth for shared app state: server URL, current device
+/// token, active event/batch, and the upload queue. Views read this via
+/// `@EnvironmentObject` and route mutations back through `AppEnvironment`.
+@MainActor
+final class AppEnvironment: ObservableObject {
+    @Published var serverURL: URL
+    @Published var deviceToken: String?
+    @Published var deviceLabel: String?
+    @Published var deviceId: String?
+    @Published var activeEvent: ActiveEvent?
+    @Published private(set) var apiClient: APIClient
+
+    private let tokenStore = KeychainTokenStore()
+    private let eventStore = ActiveEventStore()
+
+    init() {
+        let defaultURL = URL(string: "https://dazbeez.com")!
+        self.serverURL = defaultURL
+        self.apiClient = APIClient(baseURL: defaultURL, tokenProvider: { nil })
+    }
+
+    func bootstrap() async {
+        // Restore server URL from UserDefaults if previously set.
+        if let stored = UserDefaults.standard.string(forKey: "server_url"),
+           let url = URL(string: stored) {
+            serverURL = url
+        }
+        deviceToken = tokenStore.read()
+        activeEvent = eventStore.read()
+        apiClient = APIClient(baseURL: serverURL, tokenProvider: { [weak self] in
+            self?.deviceToken
+        })
+        if deviceToken != nil {
+            await refreshDevice()
+        }
+    }
+
+    func saveToken(_ token: String, deviceId: String) {
+        tokenStore.write(token)
+        self.deviceToken = token
+        self.deviceId = deviceId
+    }
+
+    func clearToken() {
+        tokenStore.delete()
+        deviceToken = nil
+        deviceId = nil
+        deviceLabel = nil
+    }
+
+    func setActiveEvent(_ event: ActiveEvent?) {
+        activeEvent = event
+        eventStore.write(event)
+    }
+
+    func updateServerURL(_ url: URL) {
+        serverURL = url
+        UserDefaults.standard.set(url.absoluteString, forKey: "server_url")
+        apiClient = APIClient(baseURL: url, tokenProvider: { [weak self] in
+            self?.deviceToken
+        })
+    }
+
+    func refreshDevice() async {
+        guard let result = try? await apiClient.fetchMe() else { return }
+        deviceId = result.deviceId
+        deviceLabel = result.label
+    }
+}
+
+struct ActiveEvent: Codable, Equatable {
+    let id: Int?          // server-side batch_id once known
+    let name: String
+    let createdAtClient: Date
+}

--- a/ios/DazbeezCapture/App/DazbeezCaptureApp.swift
+++ b/ios/DazbeezCapture/App/DazbeezCaptureApp.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+@main
+struct DazbeezCaptureApp: App {
+    @StateObject private var environment = AppEnvironment()
+
+    var body: some Scene {
+        WindowGroup {
+            RootView()
+                .environmentObject(environment)
+                .task {
+                    await environment.bootstrap()
+                }
+        }
+    }
+}

--- a/ios/DazbeezCapture/App/RootView.swift
+++ b/ios/DazbeezCapture/App/RootView.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+struct RootView: View {
+    @EnvironmentObject private var environment: AppEnvironment
+
+    var body: some View {
+        if environment.deviceToken == nil {
+            PairingView()
+        } else {
+            HomeView()
+        }
+    }
+}

--- a/ios/DazbeezCapture/Capture/HomeView.swift
+++ b/ios/DazbeezCapture/Capture/HomeView.swift
@@ -1,0 +1,107 @@
+import SwiftUI
+
+struct HomeView: View {
+    @EnvironmentObject private var environment: AppEnvironment
+    @State private var captureMode: CaptureMode = .receipt
+
+    enum CaptureMode { case receipt, businessCard }
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 16) {
+                Picker("Mode", selection: $captureMode) {
+                    Text("Receipt").tag(CaptureMode.receipt)
+                    Text("Business card").tag(CaptureMode.businessCard)
+                }
+                .pickerStyle(.segmented)
+                .padding(.horizontal)
+
+                NavigationLink {
+                    captureMode == .receipt
+                        ? AnyView(ReceiptCaptureView())
+                        : AnyView(BusinessCardCaptureView())
+                } label: {
+                    Text(captureMode == .receipt ? "Capture Receipt" : "Capture Business Card")
+                        .font(.title2.weight(.semibold))
+                        .frame(maxWidth: .infinity, minHeight: 80)
+                        .padding()
+                        .background(Color.yellow.opacity(0.2))
+                        .clipShape(RoundedRectangle(cornerRadius: 20))
+                }
+                .padding(.horizontal)
+
+                if captureMode == .businessCard {
+                    EventBannerView()
+                }
+
+                Spacer()
+
+                NavigationLink("Upload queue") { UploadQueueView() }
+                NavigationLink("Settings") { SettingsView() }
+            }
+            .padding(.vertical)
+            .navigationTitle("Dazbeez Capture")
+        }
+    }
+}
+
+/// Placeholders so the scaffold compiles before the M2 work fleshes them out.
+
+struct ReceiptCaptureView: View {
+    var body: some View {
+        Text("Receipt capture (M2)")
+            .navigationTitle("Receipt")
+    }
+}
+
+struct BusinessCardCaptureView: View {
+    var body: some View {
+        Text("Business card capture (M2)")
+            .navigationTitle("Business card")
+    }
+}
+
+struct UploadQueueView: View {
+    var body: some View {
+        Text("Upload queue (M3)")
+            .navigationTitle("Queue")
+    }
+}
+
+struct EventBannerView: View {
+    @EnvironmentObject private var environment: AppEnvironment
+
+    var body: some View {
+        Group {
+            if let event = environment.activeEvent {
+                NavigationLink {
+                    EventPickerView()
+                } label: {
+                    HStack {
+                        Image(systemName: "calendar")
+                        Text("Active event: \(event.name)")
+                            .lineLimit(1)
+                        Spacer()
+                        Text("Change")
+                            .foregroundStyle(.tint)
+                    }
+                    .padding()
+                    .background(Color(.secondarySystemBackground))
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                    .padding(.horizontal)
+                }
+            } else {
+                NavigationLink {
+                    EventPickerView()
+                } label: {
+                    Text("Choose or create an event to scan into")
+                        .padding()
+                        .frame(maxWidth: .infinity)
+                        .background(Color.orange.opacity(0.15))
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                        .padding(.horizontal)
+                }
+            }
+        }
+    }
+}

--- a/ios/DazbeezCapture/Events/ActiveEventStore.swift
+++ b/ios/DazbeezCapture/Events/ActiveEventStore.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// Persists the active event (used for business-card capture) in
+/// `UserDefaults`. The active event applies to every subsequent business-card
+/// scan until the user changes or clears it.
+struct ActiveEventStore {
+    private let key = "active_event_v1"
+
+    func read() -> ActiveEvent? {
+        guard let data = UserDefaults.standard.data(forKey: key) else { return nil }
+        return try? JSONDecoder().decode(ActiveEvent.self, from: data)
+    }
+
+    func write(_ event: ActiveEvent?) {
+        guard let event else {
+            UserDefaults.standard.removeObject(forKey: key)
+            return
+        }
+        if let data = try? JSONEncoder().encode(event) {
+            UserDefaults.standard.set(data, forKey: key)
+        }
+    }
+}

--- a/ios/DazbeezCapture/Events/EventPickerView.swift
+++ b/ios/DazbeezCapture/Events/EventPickerView.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+struct EventPickerView: View {
+    @EnvironmentObject private var environment: AppEnvironment
+    @Environment(\.dismiss) private var dismiss
+    @State private var eventName: String = ""
+
+    var body: some View {
+        Form {
+            Section("Active event") {
+                if let event = environment.activeEvent {
+                    HStack {
+                        Text(event.name)
+                        Spacer()
+                        Button("Clear", role: .destructive) {
+                            environment.setActiveEvent(nil)
+                            dismiss()
+                        }
+                    }
+                } else {
+                    Text("No active event").foregroundStyle(.secondary)
+                }
+            }
+            Section("Start a new event") {
+                TextField("Event name (e.g. AI Tokyo Mixer 2026-05)", text: $eventName)
+                Button("Use this event") {
+                    let trimmed = eventName.trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard !trimmed.isEmpty else { return }
+                    environment.setActiveEvent(ActiveEvent(id: nil, name: trimmed, createdAtClient: Date()))
+                    dismiss()
+                }
+                .disabled(eventName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
+        .navigationTitle("Event")
+    }
+}

--- a/ios/DazbeezCapture/Networking/APIClient.swift
+++ b/ios/DazbeezCapture/Networking/APIClient.swift
@@ -1,0 +1,202 @@
+import Foundation
+
+/// HTTP client targeting the `/api/mobile/*` namespace. Bearer token is
+/// fetched per request so token rotation in `AppEnvironment` propagates
+/// without reconstructing the client.
+struct APIClient {
+    let baseURL: URL
+    let tokenProvider: () -> String?
+
+    private var session: URLSession {
+        let config = URLSessionConfiguration.default
+        config.waitsForConnectivity = true
+        config.timeoutIntervalForRequest = 30
+        config.timeoutIntervalForResource = 5 * 60
+        return URLSession(configuration: config)
+    }
+
+    // MARK: - Pairing (unauthenticated)
+
+    struct StartPairingResponse: Decodable {
+        let code: String
+        let expiresAt: String
+    }
+
+    struct CheckPairingResponse: Decodable {
+        let ready: Bool?
+        let expired: Bool?
+        let bearerToken: String?
+        let deviceId: String?
+    }
+
+    func startPairing() async throws -> StartPairingResponse {
+        let request = makeRequest(path: "/api/mobile/auth/start-pairing", method: "POST", authenticated: false)
+        return try await send(request)
+    }
+
+    func checkPairing(code: String) async throws -> CheckPairingResponse {
+        var components = URLComponents(url: baseURL.appendingPathComponent("/api/mobile/auth/check"), resolvingAgainstBaseURL: false)!
+        components.queryItems = [URLQueryItem(name: "code", value: code)]
+        var request = URLRequest(url: components.url!)
+        request.httpMethod = "GET"
+        return try await send(request)
+    }
+
+    // MARK: - Authenticated
+
+    struct MeResponse: Decodable {
+        let deviceId: String
+        let actor: String
+        let scopes: [String]
+        let label: String?
+        let appVersion: String?
+        let platform: String?
+        let lastSeenAt: String?
+    }
+
+    func fetchMe() async throws -> MeResponse {
+        let request = makeRequest(path: "/api/mobile/me", method: "GET", authenticated: true)
+        return try await send(request)
+    }
+
+    func revokeSelf() async throws {
+        let request = makeRequest(path: "/api/mobile/auth/revoke", method: "POST", authenticated: true)
+        let (_, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            throw APIError.badStatus
+        }
+    }
+
+    // MARK: - Uploads
+
+    struct ReceiptUploadResult: Decodable {
+        let ok: Bool
+        let duplicate: Bool
+        let receiptId: String
+        let reviewUrl: String?
+    }
+
+    struct BusinessCardUploadResult: Decodable {
+        let ok: Bool
+        let duplicate: Bool
+        let batchId: Int
+        let batchCardId: Int
+        let businessCardImageId: Int
+        let reviewUrl: String?
+    }
+
+    func uploadReceipt(jpeg: Data, fields: ReceiptUploadFields) async throws -> ReceiptUploadResult {
+        let boundary = "Boundary-\(UUID().uuidString)"
+        var request = makeRequest(path: "/api/mobile/receipts/upload", method: "POST", authenticated: true)
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+        request.httpBody = MultipartBuilder.build(boundary: boundary, parts: fields.parts(jpeg: jpeg))
+        return try await send(request)
+    }
+
+    func uploadBusinessCard(jpeg: Data, fields: BusinessCardUploadFields) async throws -> BusinessCardUploadResult {
+        let boundary = "Boundary-\(UUID().uuidString)"
+        var request = makeRequest(path: "/api/mobile/business-cards/upload", method: "POST", authenticated: true)
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+        request.httpBody = MultipartBuilder.build(boundary: boundary, parts: fields.parts(jpeg: jpeg))
+        return try await send(request)
+    }
+
+    // MARK: - Internals
+
+    private func makeRequest(path: String, method: String, authenticated: Bool) -> URLRequest {
+        let url = baseURL.appendingPathComponent(path)
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        if authenticated, let token = tokenProvider() {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        return request
+    }
+
+    private func send<T: Decodable>(_ request: URLRequest) async throws -> T {
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else { throw APIError.badResponse }
+        if !(200..<300).contains(http.statusCode) {
+            throw APIError.serverError(status: http.statusCode, body: data)
+        }
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+}
+
+enum APIError: Error {
+    case badResponse
+    case badStatus
+    case serverError(status: Int, body: Data)
+}
+
+struct ReceiptUploadFields {
+    let clientCaptureId: String
+    let capturedAtClient: Date
+    let paymentHint: String?     // "AMEX" | "CASH" | nil
+    let note: String?
+    let appVersion: String
+
+    func parts(jpeg: Data) -> [MultipartBuilder.Part] {
+        var parts: [MultipartBuilder.Part] = [
+            .file(name: "file", filename: "\(clientCaptureId).jpg", contentType: "image/jpeg", data: jpeg),
+            .text(name: "client_capture_id", value: clientCaptureId),
+            .text(name: "captured_at_client", value: ISO8601DateFormatter().string(from: capturedAtClient)),
+            .text(name: "app_version", value: appVersion),
+        ]
+        if let hint = paymentHint { parts.append(.text(name: "payment_hint", value: hint)) }
+        if let note = note { parts.append(.text(name: "note", value: note)) }
+        return parts
+    }
+}
+
+struct BusinessCardUploadFields {
+    let clientCaptureId: String
+    let capturedAtClient: Date
+    let eventName: String?
+    let batchId: Int?
+    let note: String?
+    let appVersion: String
+
+    func parts(jpeg: Data) -> [MultipartBuilder.Part] {
+        var parts: [MultipartBuilder.Part] = [
+            .file(name: "file", filename: "\(clientCaptureId).jpg", contentType: "image/jpeg", data: jpeg),
+            .text(name: "client_capture_id", value: clientCaptureId),
+            .text(name: "captured_at_client", value: ISO8601DateFormatter().string(from: capturedAtClient)),
+            .text(name: "app_version", value: appVersion),
+        ]
+        if let event = eventName { parts.append(.text(name: "event_name", value: event)) }
+        if let batchId = batchId { parts.append(.text(name: "batch_id", value: String(batchId))) }
+        if let note = note { parts.append(.text(name: "note", value: note)) }
+        return parts
+    }
+}
+
+enum MultipartBuilder {
+    enum Part {
+        case text(name: String, value: String)
+        case file(name: String, filename: String, contentType: String, data: Data)
+    }
+
+    static func build(boundary: String, parts: [Part]) -> Data {
+        var body = Data()
+        let line = "\r\n"
+        for part in parts {
+            body.append("--\(boundary)\(line)".data(using: .utf8)!)
+            switch part {
+            case .text(let name, let value):
+                body.append("Content-Disposition: form-data; name=\"\(name)\"\(line)\(line)".data(using: .utf8)!)
+                body.append("\(value)\(line)".data(using: .utf8)!)
+            case .file(let name, let filename, let contentType, let data):
+                body.append(
+                    "Content-Disposition: form-data; name=\"\(name)\"; filename=\"\(filename)\"\(line)"
+                        .data(using: .utf8)!)
+                body.append("Content-Type: \(contentType)\(line)\(line)".data(using: .utf8)!)
+                body.append(data)
+                body.append("\(line)".data(using: .utf8)!)
+            }
+        }
+        body.append("--\(boundary)--\(line)".data(using: .utf8)!)
+        return body
+    }
+}

--- a/ios/DazbeezCapture/Networking/KeychainTokenStore.swift
+++ b/ios/DazbeezCapture/Networking/KeychainTokenStore.swift
@@ -1,0 +1,50 @@
+import Foundation
+import Security
+
+/// Stores the mobile bearer token in the Keychain with
+/// `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` so it survives reboots
+/// once the device has been unlocked once but never syncs to iCloud.
+struct KeychainTokenStore {
+    private let service = "com.dazbeez.capture"
+    private let account = "mobile_bearer_token"
+
+    func read() -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var item: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard status == errSecSuccess,
+              let data = item as? Data,
+              let token = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        return token
+    }
+
+    func write(_ token: String) {
+        delete()
+        let data = Data(token.utf8)
+        let attributes: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+            kSecValueData as String: data,
+        ]
+        SecItemAdd(attributes as CFDictionary, nil)
+    }
+
+    func delete() {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+}

--- a/ios/DazbeezCapture/Pairing/PairingView.swift
+++ b/ios/DazbeezCapture/Pairing/PairingView.swift
@@ -1,0 +1,113 @@
+import SwiftUI
+
+struct PairingView: View {
+    @EnvironmentObject private var environment: AppEnvironment
+    @StateObject private var viewModel = PairingViewModel()
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 24) {
+                Spacer()
+                Image(systemName: "iphone.gen3.circle.fill")
+                    .font(.system(size: 72))
+                    .foregroundStyle(.tint)
+                Text("Pair with Dazbeez")
+                    .font(.title.bold())
+                Text("Open /receipts/pair in Safari on a signed-in browser and enter the code below.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal)
+
+                if let code = viewModel.code {
+                    Text(code)
+                        .font(.system(size: 40, weight: .semibold, design: .monospaced))
+                        .padding(.horizontal, 24)
+                        .padding(.vertical, 12)
+                        .background(Color.yellow.opacity(0.2))
+                        .clipShape(RoundedRectangle(cornerRadius: 16))
+                } else {
+                    ProgressView()
+                }
+
+                if let message = viewModel.statusMessage {
+                    Text(message)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                Button(action: { Task { await viewModel.startNewCode() } }) {
+                    Text("Generate new code")
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                }
+                .buttonStyle(.bordered)
+                .padding(.horizontal)
+            }
+            .navigationTitle("")
+            .navigationBarHidden(true)
+            .task {
+                viewModel.attach(environment: environment)
+                await viewModel.startNewCode()
+            }
+            .onDisappear { viewModel.stopPolling() }
+        }
+    }
+}
+
+@MainActor
+final class PairingViewModel: ObservableObject {
+    @Published var code: String?
+    @Published var statusMessage: String?
+    private var environment: AppEnvironment?
+    private var pollTask: Task<Void, Never>?
+
+    func attach(environment: AppEnvironment) {
+        self.environment = environment
+    }
+
+    func startNewCode() async {
+        guard let environment else { return }
+        stopPolling()
+        statusMessage = "Requesting a pairing code…"
+        do {
+            let response = try await environment.apiClient.startPairing()
+            code = response.code
+            statusMessage = "Waiting for the browser confirmation…"
+            startPolling()
+        } catch {
+            statusMessage = "Could not request a code. Tap to retry."
+        }
+    }
+
+    func startPolling() {
+        guard let environment, let code else { return }
+        pollTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 2_000_000_000)
+                if Task.isCancelled { return }
+                guard let result = try? await environment.apiClient.checkPairing(code: code) else { continue }
+                if result.expired == true {
+                    await MainActor.run {
+                        self?.statusMessage = "Code expired. Tap below for a new one."
+                    }
+                    return
+                }
+                if result.ready == true, let token = result.bearerToken, let deviceId = result.deviceId {
+                    await MainActor.run {
+                        environment.saveToken(token, deviceId: deviceId)
+                        self?.statusMessage = "Paired!"
+                    }
+                    return
+                }
+            }
+        }
+    }
+
+    func stopPolling() {
+        pollTask?.cancel()
+        pollTask = nil
+    }
+}

--- a/ios/DazbeezCapture/Queue/UploadQueue.swift
+++ b/ios/DazbeezCapture/Queue/UploadQueue.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Encrypted persistent upload queue.
+///
+/// This file is a placeholder for the GRDB-backed queue scheduled for M3 of
+/// the PRD. The plan:
+///
+///   - SQLite database opened with SQLCipher / SQLiteEncryptionExtension
+///   - Schema: `captures(id, kind, client_capture_id, file_path, metadata_json,
+///                          status, retry_count, next_retry_at, created_at)`
+///   - Retries via `URLSessionConfiguration.background(_:)` with
+///     `waitsForConnectivity = true`
+///   - `BGTaskScheduler` "com.dazbeez.capture.queue-drain" to trigger periodic
+///     drains when the app is suspended
+///   - On `uploaded`, delete the local file and remove the row so the
+///     app keeps no successful-upload history
+///   - Statuses surfaced in UI: `queued`, `uploading`, `failed`, `duplicate`
+///
+/// The MVP online path bypasses the queue and posts directly via
+/// `APIClient.uploadReceipt` / `uploadBusinessCard`. M3 makes the queue the
+/// only path so offline capture stops dropping events.
+enum UploadQueue {
+    static let placeholderTodo = "Implement in M3 — see PRD §6.4 and PRD_CaptureApp_Architecture §iPhone app structure"
+}

--- a/ios/DazbeezCapture/README.md
+++ b/ios/DazbeezCapture/README.md
@@ -1,0 +1,73 @@
+# Dazbeez Capture (iPhone)
+
+SwiftUI native capture app for receipts and business cards. Companion to the
+backend mobile API documented in [`../../docs/PRD_CaptureApp.md`](../../docs/PRD_CaptureApp.md)
+and [`../../docs/PRD_CaptureApp_Architecture.md`](../../docs/PRD_CaptureApp_Architecture.md).
+
+This directory contains plain Swift sources organized by feature. The Xcode
+project (`.xcodeproj`) is **not** committed yet — it must be generated on the
+Mac after a one-time setup step (see "Initial Mac setup" below). The sources
+are designed to drop straight into an Xcode project with no rearrangement.
+
+## Module layout
+
+```
+ios/DazbeezCapture/
+├── App/         App entry, environment, root view
+├── Pairing/     Pairing flow (DAZ-XXXX code + browser handoff + polling)
+├── Capture/     Home, ReceiptCaptureView, BusinessCardCaptureView (VisionKit)
+├── Events/      Active event/batch selection for business-card scans
+├── Queue/       Persistent encrypted upload queue (GRDB + URLSession background)
+├── Networking/  APIClient (Bearer), KeychainTokenStore, server URL config
+└── Settings/    Revoke device, app version, privacy policy link
+```
+
+## Initial Mac setup
+
+1. Open Xcode → File → New → Project → iOS → App
+2. Product Name: `DazbeezCapture`, Interface: SwiftUI, Language: Swift,
+   Storage: None (we add GRDB manually).
+3. Save the project at this path so the generated folder structure is
+   `ios/DazbeezCapture/DazbeezCapture.xcodeproj`.
+4. Delete the auto-generated `ContentView.swift` and `DazbeezCaptureApp.swift`
+   stubs — the sources here replace them.
+5. Add the existing Swift files in this directory to the Xcode project
+   (File → Add Files to "DazbeezCapture"... and select the feature folders).
+6. Add dependencies via Swift Package Manager:
+   - GRDB.swift (`https://github.com/groue/GRDB.swift`) for the encrypted local queue.
+7. Configure capabilities in Signing & Capabilities:
+   - Background Modes → Background fetch + Background processing
+   - Keychain Sharing (default group)
+8. Set `Info.plist`:
+   - `NSCameraUsageDescription` = "Take photos of receipts and business cards."
+9. Configure the server URL in `Networking/AppEnvironment.swift` (or via
+   the Settings screen) to point at your Dazbeez deployment.
+
+## Distribution
+
+TestFlight internal testing only for the MVP. See PRD §15 Decision 9.
+
+## Things this scaffold does NOT do (yet)
+
+- It does not include the Xcode project file. That's a one-time Mac step.
+- It does not include the encrypted GRDB schema or background URLSession
+  delegate plumbing — those are M3 (offline queue) work. The Networking and
+  Capture modules currently target the online happy path.
+- It does not include any analytics, crash reporting, or third-party SDKs
+  beyond GRDB. Apple's built-in crash reporting is the only telemetry.
+
+## Backend contract
+
+| Endpoint | Method | Auth | Used by |
+|---|---|---|---|
+| `/api/mobile/auth/start-pairing` | POST | none | `PairingViewModel.start()` |
+| `/api/mobile/auth/check?code=…` | GET | none | `PairingViewModel.poll()` |
+| `/api/mobile/auth/revoke` | POST | Bearer | `SettingsViewModel.revoke()` |
+| `/api/mobile/me` | GET | Bearer | `AppEnvironment.refreshDevice()` |
+| `/api/mobile/receipts/upload` | POST multipart | Bearer (`receipt:create`) | `UploadQueue.uploadReceipt()` |
+| `/api/mobile/business-cards/upload` | POST multipart | Bearer (`business_card:create`) | `UploadQueue.uploadBusinessCard()` |
+
+Pairing is "code only": the iPhone shows `DAZ-XXXX`; an operator types it
+into `/receipts/pair` in a browser behind Cloudflare Access. The bearer
+token is delivered exclusively to the polling iPhone — it is never shown
+in the browser.

--- a/ios/DazbeezCapture/Settings/SettingsView.swift
+++ b/ios/DazbeezCapture/Settings/SettingsView.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @EnvironmentObject private var environment: AppEnvironment
+    @State private var serverURLString: String = ""
+    @State private var revoking = false
+
+    var appVersion: String {
+        let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "?"
+        let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "?"
+        return "\(version) (\(build))"
+    }
+
+    var body: some View {
+        Form {
+            Section("Device") {
+                LabeledContent("Label", value: environment.deviceLabel ?? "—")
+                LabeledContent("Device id", value: environment.deviceId ?? "—")
+                LabeledContent("App version", value: appVersion)
+            }
+
+            Section("Server") {
+                TextField("https://dazbeez.com", text: $serverURLString)
+                    .textInputAutocapitalization(.never)
+                    .keyboardType(.URL)
+                Button("Save server URL") {
+                    if let url = URL(string: serverURLString.trimmingCharacters(in: .whitespacesAndNewlines)) {
+                        environment.updateServerURL(url)
+                    }
+                }
+            }
+
+            Section {
+                Button(role: .destructive) {
+                    Task { await revoke() }
+                } label: {
+                    HStack {
+                        Text(revoking ? "Revoking…" : "Revoke this device")
+                        Spacer()
+                        if revoking { ProgressView() }
+                    }
+                }
+                .disabled(revoking)
+            }
+
+            Section("Privacy") {
+                Link("Privacy policy", destination: URL(string: "https://dazbeez.com/privacy")!)
+            }
+        }
+        .navigationTitle("Settings")
+        .onAppear {
+            serverURLString = environment.serverURL.absoluteString
+        }
+    }
+
+    private func revoke() async {
+        revoking = true
+        defer { revoking = false }
+        try? await environment.apiClient.revokeSelf()
+        environment.clearToken()
+    }
+}

--- a/lib/crm.ts
+++ b/lib/crm.ts
@@ -666,6 +666,122 @@ async function refreshBatchReviewCounts(batchId: number): Promise<void> {
     .run();
 }
 
+export interface InsertBatchCardInput {
+  batchId: number;
+  sortOrder: number;
+  actor: string;
+  label: string;
+  detection: CardDetectionCandidate;
+  image: StoredFileInput;
+  extracted: ExtractedCardPayload;
+  croppedStorageKey: string;
+  createdAt: string;
+}
+
+export interface InsertBatchCardResult {
+  batchCardId: number;
+  needsReview: boolean;
+  duplicateCandidates: DuplicateCandidate[];
+}
+
+// Per-card insertion shared by the admin composite path and the mobile
+// event/batch capture path. Extracts the body of the for loop in
+// createBusinessCardBatch so audit / review-task / dedupe logic does not
+// diverge between the two callers.
+export async function insertBatchCard(
+  input: InsertBatchCardInput,
+  thresholds: CrmThresholdSettings,
+): Promise<InsertBatchCardResult> {
+  const db = getCrmDb();
+  const normalized = normalizeExtractedFields(input.extracted.fields);
+  const duplicateCandidates = buildDuplicateCandidates(
+    normalized,
+    await queryDedupeContactsByKeys(normalized),
+  );
+  const review = assessBatchCardReviewState({
+    normalized,
+    confidence: input.extracted.confidence,
+    duplicateCandidates,
+    thresholds,
+  });
+
+  const batchCardResult = await db
+    .prepare(
+      `INSERT INTO batch_cards
+        (batch_id, sort_order, status, detection_label, detection_confidence, detection_box_json, transform_json, extraction_provider, raw_ocr_text, extracted_json, normalized_json, confidence_json, duplicate_candidates_json, needs_review, notes, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .bind(
+      input.batchId,
+      input.sortOrder,
+      review.needsReview ? "needs_review" : "extracted",
+      input.label,
+      input.detection.confidence,
+      stringifyJson(input.detection.polygon),
+      stringifyJson({ rotationDegrees: input.detection.rotationDegrees ?? 0 }),
+      "cloudflare_ai",
+      normalized.raw_ocr_text,
+      stringifyJson(input.extracted.fields),
+      stringifyJson(normalized),
+      stringifyJson(input.extracted.confidence),
+      stringifyJson(duplicateCandidates),
+      review.needsReview ? 1 : 0,
+      review.reasons.join("; ") || null,
+      input.createdAt,
+      input.createdAt,
+    )
+    .run();
+
+  const batchCardId = Number(batchCardResult.meta.last_row_id ?? 0);
+
+  await insertImage({
+    batchId: input.batchId,
+    batchCardId,
+    role: "cropped_card",
+    storageKey: input.croppedStorageKey,
+    file: input.image,
+  });
+
+  if (review.needsReview) {
+    await createReviewTask({
+      entityType: "batch_card",
+      entityId: batchCardId,
+      batchId: input.batchId,
+      taskType: duplicateCandidates.length > 0 ? "dedupe_review" : "ocr_review",
+      priority: duplicateCandidates.length > 0 ? "high" : "medium",
+      title:
+        duplicateCandidates.length > 0
+          ? `Resolve duplicate candidate for ${normalized.full_name ?? `card ${input.sortOrder + 1}`}`
+          : `Review low-confidence extraction for card ${input.sortOrder + 1}`,
+      detail: {
+        duplicateCandidates,
+        confidence: input.extracted.confidence,
+        normalized,
+        reasons: review.reasons,
+      },
+    });
+  }
+
+  await logAudit({
+    actor: input.actor,
+    action: "batch_card.created",
+    entityType: "batch_card",
+    entityId: batchCardId,
+    batchId: input.batchId,
+    afterJson: stringifyJson({
+      normalized,
+      confidence: input.extracted.confidence,
+      duplicateCandidates,
+    }),
+  });
+
+  return {
+    batchCardId,
+    needsReview: review.needsReview,
+    duplicateCandidates,
+  };
+}
+
 export async function createBusinessCardBatch(input: BatchUploadInput): Promise<number> {
   const db = getCrmDb();
   const thresholds = await getCrmThresholds();
@@ -708,88 +824,21 @@ export async function createBusinessCardBatch(input: BatchUploadInput): Promise<
 
   for (let index = 0; index < input.crops.length; index += 1) {
     const crop = input.crops[index];
-    const normalized = normalizeExtractedFields(crop.extracted.fields);
-    const duplicateCandidates = buildDuplicateCandidates(
-      normalized,
-      await queryDedupeContactsByKeys(normalized),
-    );
-    const review = assessBatchCardReviewState({
-      normalized,
-      confidence: crop.extracted.confidence,
-      duplicateCandidates,
+    const result = await insertBatchCard(
+      {
+        batchId,
+        sortOrder: index,
+        actor: input.actor,
+        label: crop.label,
+        detection: crop.detection,
+        image: crop.image,
+        extracted: crop.extracted,
+        croppedStorageKey: `batch/${batchId}/card/${String(index + 1).padStart(2, "0")}.png`,
+        createdAt,
+      },
       thresholds,
-    });
-
-    const batchCardResult = await db
-      .prepare(
-        `INSERT INTO batch_cards
-          (batch_id, sort_order, status, detection_label, detection_confidence, detection_box_json, transform_json, extraction_provider, raw_ocr_text, extracted_json, normalized_json, confidence_json, duplicate_candidates_json, needs_review, notes, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      )
-      .bind(
-        batchId,
-        index,
-        review.needsReview ? "needs_review" : "extracted",
-        crop.label,
-        crop.detection.confidence,
-        stringifyJson(crop.detection.polygon),
-        stringifyJson({ rotationDegrees: crop.detection.rotationDegrees ?? 0 }),
-        "cloudflare_ai",
-        normalized.raw_ocr_text,
-        stringifyJson(crop.extracted.fields),
-        stringifyJson(normalized),
-        stringifyJson(crop.extracted.confidence),
-        stringifyJson(duplicateCandidates),
-        review.needsReview ? 1 : 0,
-        review.reasons.join("; ") || null,
-        createdAt,
-        createdAt,
-      )
-      .run();
-
-    const batchCardId = Number(batchCardResult.meta.last_row_id ?? 0);
-
-    await insertImage({
-      batchId,
-      batchCardId,
-      role: "cropped_card",
-      storageKey: `batch/${batchId}/card/${String(index + 1).padStart(2, "0")}.png`,
-      file: crop.image,
-    });
-
-    if (review.needsReview) {
-      needsReviewCount += 1;
-      await createReviewTask({
-        entityType: "batch_card",
-        entityId: batchCardId,
-        batchId,
-        taskType: duplicateCandidates.length > 0 ? "dedupe_review" : "ocr_review",
-        priority: duplicateCandidates.length > 0 ? "high" : "medium",
-        title:
-          duplicateCandidates.length > 0
-            ? `Resolve duplicate candidate for ${normalized.full_name ?? `card ${index + 1}`}`
-            : `Review low-confidence extraction for card ${index + 1}`,
-        detail: {
-          duplicateCandidates,
-          confidence: crop.extracted.confidence,
-          normalized,
-          reasons: review.reasons,
-        },
-      });
-    }
-
-    await logAudit({
-      actor: input.actor,
-      action: "batch_card.created",
-      entityType: "batch_card",
-      entityId: batchCardId,
-      batchId,
-      afterJson: stringifyJson({
-        normalized,
-        confidence: crop.extracted.confidence,
-        duplicateCandidates,
-      }),
-    });
+    );
+    if (result.needsReview) needsReviewCount += 1;
   }
 
   if (input.crops.length === 0) {
@@ -846,6 +895,247 @@ export async function createBusinessCardBatch(input: BatchUploadInput): Promise<
   });
 
   return batchId;
+}
+
+// ─── Mobile capture ──────────────────────────────────────────────────────────
+
+export interface MobileBusinessCardCaptureInput {
+  actor: string;
+  deviceId: string;
+  clientCaptureId: string;
+  capturedAtClient: string | null;
+  appVersion: string | null;
+  note: string | null;
+  // When provided, append to an existing batch. Otherwise create a new batch
+  // using `eventName`.
+  batchId: number | null;
+  eventName: string | null;
+  image: StoredFileInput;
+  extracted: ExtractedCardPayload;
+}
+
+export interface MobileBusinessCardCaptureResult {
+  batchId: number;
+  batchCardId: number;
+  businessCardImageId: number;
+  duplicate: boolean;
+}
+
+// Idempotency: every mobile-captured card image carries (device_id,
+// client_capture_id). A unique index in 0012_mobile_capture.sql enforces
+// at-most-once insertion. On retry we return the existing card.
+async function findMobileBusinessCardImage(
+  deviceId: string,
+  clientCaptureId: string,
+): Promise<{ id: number; batch_card_id: number | null; batch_id: number | null } | null> {
+  const db = getCrmDb();
+  return db
+    .prepare(
+      `SELECT id, batch_card_id, batch_id
+       FROM business_card_images_v2
+       WHERE device_id = ? AND client_capture_id = ?
+       LIMIT 1`,
+    )
+    .bind(deviceId, clientCaptureId)
+    .first<{ id: number; batch_card_id: number | null; batch_id: number | null }>();
+}
+
+async function findOrCreateMobileBatch(
+  input: MobileBusinessCardCaptureInput,
+): Promise<number> {
+  const db = getCrmDb();
+  if (input.batchId) {
+    const row = await db
+      .prepare(`SELECT id FROM contact_batches WHERE id = ? LIMIT 1`)
+      .bind(input.batchId)
+      .first<{ id: number }>();
+    if (!row) {
+      throw new Error(`Batch ${input.batchId} not found.`);
+    }
+    return row.id;
+  }
+
+  const createdAt = nowIso();
+  const insert = await db
+    .prepare(
+      `INSERT INTO contact_batches
+        (status, event_name, source_filename, source_mime_type,
+         detected_card_count, created_by, updated_by, created_at, updated_at)
+       VALUES ('processing', ?, ?, ?, 0, ?, ?, ?, ?)`,
+    )
+    .bind(
+      input.eventName,
+      `mobile-capture/${input.deviceId.slice(0, 8)}`,
+      input.image.mimeType,
+      input.actor,
+      input.actor,
+      createdAt,
+      createdAt,
+    )
+    .run();
+  return Number(insert.meta.last_row_id ?? 0);
+}
+
+async function nextBatchSortOrder(batchId: number): Promise<number> {
+  const db = getCrmDb();
+  const row = await db
+    .prepare(`SELECT MAX(sort_order) AS max_sort FROM batch_cards WHERE batch_id = ?`)
+    .bind(batchId)
+    .first<{ max_sort: number | null }>();
+  return Number(row?.max_sort ?? -1) + 1;
+}
+
+export async function createMobileBusinessCardCapture(
+  input: MobileBusinessCardCaptureInput,
+): Promise<MobileBusinessCardCaptureResult> {
+  const db = getCrmDb();
+
+  const existing = await findMobileBusinessCardImage(
+    input.deviceId,
+    input.clientCaptureId,
+  );
+  if (existing) {
+    return {
+      batchId: existing.batch_id ?? 0,
+      batchCardId: existing.batch_card_id ?? 0,
+      businessCardImageId: existing.id,
+      duplicate: true,
+    };
+  }
+
+  if (!input.batchId && !input.eventName) {
+    throw new Error("event_name is required when no batch_id is provided.");
+  }
+
+  const thresholds = await getCrmThresholds();
+  const createdAt = nowIso();
+  const batchId = await findOrCreateMobileBatch(input);
+  const sortOrder = await nextBatchSortOrder(batchId);
+
+  const detection: CardDetectionCandidate = {
+    label: `mobile-${sortOrder + 1}`,
+    confidence: 1,
+    polygon: {
+      topLeft: { x: 0, y: 0 },
+      topRight: { x: input.image.width ?? 0, y: 0 },
+      bottomRight: { x: input.image.width ?? 0, y: input.image.height ?? 0 },
+      bottomLeft: { x: 0, y: input.image.height ?? 0 },
+    },
+    rotationDegrees: 0,
+  };
+
+  // Insert the card. The idempotency unique index is on
+  // business_card_images_v2(device_id, client_capture_id), so we tag the
+  // image row with those identifiers after insertBatchCard creates it.
+  const result = await insertBatchCard(
+    {
+      batchId,
+      sortOrder,
+      actor: input.actor,
+      label: detection.label,
+      detection,
+      image: {
+        ...input.image,
+        metadata: {
+          ...(input.image.metadata ?? {}),
+          uploadedVia: "mobile",
+          deviceId: input.deviceId,
+          clientCaptureId: input.clientCaptureId,
+          capturedAtClient: input.capturedAtClient,
+          appVersion: input.appVersion,
+          note: input.note,
+        },
+      },
+      extracted: input.extracted,
+      croppedStorageKey: `batch/${batchId}/mobile/${input.clientCaptureId}.jpg`,
+      createdAt,
+    },
+    thresholds,
+  );
+
+  // Tag the image row with mobile metadata so the unique index protects
+  // future retries. If a concurrent retry already tagged a row with this
+  // (device_id, client_capture_id), the UPDATE hits the unique index and
+  // throws; surface that as a duplicate of the prior successful insert.
+  try {
+    const tagResult = await db
+      .prepare(
+        `UPDATE business_card_images_v2
+           SET device_id = ?, client_capture_id = ?, captured_at_client = ?,
+               upload_origin = 'mobile', source_app_version = ?
+         WHERE batch_card_id = ? AND image_role = 'cropped_card'`,
+      )
+      .bind(
+        input.deviceId,
+        input.clientCaptureId,
+        input.capturedAtClient,
+        input.appVersion,
+        result.batchCardId,
+      )
+      .run();
+    const tagChanges = Number(tagResult.meta?.changes ?? 0);
+    if (tagChanges === 0) {
+      throw new Error("Mobile metadata tag failed: no image row updated.");
+    }
+  } catch (err) {
+    const existingAfter = await findMobileBusinessCardImage(
+      input.deviceId,
+      input.clientCaptureId,
+    );
+    if (existingAfter) {
+      return {
+        batchId: existingAfter.batch_id ?? batchId,
+        batchCardId: existingAfter.batch_card_id ?? result.batchCardId,
+        businessCardImageId: existingAfter.id,
+        duplicate: true,
+      };
+    }
+    throw err;
+  }
+
+  const imageRow = await db
+    .prepare(
+      `SELECT id FROM business_card_images_v2
+       WHERE batch_card_id = ? AND image_role = 'cropped_card' LIMIT 1`,
+    )
+    .bind(result.batchCardId)
+    .first<{ id: number }>();
+
+  await db
+    .prepare(
+      `UPDATE contact_batches
+         SET detected_card_count = (
+               SELECT COUNT(*) FROM batch_cards WHERE batch_id = ?
+             ),
+             updated_at = ?
+       WHERE id = ?`,
+    )
+    .bind(batchId, nowIso(), batchId)
+    .run();
+
+  await refreshBatchReviewCounts(batchId);
+
+  await logAudit({
+    actor: input.actor,
+    action: "contact_batch.created",
+    entityType: "contact_batch",
+    entityId: batchId,
+    batchId,
+    afterJson: stringifyJson({
+      uploadedVia: "mobile",
+      deviceId: input.deviceId,
+      clientCaptureId: input.clientCaptureId,
+      eventName: input.eventName,
+      appVersion: input.appVersion,
+    }),
+  });
+
+  return {
+    batchId,
+    batchCardId: result.batchCardId,
+    businessCardImageId: Number(imageRow?.id ?? 0),
+    duplicate: false,
+  };
 }
 
 export async function listBatches(): Promise<BatchListItem[]> {

--- a/lib/receipts/mobile-pairing.ts
+++ b/lib/receipts/mobile-pairing.ts
@@ -1,0 +1,215 @@
+// Mobile device pairing flow.
+//
+// 1. iPhone calls POST /api/mobile/auth/start-pairing → backend mints code DAZ-7K3M.
+// 2. Operator visits /receipts/pair?code=DAZ-7K3M behind Cloudflare Access
+//    and clicks "Pair this iPhone" → POST /api/mobile/auth/complete-pairing
+//    consumes the code, enrolls the device, and stores the bearer token in the
+//    pairing-codes row so the polling iPhone can pick it up.
+// 3. iPhone polls GET /api/mobile/auth/check?code=DAZ-7K3M and receives the
+//    bearer token exactly once. The browser never sees the token.
+
+import { getReceiptsDb } from "@/lib/cloudflare-runtime";
+import { nowIso } from "@/lib/receipts/db-utils";
+import {
+  DEFAULT_MOBILE_SCOPES,
+  enrollMobileDevice,
+  type MobileScope,
+} from "@/lib/receipts/trusted-devices";
+
+const CODE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const CODE_ALPHABET = "ABCDEFGHJKMNPQRSTUVWXYZ23456789"; // no I, L, O, 0, 1
+const CODE_PREFIX = "DAZ";
+const CODE_DIGITS = 4;
+
+export interface PairingCodeRow {
+  code: string;
+  created_at: string;
+  expires_at: string;
+  consumed_device_id: string | null;
+  consumed_at: string | null;
+  bearer_token: string | null;
+}
+
+function randomCode(): string {
+  const buf = new Uint8Array(CODE_DIGITS);
+  crypto.getRandomValues(buf);
+  let body = "";
+  for (let i = 0; i < CODE_DIGITS; i += 1) {
+    body += CODE_ALPHABET[buf[i]! % CODE_ALPHABET.length];
+  }
+  return `${CODE_PREFIX}-${body}`;
+}
+
+export function isValidPairingCodeShape(code: string): boolean {
+  return /^DAZ-[A-Z0-9]{4}$/.test(code);
+}
+
+export async function createPairingCode(): Promise<{ code: string; expiresAt: string }> {
+  const db = getReceiptsDb();
+  const now = Date.now();
+  const expiresAt = new Date(now + CODE_TTL_MS).toISOString();
+  const createdAt = new Date(now).toISOString();
+
+  // Try up to 5 times to dodge a collision against an active (unconsumed,
+  // unexpired) code. Total entropy of the alphabet × digit count makes
+  // collisions extremely rare in practice.
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    const code = randomCode();
+    try {
+      await db
+        .prepare(
+          `INSERT INTO mobile_pairing_codes (code, created_at, expires_at)
+           VALUES (?, ?, ?)`,
+        )
+        .bind(code, createdAt, expiresAt)
+        .run();
+      return { code, expiresAt };
+    } catch (err) {
+      // PRIMARY KEY collision → retry. Other errors should surface.
+      if (err instanceof Error && /UNIQUE|PRIMARY/i.test(err.message)) continue;
+      throw err;
+    }
+  }
+  throw new Error("Failed to allocate pairing code after retries.");
+}
+
+export interface CompletePairingInput {
+  code: string;
+  actor: string;
+  label: string;
+  userAgent: string | null;
+  platform: "ios" | "android";
+  appVersion: string | null;
+  scopes?: MobileScope[];
+}
+
+// Atomically consume a pairing code and enroll a mobile device. The bearer
+// token is stashed in mobile_pairing_codes.bearer_token so the polling iPhone
+// can retrieve it via /check. The browser never sees the token.
+export async function completePairing(
+  input: CompletePairingInput,
+): Promise<{ deviceId: string }> {
+  const normalized = input.code.trim().toUpperCase();
+  if (!isValidPairingCodeShape(normalized)) {
+    throw new Error("Invalid pairing code format.");
+  }
+
+  const db = getReceiptsDb();
+  const row = await db
+    .prepare(
+      `SELECT code, created_at, expires_at, consumed_device_id
+       FROM mobile_pairing_codes WHERE code = ? LIMIT 1`,
+    )
+    .bind(normalized)
+    .first<{
+      code: string;
+      created_at: string;
+      expires_at: string;
+      consumed_device_id: string | null;
+    }>();
+
+  if (!row) throw new Error("Pairing code not found.");
+  if (row.consumed_device_id) throw new Error("Pairing code already used.");
+  if (Date.parse(row.expires_at) < Date.now()) {
+    throw new Error("Pairing code has expired.");
+  }
+
+  const { id: deviceId, bearerToken } = await enrollMobileDevice({
+    actor: input.actor,
+    label: input.label,
+    userAgent: input.userAgent,
+    platform: input.platform,
+    appVersion: input.appVersion,
+    scopes: input.scopes ?? DEFAULT_MOBILE_SCOPES,
+  });
+
+  // Stash the token on the code row so the polling client can read it. Use a
+  // conditional UPDATE so two concurrent /complete-pairing calls cannot both
+  // consume the same code; the loser sees affected_rows = 0 and we revoke
+  // the second device immediately.
+  const update = await db
+    .prepare(
+      `UPDATE mobile_pairing_codes
+         SET consumed_device_id = ?,
+             consumed_at = ?,
+             bearer_token = ?
+       WHERE code = ? AND consumed_device_id IS NULL`,
+    )
+    .bind(deviceId, nowIso(), bearerToken, normalized)
+    .run();
+
+  // D1 returns meta.changes for affected rows.
+  const changes = Number(update.meta?.changes ?? 0);
+  if (changes === 0) {
+    // Race lost — revoke this device and surface the failure.
+    await db
+      .prepare(`UPDATE trusted_devices SET revoked_at = ? WHERE id = ?`)
+      .bind(nowIso(), deviceId)
+      .run();
+    throw new Error("Pairing code already used.");
+  }
+
+  return { deviceId };
+}
+
+// Polling endpoint result. Bearer token is returned exactly once: the row is
+// cleared after a successful read so the token cannot be replayed.
+export async function checkPairingCode(code: string): Promise<
+  | { status: "pending" }
+  | { status: "expired" }
+  | { status: "ready"; bearerToken: string; deviceId: string }
+  | { status: "not_found" }
+> {
+  const normalized = code.trim().toUpperCase();
+  if (!isValidPairingCodeShape(normalized)) return { status: "not_found" };
+
+  const db = getReceiptsDb();
+  const row = await db
+    .prepare(
+      `SELECT expires_at, consumed_device_id, bearer_token
+       FROM mobile_pairing_codes WHERE code = ? LIMIT 1`,
+    )
+    .bind(normalized)
+    .first<{
+      expires_at: string;
+      consumed_device_id: string | null;
+      bearer_token: string | null;
+    }>();
+
+  if (!row) return { status: "not_found" };
+
+  if (!row.consumed_device_id) {
+    if (Date.parse(row.expires_at) < Date.now()) return { status: "expired" };
+    return { status: "pending" };
+  }
+
+  if (!row.bearer_token) {
+    // Already delivered.
+    return { status: "not_found" };
+  }
+
+  await db
+    .prepare(
+      `UPDATE mobile_pairing_codes SET bearer_token = NULL WHERE code = ?`,
+    )
+    .bind(normalized)
+    .run();
+
+  return {
+    status: "ready",
+    bearerToken: row.bearer_token,
+    deviceId: row.consumed_device_id,
+  };
+}
+
+export async function deleteExpiredPairingCodes(): Promise<void> {
+  const db = getReceiptsDb();
+  await db
+    .prepare(
+      `DELETE FROM mobile_pairing_codes
+       WHERE (consumed_device_id IS NULL AND expires_at < ?)
+          OR (consumed_at IS NOT NULL AND bearer_token IS NULL AND consumed_at < ?)`,
+    )
+    .bind(nowIso(), new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString())
+    .run();
+}

--- a/lib/receipts/mobile-upload.ts
+++ b/lib/receipts/mobile-upload.ts
@@ -1,0 +1,108 @@
+import { getReceiptsDb } from "@/lib/cloudflare-runtime";
+import { createAuditEntry } from "@/lib/receipts/audit";
+import { newUuid, nowIso, stringifyJson } from "@/lib/receipts/db-utils";
+import { retentionUntilIso } from "@/lib/receipts/retention";
+import type { PaymentPath } from "@/lib/receipts/types";
+
+export interface MobileReceiptInput {
+  actor: string;
+  deviceId: string;
+  clientCaptureId: string;
+  capturedAtClient: string | null;
+  appVersion: string | null;
+  note: string | null;
+  paymentPath: PaymentPath;
+  originalFilename: string;
+  originalR2Key: string;
+  originalSha256: string;
+  originalContentType: string;
+  originalSizeBytes: number;
+}
+
+export interface MobileReceiptIdempotencyHit {
+  id: string;
+  status: string;
+}
+
+export async function findMobileReceiptByIdempotency(
+  deviceId: string,
+  clientCaptureId: string,
+): Promise<MobileReceiptIdempotencyHit | null> {
+  const db = getReceiptsDb();
+  const row = await db
+    .prepare(
+      `SELECT id, status FROM receipt_records
+       WHERE device_id = ? AND client_capture_id = ?
+       LIMIT 1`,
+    )
+    .bind(deviceId, clientCaptureId)
+    .first<{ id: string; status: string }>();
+  return row ?? null;
+}
+
+export async function createMobileReceiptRecord(input: MobileReceiptInput): Promise<string> {
+  const db = getReceiptsDb();
+  const id = newUuid();
+  const now = nowIso();
+
+  await db
+    .prepare(
+      `INSERT INTO receipt_records
+        (id, captured_at, captured_by, source, original_filename,
+         payment_path, expense_type,
+         alcohol_present, attendees_required, status,
+         original_r2_key, original_sha256, original_content_type, original_size_bytes,
+         legacy, retention_until, legal_hold,
+         source_type, preservation_status, qualified_invoice_status,
+         device_id, client_capture_id, captured_at_client, upload_origin,
+         currency,
+         created_at, updated_at)
+       VALUES
+        (?, ?, ?, 'mobile_capture', ?,
+         ?, 'UNKNOWN',
+         0, 0, 'needs_review',
+         ?, ?, ?, ?,
+         0, ?, 1,
+         'paper_scanned', 'captured', 'not_checked',
+         ?, ?, ?, 'mobile',
+         'JPY',
+         ?, ?)`,
+    )
+    .bind(
+      id,
+      now,
+      input.actor,
+      input.originalFilename,
+      input.paymentPath,
+      input.originalR2Key,
+      input.originalSha256,
+      input.originalContentType,
+      input.originalSizeBytes,
+      retentionUntilIso(now),
+      input.deviceId,
+      input.clientCaptureId,
+      input.capturedAtClient,
+      now,
+      now,
+    )
+    .run();
+
+  await createAuditEntry(db, {
+    actor: input.actor,
+    action: "receipt.uploaded",
+    objectType: "receipt",
+    objectId: id,
+    newValueJson: stringifyJson({
+      source: "mobile_capture",
+      source_type: "paper_scanned",
+      upload_origin: "mobile",
+      payment_path: input.paymentPath,
+      device_id: input.deviceId,
+      client_capture_id: input.clientCaptureId,
+      app_version: input.appVersion,
+      note: input.note,
+    }),
+  });
+
+  return id;
+}

--- a/lib/receipts/trusted-devices.ts
+++ b/lib/receipts/trusted-devices.ts
@@ -19,6 +19,9 @@ export interface TrustedDeviceRow {
   created_at: string;
   last_seen_at: string | null;
   revoked_at: string | null;
+  platform: string | null;
+  app_version: string | null;
+  scopes_json: string | null;
 }
 
 interface DevicePayload {
@@ -26,6 +29,26 @@ interface DevicePayload {
   actor: string;
   exp: number; // unix seconds
 }
+
+// Mobile bearer tokens have no fixed expiry; revocation in trusted_devices is
+// the only control. The token payload still carries id+actor so the route can
+// verify HMAC without a DB hit before doing the revocation lookup.
+interface MobileTokenPayload {
+  id: string;
+  actor: string;
+  iat: number; // unix seconds, informational
+}
+
+export type MobileScope =
+  | "receipt:create"
+  | "business_card:create"
+  | "device:heartbeat";
+
+export const DEFAULT_MOBILE_SCOPES: MobileScope[] = [
+  "receipt:create",
+  "business_card:create",
+  "device:heartbeat",
+];
 
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
@@ -223,7 +246,8 @@ export async function listDevicesForActor(actor: string): Promise<TrustedDeviceR
   const db = getReceiptsDb();
   const result = await db
     .prepare(
-      `SELECT id, actor, label, user_agent, created_at, last_seen_at, revoked_at
+      `SELECT id, actor, label, user_agent, created_at, last_seen_at, revoked_at,
+              platform, app_version, scopes_json
        FROM trusted_devices WHERE actor = ? AND revoked_at IS NULL ORDER BY created_at DESC`,
     )
     .bind(actor)
@@ -246,4 +270,170 @@ export async function revokeDevice(id: string, actor: string): Promise<void> {
 export async function getCurrentDeviceId(headers: Headers): Promise<string | null> {
   const light = await verifyDeviceCookieLight(headers).catch(() => null);
   return light?.id ?? null;
+}
+
+// ─── Mobile bearer tokens ─────────────────────────────────────────────────────
+//
+// Format: base64url(JSON {id, actor, iat}) + "." + hex(HMAC-SHA256(secret, payload))
+// Stored only on the device. Server keeps no copy; revocation is enforced by
+// the trusted_devices.revoked_at column.
+
+function parseBearerToken(value: string): { raw: Uint8Array; encodedPayload: string; sig: string } | null {
+  return parseCookieValue(value);
+}
+
+function readBearerToken(headers: Headers): string | null {
+  const auth = headers.get("authorization");
+  if (!auth) return null;
+  const m = /^Bearer\s+(.+)$/i.exec(auth.trim());
+  return m ? m[1]!.trim() : null;
+}
+
+export async function enrollMobileDevice(input: {
+  actor: string;
+  label: string;
+  userAgent: string | null;
+  platform: "ios" | "android";
+  appVersion: string | null;
+  scopes: MobileScope[];
+}): Promise<{ id: string; bearerToken: string }> {
+  const secret = getDeviceSecret();
+  if (!secret) {
+    throw new Error("RECEIPTS_DEVICE_SECRET is not configured (must be ≥32 chars).");
+  }
+
+  const id = newUuid();
+  const iat = Math.floor(Date.now() / 1000);
+  const payload: MobileTokenPayload = { id, actor: input.actor, iat };
+  const payloadBytes = textEncoder.encode(JSON.stringify(payload));
+  const sig = await hmacHex(secret, payloadBytes);
+  const bearerToken = encodeCookieValue(payload as unknown as DevicePayload, sig);
+
+  const db = getReceiptsDb();
+  const now = nowIso();
+  await db
+    .prepare(
+      `INSERT INTO trusted_devices
+        (id, actor, label, user_agent, created_at, last_seen_at,
+         platform, app_version, scopes_json)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .bind(
+      id,
+      input.actor,
+      input.label,
+      input.userAgent,
+      now,
+      now,
+      input.platform,
+      input.appVersion,
+      JSON.stringify(input.scopes),
+    )
+    .run();
+
+  return { id, bearerToken };
+}
+
+interface MobileActor {
+  deviceId: string;
+  actor: string;
+  scopes: MobileScope[];
+  platform: string | null;
+  appVersion: string | null;
+}
+
+export async function verifyBearerDevice(headers: Headers): Promise<MobileActor | null> {
+  const secret = getDeviceSecret();
+  if (!secret) return null;
+  const token = readBearerToken(headers);
+  if (!token) return null;
+  const parsed = parseBearerToken(token);
+  if (!parsed) return null;
+
+  const expected = await hmacHex(secret, parsed.raw);
+  if (!constantTimeEqual(expected, parsed.sig)) return null;
+
+  let payload: MobileTokenPayload;
+  try {
+    payload = JSON.parse(textDecoder.decode(parsed.raw)) as MobileTokenPayload;
+  } catch {
+    return null;
+  }
+  if (!payload.id || !payload.actor) return null;
+
+  const db = getReceiptsDb();
+  const row = await db
+    .prepare(
+      `SELECT revoked_at, last_seen_at, scopes_json, platform, app_version
+       FROM trusted_devices WHERE id = ? LIMIT 1`,
+    )
+    .bind(payload.id)
+    .first<{
+      revoked_at: string | null;
+      last_seen_at: string | null;
+      scopes_json: string | null;
+      platform: string | null;
+      app_version: string | null;
+    }>();
+  if (!row || row.revoked_at) return null;
+
+  let scopes: MobileScope[] = DEFAULT_MOBILE_SCOPES;
+  if (row.scopes_json) {
+    try {
+      const parsedScopes = JSON.parse(row.scopes_json);
+      if (Array.isArray(parsedScopes)) {
+        scopes = parsedScopes.filter(
+          (s): s is MobileScope =>
+            s === "receipt:create" ||
+            s === "business_card:create" ||
+            s === "device:heartbeat",
+        );
+      }
+    } catch {
+      // fall through to default scopes
+    }
+  }
+
+  // last_seen_at throttle, same as cookie path.
+  const now = Date.now();
+  const last = row.last_seen_at ? Date.parse(row.last_seen_at) : 0;
+  if (!Number.isFinite(last) || now - last > LAST_SEEN_THROTTLE_MS) {
+    db.prepare(`UPDATE trusted_devices SET last_seen_at = ? WHERE id = ?`)
+      .bind(new Date(now).toISOString(), payload.id)
+      .run()
+      .catch(() => {});
+  }
+
+  return {
+    deviceId: payload.id,
+    actor: payload.actor,
+    scopes,
+    platform: row.platform,
+    appVersion: row.app_version,
+  };
+}
+
+export async function requireMobileActor(
+  headers: Headers,
+  requiredScope: MobileScope,
+): Promise<MobileActor> {
+  const actor = await verifyBearerDevice(headers);
+  if (!actor) {
+    throw new Error("Unauthorized mobile request.");
+  }
+  if (!actor.scopes.includes(requiredScope)) {
+    throw new Error(`Forbidden: missing scope ${requiredScope}`);
+  }
+  return actor;
+}
+
+export async function updateMobileDeviceAppVersion(
+  deviceId: string,
+  appVersion: string,
+): Promise<void> {
+  const db = getReceiptsDb();
+  await db
+    .prepare(`UPDATE trusted_devices SET app_version = ? WHERE id = ?`)
+    .bind(appVersion, deviceId)
+    .run();
 }

--- a/networking-card/migrations/0012_mobile_capture.sql
+++ b/networking-card/migrations/0012_mobile_capture.sql
@@ -1,0 +1,12 @@
+-- CRM Module: mobile business-card capture columns + idempotency
+-- Run: npx wrangler d1 migrations apply CRM_DB [--local]
+
+ALTER TABLE business_card_images_v2 ADD COLUMN device_id TEXT;
+ALTER TABLE business_card_images_v2 ADD COLUMN client_capture_id TEXT;
+ALTER TABLE business_card_images_v2 ADD COLUMN captured_at_client TEXT;
+ALTER TABLE business_card_images_v2 ADD COLUMN upload_origin TEXT;     -- 'web' | 'mobile'
+ALTER TABLE business_card_images_v2 ADD COLUMN source_app_version TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_business_card_mobile_idempotency
+  ON business_card_images_v2(device_id, client_capture_id)
+  WHERE device_id IS NOT NULL AND client_capture_id IS NOT NULL;

--- a/tests/receipts/mobile-pairing.test.ts
+++ b/tests/receipts/mobile-pairing.test.ts
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { isValidPairingCodeShape } from "@/lib/receipts/mobile-pairing";
+
+test("isValidPairingCodeShape: accepts canonical DAZ-XXXX codes", () => {
+  assert.equal(isValidPairingCodeShape("DAZ-7K3M"), true);
+  assert.equal(isValidPairingCodeShape("DAZ-ABCD"), true);
+  assert.equal(isValidPairingCodeShape("DAZ-2345"), true);
+});
+
+test("isValidPairingCodeShape: rejects malformed codes", () => {
+  assert.equal(isValidPairingCodeShape("daz-7k3m"), false, "lowercase rejected");
+  assert.equal(isValidPairingCodeShape("DAZ7K3M"), false, "missing dash rejected");
+  assert.equal(isValidPairingCodeShape("DAZ-7K3"), false, "short body rejected");
+  assert.equal(isValidPairingCodeShape("DAZ-7K3MX"), false, "long body rejected");
+  assert.equal(isValidPairingCodeShape(""), false, "empty rejected");
+  assert.equal(isValidPairingCodeShape("FOO-7K3M"), false, "wrong prefix rejected");
+});


### PR DESCRIPTION
PRD: [`docs/PRD_CaptureApp.md`](docs/PRD_CaptureApp.md) · Architecture: [`docs/PRD_CaptureApp_Architecture.md`](docs/PRD_CaptureApp_Architecture.md)

## Backend — Milestone 1

**Migrations**
- `db/receipts/0015_mobile_devices.sql` — extends `trusted_devices` with `platform`, `app_version`, `scopes_json`; creates `mobile_pairing_codes` (with one-shot `bearer_token` column); adds `device_id` / `client_capture_id` / `captured_at_client` / `upload_origin` to `receipt_records` plus the unique idempotency index.
- `networking-card/migrations/0012_mobile_capture.sql` — same mobile columns + unique idempotency index on `business_card_images_v2`.

**Library additions**
- `lib/receipts/trusted-devices.ts` — `enrollMobileDevice`, `verifyBearerDevice`, `requireMobileActor`; bearer tokens have no fixed expiry, revocation is the only control.
- `lib/receipts/mobile-pairing.ts` — `DAZ-XXXX` code lifecycle. The bearer token is delivered exclusively to the polling iPhone via `/api/mobile/auth/check` and cleared after one read; the browser never sees it.
- `lib/receipts/mobile-upload.ts` — `createMobileReceiptRecord` with a pre-R2 idempotency check (inverts the browser route order so offline-queue retries don't leave R2 orphans).
- `lib/crm.ts` — extracts `insertBatchCard()` from `createBusinessCardBatch` so the admin composite path and the new mobile path share audit / review-task / dedupe logic. Adds `createMobileBusinessCardCapture` that appends to an active event/batch or creates a new one.

**Routes**
- `POST /api/mobile/auth/start-pairing` (public)
- `GET /api/mobile/auth/check?code=…` (public, polling)
- `POST /api/mobile/auth/complete-pairing` (CF Access required, browser)
- `POST /api/mobile/auth/revoke` (Bearer)
- `GET /api/mobile/me` (Bearer)
- `POST /api/mobile/receipts/upload` (Bearer + `receipt:create`)
- `POST /api/mobile/business-cards/upload` (Bearer + `business_card:create`)
- `/receipts/pair` — CF-Access-protected pairing page.

**UI**
- Trusted devices page now surfaces the iPhone/Android badge and app version.

**Tests**
- `tests/receipts/mobile-pairing.test.ts` — pairing-code shape validation. DB-bound paths are exercised end-to-end on the Mac via `cf:dev`.

## iOS scaffold — `ios/DazbeezCapture/`

SwiftUI sources organised by feature: `App`, `Pairing`, `Capture`, `Events`, `Queue`, `Networking`, `Settings`. `APIClient` matches the new backend contract; `KeychainTokenStore` uses `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`. `ActiveEventStore` persists the active event for business-card capture. Capture views and the GRDB-backed queue are stubbed for M2/M3 work. The Xcode project is generated on the Mac (steps in `ios/DazbeezCapture/README.md`).

## Verification

- `npx tsc --noEmit` — clean
- `npm run lint` — clean
- `npm test` — 166/166 pass
- `npm run build:cf` — must run on the Mac (requires `wrangler` credentials per `AGENTS.md`)

## User setup required (Mac)

1. `npx wrangler d1 migrations apply RECEIPTS_DB` (local + remote)
2. `npx wrangler d1 migrations apply CRM_DB` (local + remote)
3. Confirm `RECEIPTS_DEVICE_SECRET` is set in the Worker (≥32 chars) — same secret already used by browser device cookies.
4. Ensure the Cloudflare Access policy covering `/receipts/*` also covers `/receipts/pair`.
5. `npm run build:cf` then `npm run deploy`.
6. Smoke-test pairing: `curl -X POST .../api/mobile/auth/start-pairing` → visit `/receipts/pair?code=DAZ-…` → poll `/check` and verify a bearer token is returned exactly once.
7. Generate the Xcode project under `ios/DazbeezCapture/` per its `README.md`, add GRDB via SPM, configure capabilities (Background Modes, Keychain Sharing), set `NSCameraUsageDescription`, and submit to TestFlight.

Non-goals carried over from the PRD: no in-app review, categorization, AMEX reconciliation, exports, contact enrichment, or tax determinations.

---
_Generated by [Claude Code](https://claude.ai/code/session_013bdJLBskUzKdqPZdUFoasc)_