### PR TITLE
feat(clerk): Phase 2 cutover — Clerk as single auth for receipts + admin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,13 @@ CF_ACCESS_AUD=
 RECEIPTS_AUTH_USERNAME=
 RECEIPTS_AUTH_PASSWORD=
 RECEIPTS_DEVICE_SECRET=
+
+# Clerk — publishable key is build-time (NEXT_PUBLIC_*),.env.production holds
+# the live pk_live_... key for `build:cf`. CLERK_SECRET_KEY is a Wrangler
+# runtime secret, NEVER here. Sign-in/up + post-auth landing routes are public
+# values (URL paths), safe to inline into the client bundle.
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=
+NEXT_PUBLIC_CLERK_SIGN_IN_URL=/receipts/sign-in
+NEXT_PUBLIC_CLERK_SIGN_UP_URL=/receipts/sign-in
+NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL=/receipts
+NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL=/receipts

--- a/app/(receipt-system)/receipts/enroll/page.tsx
+++ b/app/(receipt-system)/receipts/enroll/page.tsx
@@ -1,66 +1,11 @@
+import { redirect } from "next/navigation";
 import type { Metadata } from "next";
-import { headers } from "next/headers";
-import { requireReceiptsActor } from "@/lib/receipts/auth";
-import { EnrollDeviceForm } from "@/components/receipts/enroll-device-form";
 
 export const metadata: Metadata = {
-  title: "Trust this device — Receipts",
+  title: "Sign in — Receipts",
   robots: { index: false, follow: false },
 };
 
