### PR TITLE
feat(receipts): store-and-forward extraction — Queue + Mac MLX (ADR 0001)

### DIFF
--- a/app/api/receipts/[id]/extract/route.ts
+++ b/app/api/receipts/[id]/extract/route.ts
@@ -1,26 +1,55 @@
 import { NextResponse } from "next/server";
 import { requireReceiptsActor } from "@/lib/receipts/auth";
 import { getReceiptRecord, updateReceiptRecord } from "@/lib/receipts/db";
-import { getReceiptFile } from "@/lib/receipts/storage";
-import { extractReceiptData } from "@/lib/receipts/extraction";
+import {
+  buildGuardedExtraction,
+  type ModelExtractionFields,
+} from "@/lib/receipts/extraction";
 import { createAuditEntry } from "@/lib/receipts/audit";
 import { nowIso, stringifyJson } from "@/lib/receipts/db-utils";
-import { getReceiptsDb } from "@/lib/cloudflare-runtime";
-import { MAX_RECEIPT_FILE_BYTES } from "@/lib/receipts/validation";
-
-const EXTRACTION_MAX_BYTES = MAX_RECEIPT_FILE_BYTES;
+import { getReceiptsDb, getReceiptsProcessorKey } from "@/lib/cloudflare-runtime";
+import type { ExtractionResult } from "@/lib/receipts/types";
 
 type RouteContext = { params: Promise<{ id: string }> };
 
