### PR TITLE
fix(amex): dedup check ignores 'failed'/'replaced' artifacts

### DIFF
--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -1024,9 +1024,16 @@ export async function getAmexArtifactBySha256(
   sha256: string,
 ): Promise<AmexStatementArtifact | null> {
   const db = getReceiptsDb();
+  // Exclude 'failed' and 'replaced' artifacts — a prior import that failed
+  // validation never actually inserted any line items, so it must not
+  // permanently block re-uploading the identical file once the underlying
+  // issue is fixed (e.g. a parser bug). Same filter as getAmexArtifactByMonth
+  // below, for the same reason.
   return db
     .prepare(
-      `SELECT * FROM amex_statement_artifacts WHERE sha256_hash = ? LIMIT 1`,
+      `SELECT * FROM amex_statement_artifacts
+       WHERE sha256_hash = ? AND import_status NOT IN ('failed', 'replaced')
+       ORDER BY created_at DESC LIMIT 1`,
     )
     .bind(sha256)
     .first<AmexStatementArtifact>();


### PR DESCRIPTION
## Summary

- `getAmexArtifactBySha256` was matching prior artifacts purely by file hash with no filter on `import_status`. A \"failed\" artifact never inserted any line items (CSV was rejected at validation), but dedup treated it identically to a successful upload.
- Symptom today: re-uploading SAISON_2607.csv after the annual-fee parsing fix shipped returned \"already uploaded\" and showed the stale pre-fix result (18 lines, status failed).
- Mirrors the existing filter pattern already in `getAmexArtifactByMonth` (same file, directly below).

## Test plan

- [x] `npm run build:cf` passes
- [ ] Live re-upload of SAISON_2607.csv against production: imports 20 lines, parsedTotalCents == statementTotalCents == 175,623, both annual-fee lines flagged receipt_status = 'no_receipt_required'

🤖 Generated with [Claude Code](https://claude.com/claude-code)