-interface PageProps {
-  searchParams: Promise<{ next?: string }>;
-}
-
-export default async function EnrollDevicePage({ searchParams }: PageProps) {
-  const requestHeaders = await headers();
-  let actor: string;
-  try {
-    actor = await requireReceiptsActor(requestHeaders);
-  } catch {
-    return (
-      <div className="mx-auto my-12 max-w-lg rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
-        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-amber-600">
-          Protected receipts
-        </p>
-        <h1 className="mt-2 text-2xl font-semibold text-gray-900">
-          Sign in required
-        </h1>
-        <p className="mt-2 text-sm text-gray-600">
-          Open this module through the protected Dazbeez receipts route, or use
-          the local development credentials configured for this workspace.
-        </p>
-      </div>
-    );
-  }
-  const { next } = await searchParams;
-  const safeNext = next && next.startsWith("/receipts") ? next : "/receipts";
-
-  return (
-    <div className="mx-auto my-12 max-w-lg rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
-      <p className="text-xs font-semibold uppercase tracking-[0.24em] text-amber-600">
-        Trusted device
-      </p>
-      <h1 className="mt-2 text-2xl font-semibold text-gray-900">
-        Trust this device
-      </h1>
-      <p className="mt-2 text-sm text-gray-600">
-        You&rsquo;re signed in as{" "}
-        <span className="font-medium text-gray-900">{actor}</span>. Naming this
-        device sets a long-lived cookie so you won&rsquo;t need to sign in again
-        for a year.
-      </p>
-      <EnrollDeviceForm next={safeNext} />
-      <p className="mt-4 text-xs text-gray-500">
-        Manage or revoke devices from{" "}
-        <a
-          href="/receipts/settings/devices"
-          className="text-amber-700 underline"
-        >
-          Settings → Devices
-        </a>
-        .
-      </p>
-    </div>
-  );
+export default function EnrollDevicePage() {
+  redirect("/receipts/sign-in");
 }

--- a/app/(receipt-system)/receipts/settings/devices/page.tsx
+++ b/app/(receipt-system)/receipts/settings/devices/page.tsx
@@ -17,7 +17,7 @@ export const metadata: Metadata = {
 export default async function DevicesPage() {
   const requestHeaders = await headers();
   const actor = await getReceiptsPageActor();
-  const isOwner = isReceiptsOwner(actor);
+  const isOwner = await isReceiptsOwner(actor);
   // Owners get the full fleet across every user; everyone else sees their own.
   const devices = isOwner
     ? await listAllDevices()

--- a/app/(receipt-system)/receipts/sign-in/[[...sign-in]]/page.tsx
+++ b/app/(receipt-system)/receipts/sign-in/[[...sign-in]]/page.tsx
@@ -1,0 +1,25 @@
+import { SignIn } from "@clerk/nextjs";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Sign in — Dazbeez Receipts",
+  robots: { index: false, follow: false },
+};
+
+export default function ReceiptsSignInPage() {
+  return (
+    <div className="mx-auto my-12 flex max-w-md flex-col gap-6 rounded-2xl border border-gray-200 bg-white p-8 shadow-sm">
+      <header>
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-amber-600">
+          Dazbeez Receipts
+        </p>
+        <h1 className="mt-2 text-2xl font-semibold text-gray-900">Sign in</h1>
+        <p className="mt-1 text-sm text-gray-600">
+          Use the email address associated with your receipts account. A
+          one-time code will be sent to confirm.
+        </p>
+      </header>
+      <SignIn />
+    </div>
+  );
+}

--- a/app/api/receipts/devices/[id]/revoke/route.ts
+++ b/app/api/receipts/devices/[id]/revoke/route.ts
@@ -20,7 +20,7 @@ export async function POST(
     }
 
     // Owners can revoke any device; everyone else only their own.
-    if (isReceiptsOwner(actor)) {
+    if (await isReceiptsOwner(actor)) {
       await revokeDeviceById(id);
     } else {
       await revokeDevice(id, actor);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import Image from "next/image";
 import Link from "next/link";
+import { ClerkProvider } from "@clerk/nextjs";
 import { SiteNavigation } from "@/components/site-navigation";
 import "./globals.css";
 
@@ -119,15 +120,17 @@ export default function RootLayout({
   return (
     <html lang="en" className={`${inter.variable} antialiased`}>
       <body className="min-h-screen flex flex-col">
-        <a
-          href="#main-content"
-          className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-[60] focus:rounded-md focus:bg-amber-500 focus:px-4 focus:py-2 focus:text-white focus:shadow-lg"
-        >
-          Skip to main content
-        </a>
-        <SiteNavigation />
-        <main id="main-content" className="flex-1">{children}</main>
-        <Footer />
+        <ClerkProvider>
+          <a
+            href="#main-content"
+            className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-[60] focus:rounded-md focus:bg-amber-500 focus:px-4 focus:py-2 focus:text-white focus:shadow-lg"
+          >
+            Skip to main content
+          </a>
+          <SiteNavigation />
+          <main id="main-content" className="flex-1">{children}</main>
+          <Footer />
+        </ClerkProvider>
       </body>
     </html>
   );

--- a/docs/runbooks/clerk-auth-migration.md
+++ b/docs/runbooks/clerk-auth-migration.md
@@ -1,0 +1,199 @@
+# Migration plan — Clerk replaces CF Access + Basic-auth + owners.ts
+
+Status: Phase 0 closed (3 of 4 secrets rotated out of the bundle; `NFC_ADMIN_API_KEY` deferred).
+Phase 1 in progress — Clerk app created (Production instance, custom domain `clerk.dazbeez.com`),
+keys wired (publishable in `.env.production`, secret via `wrangler secret put`), session duration
+and sign-in methods configured. Remaining Phase 1 item: `publicMetadata.role` on each user (requires
+first sign-in). Spike (`spike/clerk-feasibility`) confirmed Clerk builds and runs cleanly on this
+app's Cloudflare Workers/OpenNext setup, and the build-time publishable-key delivery question is also
+resolved (`spike/clerk-publishable-key-build-time`).
+
+## ⚠️ Unrelated urgent issue found during the build-time-key spike (fix before Phase 1)
+
+While confirming how `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` gets inlined at build time, the spike discovered
+that `.open-next/cloudflare/next-env.mjs` exports **every** var from the root `.env` file — not just
+`NEXT_PUBLIC_*` ones — into the deployed Worker bundle. `ADMIN_PAGE_PASSWORD`, `CLOUDFLARE_TUNNEL_TOKEN`,
+`ANTHROPIC_API_KEY`, and `NFC_ADMIN_API_KEY` are currently shipping in plaintext inside the live deployed
+Worker code. This is pre-existing and unrelated to Clerk, but was surfaced by this work.
+
+**Action, independent of this migration and higher priority:** rotate all four credentials, then move them
+out of the root `.env` file into real Wrangler secrets (`wrangler secret put ...`) or `.dev.vars`
+(local-only), so they're runtime-only and never enter the build artifact. Root `.env` /
+`.env.production` should hold **only** genuinely public `NEXT_PUBLIC_*` values from here on (i.e. just the
+Clerk publishable key). See the "Decisions" section below — this has its own line item now.
+
+**Status: closed, except NFC_ADMIN_API_KEY (deferred by David).** Findings from the closeout task
+(`fix/secrets-hygiene-next-env-mjs`, deployed as `dc0360b1-...`):
+- `ADMIN_PAGE_USERNAME`/`ADMIN_PAGE_PASSWORD` are the only ones of the four actually read by live Worker
+  code (`lib/admin-page-auth.ts`). Both are now real Wrangler secrets with rotated values — the actual
+  runtime credential is fixed, not just the `.env` file.
+- `ANTHROPIC_API_KEY` and `CLOUDFLARE_TUNNEL_TOKEN` were confirmed (by the Mac session, and independently
+  re-verified by a repo-wide grep in the sandbox) to be unused by any committed application code — they
+  were vestigial `.env` entries that got swept into the bundle by OpenNext's blanket env export, not live
+  credentials the app reads. Removed from `.env` entirely; no Wrangler secret needed since nothing
+  consumes them. The Cloudflare Tunnel's actual signing credential (a local `.json` file, never in the
+  repo) was never exposed — only its UUID was, via `.env`.
+- Old values confirmed purged from `.open-next/cloudflare/next-env.mjs` after rebuild + redeploy; smoke
+  test passed (same pre-existing `/admin` 500, unrelated).
+- **Follow-up caught during sandbox verification, not yet done:** the old (pre-rotation) values were
+  also found cached in plaintext in local `.wrangler/tmp/dev-*/worker.js` build artifacts from earlier
+  `wrangler dev`/`cf:dev` runs. Confirmed gitignored — never reached git or a real deployment — but still
+  worth clearing: `rm -rf .wrangler/tmp` (safe, regenerates automatically).
+- **Separate, low-urgency cleanup suggestion:** the tunnel whose UUID was exposed (`server-tunnel`,
+  serving 404s) is vestigial per README.md:116 — production no longer uses Cloudflare Tunnel. Consider
+  deleting it outright rather than just noting the exposure.
+- `NFC_ADMIN_API_KEY` remains untouched and still exposed in the bundle, per David's explicit deferral.
+
+## Why
+
+Five independent, ad hoc auth mechanisms currently gate this app for exactly 2 real users:
+
+| # | Mechanism | File(s) | Problem |
+|---|---|---|---|
+| 1 | Cloudflare Access (edge JWT) | `lib/receipts/auth.ts:130-234`, config lives only in the CF dashboard | Config has no source of truth in the repo (see `docs/runbooks/cf-access-app.md`) — drifts silently |
+| 2 | Web "trusted device" cookie | `lib/receipts/trusted-devices.ts` | Custom HMAC scheme, 1-year expiry, one more thing to maintain |
+| 3 | Basic-auth fallback | `lib/receipts/auth.ts:15-24,264-275` (`RECEIPTS_AUTH_USERNAME/PASSWORD`) | Meant for local dev, live as a real prod path with no env gate |
+| 4 | Admin Basic-auth | `lib/admin-page-auth.ts` (`ADMIN_PAGE_USERNAME/PASSWORD`) | Entirely separate from everything else — third identity concept |
+| 5 | Owner allowlist | `lib/receipts/owners.ts:9` (`RECEIPTS_OWNER_EMAILS`) | Manually duplicated against the CF Access dashboard policy; nothing checks the two agree |
+
+Enforcement is also scattered across ~30 individual page/route call sites since `middleware.ts` was
+deleted (commit `7babde1`, 2026-05-16) — a new route that forgets to call the guard fails open.
+
+Two more mechanisms exist for **machines**, not people, and are explicitly **out of scope** — Clerk
+doesn't fit them and they aren't part of the "clunky" problem:
+
+- Mobile device pairing (`lib/receipts/mobile-pairing.ts`) — the iPhone capture app.
+- `RECEIPTS_PROCESSOR_KEY` — the Mac MLX OCR consumer.
+
+## Target state
+
+One Clerk application. `clerkMiddleware()` becomes the single chokepoint gating `/receipts/:path*` and
+`/admin/:path*` — this also fixes the "scattered, fails-open" regression from the `middleware.ts`
+deletion, as a side effect of adopting Clerk's idiomatic Next.js pattern. "Owner" becomes a Clerk
+`publicMetadata.role` field on your two Clerk users instead of an env var that has to match a second,
+separately-maintained list. CF Access, both Basic-auth schemes, and `owners.ts`'s allowlist are retired.
+
+## Sequencing
+
+Given this is a live system 2 people use daily, this plan avoids both extremes — no long-lived
+dual-auth transition layer (more code than it's worth for 2 users), and no uncoordinated flag-day
+cutover either. Four phases, each independently reversible.
+
+### Phase 0 — Unrelated secrets hygiene fix (do first, blocks nothing else but shouldn't wait)
+
+- [ ] Rotate `ADMIN_PAGE_PASSWORD`, `CLOUDFLARE_TUNNEL_TOKEN`, `ANTHROPIC_API_KEY`, `NFC_ADMIN_API_KEY` —
+      all four are currently exposed in plaintext in the deployed Worker bundle (see callout above).
+- [ ] Move the rotated values out of the root `.env` file into `wrangler secret put` (or `.dev.vars` for
+      local-only use). Confirm `next-env.mjs` no longer contains them after the next `build:cf`.
+
+### Phase 1 — Clerk setup (config only, nothing deployed)
+
+- [x] **Decided: Production instance with custom domain `clerk.dazbeez.com`.** Reversal of an earlier
+      "stay on Development" draft — confirmed intentional by David, Jul 4. The tighter same-site session
+      cookie behavior of Production is worth the one-time DNS CNAME setup; Development's
+      querystring-based `__clerk_db_jwt` mechanism (which the spike proved works) is acceptable but the
+      same-site cookie is cleaner. Custom domain live, `pk_live_...` wired into `.env.production`,
+      `sk_live_...` set as a Wrangler runtime secret.
+- [x] **Clerk Application created** — Production instance with custom domain `clerk.dazbeez.com`. The
+      `spike/clerk-feasibility` test app (`golden-mosquito-...`) on Development is now superseded; its
+      test keys (`pk_test_...` / `sk_test_...`) passed through chat during the spike and should be
+      discarded/rotated in the Clerk dashboard (no production path depends on them).
+- [x] **Decided: email one-time code only.** No social/OAuth providers for now — avoids the
+      sso-callback route entirely. Revisit later if Google sign-in becomes wanted.
+- [x] **Decided: longest session duration Clerk's dashboard allows ("no limit / max").** Clerk's
+      Session settings expose an "Inactivity timeout" and a "Maximum lifetime" — set both to the longest
+      values the dashboard offers (Clerk may not literally offer "infinite"; if there's a practical cap,
+      use it). This matches the 1-year, effectively-indefinite behavior of the trusted-device cookie it's
+      replacing. Confirm the actual max in the dashboard when creating the app — the exact ceiling wasn't
+      verified here.
+- [ ] In the Clerk dashboard, manually set `publicMetadata: { role: "owner" }` on your account and
+      `publicMetadata: { role: "member" }` (or leave unset) on Taz's — trivial with 2 users, no code needed.
+      Can only be done after each of you has signed in at least once (Clerk users don't exist before that).
+- [x] **Resolved: build-time publishable key delivery.** `.env.production` at the repo root (gitignored),
+      containing `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_...`. `npm run build:cf` → `opennextjs-cloudflare
+      build` runs `next build` as a subprocess inheriting the parent env; Next.js auto-loads
+      `.env.production` and inlines `NEXT_PUBLIC_*` vars into client chunks at build time. Confirmed
+      empirically (placeholder value found literally inlined in `.open-next/assets/.../*.js` after a real
+      build) — see `spike/clerk-publishable-key-build-time`. `wrangler.jsonc`'s `vars` block is NOT the
+      right place — that's runtime Worker env, not build-time. `CLERK_SECRET_KEY` remains a genuine
+      runtime secret via `wrangler secret put CLERK_SECRET_KEY`, unaffected by any of this.
+      **Do not put the four Phase-0 secrets in `.env`/`.env.production` — that file ships into the bundle
+      wholesale, which is exactly the Phase 0 problem.**
+
+### Phase 2 — Wire Clerk as the real gate (one deploy, reversible)
+
+- [x] Create `middleware.ts` using `clerkMiddleware()`. The matcher explicitly includes
+      `/receipts/:path*`, `/admin/:path*`, **and** `/api/receipts/:path*` — the API path does not match
+      `/receipts/:path*` and would be unprotected otherwise. `/api/mobile/*` is intentionally NOT in the
+      matcher (separate bearer-token scheme).
+      **Deviation from the original plan** (which called for `proxy.ts`): Next.js 16 made `proxy.ts`
+      Node.js-only (`runtime = "edge"` is rejected outright with "Proxy always runs on Node.js runtime"),
+      but OpenNext-on-Cloudflare-Workers only supports Edge middleware. The legacy `middleware.ts`
+      name still defaults to Edge under OpenNext and is the only path that builds today. Spike
+      (`spike/clerk-feasibility`, commit `881d51d`) established this. Revisit when OpenNext supports
+      Node.js proxy, or when Next.js 17 removes `middleware.ts` entirely.
+- [x] Add a real sign-in route at `app/(receipt-system)/receipts/sign-in/[[...sign-in]]/page.tsx` using
+      `<SignIn />`. (Note the `(receipt-system)` route group — `app/receipts/sign-in/...` would not
+      resolve.) `/receipts/enroll` kept alive as a redirect shim to it, in case it's bookmarked.
+- [x] Rewrite `requireReceiptsActor` / `isReceiptsAuthorizedLight` (`lib/receipts/auth.ts`) to resolve
+      identity via Clerk's `auth()` (from `@clerk/nextjs/server` — **not** `@clerk/nextjs`, per the spike's
+      own gotcha) instead of the CF-Access/cookie/Basic-auth chain. Keep the returned "actor" shaped as an
+      email string, so the audit log, cardholder matching, etc. don't need to change.
+- [x] Replace `owners.ts`'s array check with `sessionClaims?.publicMetadata?.role === "owner"`.
+- [x] Point `/admin`'s guard (`lib/admin-page-auth.ts` / `assertAdminPageAccess`) at the same Clerk +
+      owner-role check, folding admin into one identity system instead of a third, separate one. This
+      also fixes the `/admin` 500 (broken since the `middleware.ts` deletion) as a side effect, since it'll
+      get a real redirect instead of an uncaught throw.
+- [ ] **Do not delete Cloudflare Access yet.** Leave the edge policy active through this phase as a
+      safety net — if something in the Clerk wiring is wrong, Access still gates the edge and the failure
+      mode is "broken app page," not "receipts data exposed." This is what makes Phase 2 reversible:
+      rollback = redeploy the previous Worker version (Cloudflare keeps prior deployments; roll back via
+      dashboard or `wrangler`).
+- [ ] Ship at a quiet time. Verify both you and Taz can sign in for real, on your real devices, before
+      moving on.
+
+### Phase 3 — Device trust cleanup
+
+- [ ] Decide whether to delete the web half of `lib/receipts/trusted-devices.ts` (the "remember this
+      browser" HMAC cookie) now that Clerk's own session cookie covers the same need. **Recommended: yes**
+      — one less custom crypto scheme — but confirm Clerk's session duration (set in Phase 1) actually
+      matches what you want before removing the old fallback.
+- [ ] Confirm the mobile-pairing "approve this device" step (`complete-pairing` route) now runs through
+      the Clerk-based `requireReceiptsActor` from Phase 2 — this should fall out automatically since that
+      route already calls `requireReceiptsActor`, but verify it explicitly with a real pairing test.
+- [ ] Add an actual expiry to the mobile bearer token (`lib/receipts/mobile-pairing.ts`) — it currently
+      has none, only revocation. Unrelated to Clerk itself, but worth bundling in since this code is
+      already being touched. Suggest 90 days to 1 year with a silent re-pair prompt.
+
+### Phase 4 — Retire the old mechanisms (after a 2-day burn-in period on Clerk with no issues — decided)
+
+- [ ] Delete the Cloudflare Access application/policy in the dashboard.
+- [ ] Delete the `RECEIPTS_AUTH_USERNAME`/`RECEIPTS_AUTH_PASSWORD` Basic-auth code path and secrets.
+- [ ] Delete the `ADMIN_PAGE_USERNAME`/`ADMIN_PAGE_PASSWORD` Basic-auth code and secrets.
+- [ ] Delete `lib/receipts/owners.ts`'s env-var allowlist path entirely.
+- [ ] Remove now-dead Wrangler secrets: `CF_ACCESS_TEAM`, `CF_ACCESS_AUD`, `RECEIPTS_AUTH_USERNAME`,
+      `RECEIPTS_AUTH_PASSWORD`, `ADMIN_PAGE_USERNAME`, `ADMIN_PAGE_PASSWORD`, `RECEIPTS_OWNER_EMAILS`.
+- [ ] Archive `docs/runbooks/cf-access-app.md` (or delete it) and write a replacement
+      `docs/runbooks/clerk-auth.md` documenting the new single-system setup, so the next "sign-in doesn't
+      persist" investigation starts from Clerk's dashboard, not a stale CF Access runbook.
+
+## Decisions
+
+1. **Build-time publishable key delivery** — resolved: `.env.production`, confirmed empirically. See
+   Phase 1.
+2. **Sign-in methods** — email one-time code only. Decided.
+3. **Session duration** — longest available / no practical limit. Decided.
+4. **Burn-in length before Phase 4** — 2 days. Decided (shorter than the 2-week default originally
+   suggested — David's call).
+5. **Clerk instance type** — Production with custom domain `clerk.dazbeez.com`. Decided Jul 4 (reversal
+   of an earlier "stay on Development" draft — the same-site session cookie is worth the DNS setup).
+6. **Unrelated secrets exposure (Phase 0)** — rotate `ADMIN_PAGE_PASSWORD`, `CLOUDFLARE_TUNNEL_TOKEN`,
+   `ANTHROPIC_API_KEY`, `NFC_ADMIN_API_KEY` and move them off the root `.env` file. Higher priority than
+   the rest of this plan; doesn't block it either way.
+
+## Rollback
+
+Every phase before Phase 4 is a single deploy or a dashboard-only config change — rollback is "redeploy
+the previous Worker version" (Phase 2) or "no-op, nothing shipped yet" (Phase 1, 3 config parts). Phase 4
+is the only one that removes fallback paths permanently, which is why it's gated on a burn-in period with
+no issues on the new system first.

--- a/docs/runbooks/clerk-auth-migration.md
+++ b/docs/runbooks/clerk-auth-migration.md
@@ -1,12 +1,16 @@
 # Migration plan — Clerk replaces CF Access + Basic-auth + owners.ts
 
 Status: Phase 0 closed (3 of 4 secrets rotated out of the bundle; `NFC_ADMIN_API_KEY` deferred).
-Phase 1 in progress — Clerk app created (Production instance, custom domain `clerk.dazbeez.com`),
-keys wired (publishable in `.env.production`, secret via `wrangler secret put`), session duration
-and sign-in methods configured. Remaining Phase 1 item: `publicMetadata.role` on each user (requires
-first sign-in). Spike (`spike/clerk-feasibility`) confirmed Clerk builds and runs cleanly on this
-app's Cloudflare Workers/OpenNext setup, and the build-time publishable-key delivery question is also
-resolved (`spike/clerk-publishable-key-build-time`).
+Phase 1 closed Jul 4 via `clerk` CLI — see Phase 1 section for what's now verified firsthand.
+Phase 2 implemented on `feat/clerk-phase2` (commit `aaa2549`), pending S7 cf:dev sign-in test
+and S8 deploy.
+
+The original Phase 1 status note (kept for history): Clerk app created (Production instance,
+custom domain `clerk.dazbeez.com`), keys wired (publishable in `.env.production`, secret via
+`wrangler secret put`), session duration and sign-in methods configured. Spike
+(`spike/clerk-feasibility`) confirmed Clerk builds and runs cleanly on this app's Cloudflare
+Workers/OpenNext setup, and the build-time publishable-key delivery question is also resolved
+(`spike/clerk-publishable-key-build-time`).
 
 ## ⚠️ Unrelated urgent issue found during the build-time-key spike (fix before Phase 1)
 
@@ -94,21 +98,56 @@ cutover either. Four phases, each independently reversible.
       querystring-based `__clerk_db_jwt` mechanism (which the spike proved works) is acceptable but the
       same-site cookie is cleaner. Custom domain live, `pk_live_...` wired into `.env.production`,
       `sk_live_...` set as a Wrangler runtime secret.
-- [x] **Clerk Application created** — Production instance with custom domain `clerk.dazbeez.com`. The
-      `spike/clerk-feasibility` test app (`golden-mosquito-...`) on Development is now superseded; its
-      test keys (`pk_test_...` / `sk_test_...`) passed through chat during the spike and should be
-      discarded/rotated in the Clerk dashboard (no production path depends on them).
+      **Verified firsthand Jul 4 via `clerk deploy status`:** domain `dazbeez.com` reports
+      `dns: complete`, `ssl: complete`, `mail: complete`, no pending DNS records. Production
+      instance ID `ins_3G1ekzEjYUWPN7XHC6tr0IgRgmn`. (Caveat: `deploy status` also reports
+      `state: oauth_pending` because Google OAuth is "configured but missing production credentials"
+      — David needs to either finish Google OAuth or remove it from the production instance. Not a
+      blocker for email-code sign-in, which is the only sign-in method this app uses.)
+- [x] **Clerk Application created** — one "Dazbeez" application (`app_3G1RAC2rvCzeSrA48wPNkoP1D0q`)
+      with two instances: Development (`ins_3G1RAD5kUWoayFhcHLOvKcAybTn`, frontend host
+      `golden-mosquito-0.clerk.accounts.dev`, `pk_test_...`) and Production
+      (`ins_3G1ekzEjYUWPN7XHC6tr0IgRgmn`, `clerk.dazbeez.com`, `pk_live_...`). The spike's
+      "separate test app `golden-mosquito-...`" turned out to be just the Development instance of
+      the same Dazbeez app (Clerk's standard one-app-two-instances pattern), not a separate app —
+      verified via `clerk apps list`. The dev instance's test keys (`pk_test_...` / `sk_test_...`)
+      passed through chat during the spike should still be rotated in the Clerk dashboard for hygiene.
 - [x] **Decided: email one-time code only.** No social/OAuth providers for now — avoids the
       sso-callback route entirely. Revisit later if Google sign-in becomes wanted.
+      **Verified firsthand Jul 4 via `clerk config pull --instance prod`:**
+      `auth_email.sign_in_strategies: ["email_code"]`, `verification_strategies: ["email_code"]`,
+      `used_for_sign_in: true`, `used_for_sign_up: true`, `verify_at_sign_up: true`. No other
+      auth_* blocks enabled.
 - [x] **Decided: longest session duration Clerk's dashboard allows ("no limit / max").** Clerk's
       Session settings expose an "Inactivity timeout" and a "Maximum lifetime" — set both to the longest
       values the dashboard offers (Clerk may not literally offer "infinite"; if there's a practical cap,
       use it). This matches the 1-year, effectively-indefinite behavior of the trusted-device cookie it's
       replacing. Confirm the actual max in the dashboard when creating the app — the exact ceiling wasn't
       verified here.
-- [ ] In the Clerk dashboard, manually set `publicMetadata: { role: "owner" }` on your account and
-      `publicMetadata: { role: "member" }` (or leave unset) on Taz's — trivial with 2 users, no code needed.
-      Can only be done after each of you has signed in at least once (Clerk users don't exist before that).
+      **Resolved Jul 4 — decision revised, not achievable as originally scoped:** David checked the
+      dashboard's "Inactivity timeout" / "Maximum lifetime" settings directly — both are **Pro-plan-only**
+      for production instances. Free plan is fixed at a **7-day maximum session lifetime**, non-
+      configurable. David's call: stay on the free plan, accept 7 days rather than upgrade. Real
+      consequence: both of you will need to re-sign-in (email code) roughly weekly, versus the ~1-year
+      effective lifetime of the trusted-device cookie this replaces — a real but minor UX step down,
+      accepted as worth it to avoid a paid plan for 2 users. (`session.lifetime` in the CLI's config
+      schema is a separate, unrelated setting — the underlying JWT token's technical lifetime, not the
+      persistent session; that one Clerk deliberately keeps short (default 60s) and silently refreshes,
+      and is not what needed changing here.)
+- [x] **`publicMetadata.role` set on both real users via Clerk CLI** (Jul 4). Done via
+      `clerk api /users/{id}/metadata -X PATCH -d '{"public_metadata":{"role":"..."}}' --instance prod`.
+      - `david.klan@gmail.com` (`user_3G1q2nsu5ddo2H6wtKcvseX8gGs`) → `public_metadata: {role: "owner"}`
+      - `tazukowen@gmail.com` (`user_3G1q4tZjrym0fH2IqfZmJh440AM`) → `public_metadata: {role: "member"}`
+      Both users already existed in the production instance (likely from earlier dashboard preview or
+      spike testing — `last_active_at: null` confirms neither has done a real browser sign-in yet).
+      No pre-create/invite needed; roles are pre-set so first real sign-in will already carry the claim.
+      **Gotcha:** the older `PATCH /users/{id}` with `public_metadata` in the body is deprecated and
+      silently no-ops — must use the dedicated `PATCH /users/{id}/metadata` endpoint instead.
+- [x] **Session claim exposing `publicMetadata` configured** (Jul 4). `clerk config patch --instance prod`
+      with `{"session":{"claims":{"publicMetadata":"{{user.public_metadata}}"}}}`. Resulting session
+      config: `{"allowed_clock_skew":5,"claims":{"publicMetadata":"{{user.public_metadata}}"},"lifetime":60}`.
+      This shape keeps `lib/clerk-owner.ts` and `lib/receipts/owners.ts` working unchanged — they read
+      `session.sessionClaims.publicMetadata.role`, which is now populated.
 - [x] **Resolved: build-time publishable key delivery.** `.env.production` at the repo root (gitignored),
       containing `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_...`. `npm run build:cf` → `opennextjs-cloudflare
       build` runs `next build` as a subprocess inheriting the parent env; Next.js auto-loads
@@ -181,8 +220,11 @@ cutover either. Four phases, each independently reversible.
 
 1. **Build-time publishable key delivery** — resolved: `.env.production`, confirmed empirically. See
    Phase 1.
-2. **Sign-in methods** — email one-time code only. Decided.
-3. **Session duration** — longest available / no practical limit. Decided.
+2. **Sign-in methods** — email one-time code only. Decided; Google OAuth disabled Jul 4 (was
+   half-configured/pending, never completed, would have shown a broken button).
+3. **Session duration** — revised Jul 4: 7-day maximum lifetime (free-plan fixed limit; Pro required to
+   extend). David chose to stay on the free plan rather than upgrade — accepted weekly re-sign-in as the
+   real cost, down from the trusted-device cookie's ~1-year lifetime.
 4. **Burn-in length before Phase 4** — 2 days. Decided (shorter than the 2-week default originally
    suggested — David's call).
 5. **Clerk instance type** — Production with custom domain `clerk.dazbeez.com`. Decided Jul 4 (reversal

--- a/docs/runbooks/clerk-auth-migration.md
+++ b/docs/runbooks/clerk-auth-migration.md
@@ -2,8 +2,11 @@
 
 Status: Phase 0 closed (3 of 4 secrets rotated out of the bundle; `NFC_ADMIN_API_KEY` deferred).
 Phase 1 closed Jul 4 via `clerk` CLI — see Phase 1 section for what's now verified firsthand.
-Phase 2 implemented on `feat/clerk-phase2` (commit `aaa2549`), pending S7 cf:dev sign-in test
-and S8 deploy.
+Phase 2 implemented on `feat/clerk-phase2` (commits `aaa2549`, `db77a9e`, `522bf50`), with the
+middleware `await` fix from S7 applied. cf:dev sign-in flow **cannot be verified locally** —
+production publishable keys reject `localhost` Origin (Clerk allowlist, not a code bug); see the
+Phase 2 gotcha note below. Server-side gates verified via curl. S7 sub-checks (b), (c), (d) deferred
+to the post-deploy production smoke test.
 
 The original Phase 1 status note (kept for history): Clerk app created (Production instance,
 custom domain `clerk.dazbeez.com`), keys wired (publishable in `.env.production`, secret via
@@ -186,6 +189,26 @@ cutover either. Four phases, each independently reversible.
       handler ever runs. A 404 doesn't leak whether the route exists, which is fine for an internal
       API. No frontend code observed depending on the 401 status specifically. Revisit only if it
       causes real friction.
+- [ ] **cf:dev cannot exercise the real Clerk sign-in flow with production keys.** Caught during S7:
+      the production publishable key (`pk_live_...`) rejects any request whose `Origin` is not
+      `dazbeez.com` or a subdomain. Browser DevTools shows `GET https://clerk.dazbeez.com/v1/client
+      400 (Bad Request)` and `Clerk: Production Keys are only allowed for domain "dazbeez.com"`.
+      ClerkJS hydration aborts, so `<SignIn />` renders as an empty card with no inputs. This is a
+      Clerk-side allowlist, not a code bug. Workarounds: (a) add `http://localhost:8787` to the
+      production instance's allowed origins in Clerk Dashboard → Domains & Proxy, or (b) verify
+      sign-in on the production URL instead. We chose (b) — server-side gates (middleware, redirect,
+      matcher) all verify via curl locally, and sign-in end-to-end is meaningless against anything
+      other than the real production instance anyway. **Consequence:** S7 sub-checks (b) real sign-in,
+      (c) session persistence, (d) admin/owner role verification are deferred to the post-deploy
+      production smoke test. The spike (`spike/clerk-feasibility`) only ever used test keys, which
+      don't have this restriction, so this gotcha wasn't surfaced earlier.
+- [x] **Publishable key typo caught during S7:** the key `clerk env pull --instance prod` returned
+      decoded (via base64) to `clerk.dazbeiz.com` — a typo (missing `e`). Symptom: ClerkJS script
+      tag pointed at a non-resolvable host (`clerk.dazbeiz.com` → NXDOMAIN), so the form never
+      started hydrating at all. Correct key synthesized via `echo -n 'clerk.dazbeez.com' | base64`
+      = `Y2xlcmsuZGF6YmVlei5jb20k`, prefix `pk_live_`. Fixed in `.dev.vars` and `.env.production`.
+      Root cause: stale/wrong data from `clerk env pull`. Mitigation going forward: trust the
+      Clerk Dashboard's "Frontend API URL" field, not the CLI output, when reconstructing a key.
 - [x] Add a real sign-in route at `app/(receipt-system)/receipts/sign-in/[[...sign-in]]/page.tsx` using
       `<SignIn />`. (Note the `(receipt-system)` route group — `app/receipts/sign-in/...` would not
       resolve.) `/receipts/enroll` kept alive as a redirect shim to it, in case it's bookmarked.

--- a/docs/runbooks/clerk-auth-migration.md
+++ b/docs/runbooks/clerk-auth-migration.md
@@ -171,6 +171,21 @@ cutover either. Four phases, each independently reversible.
       name still defaults to Edge under OpenNext and is the only path that builds today. Spike
       (`spike/clerk-feasibility`, commit `881d51d`) established this. Revisit when OpenNext supports
       Node.js proxy, or when Next.js 17 removes `middleware.ts` entirely.
+      **Gotcha caught during S7 cf:dev verification:** the handler MUST `await auth.protect()` (or
+      `return` it). A bare `auth.protect();` is a floating promise — the synchronous throw inside
+      `createProtect`'s async wrapper (`node_modules/@clerk/nextjs/dist/esm/server/protect.js`) becomes
+      a silent Promise rejection, and the request falls through to the page with the middleware a
+      no-op. Symptom: `/admin` kept 500-ing (the layout's `assertAdminPageAccess` threw instead of
+      getting the redirect), and the cf:dev log showed zero `/clerk_<timestamp>` rewrites. Fix:
+      `async (auth, request) => { ...; await auth.protect(); }`. After fix, browser requests with
+      `Accept: text/html` get the expected 307 → `/receipts/sign-in?redirect_url=...`, and non-page
+      probes get a 404 + `x-clerk-auth-reason: protect-rewrite` (Clerk's standard notFound-rewrite).
+- [x] **Accepted behavior change for `/api/receipts/*`:** unauthenticated API requests now return
+      **404** from Clerk's notFound-rewrite, not the previous 401 from the per-route
+      `requireReceiptsActor` fallback. Reasoning: middleware now short-circuits before the route
+      handler ever runs. A 404 doesn't leak whether the route exists, which is fine for an internal
+      API. No frontend code observed depending on the 401 status specifically. Revisit only if it
+      causes real friction.
 - [x] Add a real sign-in route at `app/(receipt-system)/receipts/sign-in/[[...sign-in]]/page.tsx` using
       `<SignIn />`. (Note the `(receipt-system)` route group — `app/receipts/sign-in/...` would not
       resolve.) `/receipts/enroll` kept alive as a redirect shim to it, in case it's bookmarked.

--- a/lib/admin-page-auth-request.ts
+++ b/lib/admin-page-auth-request.ts
@@ -1,13 +1,9 @@
-import { headers } from "next/headers";
-import { assertAdminPageAccessFromHeaders, getAdminPageUsernameFromHeaders } from "@/lib/admin-page-auth";
+import { requireOwnerActor } from "@/lib/clerk-owner";
 
-export async function assertAdminPageAccess() {
-  const requestHeaders = await headers();
-  assertAdminPageAccessFromHeaders(requestHeaders);
+export async function assertAdminPageAccess(): Promise<void> {
+  await requireOwnerActor();
 }
 
-export async function getAdminActor() {
-  const requestHeaders = await headers();
-  assertAdminPageAccessFromHeaders(requestHeaders);
-  return getAdminPageUsernameFromHeaders(requestHeaders) ?? "admin";
+export async function getAdminActor(): Promise<string> {
+  return requireOwnerActor();
 }

--- a/lib/admin-page-auth.ts
+++ b/lib/admin-page-auth.ts
@@ -95,8 +95,9 @@ export function isAdminPageAuthorized(requestHeaders: Headers) {
   );
 }
 
-export function assertAdminPageAccessFromHeaders(requestHeaders: Headers) {
-  if (!isAdminPageAuthorized(requestHeaders)) {
-    throw new Error("Unauthorized admin request.");
-  }
+export async function assertAdminPageAccessFromHeaders(
+  _requestHeaders: Headers,
+): Promise<void> {
+  const { requireOwnerActor } = await import("@/lib/clerk-owner");
+  await requireOwnerActor();
 }

--- a/lib/clerk-owner.ts
+++ b/lib/clerk-owner.ts
@@ -1,0 +1,32 @@
+import { auth, clerkClient } from "@clerk/nextjs/server";
+
+/**
+ * Shape of the Clerk session JWT's `publicMetadata` claim. Clerk's
+ * `CustomJwtSessionClaims` is `{ [k: string]: unknown }`, so we narrow here.
+ */
+type SessionClaimsWithRole = {
+  publicMetadata?: { role?: string };
+};
+
+/**
+ * Returns the actor email if the current Clerk session's user has
+ * `publicMetadata.role === "owner"`, otherwise throws. Single source of
+ * truth for /admin and cross-user device revoke. The role is read from
+ * `sessionClaims.publicMetadata` (no network call) since Clerk includes
+ * publicMetadata in the session JWT by default; the email requires a
+ * `clerkClient.users.getUser()` lookup.
+ */
+export async function requireOwnerActor(): Promise<string> {
+  const session = await auth();
+  const role = (session.sessionClaims as SessionClaimsWithRole | undefined)
+    ?.publicMetadata?.role;
+  if (!session.userId || role !== "owner") {
+    throw new Error("Unauthorized: owner role required.");
+  }
+  const client = await clerkClient();
+  const user = await client.users.getUser(session.userId);
+  const email = user.emailAddresses.find(
+    (e) => e.id === user.primaryEmailAddressId,
+  )?.emailAddress;
+  return email ?? user.username ?? session.userId;
+}

--- a/lib/receipts/auth-request.ts
+++ b/lib/receipts/auth-request.ts
@@ -5,18 +5,24 @@ import {
   requireReceiptsActor,
 } from "@/lib/receipts/auth";
 
-// Used by receipt pages before rendering protected content. Keeps to cheap
-// checks only (HMAC cookie, CF Access header presence) so page loads avoid
-// unnecessary D1 work and Worker CPU pressure.
+// Used by receipt pages before rendering protected content. The proxy already
+// gates these routes via Clerk, so this is now defense-in-depth: if the proxy
+// somehow let an unauthenticated request through, redirect to sign-in.
 export async function assertReceiptsPageAccess(): Promise<void> {
   const requestHeaders = await headers();
   const ok = await isReceiptsAuthorizedLight(requestHeaders);
-  if (!ok) redirect("/receipts/enroll");
+  if (!ok) redirect("/receipts/sign-in");
 }
 
 // Used by pages that need to know who is acting (actor shown in UI,
-// written to audit log). Runs the full check including DB revocation —
-// single pass, one verifyDeviceCookie round-trip.
+// written to audit log). Identity comes from Clerk via requireReceiptsActor.
+// The proxy guarantees a valid session by the time we get here; the try/catch
+// is defense-in-depth (clerkClient network failure, etc.) so a transient
+// error redirects to sign-in instead of crashing the page.
 export async function getReceiptsPageActor(): Promise<string> {
-  return requireReceiptsActor(await headers());
+  try {
+    return await requireReceiptsActor(await headers());
+  } catch {
+    redirect("/receipts/sign-in");
+  }
 }

--- a/lib/receipts/auth.ts
+++ b/lib/receipts/auth.ts
@@ -1,7 +1,5 @@
-import {
-  verifyDeviceCookie,
-  verifyDeviceCookieLight,
-} from "@/lib/receipts/trusted-devices";
+import { verifyDeviceCookie } from "@/lib/receipts/trusted-devices";
+import { auth, clerkClient } from "@clerk/nextjs/server";
 
 const RECEIPTS_REALM = "Dazbeez Receipts";
 
@@ -278,61 +276,38 @@ export async function isReceiptsAuthorized(
 }
 
 // Middleware-safe: no DB calls. Cookie via HMAC only; CF Access via decode.
+//
+// Phase 2 Clerk cutover: the entire CF-Access/cookie/Basic-auth chain above
+// is now bypassed — auth is enforced by `proxy.ts` via clerkMiddleware.
+// `auth()` here reads the Clerk session that the proxy already established.
+// The legacy helpers (isCfAccessTokenAcceptable, decodeBasicAuthorization,
+// verifyDeviceCookieLight) are kept as dead code, deleted in Phase 4.
 export async function isReceiptsAuthorizedLight(
-  requestHeaders: Headers,
+  _requestHeaders: Headers,
 ): Promise<boolean> {
-  const device = await verifyDeviceCookieLight(requestHeaders).catch(() => null);
-  if (device) return true;
-
-  const token = requestHeaders.get("Cf-Access-Jwt-Assertion");
-  const { ok } = await isCfAccessTokenAcceptable(token);
-  if (ok) return true;
-
-  const configuredUsername = process.env.RECEIPTS_AUTH_USERNAME?.trim();
-  const configuredPassword = process.env.RECEIPTS_AUTH_PASSWORD;
-  if (configuredUsername && configuredPassword) {
-    const provided = decodeBasicAuthorization(requestHeaders.get("authorization"));
-    if (
-      provided &&
-      safeEqual(provided.username, configuredUsername) &&
-      safeEqual(provided.password, configuredPassword)
-    ) {
-      return true;
-    }
-  }
-
-  return false;
+  const session = await auth();
+  return !!session.userId;
 }
 
 // Single-pass: verifies auth and returns the actor. Replaces the previous
 // assertReceiptsAccessFromHeaders + getReceiptsActor pair that every receipts
 // route called, which performed verifyDeviceCookie (HMAC + D1 lookup for
 // revocation) twice per request.
+//
+// Phase 2 Clerk cutover: identity comes from Clerk. The proxy gates the route,
+// so by the time we get here the session is valid; the userId check is
+// defense-in-depth. The legacy verification chain above is dead code (Phase 4).
 export async function requireReceiptsActor(
-  requestHeaders: Headers,
+  _requestHeaders: Headers,
 ): Promise<string> {
-  // 1. Trusted-device cookie (HMAC + DB revocation check).
-  const device = await verifyDeviceCookie(requestHeaders).catch(() => null);
-  if (device) return device.actor;
-
-  // 2. CF Access JWT.
-  const token = requestHeaders.get("Cf-Access-Jwt-Assertion");
-  const { ok, email } = await isCfAccessTokenAcceptable(token);
-  if (ok) return email ?? "receipts";
-
-  // 3. Basic auth — local dev only.
-  const configuredUsername = process.env.RECEIPTS_AUTH_USERNAME?.trim();
-  const configuredPassword = process.env.RECEIPTS_AUTH_PASSWORD;
-  if (configuredUsername && configuredPassword) {
-    const provided = decodeBasicAuthorization(requestHeaders.get("authorization"));
-    if (
-      provided &&
-      safeEqual(provided.username, configuredUsername) &&
-      safeEqual(provided.password, configuredPassword)
-    ) {
-      return provided.username;
-    }
+  const session = await auth();
+  if (!session.userId) {
+    throw new Error("Unauthorized receipts request.");
   }
-
-  throw new Error("Unauthorized receipts request.");
+  const client = await clerkClient();
+  const user = await client.users.getUser(session.userId);
+  const email = user.emailAddresses.find(
+    (e) => e.id === user.primaryEmailAddressId,
+  )?.emailAddress;
+  return email ?? user.username ?? session.userId;
 }

--- a/lib/receipts/owners.ts
+++ b/lib/receipts/owners.ts
@@ -2,9 +2,14 @@
 //
 // Owners get an admin view of the Trusted Devices settings page: every enrolled
 // device across all users, with the ability to revoke any of them. Everyone
-// else stays scoped to their own devices. Configure via the
-// RECEIPTS_OWNER_EMAILS secret (comma-separated emails); defaults to the
-// project owner so the feature works before the secret is set.
+// else stays scoped to their own devices.
+//
+// Phase 2 Clerk cutover: ownership is now a Clerk `publicMetadata.role`
+// ("owner") field on the user, not an env-var allowlist. The legacy
+// `getReceiptsOwnerEmails` / `DEFAULT_OWNER_EMAILS` helpers below are dead
+// code, deleted in Phase 4.
+
+import { auth } from "@clerk/nextjs/server";
 
 const DEFAULT_OWNER_EMAILS = ["david.klan@gmail.com"];
 
@@ -18,8 +23,21 @@ export function getReceiptsOwnerEmails(): string[] {
   return list.length > 0 ? list : DEFAULT_OWNER_EMAILS;
 }
 
-/** True if the actor (CF Access email) is a designated receipts owner. */
-export function isReceiptsOwner(actor: string | null | undefined): boolean {
-  if (!actor) return false;
-  return getReceiptsOwnerEmails().includes(actor.trim().toLowerCase());
+type SessionClaimsWithRole = {
+  publicMetadata?: { role?: string };
+};
+
+/**
+ * True if the current Clerk session's user has `publicMetadata.role ===
+ * "owner"`. Reads from sessionClaims (no network call). Now async — both
+ * call sites need `await`. The `_actor` parameter is retained for the
+ * 2 existing callers but unused (Phase 4 deletes it).
+ */
+export async function isReceiptsOwner(
+  _actor?: string | null,
+): Promise<boolean> {
+  const session = await auth();
+  const role = (session.sessionClaims as SessionClaimsWithRole | undefined)
+    ?.publicMetadata?.role;
+  return role === "owner";
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,38 @@
+import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
+
+// File name: `middleware.ts`, NOT `proxy.ts`.
+//
+// The Clerk Phase 2 plan called for `proxy.ts` (Next.js 16's preferred name
+// for the deprecated `middleware.ts`). That does not work here: Next.js 16
+// made `proxy.ts` Node.js-only (the `runtime` segment config is rejected
+// outright — "Proxy always runs on Node.js runtime"), but OpenNext-on-
+// Cloudflare-Workers only supports Edge middleware ("Node.js middleware is
+// not currently supported. Consider switching to Edge Middleware."). The
+// legacy `middleware.ts` name still defaults to Edge and is the only path
+// that builds under OpenNext today. Tracked as a deviation from the plan;
+// revisit when OpenNext supports Node.js proxy (or Next.js 17 removes
+// `middleware.ts` entirely — at which point we'll need a different fix).
+//
+// Sign-in URL is configured via NEXT_PUBLIC_CLERK_SIGN_IN_URL (set in
+// .env.production and .dev.vars). Clerk's auth.protect() redirects
+// unauthenticated users there.
+
+const isPublicRoute = createRouteMatcher([
+  "/receipts/sign-in(.*)",
+  "/receipts/enroll(.*)", // redirect shim → /receipts/sign-in; must not be gated
+]);
+
+export default clerkMiddleware((auth, request) => {
+  if (!isPublicRoute(request)) {
+    auth.protect();
+  }
+});
+
+export const config = {
+  matcher: [
+    "/receipts/:path*",
+    "/admin/:path*",
+    "/api/receipts/:path*",
+    // /api/mobile/* intentionally NOT matched (bearer-token scheme, never Clerk)
+  ],
+};

--- a/middleware.ts
+++ b/middleware.ts
@@ -22,9 +22,15 @@ const isPublicRoute = createRouteMatcher([
   "/receipts/enroll(.*)", // redirect shim → /receipts/sign-in; must not be gated
 ]);
 
-export default clerkMiddleware((auth, request) => {
+export default clerkMiddleware(async (auth, request) => {
   if (!isPublicRoute(request)) {
-    auth.protect();
+    // MUST `await` the promise. `auth.protect()` throws synchronously inside
+    // an async wrapper when the user is signed out, which converts the throw
+    // to a Promise rejection. Without `await` (or `return`), the rejection is
+    // silently dropped and the request falls through to the page — making the
+    // middleware a no-op. Verified against @clerk/nextjs 7.5.12 source
+    // (createProtect in dist/esm/server/protect.js).
+    await auth.protect();
   }
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "dazbeez",
       "version": "0.1.0",
       "dependencies": {
+        "@clerk/nextjs": "^7.5.12",
         "@opennextjs/cloudflare": "^1.19.1",
         "@reactflow/background": "^11.3.14",
         "@reactflow/controls": "^11.2.14",
@@ -1618,6 +1619,85 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@clerk/backend": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.10.0.tgz",
+      "integrity": "sha512-+No8bg+3SQ76zfu199l4lwpi3z+RqmO8N33CDXPkAnhXt6cAZu4HPT0WvZ/GDpbi7ZqpDmmP9yXpCQNGwEd0+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/shared": "^4.23.0",
+        "standardwebhooks": "^1.0.0",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      }
+    },
+    "node_modules/@clerk/nextjs": {
+      "version": "7.5.12",
+      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-7.5.12.tgz",
+      "integrity": "sha512-zJLGVBBzwT5DTsfDJYjTwbw59GTzuDWg6fPVqWIau1x2qlJ3y7FBicuOEZTxWvmSuF8zCP7Za1M5SGTcb7Ms8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/backend": "^3.10.0",
+        "@clerk/react": "^6.11.3",
+        "@clerk/shared": "^4.23.0",
+        "server-only": "0.0.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "peerDependencies": {
+        "next": "^15.2.8 || ^15.3.8 || ^15.4.10 || ^15.5.9 || ^15.6.0-0 || ^16.0.10 || ^16.1.0-0",
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      }
+    },
+    "node_modules/@clerk/react": {
+      "version": "6.11.3",
+      "resolved": "https://registry.npmjs.org/@clerk/react/-/react-6.11.3.tgz",
+      "integrity": "sha512-MLtclctwVoB4ECMJvl5ZH48rxLPduVsybZS2YnnljHH1rvxRV67cOAmInafgYgt2/LH63SVwRPIrTabbSx6lFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/shared": "^4.23.0",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      }
+    },
+    "node_modules/@clerk/shared": {
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.23.0.tgz",
+      "integrity": "sha512-v4roxB9AwEVq56luLc9MtQ+RkVR66XZJGAfTbQXD0ArdW+fs1P/FhlKwm6OQfvDFNiCCVZA6GoP648t9dGtfrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "^5.100.6",
+        "dequal": "2.0.3",
+        "glob-to-regexp": "0.4.1",
+        "js-cookie": "3.0.7"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
@@ -4319,6 +4399,12 @@
       "integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
       "license": "CC0-1.0"
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -4597,6 +4683,16 @@
         "@tailwindcss/oxide": "4.2.2",
         "postcss": "^8.5.6",
         "tailwindcss": "4.2.2"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.101.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.2.tgz",
+      "integrity": "sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tsconfig/node18": {
@@ -6539,6 +6635,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -7504,6 +7609,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fast-xml-builder": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
@@ -8012,6 +8123,12 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/glob/node_modules/balanced-match": {
       "version": "4.0.4",
@@ -8828,6 +8945,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.7.tgz",
+      "integrity": "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/js-tokens": {
@@ -10516,6 +10642,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
+    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -10760,6 +10892,16 @@
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
     },
     "node_modules/statuses": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test": "tsx --test tests/**/*.test.ts"
   },
   "dependencies": {
+    "@clerk/nextjs": "^7.5.12",
     "@opennextjs/cloudflare": "^1.19.1",
     "@reactflow/background": "^11.3.14",
     "@reactflow/controls": "^11.2.14",


### PR DESCRIPTION
## Summary

Phase 2 of the Clerk migration (`docs/runbooks/clerk-auth-migration.md`). Ships Clerk as the single auth chokepoint for `/receipts/:path*`, `/admin/:path*`, and `/api/receipts/:path*`, replacing the four human-auth mechanisms (CF Access JWT, trusted-device cookie, receipts Basic-auth, admin Basic-auth). Mobile bearer-token scheme (`/api/mobile/*`) is untouched.

- New `middleware.ts` (Edge, with explicit matcher including `/api/receipts/:path*` and excluding `/api/mobile/*`).
- New sign-in route at `app/(receipt-system)/receipts/sign-in/[[...sign-in]]/page.tsx` using Clerk's `<SignIn />` (email one-time code).
- New `lib/clerk-owner.ts` as single source of truth for the `publicMetadata.role === "owner"` check.
- `requireReceiptsActor` / `isReceiptsAuthorizedLight` / admin guards all rewritten to resolve identity via `auth()` + `clerkClient`.
- `/receipts/enroll` kept as redirect shim to `/receipts/sign-in` (bookmark compat).
- `isReceiptsOwner` async — two call sites updated.
- Cloudflare Access intentionally left active at the edge as a safety net through this phase (Phase 4 removal).

## S7 verification status

- **Sub-checks (a), (e), (f): PASSED** via curl against `cf:dev` — middleware gates correctly, signed-out `/receipts` → 307 → `/receipts/sign-in?redirect_url=...`, signed-out `/admin` → 307 (no more 500), signed-out `/api/receipts/test` → 404 (accepted behavior change), `/api/mobile/*` unaffected.
- **Sub-checks (b), (c), (d): DEFERRED to production.** cf:dev cannot exercise real Clerk sign-in because production publishable keys reject `localhost` Origin (Clerk allowlist, not a code bug). See the Phase 2 gotcha note in `docs/runbooks/clerk-auth-migration.md`.

## Fixes included

- **Middleware no-op bug:** `auth.protect()` was a floating promise — synchronous throw inside Clerk's async wrapper became a silent Promise rejection, so the middleware fell through and `/admin` kept 500-ing. Fix: `async (auth, request) => { ...; await auth.protect(); }`.
- **Publishable key typo:** `clerk env pull --instance prod` returned a key whose base64 payload decoded to `clerk.dazbeiz.com` (missing `e`). Synthesized the correct key from `echo -n 'clerk.dazbeez.com' | base64`. Mitigation going forward: trust Clerk Dashboard, not CLI output.

## Test plan

- [x] `npm run build:cf` passes; `.open-next/` confirms `/receipts/sign-in/[[...sign-in]]` registered, no `dazbeiz` typo leaked
- [x] cf:dev curl matrix (a, e, f) passes
- [ ] Post-deploy production smoke test (b, c, d) — see Verification section of runbook
- [ ] `bash scripts/check-deployment.sh https://dazbeez.com` passes after deploy
- [ ] Both David and Taz sign in on real devices
- [ ] Mobile bearer-token path (`/api/mobile/*`) regression-free
- [ ] Pairing regression-free (pair a new iPhone via `/receipts/pair`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)