+const PROCESSOR_ACTOR = "mlx-consumer@mac";
+
+interface ApplyBody {
+  /** OCR text produced by the Mac MLX model. Authoritative source of fields. */
+  rawText?: string;
+  /** Optional structured fields the model emitted alongside the OCR text. */
+  fields?: ModelExtractionFields;
+  /** Provider/model label for audit + provenance, e.g. "mlx_local:qwen2-vl-7b". */
+  model?: string;
+}
+
+/**
+ * Apply an extraction result to a receipt (ADR 0001).
+ *
+ * Two callers:
+ *  - The Mac MLX consumer posts `{ rawText, fields, model }` with the processor
+ *    key header. The Worker runs the regex guardrail over the model output,
+ *    merges fields, advances captured → needs_review, and acks via 200.
+ *  - A human "reprocess" (`?force=true`) with no body re-runs the regex parser
+ *    over the OCR text already stored in extraction_json — Vision-free, exactly
+ *    like scripts/reprocess-extraction.ts. No OCR runs in the Worker anymore.
+ */
 export async function POST(request: Request, { params }: RouteContext) {
   try {
-    const actor = await requireReceiptsActor(request.headers);
-    const { id } = await params;
+    // Auth: the Mac consumer authenticates with a shared processor key; humans
+    // go through CF Access / basic auth as before.
+    const processorKey = getReceiptsProcessorKey();
+    const presentedKey = request.headers.get("x-receipts-processor-key");
+    const isProcessor = Boolean(processorKey) && presentedKey === processorKey;
+    const actor = isProcessor
+      ? PROCESSOR_ACTOR
+      : await requireReceiptsActor(request.headers);
 
-    // Reprocess mode: `?force=true` re-runs extraction and overwrites
-    // machine-set fields, but ONLY on receipts not yet reviewed
-    // (captured / needs_review). Reviewed+ receipts are never overwritten.
-    const force = new URL(request.url).searchParams.get("force") === "true";
+    const { id } = await params;
+    const url = new URL(request.url);
+    const force = url.searchParams.get("force") === "true";
+
+    const body = (await request.json().catch(() => null)) as ApplyBody | null;
 
     const receipt = await getReceiptRecord(id);
     const db = getReceiptsDb();
@@ -36,7 +65,8 @@ export async function POST(request: Request, { params }: RouteContext) {
       return NextResponse.json({ error: "Receipt not found." }, { status: 404 });
     }
 
-    if (receipt.status === "exported" || receipt.status === "archived") {
+    // Reviewed-and-beyond receipts are never machine-overwritten.
+    if (receipt.status !== "captured" && receipt.status !== "needs_review") {
       await createAuditEntry(db, {
         actor,
         action: "receipt.extraction_denied",
@@ -50,24 +80,31 @@ export async function POST(request: Request, { params }: RouteContext) {
       );
     }
 
-    if (receipt.original_size_bytes > EXTRACTION_MAX_BYTES) {
+    // Resolve the OCR text: fresh from the model, else the text already stored.
+    let rawText = body?.rawText?.trim() || "";
+    if (!rawText && receipt.extraction_json) {
+      try {
+        const prior = JSON.parse(receipt.extraction_json) as Partial<ExtractionResult>;
+        rawText = (prior.rawText ?? "").trim();
+      } catch {
+        /* ignore malformed prior extraction */
+      }
+    }
+
+    if (!rawText) {
       await createAuditEntry(db, {
         actor,
         action: "receipt.extraction_denied",
         objectType: "receipt",
         objectId: id,
-        newValueJson: stringifyJson({
-          reason: "file_too_large",
-          sizeBytes: receipt.original_size_bytes,
-          limitBytes: EXTRACTION_MAX_BYTES,
-        }),
+        newValueJson: stringifyJson({ reason: "no_ocr_text" }),
       });
       return NextResponse.json(
         {
           error:
-            "Receipt image is too large for OCR extraction (max 5 MB). Please resize and re-upload.",
+            "No OCR text to apply. The Mac MLX consumer must post rawText, or a prior extraction must exist to reprocess.",
         },
-        { status: 413 },
+        { status: 422 },
       );
     }
 
@@ -76,55 +113,34 @@ export async function POST(request: Request, { params }: RouteContext) {
       action: "receipt.extraction_requested",
       objectType: "receipt",
       objectId: id,
-      newValueJson: stringifyJson({ sizeBytes: receipt.original_size_bytes }),
+      newValueJson: stringifyJson({ via: isProcessor ? "mlx_consumer" : "reprocess" }),
     });
 
-    const file = await getReceiptFile(receipt.original_r2_key);
-    if (!file) {
-      return NextResponse.json({ error: "Receipt file not found in storage." }, { status: 404 });
-    }
+    const provider = body?.model || (isProcessor ? "mlx_local" : "regex_reprocess");
+    const { result, discrepancies } = buildGuardedExtraction(
+      rawText,
+      body?.fields ?? {},
+      provider,
+    );
 
-    const reader = file.body.getReader();
-    const chunks: Uint8Array[] = [];
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      if (value) chunks.push(value);
-    }
-    const totalLength = chunks.reduce((acc, c) => acc + c.length, 0);
-    const imageBytes = new Uint8Array(totalLength);
-    let offset = 0;
-    for (const chunk of chunks) {
-      imageBytes.set(chunk, offset);
-      offset += chunk.length;
-    }
-
-    let result;
-    try {
-      result = await extractReceiptData(imageBytes, file.contentType);
-    } catch (extractionError) {
-      await createAuditEntry(db, {
-        actor,
-        action: "receipt.extraction_failed",
-        objectType: "receipt",
-        objectId: id,
-        newValueJson: stringifyJson({
-          error: extractionError instanceof Error ? extractionError.message : String(extractionError),
-        }),
-      });
-      throw extractionError;
-    }
-
-    // Default: only populate fields that are currently empty — never overwrite
-    // confirmed data. With `force` on a pre-review receipt, re-extracted values
-    // replace earlier machine guesses (e.g. a bad merchant from a noisy photo).
-    const reprocessable = receipt.status === "captured" || receipt.status === "needs_review";
-    const overwrite = force && reprocessable;
-    const canSet = (current: unknown) => overwrite || current === null || current === undefined || current === "";
+    // Field-merge: by default only fill empty fields (never clobber confirmed
+    // data). `force` on a pre-review receipt replaces earlier machine guesses.
+    const overwrite = force; // status already guaranteed captured/needs_review
+    const canSet = (current: unknown) =>
+      overwrite || current === null || current === undefined || current === "";
 
     const updates: Parameters<typeof updateReceiptRecord>[1] = {
-      extractionJson: JSON.stringify(result),
+      extractionJson: JSON.stringify({ ...result, discrepancies }),
+      extractionState: "processed",
+      extractionProcessedAt: nowIso(),
+      extractionProcessor: provider,
+      extractionAttempts: (receipt.extraction_attempts ?? 0) + 1,
     };
+
+    // A captured receipt becomes review-ready once the model has run.
+    if (receipt.status === "captured") {
+      updates.status = "needs_review";
+    }
 
     if (canSet(receipt.transaction_date) && result.transactionDate) {
       updates.transactionDate = result.transactionDate;
@@ -138,9 +154,6 @@ export async function POST(request: Request, { params }: RouteContext) {
     if (result.currency && receipt.currency === "JPY") {
       updates.currency = result.currency;
     }
-    if ((overwrite || receipt.expense_type === "UNKNOWN") && result.expenseType) {
-      updates.expenseType = result.expenseType;
-    }
     if (canSet(receipt.business_purpose) && result.businessPurpose) {
       updates.businessPurpose = result.businessPurpose;
     }
@@ -150,7 +163,10 @@ export async function POST(request: Request, { params }: RouteContext) {
     if (canSet(receipt.tax_rate) && result.taxRate) {
       updates.taxRate = result.taxRate;
     }
-    if (canSet(receipt.invoice_registration_number) && result.invoiceRegistrationNumber) {
+    if (
+      canSet(receipt.invoice_registration_number) &&
+      result.invoiceRegistrationNumber
+    ) {
       updates.invoiceRegistrationNumber = result.invoiceRegistrationNumber;
     }
 
@@ -161,10 +177,13 @@ export async function POST(request: Request, { params }: RouteContext) {
       action: "receipt.extraction_completed",
       objectType: "receipt",
       objectId: id,
-      newValueJson: stringifyJson({ provider: result.provider }),
+      newValueJson: stringifyJson({ provider, discrepancies }),
     });
 
-    return NextResponse.json({ ok: true, extracted: result, extractedAt: nowIso() }, { status: 200 });
+    return NextResponse.json(
+      { ok: true, extracted: result, discrepancies, extractedAt: nowIso() },
+      { status: 200 },
+    );
   } catch (error) {
     if (error instanceof Error && error.message.startsWith("Unauthorized")) {
       return NextResponse.json({ error: "Unauthorized." }, { status: 401 });

--- a/app/api/receipts/reconcile/finalize/route.ts
+++ b/app/api/receipts/reconcile/finalize/route.ts
@@ -9,10 +9,13 @@ import {
   listAmexLineAttendeeNamesByMonth,
   listAmexLines,
   listAttendees,
+  listReceiptRecords,
   listReceiptRecordsByIds,
 } from "@/lib/receipts/db";
 import { hashCsvContent } from "@/lib/receipts/export";
 import { buildReconciliationManifestCsv, validateAmexLinesForSignoff } from "@/lib/receipts/reconciliation-signoff";
+import { deriveStatementWindow, isReceiptInWindow } from "@/lib/receipts/statement-window";
+import { isPendingProcessing } from "@/lib/receipts/extraction-state";
 import { archiveManifest, deleteArchiveObject } from "@/lib/receipts/storage";
 
 export async function POST(request: Request) {
@@ -42,6 +45,29 @@ export async function POST(request: Request) {
       return NextResponse.json(
         { error: `No AMEX lines found for ${month}.` },
         { status: 400 },
+      );
+    }
+
+    // ADR 0001 — hard gate: a period cannot be finalized while the extraction
+    // queue still holds unprocessed receipts for its window. "Drain the queue
+    // before close" is enforced, not advice. A captured-but-unprocessed receipt
+    // has no field key yet, so it cannot be matched — without this gate a queue
+    // backlog masquerades as missing receipts. Captured receipts have no date
+    // yet, so isReceiptInWindow treats them as in-window (conservative).
+    const window = deriveStatementWindow(amexLines, month);
+    const capturedReceipts = await listReceiptRecords({ status: "captured", limit: 1000 });
+    const pendingInWindow = capturedReceipts.filter(
+      (r) => isPendingProcessing(r) && isReceiptInWindow(r, window),
+    );
+    if (pendingInWindow.length > 0) {
+      return NextResponse.json(
+        {
+          error:
+            `Cannot finalize ${month}: ${pendingInWindow.length} receipt(s) are still pending extraction. ` +
+            `Run the Mac MLX consumer to drain the queue, then retry.`,
+          pendingProcessing: pendingInWindow.length,
+        },
+        { status: 409 },
       );
     }
 

--- a/app/api/receipts/upload/route.ts
+++ b/app/api/receipts/upload/route.ts
@@ -2,8 +2,9 @@ import { NextResponse } from "next/server";
 import { requireReceiptsActor } from "@/lib/receipts/auth";
 import { validateReceiptFile } from "@/lib/receipts/validation";
 import { generateR2Key, uploadOriginal } from "@/lib/receipts/storage";
-import { createReceiptRecord } from "@/lib/receipts/db";
+import { createReceiptRecord, updateReceiptRecord } from "@/lib/receipts/db";
 import { createReceiptFile } from "@/lib/receipts/files";
+import { buildExtractionJob, enqueueExtractionJob } from "@/lib/receipts/queue";
 import { getReceiptsBucket, getReceiptsDb } from "@/lib/cloudflare-runtime";
 import type { PaymentPath, SourceType } from "@/lib/receipts/types";
 
@@ -94,6 +95,10 @@ export async function POST(request: Request) {
           originalSha256: sha256,
           originalContentType: contentType,
           originalSizeBytes: file.size,
+          // ADR 0001: capture path is async store-and-forward. The receipt lands
+          // as 'captured' (pending processing) and an extraction job is enqueued
+          // for the Mac MLX consumer to drain. No AI runs in the Worker.
+          status: "captured",
         },
         actor,
       );
@@ -128,11 +133,33 @@ export async function POST(request: Request) {
       console.error("[receipts/upload] file manifest write failed", fileError);
     }
 
+    // ADR 0001: enqueue the extraction job. Best-effort — if the queue binding
+    // is missing or send fails, the receipt remains at status='captured' /
+    // extraction_state='captured' and a backfill can enqueue it later. Capture
+    // must never fail because the queue is unavailable.
+    const enqueuedAt = new Date().toISOString();
+    const enqueued = await enqueueExtractionJob(
+      buildExtractionJob({ receiptId, r2Key, contentType, enqueuedAt }),
+    );
+    if (enqueued) {
+      try {
+        await updateReceiptRecord(
+          receiptId,
+          { extractionState: "queued", extractionEnqueuedAt: enqueuedAt },
+          actor,
+        );
+      } catch (markError) {
+        console.error("[receipts/upload] mark-queued failed", markError);
+      }
+    }
+
     return NextResponse.json(
       {
         ok: true,
         receiptId,
-        status: "needs_review",
+        status: "captured",
+        extractionState: enqueued ? "queued" : "captured",
+        pendingProcessing: true,
         sourceType,
         reviewUrl: `/receipts/review/${receiptId}`,
       },

--- a/components/receipts/capture/capture-mobile.tsx
+++ b/components/receipts/capture/capture-mobile.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useRef, useState, type ChangeEvent } from "react";
+import { useRef, useState, type ChangeEvent } from "react";
 import { Btn } from "@/components/ui/btn";
 import { Pill } from "@/components/ui/pill";
-import { ArrowRightIcon, CameraIcon, CheckIcon, PlusIcon } from "@/components/ui/icons";
+import { CameraIcon, CheckIcon, PlusIcon } from "@/components/ui/icons";
 import { BeeMark } from "@/components/receipts/ui/bee-mark";
 import { ReceiptThumb } from "@/components/receipts/ui/receipt-thumb";
 import type { PaymentPath } from "@/lib/receipts/types";
@@ -52,9 +52,8 @@ export function CaptureMobile(props: CaptureMobileProps) {
       ) : props.phase.kind === "saved" ? (
         <CaptureSavedMobile
           phase={props.phase}
-          rapidMode={props.rapidMode}
-          onAddAnother={props.onReset}
-          onRetake={pickFile}
+          onCaptureNext={pickFile}
+          onDone={props.onReset}
         />
       ) : (
         <CaptureIdleMobile
@@ -96,7 +95,8 @@ function CaptureIdleMobile({
           just pay for?
         </h2>
         <p className="mt-2 max-w-[280px] text-sm text-gray-500">
-          Snap the receipt. We&rsquo;ll OCR it and you can fix anything tonight.
+          Snap it and keep going. We&rsquo;ll read each one during processing —
+          review later.
         </p>
 
         <div className="mt-5 flex flex-1 items-center justify-center">
@@ -252,7 +252,7 @@ function CaptureUploadingMobile({
         </div>
         <div className="mt-1 text-sm font-semibold">Uploading…</div>
         <div className="text-[11.5px] text-white/55">
-          resized from HEIC · running OCR
+          resized from HEIC · queued for processing
         </div>
       </div>
 
@@ -276,116 +276,57 @@ function CaptureUploadingMobile({
 
 function CaptureSavedMobile({
   phase,
-  rapidMode,
-  onAddAnother,
-  onRetake,
+  onCaptureNext,
+  onDone,
 }: {
   phase: Extract<CapturePhase, { kind: "saved" }>;
-  rapidMode: boolean;
-  onAddAnother: () => void;
-  onRetake: () => void;
+  onCaptureNext: () => void;
+  onDone: () => void;
 }) {
-  const elapsedMs = useElapsedMs(phase.capturedAt);
-  const elapsedLabel =
-    phase.ocrStatus === "done"
-      ? `OCR done in ${Math.max(0.1, elapsedMs / 1000).toFixed(1)}s`
-      : phase.ocrStatus === "running"
-        ? "OCR running…"
-        : phase.ocrStatus === "timeout"
-          ? "OCR still working — finish it on review"
-          : "OCR failed — finish manually";
-
-  const e = phase.extracted;
-  const merchant = e?.merchant ?? "Receipt saved";
-  const amountLabel = e?.amount
-    ? `${e.currency === "JPY" || !e.currency ? "¥" : ""}${e.amount.toLocaleString()}`
-    : "—";
-
+  // ADR 0001: extraction is deferred to the queue. There is nothing to review
+  // here — just confirm the capture and re-arm for the next shot.
   return (
     <>
-      <MobileHeader queueCount={null} label="Saved" />
+      <MobileHeader queueCount={null} label="Captured" />
 
-      <div className="flex flex-1 flex-col px-5 pt-5">
-        <div className="mt-1 flex items-center gap-3.5">
-          <div className="flex h-12 w-12 items-center justify-center rounded-full bg-green-500 shadow-[0_6px_16px_rgba(16,185,129,0.35)]">
-            <CheckIcon size={28} className="text-white" />
-          </div>
-          <div>
-            <div className="text-[19px] font-bold leading-[1.1] text-gray-900">
-              Saved.
-            </div>
-            <div className="mt-0.5 text-xs text-gray-500">
-              {phase.receiptId.slice(0, 8)}… · {elapsedLabel}
-            </div>
-          </div>
+      <div className="flex flex-1 flex-col items-center px-5 pt-10 text-center">
+        <div className="flex h-16 w-16 items-center justify-center rounded-full bg-green-500 shadow-[0_8px_20px_rgba(16,185,129,0.35)]">
+          <CheckIcon size={34} className="text-white" />
         </div>
+        <div className="mt-4 text-[22px] font-bold leading-[1.1] text-gray-900">
+          Captured.
+        </div>
+        <div className="mt-2 flex items-center gap-2">
+          <Pill tone="amber" size="sm" dot>
+            Pending processing
+          </Pill>
+          <span className="text-xs text-gray-400">
+            {phase.receiptId.slice(0, 8)}…
+          </span>
+        </div>
+        <p className="mt-3 max-w-[260px] text-sm text-gray-500">
+          Saved to the queue. We&rsquo;ll read it during processing — review and
+          fix anything later.
+        </p>
 
-        <div className="mt-4 overflow-hidden rounded-2xl border border-gray-200 bg-white">
-          <div className="flex gap-3 border-b border-gray-150 p-3.5">
-            <ReceiptThumb
-              size={56}
-              merchant={merchant.slice(0, 12)}
-              amount={amountLabel}
-            />
-            <div className="min-w-0 flex-1">
-              <div className="flex items-center gap-1.5">
-                <span className="text-[11px] font-semibold uppercase tracking-[0.05em] text-gray-400">
-                  What we read
-                </span>
-                {phase.ocrStatus === "done" ? (
-                  <Pill tone="green" size="sm" dot>
-                    OCR ready
-                  </Pill>
-                ) : phase.ocrStatus === "running" ? (
-                  <Pill tone="amber" size="sm" dot>
-                    OCR…
-                  </Pill>
-                ) : (
-                  <Pill tone="gray" size="sm">
-                    pending
-                  </Pill>
-                )}
-              </div>
-              <div className="mt-1 text-[15px] font-semibold text-gray-900">
-                {merchant}
-              </div>
-              <div className="text-lg font-bold tabular-nums text-gray-900">
-                {amountLabel}
-              </div>
-            </div>
-          </div>
-          <ul className="flex flex-col gap-1.5 p-3">
-            <OcrChipRow label="Merchant" value={e?.merchant ?? null} />
-            <OcrChipRow label="Date" value={e?.transactionDate ?? null} />
-            <OcrChipRow label="Amount" value={amountLabel === "—" ? null : amountLabel} />
-            <OcrChipRow label="Expense type" value={e?.expenseType ?? null} suggest />
-          </ul>
+        <div className="mt-6 flex w-[120px] justify-center">
+          <ReceiptThumb size={96} merchant="Receipt" amount="—" />
         </div>
 
         <div className="flex-1" />
-        <div className="flex flex-col gap-2 pb-28">
-          {rapidMode ? (
-            <Btn
-              kind="primary"
-              size="lg"
-              full
-              rightIcon={<ArrowRightIcon size={16} className="text-white" />}
-              onClick={onAddAnother}
-            >
-              Add another
-            </Btn>
-          ) : (
-            <Link
-              href={phase.reviewUrl}
-              className="inline-flex h-11 w-full items-center justify-center gap-2 rounded-lg bg-amber-500 px-5 text-sm font-semibold text-white hover:bg-amber-600"
-            >
-              Review now
-              <ArrowRightIcon size={16} className="text-white" />
-            </Link>
-          )}
+        <div className="flex w-full flex-col gap-2.5 pb-28">
+          <Btn
+            kind="primary"
+            size="lg"
+            full
+            leftIcon={<CameraIcon size={18} className="text-white" />}
+            onClick={onCaptureNext}
+          >
+            Capture next
+          </Btn>
           <div className="flex gap-2">
-            <Btn kind="ghost" size="md" className="flex-1" onClick={onRetake}>
-              Retake
+            <Btn kind="ghost" size="md" className="flex-1" onClick={onDone}>
+              Done
             </Btn>
             <Link
               href={phase.reviewUrl}
@@ -400,56 +341,7 @@ function CaptureSavedMobile({
   );
 }
 
-function OcrChipRow({
-  label,
-  value,
-  suggest,
-}: {
-  label: string;
-  value: string | null;
-  suggest?: boolean;
-}) {
-  return (
-    <li className="flex items-center gap-2 px-1 py-1.5 text-[12.5px]">
-      <span className="w-[72px] text-gray-500">{label}</span>
-      <span
-        className={[
-          "flex-1 truncate tabular-nums",
-          value
-            ? suggest
-              ? "font-medium text-amber-700"
-              : "font-semibold text-gray-900"
-            : "text-gray-400",
-        ].join(" ")}
-      >
-        {value ?? "—"}
-      </span>
-      {value && !suggest ? (
-        <span className="h-1.5 w-1.5 rounded-full bg-green-500" />
-      ) : value && suggest ? (
-        <span className="text-[11px] font-semibold text-amber-700">
-          tap to confirm
-        </span>
-      ) : null}
-    </li>
-  );
-}
-
 // ─── Header & nav ──────────────────────────────────────────────────
-
-function useElapsedMs(startMs: number): number {
-  const [now, setNow] = useState<number>(startMs);
-  useEffect(() => {
-    const tick = () => setNow(Date.now());
-    const initial = setTimeout(tick, 0);
-    const interval = setInterval(tick, 1000);
-    return () => {
-      clearTimeout(initial);
-      clearInterval(interval);
-    };
-  }, [startMs]);
-  return Math.max(0, now - startMs);
-}
 
 function MobileHeader({
   queueCount,

--- a/components/receipts/capture/use-receipt-upload.ts
+++ b/components/receipts/capture/use-receipt-upload.ts
@@ -4,29 +4,16 @@ import { useCallback, useRef, useState } from "react";
 import { maybeResizeImage } from "@/lib/receipts/client-image";
 import type { PaymentPath } from "@/lib/receipts/types";
 
-export type CaptureExtraction = {
-  merchant?: string | null;
-  amount?: number | null;
-  currency?: string | null;
-  transactionDate?: string | null;
-  expenseType?: string | null;
-};
+// ADR 0001: extraction is store-and-forward. Capture no longer runs OCR inline
+// — the image is uploaded, enqueued, and processed later by the Mac MLX
+// consumer. So the capture client just confirms "captured (pending processing)"
+// and re-arms for the next shot; there is nothing to review here.
 
 export type CapturePhase =
   | { kind: "idle" }
   | { kind: "uploading"; pct: number; fileName: string; fileSizeBytes: number }
-  | {
-      kind: "saved";
-      receiptId: string;
-      reviewUrl: string;
-      ocrStatus: "running" | "done" | "timeout" | "error";
-      extracted?: CaptureExtraction;
-      capturedAt: number;
-    }
+  | { kind: "saved"; receiptId: string; reviewUrl: string; capturedAt: number }
   | { kind: "error"; message: string };
-
-const OCR_POLL_INTERVAL_MS = 800;
-const OCR_TIMEOUT_MS = 12_000;
 
 export function useReceiptUpload() {
   const [phase, setPhase] = useState<CapturePhase>({ kind: "idle" });
@@ -75,19 +62,13 @@ export function useReceiptUpload() {
           return;
         }
 
-        const receiptId = json.receiptId;
-        const reviewUrl = json.reviewUrl ?? `/receipts/review/${receiptId}`;
-
+        // Captured and enqueued. Done — extraction happens later in the queue.
         setPhase({
           kind: "saved",
-          receiptId,
-          reviewUrl,
-          ocrStatus: "running",
+          receiptId: json.receiptId,
+          reviewUrl: json.reviewUrl ?? `/receipts/review/${json.receiptId}`,
           capturedAt: Date.now(),
         });
-
-        // Fire-and-poll OCR. Best-effort; UI degrades to "no preview" if it doesn't land in time.
-        void runOcrAndPoll(receiptId, reviewUrl, abort.signal, setPhase);
       } catch (error) {
         if ((error as DOMException | undefined)?.name === "AbortError") return;
         setPhase({
@@ -113,84 +94,4 @@ export function useReceiptUpload() {
   }, []);
 
   return { phase, upload, reset, cancel };
-}
-
-async function runOcrAndPoll(
-  receiptId: string,
-  reviewUrl: string,
-  signal: AbortSignal,
-  setPhase: (next: CapturePhase) => void,
-) {
-  try {
-    await fetch(`/api/receipts/${receiptId}/extract`, {
-      method: "POST",
-      signal,
-    });
-  } catch {
-    // ignore; we still poll the record
-  }
-
-  const started = Date.now();
-  while (!signal.aborted) {
-    if (Date.now() - started > OCR_TIMEOUT_MS) {
-      setPhase({
-        kind: "saved",
-        receiptId,
-        reviewUrl,
-        ocrStatus: "timeout",
-        capturedAt: started,
-      });
-      return;
-    }
-    try {
-      const res = await fetch(`/api/receipts/${receiptId}`, { signal });
-      if (res.ok) {
-        const data = (await res.json()) as {
-          receipt?: {
-            merchant?: string | null;
-            amount_minor?: number | null;
-            currency?: string | null;
-            transaction_date?: string | null;
-            expense_type?: string | null;
-            extraction_json?: string | null;
-          };
-        };
-        const r = data.receipt;
-        if (r && (r.merchant || r.amount_minor || r.extraction_json)) {
-          setPhase({
-            kind: "saved",
-            receiptId,
-            reviewUrl,
-            ocrStatus: "done",
-            capturedAt: started,
-            extracted: {
-              merchant: r.merchant ?? null,
-              amount: r.amount_minor ?? null,
-              currency: r.currency ?? null,
-              transactionDate: r.transaction_date ?? null,
-              expenseType: r.expense_type ?? null,
-            },
-          });
-          return;
-        }
-      }
-    } catch {
-      // network blip; retry until timeout
-    }
-    await wait(OCR_POLL_INTERVAL_MS, signal);
-  }
-}
-
-function wait(ms: number, signal: AbortSignal): Promise<void> {
-  return new Promise((resolve) => {
-    const timer = setTimeout(resolve, ms);
-    signal.addEventListener(
-      "abort",
-      () => {
-        clearTimeout(timer);
-        resolve();
-      },
-      { once: true },
-    );
-  });
 }

--- a/components/receipts/receipt-capture-form.tsx
+++ b/components/receipts/receipt-capture-form.tsx
@@ -168,19 +168,13 @@ function applyPhaseToUpload(
     return { ...u, state: "uploading", pct: phase.pct };
   }
   if (phase.kind === "saved") {
-    const e = phase.extracted;
-    const amountLabel =
-      e?.amount != null
-        ? `${e.currency === "JPY" || !e.currency ? "¥" : ""}${e.amount.toLocaleString()}`
-        : "";
+    // ADR 0001: captured + enqueued. No OCR fields yet — extraction happens
+    // later in the queue, so the row shows as captured/ready with no preview.
     return {
       ...u,
-      state: phase.ocrStatus === "done" ? "ready" : "review",
+      state: "ready",
       pct: 100,
       receiptId: phase.receiptId,
-      merchant: e?.merchant ?? undefined,
-      amount: amountLabel || undefined,
-      date: e?.transactionDate ?? undefined,
     };
   }
   if (phase.kind === "error") {

--- a/db/receipts/0016_extraction_queue.sql
+++ b/db/receipts/0016_extraction_queue.sql
@@ -1,0 +1,37 @@
+-- 0016_extraction_queue.sql
+--
+-- ADR 0001: store-and-forward extraction. Capture enqueues a job to a durable
+-- Cloudflare Queue; the Mac MLX consumer drains it. `status='captured'` remains
+-- the user-facing "pending processing" marker; these columns make the queue
+-- mirror observable (which captures are queued, in flight, done, or failed)
+-- without coupling user-facing status to internal queue mechanics.
+--
+--   extraction_state lifecycle:
+--     captured   -> row created, not yet enqueued (or queue unavailable)
+--     queued     -> job is on the Cloudflare Queue, awaiting the Mac
+--     processing -> consumer leased the job and is running the model
+--     processed  -> model applied + regex guardrail run; status advanced
+--     failed     -> consumer exhausted retries; needs manual attention
+
+ALTER TABLE receipt_records
+  ADD COLUMN extraction_state TEXT NOT NULL DEFAULT 'captured'
+  CHECK (extraction_state IN ('captured', 'queued', 'processing', 'processed', 'failed'));
+
+ALTER TABLE receipt_records ADD COLUMN extraction_enqueued_at TEXT;
+ALTER TABLE receipt_records ADD COLUMN extraction_processed_at TEXT;
+ALTER TABLE receipt_records ADD COLUMN extraction_attempts INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE receipt_records ADD COLUMN extraction_processor TEXT;
+
+-- Existing rows pre-date the queue. They already have extraction_json (or were
+-- captured under the old synchronous flow), so treat them as processed so they
+-- do not block month-close as phantom "pending processing".
+UPDATE receipt_records
+SET extraction_state = 'processed',
+    extraction_processed_at = COALESCE(created_at, captured_at)
+WHERE extraction_state = 'captured';
+
+-- Finalize gate and the dashboard "pending processing" tile query captures that
+-- are not yet processed.
+CREATE INDEX IF NOT EXISTS idx_receipts_extraction_state
+  ON receipt_records(extraction_state)
+  WHERE extraction_state IN ('captured', 'queued', 'processing');

--- a/docs/adr/0001-decision-brief.md
+++ b/docs/adr/0001-decision-brief.md
@@ -1,0 +1,49 @@
+# Decision Brief — ADR 0001: Receipt Extraction Runtime
+
+- **For:** David (PM / owner)
+- **Date:** 2026-06-20
+- **Decision requested:** Approve moving receipt field-extraction from synchronous, in-Worker Google Cloud Vision to **store-and-forward**: Cloudflare captures and buffers work durably; the Mac M4 is the only thing that processes it, running a **bespoke local model (Apple MLX)**.
+- **Status after this brief:** **Approved.** See ADR 0001 (Accepted) and the resolved open questions below.
+
+## The decision in one paragraph
+
+Today, extracting merchant/date/amount/tax from a receipt runs inside the Cloudflare Worker: it calls Google Cloud Vision, blocks on the response, and sends receipt images (financial PII) to a third party. We are splitting this into a **capture path** that always works (image → R2, row → `captured`, job → a durable Cloudflare Queue) and a **processing path** that only the Mac runs (pull a batch, OCR/extract locally with MLX, write results back, advance the receipt to review). Nothing infers in the cloud anymore. Captured work survives the Mac being offline; it simply waits in the queue until the Mac drains it.
+
+## Why now
+
+Three drivers, all already true:
+
+1. **We have the hardware.** The M4 Max (128 GB) can run a large local vision-language model — we no longer need a hosted API to read a receipt.
+2. **Capture happens in the field; processing happens at the desk.** The two are already separated in time. Receipts captured while the Mac is off must persist and process later. A durable queue is the honest expression of how the work already flows.
+3. **We want to own the model.** A bespoke model trained on our own receipt corpus is the long-term accuracy and cost play. Owning extraction end-to-end is impossible while a third-party API sits in the path.
+
+## What we gain
+
+- **PII stops leaving our estate.** Images are captured to our own R2 and read only on our Mac. For a module that handles financial records under a 10-year retention/legal-hold posture, this is the single biggest reason to do it. It also drops the `GOOGLE_CLOUD_VISION_API_KEY` secret and its per-call cost.
+- **One inference engine, no dev/prod model drift.** Because nothing runs at the edge, we are not constrained by Workers-AI's fixed base-model list, and there is no second model to keep in sync.
+- **Captured work is durable regardless of Mac uptime.** Field capture and storage are Cloudflare's job; only processing depends on the Mac. Nothing is ever lost — at worst it waits.
+- **The bespoke-model ambition is unconstrained.** Model size and architecture are limited only by the 128 GB machine, not by anything we can run in a Worker.
+
+## What we accept (and how we contain it)
+
+- **Throughput is bounded by Mac uptime.** A receipt sits in `captured` ("pending processing") until the Mac runs. *Containment:* the review/reconcile UI shows **pending processing as a first-class state**, never as an error or a missing receipt, and the Mac can drain on demand (a "Process queue" action) as well as automatically on network-up.
+- **Month-close gains a hard dependency on an empty queue.** A statement period **cannot be finalized** while any receipt for that window is still unprocessed. *Containment:* this is enforced in code as a hard gate ("drain the queue before close"), with a clear blocker tile — not left to memory. This is the right behavior: without it, a queue backlog masquerades as missing receipts and someone chases receipts we already hold.
+- **Single processing point of failure.** If the Mac is gone for a long stretch, the backlog grows (nothing is lost). *Containment:* accepted for now; if unattended processing ever becomes a requirement, we revisit a cloud consumer as a **separate future ADR** — not a hidden fallback that reintroduces model drift.
+
+## Interim reality (important)
+
+The bespoke MLX model does not exist yet. This rollout **stands up the MLX runtime now** with an off-the-shelf open vision-language model as the processor, and **keeps the existing regex/heuristic extractor as a validation guardrail over the model's output** — it catches a model confidently misreading an amount, which matters for a compliance module with month-locking and audit logging. The bespoke, fine-tuned model is a later phase that drops into the same slot once the eval harness says it beats the regex baseline on a held-out reconciled month. **Google Vision is removed from the path in this rollout.**
+
+## Resolved open questions
+
+1. **Mac consumer trigger policy:** automatic on network-up (launchd) **and** a manual "Process queue" action. On-demand drain is what makes the system usable the moment a receipt is captured.
+2. **Notify the field user when captures finish processing:** out of scope for v1. The review queue surfacing "pending processing → ready for review" is sufficient; revisit if the field user and the desk user diverge.
+3. **Eval threshold before a model is trusted over regex:** a model may only outrank the regex baseline on a per-field basis after beating it on the held-out reconciled-month eval (harness already built: `docs/dashboards/slm-eval-dashboard.html`, training export script). Until then, regex is the guardrail and the model is advisory.
+
+## What approving this actually changes for you
+
+You can start capturing May and June receipts immediately. Capture is instant; classification lands a few seconds later when you drain the queue (or automatically when the Mac is online). When you go to close a month, the system will refuse if anything for that window is still sitting unprocessed — that refusal is a feature, not a bug.
+
+## Scope of this change set
+
+Code is implemented and committed on branch `feat/receipts-extraction-queue-mlx` (capture/enqueue, MLX apply + guardrail, pending-processing state, finalize gate, tests). The Cloudflare Queue creation, MLX model install, and deploy are **Mac-side steps** in `docs/runbooks/receipts-extraction-rollout.md` — they require the live bindings this environment does not hold.

--- a/docs/adr/0001-receipt-extraction-runtime.md
+++ b/docs/adr/0001-receipt-extraction-runtime.md
@@ -1,9 +1,24 @@
 # ADR 0001 — Receipt extraction runtime: Cloudflare capture/buffer + Mac-only processing
 
-- **Status:** Proposed
-- **Date:** 2026-06-09
+- **Status:** Accepted
+- **Date:** 2026-06-09 (proposed) · 2026-06-20 (accepted)
 - **Owner:** David (PM)
 - **Affects:** `app/api/receipts/*`, `lib/receipts/*`, `app/(receipt-system)/receipts/*`, `wrangler.jsonc`, `db/receipts/*`
+
+## Decision record (2026-06-20)
+
+**Approved** by David. Implemented on branch `feat/receipts-extraction-queue-mlx`. Decision brief: `docs/adr/0001-decision-brief.md`. Mac rollout steps: `docs/runbooks/receipts-extraction-rollout.md`.
+
+Choices made at sign-off:
+
+- **Rollout:** async + on-demand drain. Capture enqueues; the Mac consumer processes on network-up and via a manual "Process queue" action.
+- **Processor:** stand up the **MLX runtime now** with an off-the-shelf open vision-language model; **Google Vision is removed from the path**. The regex/heuristic extractor is retained as a **validation guardrail** over model output. The bespoke fine-tuned model is a later phase that drops into the same slot once it beats the regex baseline on the held-out eval.
+
+**Open questions — resolved:**
+
+1. *Mac consumer trigger policy* → automatic on network-up (launchd) **and** a manual "Process queue" action.
+2. *Notify field user when captures finish* → out of scope for v1; the review queue's "pending processing → ready for review" surfacing is sufficient.
+3. *Eval threshold before a model is trusted over regex* → per-field, only after beating the regex baseline on the held-out reconciled-month eval. Until then regex is the guardrail and the model is advisory.
 
 ## Context
 

--- a/docs/receipt-module.md
+++ b/docs/receipt-module.md
@@ -116,6 +116,19 @@ The application does not expose hard-delete flows for retained tax records. Soft
 4. **AMEX import and reconciliation** — CSV import, matching, reconciliation UI
 5. **Monthly export and archive** — CSV bundle, SHA-256 manifest, archive bucket
 6. **Structured extraction** — pluggable OCR/LLM provider
+7. **Store-and-forward extraction (ADR 0001)** — capture enqueues to a durable Cloudflare Queue; the Mac drains it with a local MLX model; regex runs as a guardrail
+
+## Extraction runtime (ADR 0001 — Accepted)
+
+Extraction is **store-and-forward**, not synchronous. Capture writes the image to R2, inserts the receipt at `status='captured'` (`extraction_state='captured'`), and enqueues a job on the `RECEIPTS_QUEUE` Cloudflare Queue. The **Mac MLX consumer** (`scripts/receipts-consumer/`) is the only processor: it pulls a batch, runs a local vision-language model, and POSTs the result to `POST /api/receipts/[id]/extract` (authenticated with `RECEIPTS_PROCESSOR_KEY`), which runs the deterministic regex parser as a **guardrail** over the model output, merges fields, and advances the receipt to `needs_review`.
+
+Consequences enforced in code:
+
+- **Pending processing is a first-class state.** A captured-but-unprocessed receipt shows as "Receipts pending processing" (CTA: *Process queue*), never as a missing or unreviewed receipt.
+- **Month-close is gated on an empty queue.** `POST /api/receipts/reconcile/finalize` returns `409` if any pending receipt falls in the statement window — "drain the queue before close".
+- **Google Vision is retired from the path.** No OCR runs in the Worker; images never leave our estate. The Vision provider remains as deprecated dead code pending removal.
+
+Rollout (Mac-side): `docs/runbooks/receipts-extraction-rollout.md`.
 
 ## Security Notes
 

--- a/docs/runbooks/receipts-extraction-rollout.md
+++ b/docs/runbooks/receipts-extraction-rollout.md
@@ -1,0 +1,129 @@
+# Runbook — Receipts extraction rollout (ADR 0001)
+
+Steps to take the store-and-forward extraction live. **All steps run on the Mac M4** with live Cloudflare credentials — the code is already on branch `feat/receipts-extraction-queue-mlx`. Do them in order; each is idempotent unless noted.
+
+## 0. Prerequisites
+
+- On the Mac, on the feature branch, with `wrangler` authenticated to the Dazbeez Cloudflare account.
+- Apple Silicon with the 128 GB unified memory (for MLX).
+- `python3` ≥ 3.10 and `pip`.
+
+## 1. Create the Cloudflare Queue
+
+```bash
+npx wrangler queues create dazbeez-receipts-extraction
+```
+
+The producer binding (`RECEIPTS_QUEUE`) is already declared in `wrangler.jsonc`.
+
+## 2. Create the HTTP pull consumer + API token
+
+Pull consumers are not declared in `wrangler.jsonc`; create one and note its IDs:
+
+```bash
+# Register an HTTP pull consumer on the queue
+npx wrangler queues consumer http add dazbeez-receipts-extraction
+```
+
+Then in the Cloudflare dashboard (or via API), create an **API token** scoped to
+**Queues → Read** and **Queues → Write**. Record:
+
+- `CF_ACCOUNT_ID` — your account id
+- `CF_QUEUE_ID` — the queue id (`npx wrangler queues list` / dashboard)
+- `CF_API_TOKEN` — the scoped token
+
+## 3. Set the processor secret (Worker side)
+
+The Mac consumer authenticates to the extract endpoint with a shared key:
+
+```bash
+# Generate a strong key, then:
+npx wrangler secret put RECEIPTS_PROCESSOR_KEY
+```
+
+Use the same value in the consumer's `.env` (step 5).
+
+## 4. Apply the D1 migration
+
+```bash
+# Local first, then production
+npx wrangler d1 migrations apply RECEIPTS_DB --local
+npx wrangler d1 migrations apply RECEIPTS_DB
+```
+
+`0016_extraction_queue.sql` adds `extraction_state` etc. and backfills existing
+rows to `processed` so they never block month-close as phantom pending work.
+
+## 5. Set up the MLX consumer
+
+```bash
+cd scripts/receipts-consumer
+python3 -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env        # fill in the values from steps 2–3
+```
+
+First run pulls the model weights (a few GB) and caches them:
+
+```bash
+./run.sh --once             # processes one batch, then exits
+```
+
+To install the launchd agent (drain on login/wake + every 10 min):
+
+```bash
+cp com.dazbeez.receipts-consumer.plist ~/Library/LaunchAgents/
+launchctl load ~/Library/LaunchAgents/com.dazbeez.receipts-consumer.plist
+```
+
+"Process queue" on demand = `./run.sh --once` (or `python3 consumer.py --once`).
+
+## 6. Build + deploy the Worker
+
+```bash
+npm run build:cf            # must pass
+npm run deploy
+```
+
+## 7. Smoke test
+
+```bash
+bash scripts/check-deployment.sh https://dazbeez.com
+```
+
+Then end-to-end:
+
+1. Capture a receipt at `/receipts/capture`. It should land as **pending processing** (status `captured`), not `needs_review`.
+2. Confirm the dashboard/reconcile "Receipts pending processing" tile shows it.
+3. Run `./run.sh --once`. Within a batch the receipt should advance to **needs_review** with merchant/amount/date populated.
+4. Try to finalize a month that has a pending capture in its window — finalize must return **409 "drain the queue"**. Drain, then finalize succeeds.
+
+## 8. Decommission Google Vision (after the consumer is proven)
+
+```bash
+npx wrangler secret delete GOOGLE_CLOUD_VISION_API_KEY
+```
+
+The Vision provider in `lib/receipts/extraction.ts` is already marked
+`@deprecated` and is no longer wired to any route; delete that dead code in a
+follow-up PR once you're confident in the MLX path.
+
+## Rollback
+
+The change is store-and-forward over existing tables; nothing destructive.
+
+- To pause processing: stop the consumer (`launchctl unload …`). Captures
+  accumulate safely as `captured`; nothing is lost. Month-close is gated until
+  you drain.
+- To revert capture to synchronous review-ready behavior: redeploy the previous
+  Worker. New captures will again land as `needs_review`. Already-queued
+  messages can be drained or purged (`npx wrangler queues ...`). The `0016`
+  columns are additive and harmless if unused.
+
+## Phase 2 (separate work)
+
+Swap the off-the-shelf VLM for the bespoke fine-tuned model. It drops into the
+same `MLX_MODEL` slot. Gate the switch on the extraction-accuracy eval
+(`docs/dashboards/slm-eval-dashboard.html`, `scripts/export-receipt-training-set.mjs`):
+a model may only outrank the regex baseline per-field after beating it on a
+held-out reconciled month.

--- a/lib/cloudflare-runtime.ts
+++ b/lib/cloudflare-runtime.ts
@@ -57,3 +57,27 @@ export function getReceiptsBucket(): R2Bucket {
 export function getReceiptsArchiveBucket(): R2Bucket {
   return getCloudflareEnv().RECEIPTS_ARCHIVE_BUCKET;
 }
+
+/**
+ * Extraction queue producer (ADR 0001). Returns null when the binding is not
+ * configured (e.g. before the queue is created on the Mac) so capture can
+ * degrade gracefully — the receipt still lands in D1 as `captured` and a
+ * backfill can enqueue it later.
+ */
+export function getReceiptsQueue(): Queue<unknown> | null {
+  const env = getCloudflareEnv() as CloudflareEnv & {
+    RECEIPTS_QUEUE?: Queue<unknown>;
+  };
+  return env.RECEIPTS_QUEUE ?? null;
+}
+
+/**
+ * Shared secret for the Mac MLX consumer to authenticate to the extract
+ * endpoint as a machine actor. Set via `wrangler secret put RECEIPTS_PROCESSOR_KEY`.
+ */
+export function getReceiptsProcessorKey(): string | null {
+  const env = getCloudflareEnv() as CloudflareEnv & {
+    RECEIPTS_PROCESSOR_KEY?: string;
+  };
+  return env.RECEIPTS_PROCESSOR_KEY ?? process.env.RECEIPTS_PROCESSOR_KEY ?? null;
+}

--- a/lib/receipts/blockers.ts
+++ b/lib/receipts/blockers.ts
@@ -4,6 +4,7 @@
 // screen's "Ready to seal?" summary without forking the logic.
 
 import { requiresAttendees } from "@/lib/receipts/categories";
+import { isPendingProcessing } from "@/lib/receipts/extraction-state";
 import type { AmexStatementLine, ReceiptRecord } from "@/lib/receipts/types";
 
 export type BlockerSeverity = "blocker" | "warn";
@@ -35,8 +36,25 @@ export function computeExportBlockers(
     });
   }
 
+  // ADR 0001: "pending processing" is distinct from "unreviewed". A captured
+  // receipt still in the extraction queue has no field key yet and cannot be
+  // matched — surfacing it as a missing/unreviewed receipt would send someone
+  // chasing a receipt we already hold. The fix is to drain the queue (run the
+  // Mac consumer), not to review or re-capture.
+  const pendingProcessing = receipts.filter(isPendingProcessing).length;
+  if (pendingProcessing > 0) {
+    blockers.push({
+      severity: "blocker",
+      count: pendingProcessing,
+      label: "Receipts pending processing",
+      detail: "Captured but not yet extracted. Drain the queue on the Mac.",
+      href: "/receipts/review",
+      ctaLabel: "Process queue",
+    });
+  }
+
   const unreviewed = receipts.filter(
-    (r) => r.status === "captured" || r.status === "needs_review",
+    (r) => r.status === "needs_review" && !isPendingProcessing(r),
   ).length;
   if (unreviewed > 0) {
     blockers.push({

--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -15,9 +15,11 @@ import type {
   CreateAttendeeInput,
   CreateReceiptInput,
   DashboardAlertDismissal,
+  ExtractionState,
   ImportAmexLineInput,
   MissingStatementAlert,
   ReceiptAttendee,
+  ReceiptStatus,
   ReceiptExport,
   ReceiptRecord,
   UpdateAmexLineCategoryInput,
@@ -39,6 +41,14 @@ export async function createReceiptRecord(
 
   const sourceType = input.sourceType ?? "manual_upload";
 
+  // ADR 0001: the async capture path inserts at status='captured', which seeds
+  // extraction_state='captured' (pending processing). Every other caller keeps
+  // the legacy 'needs_review' insert and is therefore 'processed' from the
+  // queue's point of view — it never blocks month-close as phantom pending work.
+  const status: ReceiptStatus = input.status ?? "needs_review";
+  const extractionState: ExtractionState =
+    status === "captured" ? "captured" : "processed";
+
   await db
     .prepare(
       `INSERT INTO receipt_records
@@ -46,11 +56,12 @@ export async function createReceiptRecord(
          payment_path, expense_type,
          transaction_date, merchant, amount_minor, currency, tax_amount_minor,
          business_purpose, alcohol_present, attendees_required, status,
+         extraction_state,
          original_r2_key, original_sha256, original_content_type, original_size_bytes,
          legacy, retention_until, legal_hold,
          source_type, preservation_status, qualified_invoice_status,
          created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, 1, ?, 'needs_review', 'not_checked', ?, ?)`,
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, 1, ?, 'needs_review', 'not_checked', ?, ?)`,
     )
     .bind(
       id,
@@ -71,7 +82,8 @@ export async function createReceiptRecord(
       expenseType === "entertainment-alcohol"
         ? 1
         : 0,
-      "needs_review",
+      status,
+      extractionState,
       input.originalR2Key,
       input.originalSha256,
       input.originalContentType,
@@ -141,6 +153,11 @@ export async function updateReceiptRecord(
   if ("counterpartyName" in input) { sets.push("counterparty_name = ?"); binds.push(input.counterpartyName ?? null); }
   if ("taxRate" in input) { sets.push("tax_rate = ?"); binds.push(input.taxRate ?? null); }
   if ("qualifiedInvoiceStatus" in input) { sets.push("qualified_invoice_status = ?"); binds.push(input.qualifiedInvoiceStatus ?? "not_checked"); }
+  if (input.extractionState !== undefined) { sets.push("extraction_state = ?"); binds.push(input.extractionState); }
+  if ("extractionEnqueuedAt" in input) { sets.push("extraction_enqueued_at = ?"); binds.push(input.extractionEnqueuedAt ?? null); }
+  if ("extractionProcessedAt" in input) { sets.push("extraction_processed_at = ?"); binds.push(input.extractionProcessedAt ?? null); }
+  if (input.extractionAttempts !== undefined) { sets.push("extraction_attempts = ?"); binds.push(input.extractionAttempts); }
+  if ("extractionProcessor" in input) { sets.push("extraction_processor = ?"); binds.push(input.extractionProcessor ?? null); }
 
   if (sets.length === 0) return;
 

--- a/lib/receipts/extraction-state.ts
+++ b/lib/receipts/extraction-state.ts
@@ -1,0 +1,27 @@
+// Pending-processing helpers (ADR 0001).
+//
+// A captured receipt sits in the extraction queue until the Mac MLX consumer
+// processes it. Until then it has no merchant/amount/date key and cannot be
+// matched to an AMEX line — so it is NOT a "missing receipt", it is "pending
+// processing". This is a first-class state the review/reconcile UI and the
+// month-close gate must reason about, per ADR 0001.
+
+import { PENDING_EXTRACTION_STATES, type ReceiptRecord } from "@/lib/receipts/types";
+
+/**
+ * True if the receipt is captured but not yet processed by the model.
+ *
+ * Prefers the explicit `extraction_state`; falls back to `status === 'captured'`
+ * for rows written before 0016 / by clients that don't set the column.
+ */
+export function isPendingProcessing(receipt: ReceiptRecord): boolean {
+  if (receipt.extraction_state) {
+    return PENDING_EXTRACTION_STATES.includes(receipt.extraction_state);
+  }
+  return receipt.status === "captured";
+}
+
+/** Receipts still waiting on the model. */
+export function pendingProcessingReceipts(receipts: ReceiptRecord[]): ReceiptRecord[] {
+  return receipts.filter(isPendingProcessing);
+}

--- a/lib/receipts/extraction.ts
+++ b/lib/receipts/extraction.ts
@@ -335,6 +335,111 @@ export function parseReceiptOcrText(rawText: string): Omit<ExtractionResult, "ra
   };
 }
 
+// ─── MLX apply path (ADR 0001) ─────────────────────────────────────────────
+//
+// OCR/inference now happens off-Worker on the Mac (Apple MLX). The consumer
+// posts the OCR text plus any structured fields the model emitted; the Worker
+// applies the deterministic regex parser as a *guardrail* over that output.
+
+/** Structured fields a local model may emit alongside its OCR text. */
+export interface ModelExtractionFields {
+  transactionDate?: string | null;
+  merchant?: string | null;
+  amountMinor?: number | null;
+  currency?: string | null;
+  taxAmountMinor?: number | null;
+  taxRate?: string | null;
+  invoiceRegistrationNumber?: string | null;
+}
+
+export interface GuardedExtraction {
+  result: ExtractionResult;
+  /** Fields where the model and the regex guardrail disagreed. */
+  discrepancies: string[];
+}
+
+function sameMoney(a: number | null, b: number | null): boolean {
+  return a != null && b != null && a === b;
+}
+
+/**
+ * Build an ExtractionResult from OCR text produced off-Worker (MLX) plus any
+ * structured fields the model emitted, running the deterministic regex parser
+ * as a guardrail. Policy:
+ *
+ *  - Amount and date: the regex is authoritative when it extracts a value — it
+ *    catches a model confidently misreading a total, which is the
+ *    compliance-critical failure for a month-locking, audit-logged module. The
+ *    model fills these only when the regex finds nothing.
+ *  - Merchant / currency / tax / invoice number: model-primary (it reads layout
+ *    and semantics the regex cannot), regex as fallback when the model is null.
+ *  - Any disagreement on amount, date, or merchant is recorded as a discrepancy
+ *    so the receipt is surfaced for human review rather than silently trusted.
+ */
+export function buildGuardedExtraction(
+  rawText: string,
+  model: ModelExtractionFields = {},
+  provider = "mlx_local",
+): GuardedExtraction {
+  const regex = parseReceiptOcrText(rawText);
+  const discrepancies: string[] = [];
+
+  // Amount — regex authoritative.
+  const mAmount = model.amountMinor ?? null;
+  const amountMinor = regex.amountMinor ?? mAmount;
+  if (regex.amountMinor != null && mAmount != null && !sameMoney(regex.amountMinor, mAmount)) {
+    discrepancies.push("amountMinor");
+  }
+
+  // Date — regex authoritative.
+  const mDate = model.transactionDate ?? null;
+  const transactionDate = regex.transactionDate ?? mDate;
+  if (regex.transactionDate && mDate && regex.transactionDate !== mDate) {
+    discrepancies.push("transactionDate");
+  }
+
+  // Merchant — model primary, regex fallback.
+  const mMerchant = model.merchant ?? null;
+  const merchant = mMerchant ?? regex.merchant;
+  if (mMerchant && regex.merchant && mMerchant !== regex.merchant) {
+    discrepancies.push("merchant");
+  }
+
+  // Tax + invoice — model primary, regex fallback.
+  const taxAmountMinor = (model.taxAmountMinor ?? null) ?? regex.taxAmountMinor ?? null;
+  const taxRate = (model.taxRate ?? null) ?? regex.taxRate ?? null;
+  const invoiceRegistrationNumber =
+    (model.invoiceRegistrationNumber ?? null) ?? regex.invoiceRegistrationNumber ?? null;
+
+  // Currency — keep the regex's validated/normalized currency unless the regex
+  // fell back to the JPY default and the model supplied an allowed currency.
+  let currency = regex.currency;
+  const mCurrency = (model.currency ?? "").toUpperCase();
+  if (regex.currency === "JPY" && ALLOWED_CURRENCIES.includes(mCurrency)) {
+    currency = mCurrency;
+  }
+
+  return {
+    discrepancies,
+    result: {
+      transactionDate,
+      merchant,
+      amountMinor,
+      currency,
+      // Category/attendees remain a reviewer judgment, never machine-invented.
+      expenseType: null,
+      expenseCategoryCode: null,
+      businessPurpose: null,
+      attendeeNames: [],
+      invoiceRegistrationNumber,
+      taxAmountMinor,
+      taxRate,
+      rawText,
+      provider,
+    },
+  };
+}
+
 class GoogleVisionOcrExtractionProvider implements ExtractionProvider {
   name = "google_vision_document_text_detection";
 
@@ -401,10 +506,18 @@ class GoogleVisionOcrExtractionProvider implements ExtractionProvider {
   }
 }
 
+/**
+ * @deprecated ADR 0001 retired in-Worker OCR. The Google Vision provider below
+ * is no longer wired to any route — extraction runs on the Mac (MLX) and the
+ * Worker applies results via {@link buildGuardedExtraction}. Kept only for
+ * reference/rollback; delete once the MLX consumer is proven in production and
+ * the GOOGLE_CLOUD_VISION_API_KEY secret has been removed.
+ */
 function getExtractionProvider(): ExtractionProvider {
   return new GoogleVisionOcrExtractionProvider();
 }
 
+/** @deprecated See {@link getExtractionProvider}. Not called by any route. */
 export async function extractReceiptData(
   imageBytes: Uint8Array,
   contentType: string,

--- a/lib/receipts/queue.ts
+++ b/lib/receipts/queue.ts
@@ -1,0 +1,61 @@
+// Extraction queue (ADR 0001).
+//
+// The capture path enqueues one job per captured receipt. A durable Cloudflare
+// Queue holds the job until the Mac's pull consumer drains it, runs the local
+// MLX model, and writes results back via the extract endpoint. No AI runs in
+// the Worker — this module only *produces* jobs.
+//
+// D1 `receipt_records.status = 'captured'` plus `extraction_state` is the
+// user-facing mirror of queue state; the Queue is the durable source of truth
+// for "processed exactly once, nothing silently dropped".
+
+import { getReceiptsQueue } from "@/lib/cloudflare-runtime";
+
+/** Current schema version for the job payload, so the consumer can branch. */
+export const EXTRACTION_JOB_VERSION = 1 as const;
+
+export interface ExtractionJob {
+  v: typeof EXTRACTION_JOB_VERSION;
+  receiptId: string;
+  /** R2 key of the original image the consumer must fetch. */
+  r2Key: string;
+  contentType: string;
+  /** ISO timestamp the job was enqueued (observability / age tracking). */
+  enqueuedAt: string;
+}
+
+export function buildExtractionJob(input: {
+  receiptId: string;
+  r2Key: string;
+  contentType: string;
+  enqueuedAt?: string;
+}): ExtractionJob {
+  return {
+    v: EXTRACTION_JOB_VERSION,
+    receiptId: input.receiptId,
+    r2Key: input.r2Key,
+    contentType: input.contentType,
+    enqueuedAt: input.enqueuedAt ?? new Date().toISOString(),
+  };
+}
+
+/**
+ * Enqueue an extraction job. Best-effort by design: if the queue binding is
+ * missing or send fails, the receipt still exists in D1 at `status='captured'`
+ * with `extraction_state='captured'`, so the reprocess/backfill path can pick
+ * it up. Capture must never fail because the queue is unavailable.
+ *
+ * Returns true if the job was enqueued, false if it could not be (caller
+ * records `extraction_state` accordingly).
+ */
+export async function enqueueExtractionJob(job: ExtractionJob): Promise<boolean> {
+  const queue = getReceiptsQueue();
+  if (!queue) return false;
+  try {
+    await queue.send(job);
+    return true;
+  } catch (error) {
+    console.error("[receipts/queue] enqueue failed", error);
+    return false;
+  }
+}

--- a/lib/receipts/types.ts
+++ b/lib/receipts/types.ts
@@ -25,6 +25,25 @@ export type ReceiptStatus =
   | "exported"
   | "archived";
 
+// Internal extraction-queue state (ADR 0001). Distinct from ReceiptStatus,
+// which is the user-facing lifecycle. A receipt can be status='captured' with
+// extraction_state 'captured' | 'queued' | 'processing' — all of which mean
+// "pending processing" — until the Mac consumer produces fields and advances
+// it to status='needs_review' with extraction_state='processed'.
+export type ExtractionState =
+  | "captured"
+  | "queued"
+  | "processing"
+  | "processed"
+  | "failed";
+
+/** States where a capture is enqueued/in-flight but not yet processed. */
+export const PENDING_EXTRACTION_STATES: readonly ExtractionState[] = [
+  "captured",
+  "queued",
+  "processing",
+];
+
 export type AmexMatchStatus =
   | "unmatched"
   | "matched"
@@ -225,6 +244,12 @@ export interface ReceiptRecord {
   counterparty_name?: string | null;
   search_text?: string | null;
   compliance_warnings_json?: string | null;
+  // Extraction queue state (0016_extraction_queue.sql, ADR 0001)
+  extraction_state?: ExtractionState;
+  extraction_enqueued_at?: string | null;
+  extraction_processed_at?: string | null;
+  extraction_attempts?: number;
+  extraction_processor?: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -472,6 +497,10 @@ export interface CreateReceiptInput {
   originalSha256: string;
   originalContentType: string;
   originalSizeBytes: number;
+  // Lifecycle status to insert at. Defaults to 'needs_review' (legacy /
+  // synchronous path). The async capture path (ADR 0001) passes 'captured',
+  // which also seeds extraction_state='captured' (pending processing).
+  status?: ReceiptStatus;
 }
 
 export interface UpdateReceiptInput {
@@ -495,6 +524,12 @@ export interface UpdateReceiptInput {
   counterpartyName?: string | null;
   taxRate?: string | null;
   qualifiedInvoiceStatus?: QualifiedInvoiceStatus | null;
+  // Extraction queue state (0016_extraction_queue.sql, ADR 0001)
+  extractionState?: ExtractionState;
+  extractionEnqueuedAt?: string | null;
+  extractionProcessedAt?: string | null;
+  extractionAttempts?: number;
+  extractionProcessor?: string | null;
 }
 
 export interface CreateAttendeeInput {

--- a/receipts-env.d.ts
+++ b/receipts-env.d.ts
@@ -5,6 +5,11 @@
 declare namespace Cloudflare {
   interface Env {
     RESEND_API_KEY: string;
+    // Extraction queue producer (ADR 0001). Optional: absent until the queue
+    // is created on the Mac; accessors degrade gracefully when undefined.
+    RECEIPTS_QUEUE?: Queue<unknown>;
+    // Shared secret authenticating the Mac MLX consumer to the extract endpoint.
+    RECEIPTS_PROCESSOR_KEY?: string;
   }
 }
 declare namespace NodeJS {
@@ -14,5 +19,6 @@ declare namespace NodeJS {
     RECEIPTS_AUTH_USERNAME?: string;
     RECEIPTS_AUTH_PASSWORD?: string;
     RECEIPTS_DEVICE_SECRET?: string;
+    RECEIPTS_PROCESSOR_KEY?: string;
   }
 }

--- a/scripts/receipts-consumer/.env.example
+++ b/scripts/receipts-consumer/.env.example
@@ -5,4 +5,8 @@ CF_API_TOKEN=          # API token scoped to Queues Read + Queues Write
 RECEIPTS_R2_BUCKET=dazbeez-receipts
 RECEIPTS_EXTRACT_URL=https://dazbeez.com/api/receipts
 RECEIPTS_PROCESSOR_KEY=   # must match `wrangler secret put RECEIPTS_PROCESSOR_KEY`
-MLX_MODEL=mlx-community/Qwen2-VL-7B-Instruct-4bit
+# Qwen3-VL: current-gen, 32-language OCR incl. Japanese, robust to blur/tilt,
+# and LoRA-fine-tunable via mlx-vlm (the ADR Phase 2 path). Start with 4B-4bit
+# to validate, then scale to a larger Qwen3-VL Instruct MLX build for accuracy
+# (the 128GB M4 Max can run 8B/30B comfortably) — verify the build on HF first.
+MLX_MODEL=mlx-community/Qwen3-VL-4B-Instruct-4bit

--- a/scripts/receipts-consumer/.env.example
+++ b/scripts/receipts-consumer/.env.example
@@ -1,0 +1,8 @@
+# Mac MLX extraction consumer config (ADR 0001). Copy to .env, fill in, keep out of git.
+CF_ACCOUNT_ID=
+CF_QUEUE_ID=
+CF_API_TOKEN=          # API token scoped to Queues Read + Queues Write
+RECEIPTS_R2_BUCKET=dazbeez-receipts
+RECEIPTS_EXTRACT_URL=https://dazbeez.com/api/receipts
+RECEIPTS_PROCESSOR_KEY=   # must match `wrangler secret put RECEIPTS_PROCESSOR_KEY`
+MLX_MODEL=mlx-community/Qwen2-VL-7B-Instruct-4bit

--- a/scripts/receipts-consumer/.env.example
+++ b/scripts/receipts-consumer/.env.example
@@ -6,7 +6,6 @@ RECEIPTS_R2_BUCKET=dazbeez-receipts
 RECEIPTS_EXTRACT_URL=https://dazbeez.com/api/receipts
 RECEIPTS_PROCESSOR_KEY=   # must match `wrangler secret put RECEIPTS_PROCESSOR_KEY`
 # Qwen3-VL: current-gen, 32-language OCR incl. Japanese, robust to blur/tilt,
-# and LoRA-fine-tunable via mlx-vlm (the ADR Phase 2 path). Start with 4B-4bit
-# to validate, then scale to a larger Qwen3-VL Instruct MLX build for accuracy
-# (the 128GB M4 Max can run 8B/30B comfortably) — verify the build on HF first.
-MLX_MODEL=mlx-community/Qwen3-VL-4B-Instruct-4bit
+# LoRA-fine-tunable via mlx-vlm (the ADR Phase 2 path). 32B-4bit validated on
+# the 128GB M4 Max (~18GB disk, ~21.6GB RAM, ~26 tok/s) with strong JA accuracy.
+MLX_MODEL=mlx-community/Qwen3-VL-32B-Instruct-4bit

--- a/scripts/receipts-consumer/AGENT_SETUP_PROMPT.md
+++ b/scripts/receipts-consumer/AGENT_SETUP_PROMPT.md
@@ -1,0 +1,35 @@
+# CLI-agent prompt — install & wire up the MLX OCR consumer
+
+Paste the block below to a CLI coding agent (e.g. Claude Code) running **on the Mac M4**, from the repo root. It sets up the local MLX vision model that reads Japanese/English receipts for the store-and-forward extraction path (ADR 0001).
+
+---
+
+You are setting up the local MLX OCR consumer for the Dazbeez receipts module on this Mac (Apple Silicon, 128 GB). Context: ADR 0001 (`docs/adr/0001-receipt-extraction-runtime.md`) made receipt extraction store-and-forward — the Worker enqueues captures to a Cloudflare Queue and THIS machine is the only processor. The consumer already exists at `scripts/receipts-consumer/` (`consumer.py`, `run.sh`, `requirements.txt`, `.env.example`, launchd plist). Your job is to install it, wire it to a Qwen3-VL model, and prove it reads both Japanese and English receipts. Work only in `scripts/receipts-consumer/` and do not deploy anything.
+
+Model decision (already made — use it): **Qwen3-VL**, via `mlx-vlm`. Rationale: current-gen, 32-language OCR including Japanese, robust to blur/tilt/low-light (real receipt photos), strong long-document/table structure parsing (invoices), and LoRA-fine-tunable via mlx-vlm — so the same family covers both the off-the-shelf model now and the bespoke fine-tuned model later (ADR Phase 2). Keep the deterministic regex guardrail in the Worker; do not try to move extraction off it.
+
+Do the following:
+
+1. **Environment.** In `scripts/receipts-consumer/`, create a Python venv and install deps: `python3 -m venv .venv && source .venv/bin/activate && pip install -U -r requirements.txt`. Confirm `mlx-vlm` is recent enough to support Qwen3-VL (needs ≥ 0.3.4); upgrade if not. Print the installed `mlx-vlm` version.
+
+2. **Pick the model.** Default in `.env.example`/`consumer.py` is `mlx-community/Qwen3-VL-4B-Instruct-4bit` (a known-good build for validating the pipeline). On Hugging Face `mlx-community`, check what larger **Qwen3-VL *Instruct*** MLX builds exist (e.g. 8B / 30B, 4-bit or 8-bit). Recommend the largest one that runs comfortably in 128 GB with headroom; report the exact repo id and its size. Do NOT silently switch the default — tell me the options and let me confirm before changing `MLX_MODEL`.
+
+3. **Verify the runtime API.** `consumer.py` calls `mlx_vlm` (`load`, `generate`, `apply_chat_template`, `load_config`). Confirm these match the installed mlx-vlm version's API for Qwen3-VL; if the signatures differ, fix `consumer.py` minimally so a single-image generate works. Do not change the consumer's queue/ack/HTTP contract.
+
+4. **Smoke-test OCR before any queue wiring.** Run the model directly (`python -m mlx_vlm.generate --model <id> --image <path> --prompt "Transcribe all text, then output JSON with merchant, transactionDate, amountMinor, currency, taxAmountMinor, taxRate, invoiceRegistrationNumber. Use null if absent."`) on TWO sample receipts: one **Japanese** (with 合計/消費税/T-invoice number) and one **English**. Show the raw output for each. Acceptance: merchant, date, and total are correct on both; the Japanese invoice registration number (T + 13 digits) is captured when present. If Japanese is weak, try the next larger Qwen3-VL build and report the difference.
+
+5. **Wire config.** Copy `.env.example` to `.env` and fill `CF_ACCOUNT_ID`, `CF_QUEUE_ID`, `CF_API_TOKEN` (Queues Read+Write), `RECEIPTS_R2_BUCKET`, `RECEIPTS_EXTRACT_URL`, `RECEIPTS_PROCESSOR_KEY`, `MLX_MODEL`. Never print secret values back in full and never commit `.env` (confirm it is gitignored).
+
+6. **End-to-end dry run.** With at least one receipt sitting in the queue (status `captured`), run `./run.sh --once`. Confirm it pulls the job, fetches the R2 image, runs the model, POSTs to the extract endpoint, and the receipt advances to `needs_review` with fields populated. Show the consumer log.
+
+7. **Optional autostart.** If I confirm, install the launchd agent (`com.dazbeez.receipts-consumer.plist`) per the comments in that file so the queue drains on login/wake.
+
+Report at the end: installed mlx-vlm version, chosen model id + memory footprint + tokens/sec, JA and EN smoke-test results, and any edits you made to `consumer.py`. Do not run `wrangler deploy`, `cf:dev`, or modify Worker code.
+
+---
+
+## Notes for David (not part of the prompt)
+
+- **Why Qwen3-VL over a dedicated OCR engine** (PaddleOCR, manga-ocr, olmOCR-2, MinerU2.5): those can edge out a general VLM on pure transcription, but a VLM transcribes *and* emits the structured fields (merchant/total/tax/invoice no.) in one pass, and — the strategic part — Qwen3-VL is the same family you'll LoRA-fine-tune for the bespoke model, so you never change architectures between "off-the-shelf now" and "our model later." One slot, one eval harness.
+- **Size vs. accuracy:** processing is async/batch, so a bigger model is essentially free on latency — accuracy is the only thing that matters. Start 4B to prove the pipe, then scale up; the 128 GB headroom is there to be used.
+- **The guardrail stays.** The regex parser already validates the model's amount/date in the Worker. Don't let model accuracy claims tempt anyone into dropping it for a compliance module.

--- a/scripts/receipts-consumer/com.dazbeez.receipts-consumer.plist
+++ b/scripts/receipts-consumer/com.dazbeez.receipts-consumer.plist
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  launchd job: drain the extraction queue on network-up and periodically.
+  Install:
+    cp com.dazbeez.receipts-consumer.plist ~/Library/LaunchAgents/
+    launchctl load ~/Library/LaunchAgents/com.dazbeez.receipts-consumer.plist
+  Edit the paths below to match where the repo and venv live on the Mac.
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.dazbeez.receipts-consumer</string>
+
+  <!-- run.sh sources .env then runs consumer.py --once. -->
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>/Users/dklan/projects/work/dazbeez/scripts/receipts-consumer/run.sh</string>
+    <string>--once</string>
+  </array>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/bin:/bin:/usr/local/bin</string>
+  </dict>
+  <key>WorkingDirectory</key>
+  <string>/Users/dklan/projects/work/dazbeez/scripts/receipts-consumer</string>
+
+  <!-- Run shortly after load / network change, then every 10 minutes as a
+       safety net. RunAtLoad fires when the agent (re)loads on login/wake. -->
+  <key>RunAtLoad</key>
+  <true/>
+  <key>StartInterval</key>
+  <integer>600</integer>
+
+  <key>StandardOutPath</key>
+  <string>/tmp/dazbeez-receipts-consumer.log</string>
+  <key>StandardErrorPath</key>
+  <string>/tmp/dazbeez-receipts-consumer.err.log</string>
+</dict>
+</plist>

--- a/scripts/receipts-consumer/consumer.py
+++ b/scripts/receipts-consumer/consumer.py
@@ -43,7 +43,7 @@ CF_API_TOKEN = os.environ["CF_API_TOKEN"]
 R2_BUCKET = os.environ.get("RECEIPTS_R2_BUCKET", "dazbeez-receipts")
 EXTRACT_BASE = os.environ["RECEIPTS_EXTRACT_URL"].rstrip("/")
 PROCESSOR_KEY = os.environ["RECEIPTS_PROCESSOR_KEY"]
-MLX_MODEL = os.environ.get("MLX_MODEL", "mlx-community/Qwen2-VL-7B-Instruct-4bit")
+MLX_MODEL = os.environ.get("MLX_MODEL", "mlx-community/Qwen3-VL-4B-Instruct-4bit")
 
 QUEUES_API = (
     f"https://api.cloudflare.com/client/v4/accounts/{CF_ACCOUNT_ID}"

--- a/scripts/receipts-consumer/consumer.py
+++ b/scripts/receipts-consumer/consumer.py
@@ -43,7 +43,9 @@ CF_API_TOKEN = os.environ["CF_API_TOKEN"]
 R2_BUCKET = os.environ.get("RECEIPTS_R2_BUCKET", "dazbeez-receipts")
 EXTRACT_BASE = os.environ["RECEIPTS_EXTRACT_URL"].rstrip("/")
 PROCESSOR_KEY = os.environ["RECEIPTS_PROCESSOR_KEY"]
-MLX_MODEL = os.environ.get("MLX_MODEL", "mlx-community/Qwen3-VL-4B-Instruct-4bit")
+# Validated on the M4 Max (128 GB): 32B-4bit ≈ 18 GB on disk, ~21.6 GB RAM
+# (17%), ~26 tok/s. Strong JA accuracy incl. T-invoice numbers + tax math.
+MLX_MODEL = os.environ.get("MLX_MODEL", "mlx-community/Qwen3-VL-32B-Instruct-4bit")
 
 QUEUES_API = (
     f"https://api.cloudflare.com/client/v4/accounts/{CF_ACCOUNT_ID}"
@@ -107,14 +109,16 @@ def fetch_image(r2_key: str) -> str:
 
 def run_mlx(image_path: str) -> dict[str, Any]:
     """Run the local MLX VLM and return {rawText, fields}."""
-    from mlx_vlm import generate, load  # imported lazily so --help works without MLX
+    from mlx_vlm import generate  # imported lazily so --help works without MLX
     from mlx_vlm.prompt_utils import apply_chat_template
     from mlx_vlm.utils import load_config
 
     model, processor = _load_model()
     config = load_config(MLX_MODEL)
     formatted = apply_chat_template(processor, config, PROMPT, num_images=1)
-    output = generate(model, processor, formatted, [image_path], max_tokens=1500, verbose=False)
+    result = generate(model, processor, formatted, [image_path], max_tokens=1500, verbose=False)
+    # mlx-vlm >= 0.5 returns GenerationResult; older returned str. Handle both.
+    output = result.text if hasattr(result, "text") else result
 
     raw_text, fields = _parse_model_output(output)
     return {"rawText": raw_text, "fields": fields}

--- a/scripts/receipts-consumer/consumer.py
+++ b/scripts/receipts-consumer/consumer.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""
+Dazbeez receipts — Mac MLX extraction consumer (ADR 0001).
+
+Store-and-forward processing path. This is the ONLY thing that processes the
+extraction queue, and it runs only on the Mac M4 with live Cloudflare creds.
+
+Per batch it:
+  1. Pulls messages from the Cloudflare Queue (HTTP pull consumer).
+  2. For each job: fetches the original image from R2 (via wrangler).
+  3. Runs the local MLX vision-language model to OCR + read fields.
+  4. POSTs the result to the Worker's extract endpoint, which applies the
+     deterministic regex guardrail, merges fields, and advances the receipt to
+     needs_review.
+  5. Acks the message on success. On failure the message is left unacked and
+     returns to the queue after the visibility timeout — nothing is dropped.
+
+Run on demand:   python3 consumer.py --once
+Run as a daemon: python3 consumer.py            (polls; used by launchd on network-up)
+
+Config via env (see .env.example):
+  CF_ACCOUNT_ID, CF_QUEUE_ID, CF_API_TOKEN   queues_read + queues_write scope
+  RECEIPTS_R2_BUCKET                          e.g. dazbeez-receipts
+  RECEIPTS_EXTRACT_URL                        https://dazbeez.com/api/receipts
+  RECEIPTS_PROCESSOR_KEY                      matches the Worker secret
+  MLX_MODEL                                   e.g. mlx-community/Qwen2-VL-7B-Instruct-4bit
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from typing import Any
+
+import requests
+
+CF_ACCOUNT_ID = os.environ["CF_ACCOUNT_ID"]
+CF_QUEUE_ID = os.environ["CF_QUEUE_ID"]
+CF_API_TOKEN = os.environ["CF_API_TOKEN"]
+R2_BUCKET = os.environ.get("RECEIPTS_R2_BUCKET", "dazbeez-receipts")
+EXTRACT_BASE = os.environ["RECEIPTS_EXTRACT_URL"].rstrip("/")
+PROCESSOR_KEY = os.environ["RECEIPTS_PROCESSOR_KEY"]
+MLX_MODEL = os.environ.get("MLX_MODEL", "mlx-community/Qwen2-VL-7B-Instruct-4bit")
+
+QUEUES_API = (
+    f"https://api.cloudflare.com/client/v4/accounts/{CF_ACCOUNT_ID}"
+    f"/queues/{CF_QUEUE_ID}/messages"
+)
+CF_HEADERS = {"Authorization": f"Bearer {CF_API_TOKEN}", "Content-Type": "application/json"}
+
+# Batch / lease tuning. The lease (visibility_timeout) must comfortably exceed
+# the model runtime per batch so jobs are not redelivered mid-process.
+BATCH_SIZE = 10
+VISIBILITY_TIMEOUT_MS = 5 * 60 * 1000
+POLL_INTERVAL_S = 20
+
+PROMPT = (
+    "You are reading a receipt or tax invoice (Japanese or English). "
+    "First transcribe ALL visible text exactly, preserving line breaks. "
+    "Then output a single JSON object on the final line with keys: "
+    "rawText (the full transcription), merchant, transactionDate (YYYY-MM-DD), "
+    "amountMinor (integer total in minor units; JPY has no minor unit so use the "
+    "whole-yen integer), currency (ISO 4217), taxAmountMinor, taxRate, "
+    "invoiceRegistrationNumber (the T + 13 digits number if present). "
+    "Use null for anything not present. Do not guess."
+)
+
+
+def pull_batch() -> list[dict[str, Any]]:
+    resp = requests.post(
+        f"{QUEUES_API}/pull",
+        headers=CF_HEADERS,
+        json={"batch_size": BATCH_SIZE, "visibility_timeout_ms": VISIBILITY_TIMEOUT_MS},
+        timeout=30,
+    )
+    resp.raise_for_status()
+    return resp.json().get("result", {}).get("messages", [])
+
+
+def ack(lease_ids: list[str]) -> None:
+    if not lease_ids:
+        return
+    requests.post(
+        f"{QUEUES_API}/ack",
+        headers=CF_HEADERS,
+        json={"acks": [{"lease_id": lid} for lid in lease_ids]},
+        timeout=30,
+    ).raise_for_status()
+
+
+def fetch_image(r2_key: str) -> str:
+    """Download the original image from R2 to a temp file; return the path."""
+    suffix = os.path.splitext(r2_key)[1] or ".bin"
+    fd, path = tempfile.mkstemp(suffix=suffix)
+    os.close(fd)
+    subprocess.run(
+        ["npx", "wrangler", "r2", "object", "get", f"{R2_BUCKET}/{r2_key}",
+         "--file", path, "--remote"],
+        check=True,
+        capture_output=True,
+    )
+    return path
+
+
+def run_mlx(image_path: str) -> dict[str, Any]:
+    """Run the local MLX VLM and return {rawText, fields}."""
+    from mlx_vlm import generate, load  # imported lazily so --help works without MLX
+    from mlx_vlm.prompt_utils import apply_chat_template
+    from mlx_vlm.utils import load_config
+
+    model, processor = _load_model()
+    config = load_config(MLX_MODEL)
+    formatted = apply_chat_template(processor, config, PROMPT, num_images=1)
+    output = generate(model, processor, formatted, [image_path], max_tokens=1500, verbose=False)
+
+    raw_text, fields = _parse_model_output(output)
+    return {"rawText": raw_text, "fields": fields}
+
+
+_MODEL_CACHE: dict[str, Any] = {}
+
+
+def _load_model():
+    if "m" not in _MODEL_CACHE:
+        from mlx_vlm import load
+        _MODEL_CACHE["m"], _MODEL_CACHE["p"] = load(MLX_MODEL)
+    return _MODEL_CACHE["m"], _MODEL_CACHE["p"]
+
+
+def _parse_model_output(output: str) -> tuple[str, dict[str, Any]]:
+    """Pull the trailing JSON object out of the model output; fall back gracefully."""
+    fields: dict[str, Any] = {}
+    raw_text = output
+    start = output.rfind("{")
+    end = output.rfind("}")
+    if start != -1 and end != -1 and end > start:
+        try:
+            parsed = json.loads(output[start : end + 1])
+            raw_text = parsed.get("rawText") or output[:start].strip()
+            for k in (
+                "merchant", "transactionDate", "amountMinor", "currency",
+                "taxAmountMinor", "taxRate", "invoiceRegistrationNumber",
+            ):
+                if k in parsed:
+                    fields[k] = parsed[k]
+        except json.JSONDecodeError:
+            pass
+    return raw_text, fields
+
+
+def apply_to_worker(receipt_id: str, payload: dict[str, Any]) -> None:
+    resp = requests.post(
+        f"{EXTRACT_BASE}/{receipt_id}/extract",
+        headers={"x-receipts-processor-key": PROCESSOR_KEY, "Content-Type": "application/json"},
+        json={**payload, "model": f"mlx_local:{MLX_MODEL.split('/')[-1]}"},
+        timeout=60,
+    )
+    resp.raise_for_status()
+
+
+def process_once() -> int:
+    messages = pull_batch()
+    if not messages:
+        return 0
+    acked: list[str] = []
+    for msg in messages:
+        lease_id = msg["lease_id"]
+        try:
+            job = msg["body"] if isinstance(msg["body"], dict) else json.loads(msg["body"])
+            receipt_id, r2_key = job["receiptId"], job["r2Key"]
+            image_path = fetch_image(r2_key)
+            try:
+                result = run_mlx(image_path)
+            finally:
+                try:
+                    os.unlink(image_path)
+                except OSError:
+                    pass
+            apply_to_worker(receipt_id, result)
+            acked.append(lease_id)
+            print(f"[ok] {receipt_id}")
+        except Exception as exc:  # noqa: BLE001 — leave unacked for redelivery
+            print(f"[retry] {msg.get('id')}: {exc}", file=sys.stderr)
+    ack(acked)
+    return len(acked)
+
+
+def main() -> None:
+    once = "--once" in sys.argv
+    while True:
+        try:
+            n = process_once()
+            if once:
+                print(f"Processed {n} message(s).")
+                return
+            if n == 0:
+                time.sleep(POLL_INTERVAL_S)
+        except requests.HTTPError as exc:
+            print(f"[error] {exc}", file=sys.stderr)
+            time.sleep(POLL_INTERVAL_S)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/receipts-consumer/requirements.txt
+++ b/scripts/receipts-consumer/requirements.txt
@@ -1,0 +1,5 @@
+# Mac (Apple Silicon) only. Install into a venv:
+#   python3 -m venv .venv && source .venv/bin/activate
+#   pip install -r requirements.txt
+requests>=2.31
+mlx-vlm>=0.1.0

--- a/scripts/receipts-consumer/run.sh
+++ b/scripts/receipts-consumer/run.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Wrapper for launchd / manual runs: load .env, then run the consumer.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+if [[ -f .env ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source .env
+  set +a
+fi
+
+PY="${PY:-.venv/bin/python3}"
+exec "$PY" consumer.py "$@"

--- a/tests/receipts/extraction-guardrail.test.ts
+++ b/tests/receipts/extraction-guardrail.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildGuardedExtraction } from "@/lib/receipts/extraction";
+
+const JP_RECEIPT = `株式会社テストストア
+領収書
+2026年5月16日
+小計 ¥1,364
+消費税 ¥136
+合計 ¥1,500`;
+
+test("guardrail: regex amount is authoritative; model disagreement is flagged", () => {
+  // Model confidently misreads the total. The regex parses ¥1,500 from the
+  // text, so the regex wins and the disagreement is surfaced for review.
+  const { result, discrepancies } = buildGuardedExtraction(JP_RECEIPT, {
+    amountMinor: 9999,
+    merchant: "株式会社テストストア",
+  });
+  assert.equal(result.amountMinor, 1500);
+  assert.ok(discrepancies.includes("amountMinor"));
+});
+
+test("guardrail: regex date is authoritative; agreement records no discrepancy", () => {
+  const { result, discrepancies } = buildGuardedExtraction(JP_RECEIPT, {
+    transactionDate: "2026-05-16",
+  });
+  assert.equal(result.transactionDate, "2026-05-16");
+  assert.ok(!discrepancies.includes("transactionDate"));
+});
+
+test("guardrail: model fills amount when regex finds none", () => {
+  const { result, discrepancies } = buildGuardedExtraction("alpha\nbravo", {
+    amountMinor: 5000,
+  });
+  assert.equal(result.amountMinor, 5000);
+  assert.ok(!discrepancies.includes("amountMinor"));
+});
+
+test("guardrail: merchant is model-primary, regex fallback, with discrepancy", () => {
+  const { result, discrepancies } = buildGuardedExtraction(JP_RECEIPT, {
+    merchant: "Cafe Bee",
+  });
+  assert.equal(result.merchant, "Cafe Bee");
+  assert.ok(discrepancies.includes("merchant"));
+});
+
+test("guardrail: model fills invoice registration number when regex finds none", () => {
+  const { result } = buildGuardedExtraction("no invoice number here", {
+    invoiceRegistrationNumber: "T1234567890123",
+  });
+  assert.equal(result.invoiceRegistrationNumber, "T1234567890123");
+});
+
+test("guardrail: provider label is carried onto the result; no invented category", () => {
+  const { result } = buildGuardedExtraction(JP_RECEIPT, {}, "mlx_local:qwen2-vl");
+  assert.equal(result.provider, "mlx_local:qwen2-vl");
+  assert.equal(result.expenseType, null);
+  assert.deepEqual(result.attendeeNames, []);
+  assert.equal(result.rawText, JP_RECEIPT);
+});

--- a/tests/receipts/pending-processing.test.ts
+++ b/tests/receipts/pending-processing.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildExtractionJob, EXTRACTION_JOB_VERSION } from "@/lib/receipts/queue";
+import { isPendingProcessing } from "@/lib/receipts/extraction-state";
+import { computeExportBlockers } from "@/lib/receipts/blockers";
+import type { AmexStatementLine, ReceiptRecord } from "@/lib/receipts/types";
+
+function receipt(partial: Partial<ReceiptRecord>): ReceiptRecord {
+  return {
+    id: "r1",
+    status: "needs_review",
+    transaction_date: null,
+    ...partial,
+  } as unknown as ReceiptRecord;
+}
+
+test("buildExtractionJob: stamps version and fields", () => {
+  const job = buildExtractionJob({ receiptId: "r1", r2Key: "k", contentType: "image/jpeg" });
+  assert.equal(job.v, EXTRACTION_JOB_VERSION);
+  assert.equal(job.receiptId, "r1");
+  assert.equal(job.r2Key, "k");
+  assert.equal(job.contentType, "image/jpeg");
+  assert.ok(job.enqueuedAt);
+});
+
+test("isPendingProcessing: queue states are pending, processed is not", () => {
+  assert.equal(isPendingProcessing(receipt({ extraction_state: "queued" })), true);
+  assert.equal(isPendingProcessing(receipt({ extraction_state: "processing" })), true);
+  assert.equal(isPendingProcessing(receipt({ extraction_state: "captured" })), true);
+  assert.equal(isPendingProcessing(receipt({ extraction_state: "processed" })), false);
+  assert.equal(isPendingProcessing(receipt({ extraction_state: "failed" })), false);
+});
+
+test("isPendingProcessing: falls back to status when extraction_state absent", () => {
+  assert.equal(isPendingProcessing(receipt({ status: "captured" })), true);
+  assert.equal(isPendingProcessing(receipt({ status: "needs_review" })), false);
+});
+
+test("blockers: pending-processing and unreviewed are distinct blockers", () => {
+  const receipts: ReceiptRecord[] = [
+    receipt({ id: "a", status: "captured", extraction_state: "queued" }),
+    receipt({ id: "b", status: "needs_review", extraction_state: "processed" }),
+  ];
+  const lines: AmexStatementLine[] = [];
+  const blockers = computeExportBlockers(receipts, lines);
+
+  const pending = blockers.find((b) => b.label === "Receipts pending processing");
+  const unreviewed = blockers.find((b) => b.label === "Unreviewed receipts");
+
+  assert.ok(pending, "expected a pending-processing blocker");
+  assert.equal(pending!.count, 1);
+  assert.equal(pending!.ctaLabel, "Process queue");
+
+  assert.ok(unreviewed, "expected an unreviewed blocker");
+  assert.equal(unreviewed!.count, 1);
+});
+
+test("blockers: a processed needs_review receipt is not counted as pending", () => {
+  const receipts: ReceiptRecord[] = [
+    receipt({ id: "b", status: "needs_review", extraction_state: "processed" }),
+  ];
+  const blockers = computeExportBlockers(receipts, []);
+  assert.equal(blockers.find((b) => b.label === "Receipts pending processing"), undefined);
+});

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -9,7 +9,11 @@
   ],
   // Manual secret setup:
   // npx wrangler secret put RESEND_API_KEY
-  // npx wrangler secret put GOOGLE_CLOUD_VISION_API_KEY
+  // npx wrangler secret put RECEIPTS_PROCESSOR_KEY   // ADR 0001: Mac MLX consumer auth
+  //
+  // GOOGLE_CLOUD_VISION_API_KEY is retired by ADR 0001 — extraction no longer
+  // runs in the Worker. Remove the secret after the MLX consumer is live:
+  //   npx wrangler secret delete GOOGLE_CLOUD_VISION_API_KEY
   "workers_dev": false,
   "preview_urls": false,
   "assets": {
@@ -58,6 +62,17 @@
       "bucket_name": "dazbeez-receipts-archive"
     }
   ],
+  // ADR 0001: extraction queue. The Worker is a producer only; the Mac runs an
+  // HTTP pull consumer (configured via the Cloudflare API/dashboard, not here).
+  // Create the queue first: `npx wrangler queues create dazbeez-receipts-extraction`.
+  "queues": {
+    "producers": [
+      {
+        "binding": "RECEIPTS_QUEUE",
+        "queue": "dazbeez-receipts-extraction"
+      }
+    ]
+  },
   "routes": [
     {
       "pattern": "dazbeez.com/*",


### PR DESCRIPTION
## Summary

Implements [ADR 0001](docs/adr/0001-receipt-extraction-runtime.md): receipt extraction becomes store-and-forward. The Worker captures receipts to R2 + D1 and enqueues an extraction job to a durable Cloudflare Queue; a Mac M4 MLX consumer drains the queue, runs a local Qwen3-VL vision model, and writes results back via the existing `/api/receipts/[id]/extract` endpoint. **Google Cloud Vision is removed from the path** — receipt images never leave the estate.

- **Capture path (Cloudflare)**: `lib/receipts/queue.ts` + producer binding `RECEIPTS_QUEUE` in `wrangler.jsonc`. `enqueueExtractionJob` degrades gracefully — capture never fails because the queue is unavailable.
- **Buffer**: Cloudflare Queue `dazbeez-receipts-extraction` with an HTTP pull consumer (registered via dashboard/API, not in `wrangler.jsonc`). 12h visibility timeout per ADR.
- **Processing path (Mac only)**: `scripts/receipts-consumer/` — Python consumer + launchd plist. Model: `mlx-community/Qwen3-VL-32B-Instruct-4bit` (validated on M4 Max 128 GB: 18 GB disk, ~21.6 GB peak RSS, ~26 tok/s, correct merchant/date/total + T-invoice numbers + tax math on Japanese receipts).
- **Guardrail retained**: the deterministic regex extractor stays in the Worker (`buildGuardedExtraction`), now applied over model output instead of Google Vision OCR. Per ADR it remains the validation layer; the model is advisory until it beats regex on the held-out eval.
- **Reconciliation**: new `pending_processing` blocker state — a captured-but-unextracted receipt blocks month-close (so a queue backlog doesn't masquerade as missing receipts). Finalize gate now requires an empty queue for the period.
- **Capture UX**: capture no longer waits on synchronous OCR (would always time out post-ADR); goes straight to a `captured — pending processing` state.

## Migration

`db/receipts/0016_extraction_queue.sql` — adds `extraction_state` (CHECK-constrained 5-state lifecycle) + sibling columns to `receipt_records`. Backfills the 23 existing rows to `extraction_state='processed'` so historical data doesn't show as phantom pending. Partial index on the active states for the dashboard tile + finalize gate. Applied to both local + remote D1.

## Not in this PR (separate WIP, intentionally uncommitted)

5 files were left out of these commits because they appear unrelated to ADR 0001:

- `app/(receipt-system)/receipts/pair/page.tsx`
- `app/(receipt-system)/receipts/settings/devices/page.tsx`
- `lib/receipts/auth-request.ts`
- `lib/receipts/client-image.ts` (80-line change)
- `networking-card/tests/helpers.ts`

**⚠️ Deployed bundle divergence**: a Worker was deployed from the working tree during bring-up (version `fc3187c0-df5e-453d-89c4-112d39b1f57b`), which **includes these 5 files**. The remote branch and the PR diff do not. Until these are either committed or the deployed Worker is rebuilt from this PR's HEAD, production is running code that isn't in this PR.

## Test plan

- [x] Migration applied to remote D1 — 23 rows backfilled, 0 captured
- [x] `wrangler secret put RECEIPTS_PROCESSOR_KEY` — set, `wrangler secret list` confirms
- [x] Hash-verified the secret matches between Worker secret store and `scripts/receipts-consumer/.env`
- [x] `npm run build:cf` passes
- [x] `npx wrangler deploy` — version `fc3187c0`, producer binding live, `Number of Producers: 1` on queue
- [x] MLX consumer smoke test on 2 real receipts (丸屋 + Holiday Sky Lounge) — all fields correct
- [ ] **Pending**: register HTTP pull consumer on queue (dashboard)
- [ ] **Pending**: create Queues Read+Edit API token, add to consumer `.env`
- [ ] **Pending**: end-to-end dry run — capture 1 receipt, run `./run.sh --once`, verify `captured → needs_review`
- [ ] **Pending**: field-level accuracy eval vs. regex baseline on held-out reconciled month (per ADR line 98)