### PR TITLE
fix(amex): purge stale failed/replaced artifacts before fresh INSERT

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,50 @@ When Claude Code runs in a cloud sandbox (e.g. claude.ai/code web session) the c
 2. For Cloudflare runtime checks, run `npm run cf:dev`
 3. Smoke-test the deployment with `bash scripts/check-deployment.sh <base-url>`
 
+## Two-Agent Workflow: Sandbox (Architect) vs. CLI (Worker)
+
+This repo is developed across two separate Claude sessions that share the same
+working tree (`/Users/dklan/projects/work/dazbeez`) but have different
+capabilities. Do not blur these roles.
+
+- **Sandbox session (this one, no live Cloudflare bindings)** is the
+  **ARCHITECT, PLANNER, and VERIFIER**. It diagnoses bugs, designs fixes,
+  reviews diffs/reports, and makes the calls on tradeoffs. It does not have
+  D1/R2/Wrangler bindings and cannot run `cf:dev`, `deploy`, or touch live
+  data — it must hand off any change that needs live verification.
+- **Mac Claude Code CLI session** is the **WORKER**. It has live bindings, runs
+  migrations, deploys, and reports back facts (what changed, what was
+  verified, what broke). It does not make architectural decisions — if it
+  hits a design fork (e.g. a schema tradeoff), it stops and reports back
+  instead of improvising.
+- The operator (David) relays prompts and reports between the two sessions
+  by hand. Every prompt written by the architect for the CLI worker must open
+  with an explicit role header so the receiving session knows immediately
+  which hat it's wearing:
+
+  ```
+  ROLE: You are the WORKER in a two-agent workflow. The ARCHITECT (a separate
+  sandboxed session) designed the following change and needs it implemented,
+  verified against live bindings, and reported back — not redesigned. If you
+  hit a design decision this prompt doesn't cover, stop and report back
+  instead of improvising.
+  ```
+
+### If you are Claude Code on the Mac M4 — you are the WORKER
+
+Implement exactly what the prompt specifies, verify against live D1/R2 (per
+the "Verification" section above), and report back concretely: what changed,
+what you tested, what passed/failed. Flag anything ambiguous or any
+unexpected finding instead of resolving it yourself — send it back to the
+architect for a decision.
+
+### Known risk: shared filesystem
+
+Both sessions mount the exact same folder. Concurrent git operations (stash,
+checkout, branch switches) from either side can transiently hide or clobber
+the other session's uncommitted files. Prefer small, quickly-committed
+changes over long-lived uncommitted edits, especially in docs like this one.
+
 <!-- BEGIN:nextjs-agent-rules -->
 # This is NOT the Next.js you know
 

--- a/app/api/receipts/amex/import/route.ts
+++ b/app/api/receipts/amex/import/route.ts
@@ -12,6 +12,7 @@ import {
   getAmexArtifactByMonth,
   getFinalizedReconciliationForMonth,
   markPreviousArtifactsReplaced,
+  purgeFailedAmexArtifactsByHash,
   updateAmexArtifactStatus,
   createBusinessTripReports,
 } from "@/lib/receipts/db";
