### PR TITLE
docs: sync AGENTS.md with codebase; fix stale /inquiry links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,17 +13,45 @@ Dazbeez is a Next.js 16.2.3 website for AI, Automation & Data consulting service
 - **Local Reference Runtime:** Docker Compose on Mac M4
 - **Optional LLM:** Ollama for chatbot enhancement
 
+### Cloudflare Bindings (`wrangler.jsonc`)
+
+| Binding | Type | Backs |
+|---------|------|-------|
+| `DB` | D1 (`dazbeez-submissions`) | Public contact-form submissions |
+| `CRM_DB` | D1 (`dazbeez-networking`) | CRM / networking data |
+| `RECEIPTS_DB` | D1 (`dazbeez-receipts`) | Receipts module (`migrations_dir: db/receipts`) |
+| `CRM_IMAGES` | R2 (`dazbeez-crm-images`) | CRM card/contact images |
+| `RECEIPTS_BUCKET` | R2 (`dazbeez-receipts`) | Receipt files |
+| `RECEIPTS_ARCHIVE_BUCKET` | R2 (`dazbeez-receipts-archive`) | Archived receipts |
+| `AI` | Workers AI | Extraction / LLM tasks |
+| `ASSETS` · `WORKER_SELF_REFERENCE` | Worker | OpenNext asset serving + self-reference |
+
+> Secrets (`RESEND_API_KEY`, `GOOGLE_CLOUD_VISION_API_KEY`) are set via `wrangler secret put`, not committed.
+
 ## Key Conventions
 
 ### File Structure (App Router)
 ```
-app/
+app/                    # Routes, layouts, and API handlers (App Router)
 ├── layout.tsx          # Root layout (no _app.tsx or _document.tsx)
 ├── page.tsx            # Home page (root route)
 ├── globals.css         # Global styles (Tailwind)
 ├── [dynamic]/          # Dynamic routes use [bracket] syntax
+├── (receipt-system)/   # Route group for the receipts UI
+├── admin/              # Internal admin console (noindex)
+├── api/                # Route handlers (contact, receipts, mobile, nfc, vcard)
 └── .../
+components/             # Shared React components (all "use client" UI lives here)
+├── ui/                 # Primitives (btn, card, field, ...)
+├── receipts/           # Receipts-specific components
+└── admin/              # Admin console components
+lib/                    # Non-component logic (services, CRM, receipts, helpers)
+└── receipts/           # Receipts domain logic
+db/receipts/            # D1 SQL migrations for the receipts DB
 ```
+
+> Interactive components are isolated under `components/`; route files in `app/`
+> stay server components by default and import client components from there.
 
 ### Styling Guidelines
 - Use bee colors: `amber-500` (#F59E0B) primary, `gray-900` (#111827) dark
@@ -38,6 +66,9 @@ app/
 - Use `Image` from `next/image` for optimized images
 
 ### Routes
+
+**Public marketing site**
+
 | Route | Purpose |
 |-------|---------|
 | `/` | Landing page |
@@ -46,7 +77,23 @@ app/
 | `/contact` | Contact form (accepts `?service=<slug>` to preselect) |
 | `/business-card` | Explainer for the NFC card |
 | `/nfc` | NFC micro-page (widget-style) |
+| `/about` | About page |
+| `/case-studies` · `/case-studies/[slug]` | Case studies list + detail |
+| `/privacy-policy` · `/terms-of-service` | Legal pages |
+
+**API & internal**
+
+| Route | Purpose |
+|-------|---------|
 | `/api/contact` | POST endpoint for contact submissions (D1 persistence) |
+| `/api/receipts/*` | Receipts capture, extract, reconcile, export, devices, compliance |
+| `/api/mobile/*` | Mobile pairing/auth + receipt & business-card uploads |
+| `/api/nfc/hit` · `/api/vcard` | NFC tap tracking + vCard download |
+| `/admin/*` | Internal admin console (CRM, batches, review) — `noindex` |
+| `/.well-known/security.txt` | Security contact disclosure |
+
+> The receipts UI itself lives under the `(receipt-system)` route group — see
+> the Receipts Module section below.
 
 > `/inquiry` has been retired and 308-redirects to `/contact`.
 

--- a/networking-card/functions/hi/[token].ts
+++ b/networking-card/functions/hi/[token].ts
@@ -118,7 +118,7 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
 
     <div class="footer-links">
       <a href="https://dazbeez.com/services">What I do</a>
-      <a href="https://dazbeez.com/inquiry">Start an inquiry</a>
+      <a href="https://dazbeez.com/contact">Start an inquiry</a>
       <a href="https://dazbeez.com/business-card">About this card</a>
     </div>
 

--- a/networking-card/functions/thanks.ts
+++ b/networking-card/functions/thanks.ts
@@ -71,7 +71,7 @@ export const onRequestGet: PagesFunction<{ DB: D1Database }> = async (context) =
       <a href="/vcard/${contactIdParam}" class="btn btn-amber" download="${vcardProfile.fileName}" data-vcard-download>Save my contact</a>
       <a href="https://www.linkedin.com/in/david-klan" target="_blank" rel="noopener" class="btn btn-linkedin">Connect with me on LinkedIn</a>
       <a href="https://dazbeez.com/services" class="btn btn-outline">What I do</a>
-      <a href="https://dazbeez.com/inquiry" class="btn btn-outline">Start an inquiry</a>
+      <a href="https://dazbeez.com/contact" class="btn btn-outline">Start an inquiry</a>
     </div>
 
     <p class="subcopy">A later tap can take you straight back into services, questions, follow-up, or my LinkedIn profile when the need is clearer.</p>


### PR DESCRIPTION
## Summary

Fixes the documentation drift and stale links surfaced by a codebase/docs audit. No application code behavior changes — these are doc and static-link corrections.

### Docs (`AGENTS.md`)
- **File structure** now includes `components/` (where all `"use client"` UI lives), `lib/`, the `(receipt-system)` route group, `admin/`, `api/`, and `db/receipts/`.
- **Routes table** split into *Public marketing site* and *API & internal*, adding previously undocumented routes: `/about`, `/case-studies` (+ `[slug]`), `/privacy-policy`, `/terms-of-service`, `/api/receipts/*`, `/api/mobile/*`, `/api/nfc/hit`, `/api/vcard`, `/admin/*`, and `/.well-known/security.txt`.
- **Cloudflare bindings** table added, documenting the full `wrangler.jsonc` set (`DB`, `CRM_DB`, `RECEIPTS_DB`, `CRM_IMAGES`, `RECEIPTS_BUCKET`, `RECEIPTS_ARCHIVE_BUCKET`, `AI`, `ASSETS`, `WORKER_SELF_REFERENCE`) — previously only the receipts subset was named.

### Stale links
- `networking-card/functions/thanks.ts` and `networking-card/functions/hi/[token].ts` linked to the retired `https://dazbeez.com/inquiry`. Repointed to `/contact` to avoid an unnecessary 308 redirect hop. (The redirect rule in `next.config.ts` stays as the safety net for any external links.)

## Verification
- `tsc --noEmit` ✅ · `eslint` ✅ · tests ✅ 164/164 (run during the audit prior to these doc-only changes)
- Only remaining `/inquiry` reference is the redirect *source* in `next.config.ts`, which is intentional.

https://claude.ai/code/session_01665TfuMDEGKFvcnHV6JHx1

---
_Generated by [Claude Code](https://claude.ai/code/session_01665TfuMDEGKFvcnHV6JHx1)_