### PR TITLE
fix(receipts): Phase 2 error-surfacing remediation (audit B1-B4, B6, C4)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,6 +166,10 @@ reconciliation finalized. Design consequences:
    cascade + clean the 2 rows in the same PR.
    DECISION (2026-07-05, audit finding A1): fail loudly — compensating
    delete of R2 object + receipt row, return 500; client shows error tile.
+   DONE (40efd02, PR #63): both routes fail loudly via new canonical
+   hardDeleteReceipt(); the 2 dangling rows were already gone from prod.
+   Remaining follow-up: iOS client must SURFACE the 500 (check untracked
+   DazbeezCapture/ sources in tree).
 6. **Consolidate month-closing validation.** After the read-through fix
    (223b22e), validateMonthReadyForExport's inline receipt loop duplicates
    checks now covered by validateAmexLinesForSignoff. Cleanup pass to
@@ -196,6 +200,12 @@ reconciliation finalized. Design consequences:
    DLQ on the extraction queue so nothing is dropped invisibly. Backfill
    remains the recovery net, but it shouldn't be the only detection.
    Audit cross-ref: findings A4 + B6 (docs/audits/2026-07-05).
+   PART DONE (beb1e96, PR #63): (b) shipped — DLQ
+   dazbeez-receipts-extraction-dlq + max_retries=5 (settings documented in
+   wrangler.jsonc; NOT introspectable via CLI). (a) failed-state marking
+   still open. Note: consumer-level visibility_timeout_ms is 12h — benign
+   because consumer.py overrides per-pull (5 min), but a trap for any
+   future consumer that doesn't.
 10. **Source provenance: desktop uploads tagged "mobile_capture".** The
     upload route doesn't validate `source` (free-form string) and the
     desktop client hardcodes "mobile_capture". Follow-up per worker report
@@ -213,9 +223,11 @@ reconciliation finalized. Design consequences:
     receipt_files manifest writes (#5), silent queue max-deliveries drops
     (#9), silently aborted client uploads (fixed, 4a08f92). Audit complete:
     docs/audits/2026-07-05-error-surfacing.md (PR #62) — 15 findings
-    (A=4, B=6, C=5) + 2 infra gaps. Phase 1 (A1, A2, DLQ+max_deliveries,
-    B5) in progress; Phase 2 = B1–B4 + newsyslog rotation (C4); C-class
-    accepted as documented.
+    (A=4, B=6, C=5) + 2 infra gaps. Phase 1 DONE (PR #63, commits
+    40efd02/58d38be/beb1e96/1e18891): A1 loud uploads, A2 atomic finalize
+    cleanup + warnings banner, DLQ+max_retries, B5 parse-failure badge.
+    Phase 2 = B1–B4 + newsyslog rotation (C4) + stuck-pending indicator;
+    C-class accepted as documented.
 13. **Multi-page PDF handling.** Real-world case: 5608427143.pdf
     (5c1ab53f…) has 2 pages; the consumer renders page 0 only and drops the
     rest with a stderr-only warning — invisible to the operator. Design:

--- a/app/(receipt-system)/receipts/capture/page.tsx
+++ b/app/(receipt-system)/receipts/capture/page.tsx
@@ -40,7 +40,10 @@ export default async function CapturePage({
   );
 }
 
-async function countCapturedToday(): Promise<number> {
+// Audit finding B1: previously returned 0 on DB error, which the mobile
+// header rendered as a confident "0 today" — silently wrong. Now returns
+// null and the UI shows "—" with a "count unavailable" title attr.
+async function countCapturedToday(): Promise<number | null> {
   try {
     const rows = await listReceiptRecords({ limit: 200 });
     const startOfDay = new Date();
@@ -48,6 +51,6 @@ async function countCapturedToday(): Promise<number> {
     const startIso = startOfDay.toISOString();
     return rows.filter((r) => r.captured_at >= startIso).length;
   } catch {
-    return 0;
+    return null;
   }
 }

--- a/app/api/receipts/[id]/route.ts
+++ b/app/api/receipts/[id]/route.ts
@@ -270,14 +270,22 @@ export async function PATCH(request: Request, { params }: RouteContext) {
     }
 
     // Re-run compliance checks so the review UI reflects the new state.
+    // Audit B4: previously swallowed silently — a stuck failure meant the
+    // compliance panel kept showing stale checks with no signal. Now we
+    // surface a warning so the review UI can toast/annotate; the receipt
+    // fields themselves did save successfully.
+    const warnings: string[] = [];
     try {
       const settings = await getComplianceSettings();
       await runComplianceChecksForReceipt(getReceiptsDb(), id, settings);
     } catch (checkError) {
       console.error("[api/receipts/[id]] compliance check failed", checkError);
+      warnings.push(
+        "Saved, but compliance checks could not be recomputed — the compliance panel may be stale. Refresh to retry.",
+      );
     }
 
-    return NextResponse.json({ ok: true }, { status: 200 });
+    return NextResponse.json({ ok: true, warnings }, { status: 200 });
   } catch (error) {
     if (error instanceof Error && error.message.startsWith("Unauthorized")) {
       return NextResponse.json({ error: "Unauthorized." }, { status: 401 });

--- a/app/api/receipts/amex/import/route.ts
+++ b/app/api/receipts/amex/import/route.ts
@@ -253,7 +253,12 @@ export async function POST(request: Request) {
     }
 
     // ── Business trip candidate detection ───────────────────────────────────
+    // Audit B3: trip-detection failure previously vanished silently. The
+    // import still succeeds (statement lines are already committed), but
+    // the operator needs to know detection didn't run so they can re-check
+    // manually or retry the import.
     let businessTripCandidatesCount = 0;
+    const warnings: string[] = [];
     try {
       const db = getReceiptsDb();
       const inserted = await db
@@ -283,8 +288,14 @@ export async function POST(request: Request) {
         await createBusinessTripReports(candidates, actor);
         businessTripCandidatesCount = candidates.length;
       }
-    } catch {
-      // Non-fatal — trip detection failure does not block import
+    } catch (tripErr) {
+      console.error(
+        "[amex/import] business trip detection failed (statement lines already committed)",
+        tripErr,
+      );
+      warnings.push(
+        "Statement lines imported, but business-trip candidate detection failed — re-check the month manually.",
+      );
     }
 
     return NextResponse.json(
@@ -304,6 +315,7 @@ export async function POST(request: Request) {
         skippedLines,
         replaced: previousArtifact !== null,
         businessTripCandidates: businessTripCandidatesCount,
+        warnings,
       },
       { status: 200 },
     );

--- a/app/api/receipts/compliance/[month]/route.ts
+++ b/app/api/receipts/compliance/[month]/route.ts
@@ -30,13 +30,21 @@ export async function GET(request: Request, { params }: RouteContext) {
     const settings = await getComplianceSettings();
 
     // Refresh checks for every receipt in the month so the report reflects
-    // current state. This is idempotent.
+    // current state. This is idempotent. Audit B2: a per-receipt check
+    // failure no longer silently skips the receipt — its id is captured and
+    // surfaced in the response so the operator knows the report is partial.
     const receipts = await listReceiptRecords({ month, limit: 1000 });
+    const checkFailedReceiptIds: string[] = [];
     for (const r of receipts) {
       try {
         await runComplianceChecksForReceipt(db, r.id, settings);
-      } catch {
-        // Per-receipt check failure shouldn't block the report.
+      } catch (err) {
+        console.error(
+          "[api/receipts/compliance/[month]] check failed for receipt",
+          r.id,
+          err,
+        );
+        checkFailedReceiptIds.push(r.id);
       }
     }
 
@@ -55,6 +63,10 @@ export async function GET(request: Request, { params }: RouteContext) {
         amexLineCount: lines.length,
         missingReceiptLines: missingReceipt,
         complianceSummary: summary,
+        // Audit B2: surface partial-report state instead of silently
+        // skipping receipts whose check threw.
+        checkFailures: checkFailedReceiptIds.length,
+        checkFailedReceiptIds,
         disclaimer: {
           en: ACCOUNTANT_DISCLAIMER_EN,
           ja: ACCOUNTANT_DISCLAIMER_JA,

--- a/components/receipts/ComplianceSummaryCards.tsx
+++ b/components/receipts/ComplianceSummaryCards.tsx
@@ -3,6 +3,11 @@ import type { ComplianceSummary } from "@/lib/receipts/compliance";
 type Props = {
   month: string;
   summary: ComplianceSummary;
+  /** Audit B2: count of receipts in the month whose check threw and was
+   *  skipped from the summary. Optional because the dashboard computes the
+   *  summary directly (no per-receipt run) — only the API route surfaces
+   *  this today. */
+  checkFailures?: number;
 };
 
 const TYPE_LABELS: Record<string, string> = {
@@ -21,7 +26,7 @@ const TYPE_LABELS: Record<string, string> = {
   export_blocker: "Export blocker",
 };
 
-export function ComplianceSummaryCards({ month, summary }: Props) {
+export function ComplianceSummaryCards({ month, summary, checkFailures = 0 }: Props) {
   const topTypes = Object.entries(summary.byType)
     .sort(([, a], [, b]) => b - a)
     .slice(0, 4);
@@ -48,6 +53,19 @@ export function ComplianceSummaryCards({ month, summary }: Props) {
         <Card label="Warnings" count={summary.warnings} tone="amber" />
         <Card label="Info" count={summary.info} tone="gray" />
       </div>
+
+      {checkFailures > 0 && (
+        <div
+          role="status"
+          className="mt-3 rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-900"
+          title="One or more receipts in this month could not be checked — the summary above is partial."
+        >
+          <span className="font-semibold">Partial report:</span>{" "}
+          {checkFailures} {checkFailures === 1 ? "receipt" : "receipts"}{" "}
+          could not be checked. See <code>checkFailedReceiptIds</code> in the
+          JSON report.
+        </div>
+      )}
 
       {topTypes.length > 0 ? (
         <ul className="mt-4 space-y-1 text-xs text-gray-700">

--- a/components/receipts/amex-import-form.tsx
+++ b/components/receipts/amex-import-form.tsx
@@ -37,6 +37,8 @@ interface ImportResult {
   message?: string;
   validationErrors?: string[];
   error?: string;
+  /** Audit B3: non-fatal post-import warnings (e.g. trip detection failed). */
+  warnings?: string[];
 }
 
 interface SkippedLineInfo {
@@ -316,6 +318,16 @@ function ImportResultSummary({ result }: { result: ImportResult }) {
                 + {result.skippedLines!.length - 5} more
               </li>
             )}
+          </ul>
+        </div>
+      )}
+      {(result.warnings?.length ?? 0) > 0 && (
+        <div className="mt-3 rounded-lg border border-amber-300 bg-amber-100 px-3 py-2 text-xs text-amber-900">
+          <p className="font-semibold">Import completed with warnings:</p>
+          <ul className="mt-1 list-disc pl-5">
+            {result.warnings!.map((w, i) => (
+              <li key={i}>{w}</li>
+            ))}
           </ul>
         </div>
       )}

--- a/components/receipts/capture/capture-mobile.tsx
+++ b/components/receipts/capture/capture-mobile.tsx
@@ -13,7 +13,7 @@ import type { CapturePhase } from "./use-receipt-upload";
 export interface CaptureMobileProps {
   initialPayment: PaymentPath | null;
   rapidMode: boolean;
-  todayCount: number;
+  todayCount: number | null;
   phase: CapturePhase;
   onPickFile: (file: File) => void;
   onCancel: () => void;
@@ -79,7 +79,7 @@ function CaptureIdleMobile({
   onTapCapture,
   error,
 }: {
-  todayCount: number;
+  todayCount: number | null;
   paymentChip: PaymentPath | null;
   setPaymentChip: (p: PaymentPath | null) => void;
   onTapCapture: () => void;
@@ -363,7 +363,23 @@ function MobileHeader({
         <BeeMark size={22} />
         <span className="text-[13px] font-semibold">{label}</span>
       </div>
-      {queueCount !== null && (
+      {queueCount === null ? (
+        // Audit B1: query failed — show "—" with a tooltip instead of
+        // silently rendering a confident "0 today".
+        <div
+          title="Today's capture count is unavailable."
+          className={[
+            "flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs",
+            dark
+              ? "border border-white/10 bg-white/5"
+              : "border border-gray-200 bg-white",
+          ].join(" ")}
+        >
+          <span className="h-[7px] w-[7px] rounded-full bg-gray-400" />
+          <span className="font-semibold tabular-nums text-gray-500">—</span>
+          <span className={dark ? "text-white/55" : "text-gray-500"}>today</span>
+        </div>
+      ) : (
         <div
           className={[
             "flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs",

--- a/components/receipts/receipt-capture-form.tsx
+++ b/components/receipts/receipt-capture-form.tsx
@@ -15,7 +15,9 @@ export type PaymentChip = PaymentPath | null;
 export interface ReceiptCaptureFormProps {
   initialPayment?: PaymentChip;
   rapidMode?: boolean;
-  todayCount?: number;
+  /** Today's captured-receipt count for the mobile header chip. null when
+   *  the count query failed (audit B1) — UI renders "—" with a title. */
+  todayCount?: number | null;
 }
 
 const SESSION_QUEUE_KEY = "dazbeez.receipts.captureQueue.v1";
@@ -84,7 +86,7 @@ interface UploadPool {
 export function ReceiptCaptureForm({
   initialPayment = null,
   rapidMode = false,
-  todayCount = 0,
+  todayCount = null,
 }: ReceiptCaptureFormProps) {
   const isMobile = useIsMobile();
   const { phase, upload, reset, cancel } = useReceiptUpload();

--- a/components/receipts/review/form-pane.tsx
+++ b/components/receipts/review/form-pane.tsx
@@ -105,6 +105,9 @@ export function FormPane(props: FormPaneProps) {
     props.initialAttendees.map((a) => a.attendee_name),
   );
   const [save, setSave] = useState<SaveState>({ kind: "idle" });
+  // Audit B4: post-save warnings from the API (e.g. compliance recompute
+  // failed). Save succeeded, so this is a toast — not an error state.
+  const [apiWarnings, setApiWarnings] = useState<string[]>([]);
 
   // ─── OCR extraction (delegated to the useExtraction hook) ───────────
   const {
@@ -192,6 +195,7 @@ export function FormPane(props: FormPaneProps) {
           });
           const json = (await res.json().catch(() => ({}))) as {
             error?: string;
+            warnings?: string[];
           };
           if (!res.ok) {
             setSave({
@@ -200,6 +204,7 @@ export function FormPane(props: FormPaneProps) {
             });
             return;
           }
+          setApiWarnings(json.warnings ?? []);
           setSave({ kind: "saved", at: Date.now() });
           // Refresh server-rendered CompliancePanel without manual reload.
           // router.refresh() preserves client state (focused input, useState
@@ -284,6 +289,10 @@ export function FormPane(props: FormPaneProps) {
           setSave({ kind: "error", message: json.error ?? "Save failed" });
           return;
         }
+        const okJson = (await res.json().catch(() => ({}))) as {
+          warnings?: string[];
+        };
+        setApiWarnings(okJson.warnings ?? []);
         setSave({ kind: "saved", at: Date.now() });
         if (props.nextReceiptId) {
           router.push(`/receipts/review/${props.nextReceiptId}`);
@@ -385,6 +394,32 @@ export function FormPane(props: FormPaneProps) {
           </span>
         </div>
       </header>
+
+      {apiWarnings.length > 0 && (
+        <div
+          role="status"
+          className="mx-6 mt-3 rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-900"
+        >
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <p className="font-semibold">Saved with warnings</p>
+              <ul className="mt-0.5 list-disc pl-5">
+                {apiWarnings.map((w, i) => (
+                  <li key={i}>{w}</li>
+                ))}
+              </ul>
+            </div>
+            <button
+              type="button"
+              onClick={() => setApiWarnings([])}
+              className="shrink-0 rounded px-1.5 py-0.5 text-amber-700 hover:bg-amber-100"
+              aria-label="Dismiss warnings"
+            >
+              ✕
+            </button>
+          </div>
+        </div>
+      )}
 
       <div className="flex-1 px-6 pb-6 pt-1">
         <FormGroup

--- a/components/receipts/review/queue-rail.tsx
+++ b/components/receipts/review/queue-rail.tsx
@@ -103,6 +103,14 @@ export function QueueRail({
                     needs {item.needs}
                   </span>
                 )}
+                {item.stuck && (
+                  <span
+                    className="mt-1 inline-block rounded bg-amber-200 px-1.5 py-px text-[10px] font-semibold text-amber-900"
+                    title="Pending extraction for >30 minutes — the MLX consumer may be stalled. Run the consumer or check launchd."
+                  >
+                    stuck?
+                  </span>
+                )}
               </div>
             </Link>
           ))

--- a/lib/receipts/queue-items.ts
+++ b/lib/receipts/queue-items.ts
@@ -2,7 +2,15 @@ import {
   requiresAttendees as categoryRequiresAttendees,
   getCategoryByCode,
 } from "@/lib/receipts/categories";
+import { isPendingProcessing } from "@/lib/receipts/extraction-state";
 import type { ReceiptRecord } from "@/lib/receipts/types";
+
+/** Audit B6 / Task 4: per-receipt "stuck?" threshold for the review queue.
+ *  Receipts pending extraction older than this get an amber badge in the
+ *  rail so the operator notices a stalled consumer immediately, not at
+ *  month-close. Distinct from STALE_PENDING_MS in extraction-state.ts (20m
+ *  header-chip threshold); this is a louder, per-row surface. */
+const STUCK_PENDING_MS = 30 * 60 * 1000;
 
 export type QueueItem = {
   id: string;
@@ -12,11 +20,16 @@ export type QueueItem = {
   categoryLabel: string;
   status: ReceiptRecord["status"];
   needs: "attendees" | "purpose" | "re-review" | null;
+  /** True when this receipt is pending extraction and was enqueued/captured
+   *  more than STUCK_PENDING_MS ago. The queue-rail renders an amber
+   *  "stuck?" badge to flag a likely-stalled consumer. */
+  stuck: boolean;
 };
 
 export function buildQueueItems(
   receipts: ReceiptRecord[],
   reReviewIds: ReadonlySet<string> = new Set(),
+  now: number = Date.now(),
 ): QueueItem[] {
   return receipts.map((r) => {
     const code = r.expense_category_code ?? "";
@@ -30,8 +43,20 @@ export function buildQueueItems(
       categoryLabel: cat ? cat.enName : code ? code : "Uncategorized",
       status: r.status,
       needs: needsFlag(r, code, reReviewIds.has(r.id)),
+      stuck: isStuckPending(r, now),
     };
   });
+}
+
+function isStuckPending(r: ReceiptRecord, now: number): boolean {
+  if (!isPendingProcessing(r)) return false;
+  // Prefer extraction_enqueued_at (true waiting-since), fall back to
+  // captured_at for legacy rows that predate the queue column.
+  const since = r.extraction_enqueued_at ?? r.captured_at;
+  if (!since) return false;
+  const t = Date.parse(since);
+  if (Number.isNaN(t)) return false;
+  return now - t >= STUCK_PENDING_MS;
 }
 
 function needsFlag(

--- a/scripts/receipts-consumer/AGENT_SETUP_PROMPT.md
+++ b/scripts/receipts-consumer/AGENT_SETUP_PROMPT.md
@@ -22,7 +22,23 @@ Do the following:
 
 6. **End-to-end dry run.** With at least one receipt sitting in the queue (status `captured`), run `./run.sh --once`. Confirm it pulls the job, fetches the R2 image, runs the model, POSTs to the extract endpoint, and the receipt advances to `needs_review` with fields populated. Show the consumer log.
 
-7. **Optional autostart.** If I confirm, install the launchd agent (`com.dazbeez.receipts-consumer.plist`) per the comments in that file so the queue drains on login/wake.
+7. **Optional autostart.** If I confirm, install the launchd agent (`com.dazbeez.receipts-consumer.plist`) per the comments in that file so the queue drains on login/wake. Also create the log directory and install the newsyslog rotation entry so logs persist across reboots and don't grow unbounded:
+
+   ```sh
+   # 1. Persistent log directory (~/Library/Logs survives reboot; /tmp does not).
+   mkdir -p ~/Library/Logs/dazbeez
+
+   # 2. Install launchd job.
+   cp com.dazbeez.receipts-consumer.plist ~/Library/LaunchAgents/
+   launchctl load ~/Library/LaunchAgents/com.dazbeez.receipts-consumer.plist
+
+   # 3. Install newsyslog rotation (1 MB size threshold, keep 5 gzip-compressed).
+   sudo cp newsyslog.d/dazbeez-receipts-consumer.conf /etc/newsyslog.d/
+
+   # 4. Verify both: tail the new log location and confirm the newsyslog entry parses.
+   tail -f ~/Library/Logs/dazbeez/receipts-consumer.log
+   sudo newsyslog -nv | grep dazbeez
+   ```
 
 Report at the end: installed mlx-vlm version, chosen model id + memory footprint + tokens/sec, JA and EN smoke-test results, and any edits you made to `consumer.py`. Do not run `wrangler deploy`, `cf:dev`, or modify Worker code.
 

--- a/scripts/receipts-consumer/com.dazbeez.receipts-consumer.plist
+++ b/scripts/receipts-consumer/com.dazbeez.receipts-consumer.plist
@@ -5,6 +5,11 @@
     cp com.dazbeez.receipts-consumer.plist ~/Library/LaunchAgents/
     launchctl load ~/Library/LaunchAgents/com.dazbeez.receipts-consumer.plist
   Edit the paths below to match where the repo and venv live on the Mac.
+
+  Logs go to ~/Library/Logs/dazbeez/ (created by the install script) and are
+  rotated by newsyslog — see newsyslog.d/dazbeez-receipts-consumer.conf.
+  Avoid /tmp: macOS clears it on reboot, which would silently erase the
+  consumer's recent history (audit C4).
 -->
 <plist version="1.0">
 <dict>
@@ -35,8 +40,8 @@
   <integer>600</integer>
 
   <key>StandardOutPath</key>
-  <string>/tmp/dazbeez-receipts-consumer.log</string>
+  <string>/Users/dklan/Library/Logs/dazbeez/receipts-consumer.log</string>
   <key>StandardErrorPath</key>
-  <string>/tmp/dazbeez-receipts-consumer.err.log</string>
+  <string>/Users/dklan/Library/Logs/dazbeez/receipts-consumer.err.log</string>
 </dict>
 </plist>

--- a/scripts/receipts-consumer/newsyslog.d/dazbeez-receipts-consumer.conf
+++ b/scripts/receipts-consumer/newsyslog.d/dazbeez-receipts-consumer.conf
@@ -1,0 +1,22 @@
+# newsyslog rotation for the MLX receipts consumer.
+# Install (one-time, requires sudo):
+#   sudo cp dazbeez-receipts-consumer.conf /etc/newsyslog.d/
+#
+# Format (see `man newsyslog.conf`):
+#   logfilename [owner:group] mode count size  when  flags
+# - count 5     keep 5 archived generations
+# - size 1024   rotate when file exceeds 1 MB
+# - when *      no time-based rotation (size-only)
+# - flags Z     gzip-compress rolled files
+#
+# Note on launchd + rotation: launchd re-opens StandardOutPath /
+# StandardErrorPath at each --once invocation (every 600s by default),
+# so a fresh run after rotation picks up the new inode automatically.
+# Worst case is one ~10-minute run writing to the renamed file before
+# the next run opens the fresh one. Acceptable for the consumer's low
+# log volume.
+#
+# Replace /Users/dklan below with the actual home directory if installing
+# on a different user account.
+/Users/dklan/Library/Logs/dazbeez/receipts-consumer.log      644  5  1024  *  Z
+/Users/dklan/Library/Logs/dazbeez/receipts-consumer.err.log  644  5  1024  *  Z


### PR DESCRIPTION
## Summary

Phase 2 of the receipts error-surfacing audit. Five code/ops changes that make silent failures noisy, plus one deferred report.

- **B1 (capture)**: `countCapturedToday` returned `0` on DB error; mobile header rendered it as a confident "0 today". Now returns `null`; UI shows "—" with a tooltip.
- **B2 (compliance)**: per-receipt check failures in `/api/receipts/compliance/[month]` were swallowed with an empty catch — receipts vanished from the report looking identical to ones that passed. Now captured into `checkFailedReceiptIds[]` with a `checkFailures` count, and `ComplianceSummaryCards` renders an amber "Partial report" banner.
- **B3 (amex import)**: business-trip candidate detection ran after line items committed; a throw was swallowed. Now captured into `warnings: string[]` and surfaced in `AmexImportForm`.
- **B4 (receipt PATCH)**: compliance recompute on PATCH swallowed failures, leaving stale checks visible. Now captured into `warnings: string[]`; review `form-pane` renders a dismissible amber banner.
- **B6 (review queue)**: receipts pending extraction for >30 min now show an amber "stuck?" pill in the queue rail, pointing at a likely-stalled MLX consumer. Computed in `buildQueueItems` so it rides the existing month-scoped query — no new global scan.
- **C4 (consumer logs)**: launchd plist moved from `/tmp/...` (cleared on reboot) to `~/Library/Logs/dazbeez/`. newsyslog entry staged at `scripts/receipts-consumer/newsyslog.d/` (1 MB threshold, keep 5 gzip). Live install verified: directory created, existing /tmp history migrated, plist reloaded, kickstart confirmed logs flow to the new path.

## Task 6 (iOS 500 surfacing) — REPORT ONLY, no commit

Repo's `DazbeezCapture/` contains only Xcode scaffolding (`Assets.xcassets` + `project.pbxproj`); the project uses `PBXFileSystemSynchronizedRootGroup` pointing at a folder with no `.swift` files committed. The actual iOS upload source is not in this repo. Cannot answer "does the iOS app surface HTTP 500s from upload?" without that source. Action: David confirms where the Swift upload code lives (likely on-disk only or separate repo) and re-runs the audit there.

## Verification

- `npx tsc --noEmit`: clean
- `npm test`: 211/211 pass
- `npm run build:cf`: clean
- `npm run deploy`: Version `f6edc177-10de-4822-9f09-2e901b89767f`
- `bash scripts/check-deployment.sh https://dazbeez.com`: 11/11 OK

## Operator follow-up (deferred — needs sudo)

Install the staged newsyslog entry for log rotation:

```sh
sudo cp scripts/receipts-consumer/newsyslog.d/dazbeez-receipts-consumer.conf /etc/newsyslog.d/
sudo newsyslog -nv | grep dazbeez   # dry-run sanity
```

Without this, the new persistent logs will grow unbounded (the live consumer writes a few KB per 10-minute cycle, so this is not urgent — but it should ship before the cycle accumulates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)