@@ -156,6 +157,16 @@ export async function POST(request: Request) {
     const artifactId = crypto.randomUUID();
     const r2Key = generateAmexArtifactKey(statementMonth, artifactId, file.name);
     await uploadAmexArtifact(r2Key, buffer);
+
+    // ── Purge stale failed/replaced rows for this hash ─────────────────────
+    // The UNIQUE constraint on sha256_hash
+    // (db/receipts/0005_amex_extended.sql:31) is a real backstop against
+    // double-importing a genuinely successful statement, but it also blocks
+    // re-uploading the identical file after a prior failed/replaced artifact
+    // has been purged from the application-layer dedup check. Clean those
+    // rows out (plus their receipt_files manifest entries + R2 objects) right
+    // before the fresh INSERT. No-op DELETE when nothing matches.
+    await purgeFailedAmexArtifactsByHash(sha256, actor);
 
     // ── Save artifact record ────────────────────────────────────────────────
     const savedArtifactId = await createAmexArtifact({

--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -3,6 +3,7 @@ import { createAuditEntry } from "@/lib/receipts/audit";
 import { nowIso, newUuid, stringifyJson } from "@/lib/receipts/db-utils";
 import { shouldOverwriteMerchant } from "@/lib/receipts/reconciliation";
 import { retentionUntilIso } from "@/lib/receipts/retention";
+import { deleteAmexArtifact } from "@/lib/receipts/storage";
 import { PENDING_EXTRACTION_STATES } from "@/lib/receipts/types";
 import type {
   AmexMatchStatus,
@@ -1037,6 +1038,85 @@ export async function getAmexArtifactBySha256(
     )
     .bind(sha256)
     .first<AmexStatementArtifact>();
+}
+
+// Purge stale failed/replaced artifact rows for a given file hash so a fresh
+// INSERT with the same sha256_hash can succeed. The application-layer dedup
+// check (getAmexArtifactBySha256) excludes these rows, but the DB-level
+// UNIQUE constraint on sha256_hash (db/receipts/0005_amex_extended.sql:31)
+// still fires on INSERT because the row physically exists. Purging right
+// before createAmexArtifact() closes that gap.
+//
+// Non-fatal R2 cleanup: each row's R2 object is deleted best-effort. R2
+// failures are logged but do not block the DB cleanup — same "non-fatal,
+// log and continue" pattern as the manifest write in the import route.
+//
+// Audit: ONE entry is written per purge call (action:
+// amex_statement.failed_artifact_purged), so the trail shows who triggered
+// the re-upload that caused the purge. receipt_audit_log rows for the
+// purged artifacts are intentionally NOT deleted (append-only, tax/
+// compliance retention).
+export async function purgeFailedAmexArtifactsByHash(
+  sha256: string,
+  actor: string,
+): Promise<void> {
+  const db = getReceiptsDb();
+
+  const stale = await db
+    .prepare(
+      `SELECT id, r2_key FROM amex_statement_artifacts
+       WHERE sha256_hash = ? AND import_status IN ('failed', 'replaced')`,
+    )
+    .bind(sha256)
+    .all<{ id: string; r2_key: string }>();
+
+  const staleRows = stale.results ?? [];
+  if (staleRows.length === 0) return;
+
+  const staleIds = staleRows.map((r) => r.id);
+
+  // Best-effort R2 cleanup. Failure here does not block the DB purge.
+  for (const row of staleRows) {
+    try {
+      await deleteAmexArtifact(row.r2_key);
+    } catch (err) {
+      console.error(
+        `[purgeFailedAmexArtifactsByHash] R2 delete failed for key ${row.r2_key}`,
+        err,
+      );
+    }
+  }
+
+  // Atomic DB cleanup: delete manifest rows first (FK-ish reference via
+  // object_type/object_id, no formal FK constraint), then the artifact
+  // rows themselves. db.batch runs both in a single transaction.
+  const placeholders = staleIds.map(() => "?").join(", ");
+  await db.batch([
+    db
+      .prepare(
+        `DELETE FROM receipt_files
+         WHERE object_type = 'amex_statement_artifact'
+           AND object_id IN (${placeholders})`,
+      )
+      .bind(...staleIds),
+    db
+      .prepare(
+        `DELETE FROM amex_statement_artifacts WHERE id IN (${placeholders})`,
+      )
+      .bind(...staleIds),
+  ]);
+
+  await createAuditEntry(db, {
+    actor,
+    action: "amex_statement.failed_artifact_purged",
+    objectType: "amex_statement_artifact",
+    objectId: staleIds.join(","),
+    newValueJson: JSON.stringify({
+      sha256,
+      purgedCount: staleIds.length,
+      purgedIds: staleIds,
+    }),
+  });
 }
 
 export async function getAmexArtifactByMonth(

--- a/lib/receipts/storage.ts
+++ b/lib/receipts/storage.ts
@@ -108,6 +108,16 @@ export async function uploadAmexArtifact(
   });
 }
 
+// Best-effort R2 delete for a stale artifact object. Used by
+// purgeFailedAmexArtifactsByHash when clearing out failed/replaced rows
+// before re-inserting. Errors are caught by the caller — this helper is
+// intentionally not try/catch'd so the caller can decide the failure
+// policy (in practice: log and continue).
+export async function deleteAmexArtifact(key: string): Promise<void> {
+  const bucket = getReceiptsBucket();
+  await bucket.delete(key);
+}
+
 export async function computeSha256Hex(buffer: ArrayBuffer): Promise<string> {
   const hashBuffer = await crypto.subtle.digest("SHA-256", buffer);
   const hashArray = Array.from(new Uint8Array(hashBuffer));

--- a/lib/receipts/types.ts
+++ b/lib/receipts/types.ts
@@ -125,6 +125,7 @@ export type AuditAction =
   | "amex_statement.uploaded"
   | "amex_statement.parsed"
   | "amex_statement.import_failed"
+  | "amex_statement.failed_artifact_purged"
   | "amex_statement.line_updated"
   | "amex_statement.line_reconciled"
   | "export.created"


### PR DESCRIPTION
## Summary

Fixes the follow-up to PR #60. PR #60 fixed the app-layer dedup check (`getAmexArtifactBySha256` excludes `failed`/`replaced`), but re-uploading `SAISON_2607.csv` still failed in production with:

```
D1_ERROR: UNIQUE constraint failed: amex_statement_artifacts.sha256_hash
SQLITE_CONSTRAINT_UNIQUE
```

The column-level `UNIQUE` constraint (`db/receipts/0005_amex_extended.sql:31`) fires on INSERT because the stale failed row physically sits in the table even after the app-layer check filters it out. The app-layer logic and the DB-level constraint disagreed.

## Fix

`purgeFailedAmexArtifactsByHash(sha256, actor)` — called right before `createAmexArtifact()` in the import route:

1. `SELECT id, r2_key` for stale `failed`/`replaced` rows matching the hash. No-op return if zero.
2. Best-effort delete each row's R2 object (try/catch + `console.error`, log and continue — same pattern as the manifest write at route line ~204).
3. Atomic `db.batch([...])` — delete `receipt_files` rows where `object_type = 'amex_statement_artifact'` AND `object_id IN (...)`, then delete the `amex_statement_artifacts` rows themselves.
4. Write ONE audit entry (`amex_statement.failed_artifact_purged`) with `objectId = <comma-joined purged ids>` and `newValueJson = { sha256, purgedCount, purgedIds }`.

`receipt_audit_log` is intentionally untouched (append-only, tax/compliance retention). The new audit action is added to the `AuditAction` union in `lib/receipts/types.ts`.

The architect considered and rejected three alternatives — dropping the UNIQUE constraint (loses a real safety net), `INSERT ... ON CONFLICT DO UPDATE` (RETURNING semantics on no-op UPSERT branch risky without live D1), hard-delete including audit rows (compliance retention).

## Verification

- [x] `tsc --noEmit` clean
- [x] 190/190 existing tests pass
- [x] `npm run build:cf` passes
- [ ] Live re-upload of SAISON_2607.csv (the same file that just failed) — see report below after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)