### PR TITLE
feat(receipts): extraction-failed endpoint + permanent-failure classifier (audit #9a)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,8 +168,9 @@ reconciliation finalized. Design consequences:
    delete of R2 object + receipt row, return 500; client shows error tile.
    DONE (40efd02, PR #63): both routes fail loudly via new canonical
    hardDeleteReceipt(); the 2 dangling rows were already gone from prod.
-   Remaining follow-up: iOS client must SURFACE the 500 (check untracked
-   DazbeezCapture/ sources in tree).
+   Remaining follow-up: iOS client must SURFACE the 500 — PARKED
+   (operator decision 2026-07-05: app development on hold until system
+   stabilized; repo contains only Xcode scaffolding, no Swift source).
 6. **Consolidate month-closing validation.** After the read-through fix
    (223b22e), validateMonthReadyForExport's inline receipt loop duplicates
    checks now covered by validateAmexLinesForSignoff. Cleanup pass to
@@ -226,7 +227,9 @@ reconciliation finalized. Design consequences:
     (A=4, B=6, C=5) + 2 infra gaps. Phase 1 DONE (PR #63, commits
     40efd02/58d38be/beb1e96/1e18891): A1 loud uploads, A2 atomic finalize
     cleanup + warnings banner, DLQ+max_retries, B5 parse-failure badge.
-    Phase 2 = B1–B4 + newsyslog rotation (C4) + stuck-pending indicator;
+    Phase 2 DONE (PR #64): B1–B4 warnings/banners, stuck-pending pill,
+    log rotation (newsyslog conf installed by operator). Theme closed
+    except #9(a) — consumer failed-state marking (in progress).
     C-class accepted as documented.
 13. **Multi-page PDF handling.** Real-world case: 5608427143.pdf
     (5c1ab53f…) has 2 pages; the consumer renders page 0 only and drops the

--- a/app/api/receipts/[id]/extraction-failed/route.ts
+++ b/app/api/receipts/[id]/extraction-failed/route.ts
@@ -1,0 +1,185 @@
+import { NextResponse } from "next/server";
+import { requireReceiptsActor } from "@/lib/receipts/auth";
+import {
+  getReceiptRecord,
+  reconcileExtractionState,
+} from "@/lib/receipts/db";
+import { createAuditEntry } from "@/lib/receipts/audit";
+import { nowIso, stringifyJson } from "@/lib/receipts/db-utils";
+import { getReceiptsDb, getReceiptsProcessorKey } from "@/lib/cloudflare-runtime";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+const PROCESSOR_ACTOR = "mlx-consumer@mac";
+
+// Constant-time string compare so the processor key can't be probed by timing.
+// Mirrors the helper in /api/receipts/[id]/extract/route.ts — kept local so a
+// future change to either route doesn't silently regress the other.
+function timingSafeEqual(a: string, b: string): boolean {
+  const enc = new TextEncoder();
+  const ab = enc.encode(a);
+  const bb = enc.encode(b);
+  const len = Math.max(ab.length, bb.length);
+  let mismatch = ab.length ^ bb.length;
+  for (let i = 0; i < len; i += 1) mismatch |= (ab[i] ?? 0) ^ (bb[i] ?? 0);
+  return mismatch === 0;
+}
+
+interface ExtractionFailedBody {
+  /** Why extraction failed (e.g. "UnidentifiedImageError", "pymupdf: empty file"). */
+  reason?: string;
+  /** Optional provider/model label for provenance, e.g. "mlx_local:qwen3-vl-32b". */
+  model?: string;
+}
+
+/**
+ * Mark a receipt's extraction as permanently failed (ADR 0001).
+ *
+ * Called by the Mac MLX consumer (`scripts/receipts-consumer/consumer.py`) when
+ * it classifies a local failure as deterministic-permanent — corrupt image,
+ * zero-byte file, pymupdf open/render error. The consumer then ACKs the queue
+ * message so it does not retry forever or land in the DLQ. Transient failures
+ * (network, HTTP 5xx, model load) stay on the existing unacked-retry path.
+ *
+ * Auth mirrors `/extract`: processor key OR Clerk-authenticated human actor.
+ * The Clerk middleware exemption (ce01989) is required so processor-key
+ * requests reach the handler instead of being 404-rewritten by `auth.protect()`
+ * — see middleware.ts isPublicRoute list.
+ *
+ * Effect: `extraction_state` moves to `'failed'` only from pending states
+ * (captured/queued/processing). Locked statuses (reviewed/reconciled/exported/
+ * archived) return 409 — a late failure report for a receipt a human already
+ * handled must not roll the queue state back.
+ */
+export async function POST(request: Request, { params }: RouteContext) {
+  try {
+    // Layered auth: processor key first, then Clerk human-actor fall-through.
+    const processorKey = getReceiptsProcessorKey();
+    const presentedKey = request.headers.get("x-receipts-processor-key");
+    const isProcessor =
+      !!processorKey &&
+      !!presentedKey &&
+      timingSafeEqual(presentedKey, processorKey);
+    const actor = isProcessor
+      ? PROCESSOR_ACTOR
+      : await requireReceiptsActor(request.headers);
+
+    const { id } = await params;
+    const body = (await request.json().catch(() => null)) as
+      | ExtractionFailedBody
+      | null;
+    const reason = (body?.reason ?? "").trim();
+    if (!reason) {
+      return NextResponse.json(
+        { error: "Body must include a non-empty `reason`." },
+        { status: 400 },
+      );
+    }
+    if (reason.length > 1000) {
+      return NextResponse.json(
+        { error: "`reason` must be 1000 characters or fewer." },
+        { status: 413 },
+      );
+    }
+
+    const receipt = await getReceiptRecord(id);
+    const db = getReceiptsDb();
+
+    if (!receipt) {
+      await createAuditEntry(db, {
+        actor,
+        action: "receipt.extraction_failed",
+        objectType: "receipt",
+        objectId: id,
+        newValueJson: stringifyJson({ reason: "not_found", failureReason: reason }),
+      });
+      return NextResponse.json({ error: "Receipt not found." }, { status: 404 });
+    }
+
+    // Locked statuses: a human has already advanced this receipt. A late
+    // failure report from the consumer must not un-review it. Mirror the
+    // guard in /extract — including reconciling any stale pending state so
+    // the month-close gate isn't blocked by a queue message that arrived
+    // after human review.
+    if (receipt.status !== "captured" && receipt.status !== "needs_review") {
+      await reconcileExtractionState(id, "processed");
+      await createAuditEntry(db, {
+        actor,
+        action: "receipt.extraction_failed",
+        objectType: "receipt",
+        objectId: id,
+        newValueJson: stringifyJson({
+          reason: "locked",
+          status: receipt.status,
+          failureReason: reason,
+        }),
+      });
+      return NextResponse.json(
+        {
+          error: `Receipt is ${receipt.status} and cannot be marked as extraction-failed.`,
+        },
+        { status: 409 },
+      );
+    }
+
+    // Persist the failure into extraction_json. This column is the canonical
+    // "latest extraction outcome" surface; the review UI reads it to badge
+    // the receipt. No DB migration needed (architect preference). Shape:
+    //   { failed: true, reason, model?, failedAt }
+    // Any prior extraction_json on a pending receipt is incomplete/stale
+    // (the receipt never reached 'processed'); overwrite is the right move.
+    const failedPayload = {
+      failed: true as const,
+      reason,
+      model: body?.model?.trim() || null,
+      failedAt: nowIso(),
+    };
+
+    // reconcileExtractionState is idempotent — only touches rows still in a
+    // pending state. If a parallel request already advanced this receipt,
+    // the UPDATE is a no-op and we surface that to the caller as 409.
+    await reconcileExtractionState(id, "failed");
+
+    // Write extraction_json separately (reconcileExtractionState does not
+    // touch it). Bypasses the finalized-reconciliation guard like /extract
+    // does for the same reason — this is queue-state mirror, not business
+    // fields.
+    await db
+      .prepare(
+        `UPDATE receipt_records
+           SET extraction_json = ?, updated_at = ?
+         WHERE id = ?
+           AND extraction_state = 'failed'`,
+      )
+      .bind(stringifyJson(failedPayload), nowIso(), id)
+      .run();
+
+    await createAuditEntry(db, {
+      actor,
+      action: "receipt.extraction_failed",
+      objectType: "receipt",
+      objectId: id,
+      newValueJson: stringifyJson({
+        failureReason: reason,
+        model: body?.model?.trim() || null,
+      }),
+    });
+
+    return NextResponse.json(
+      { ok: true, extractionState: "failed", failedAt: failedPayload.failedAt },
+      { status: 200 },
+    );
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Unauthorized")) {
+      return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+    }
+    console.error("[api/receipts/[id]/extraction-failed] failed", error);
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error ? error.message : "Failed to mark extraction-failed.",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/components/receipts/review/queue-rail.tsx
+++ b/components/receipts/review/queue-rail.tsx
@@ -111,6 +111,18 @@ export function QueueRail({
                     stuck?
                   </span>
                 )}
+                {item.extractionFailed && (
+                  <span
+                    className="mt-1 inline-block rounded bg-red-100 px-1.5 py-px text-[10px] font-semibold text-red-800"
+                    title={
+                      item.failureReason
+                        ? `Extraction failed: ${item.failureReason}. Re-run the consumer after fixing the file, or enter fields manually.`
+                        : "Extraction failed. Re-run the consumer after fixing the file, or enter fields manually."
+                    }
+                  >
+                    extraction failed
+                  </span>
+                )}
               </div>
             </Link>
           ))

--- a/lib/receipts/queue-items.ts
+++ b/lib/receipts/queue-items.ts
@@ -24,6 +24,12 @@ export type QueueItem = {
    *  more than STUCK_PENDING_MS ago. The queue-rail renders an amber
    *  "stuck?" badge to flag a likely-stalled consumer. */
   stuck: boolean;
+  /** True when extraction_state === 'failed'. Renders a red "extraction
+   *  failed" pill in the queue-rail so the operator sees the receipt needs
+   *  manual handling. `failureReason` (when present) is surfaced via the
+   *  pill's title attribute. */
+  extractionFailed: boolean;
+  failureReason: string | null;
 };
 
 export function buildQueueItems(
@@ -35,6 +41,7 @@ export function buildQueueItems(
     const code = r.expense_category_code ?? "";
     const cat = getCategoryByCode(code);
     const captured = r.captured_at ?? "";
+    const failure = readFailureInfo(r);
     return {
       id: r.id,
       merchant: r.merchant?.trim() || "Unnamed receipt",
@@ -44,8 +51,35 @@ export function buildQueueItems(
       status: r.status,
       needs: needsFlag(r, code, reReviewIds.has(r.id)),
       stuck: isStuckPending(r, now),
+      extractionFailed: failure.failed,
+      failureReason: failure.reason,
     };
   });
+}
+
+/** Parse extraction_json for the failed marker written by
+ *  POST /api/receipts/[id]/extraction-failed. Returns null-safe defaults
+ *  for receipts that never failed or have a non-JSON / mismatched shape. */
+function readFailureInfo(
+  r: ReceiptRecord,
+): { failed: boolean; reason: string | null } {
+  if (r.extraction_state !== "failed") return { failed: false, reason: null };
+  if (!r.extraction_json) return { failed: true, reason: null };
+  try {
+    const parsed = JSON.parse(r.extraction_json) as {
+      failed?: boolean;
+      reason?: string;
+    };
+    return {
+      failed: true,
+      reason:
+        typeof parsed.reason === "string" && parsed.reason.trim()
+          ? parsed.reason.trim().slice(0, 300)
+          : null,
+    };
+  } catch {
+    return { failed: true, reason: null };
+  }
 }
 
 function isStuckPending(r: ReceiptRecord, now: number): boolean {

--- a/middleware.ts
+++ b/middleware.ts
@@ -35,6 +35,7 @@ const isPublicRoute = createRouteMatcher([
   // this fix.
   "/api/receipts/:id/file",
   "/api/receipts/:id/extract",
+  "/api/receipts/:id/extraction-failed",
 ]);
 
 export default clerkMiddleware(async (auth, request) => {

--- a/scripts/receipts-consumer/consumer.py
+++ b/scripts/receipts-consumer/consumer.py
@@ -250,6 +250,122 @@ def apply_to_worker(receipt_id: str, payload: dict[str, Any]) -> None:
     resp.raise_for_status()
 
 
+def post_extraction_failed(receipt_id: str, reason: str) -> None:
+    """Tell the Worker this receipt's extraction failed permanently.
+
+    The Worker moves extraction_state to 'failed' (only from pending), persists
+    the reason into extraction_json, and the review UI surfaces a red
+    'extraction failed' pill. Caller then ACKs the queue message — retrying
+    the same bytes would produce the same failure, so the message must not
+    redeliver forever or land in the DLQ.
+
+    Failures of THIS call (network, 5xx) are swallowed because the caller
+    has already classified the original error as permanent and will ACK
+    regardless — losing the reason annotation is preferable to retrying
+    a poison pill.
+    """
+    headers = {
+        "x-receipts-processor-key": PROCESSOR_KEY,
+        "Content-Type": "application/json",
+    }
+    if CF_ACCESS_CLIENT_ID and CF_ACCESS_CLIENT_SECRET:
+        headers["CF-Access-Client-Id"] = CF_ACCESS_CLIENT_ID
+        headers["CF-Access-Client-Secret"] = CF_ACCESS_CLIENT_SECRET
+    try:
+        requests.post(
+            f"{EXTRACT_BASE}/{receipt_id}/extraction-failed",
+            headers=headers,
+            json={
+                "reason": reason[:1000],
+                "model": f"mlx_local:{MLX_MODEL.split('/')[-1]}",
+            },
+            timeout=30,
+        )
+    except requests.RequestException as exc:
+        print(
+            f"[warn] {receipt_id}: failed to post extraction-failed ({exc}); "
+            "acking anyway — reason will not be visible in the UI.",
+            file=sys.stderr,
+        )
+
+
+class PermanentExtractionFailure(Exception):
+    """Raised by the consumer for deterministic-permanent local failures we
+    detect ourselves (zero-byte download, manifest size mismatch). Distinct
+    from third-party exceptions (pymupdf.FileDataError, PIL.Unidentified
+    ImageError) which are recognized by name in `is_permanent_extraction_error`.
+
+    Carries a clean `reason` for the extraction-failed endpoint.
+    """
+
+    def __init__(self, reason: str):
+        super().__init__(reason)
+        self.reason = reason
+
+
+def _build_permanent_exception_types() -> tuple[type[Exception], ...]:
+    """Lazily resolve the tuple of permanent-failure exception classes.
+
+    Lazy so the module imports without pymupdf/PIL installed (e.g. when
+    running --help or unit tests that don't exercise the model path).
+
+    Membership:
+      - pymupdf.FileDataError (covers EmptyFileError too — subclass):
+        corrupt/truncated/empty PDF, encryption, render failure. Retrying
+        the same bytes will throw the same error.
+      - PIL.UnidentifiedImageError: corrupt or unsupported raster image.
+        Same bytes → same failure.
+    """
+    types: list[type[Exception]] = []
+    try:
+        import fitz  # noqa: WPS433 — lazy by design
+        if hasattr(fitz, "FileDataError"):
+            types.append(fitz.FileDataError)
+    except ImportError:
+        pass
+    try:
+        from PIL import UnidentifiedImageError  # noqa: WPS433
+        types.append(UnidentifiedImageError)
+    except ImportError:
+        pass
+    return tuple(types)
+
+
+# Module-level cache so we resolve the tuple at most once per process.
+_PERMANENT_TYPES_CACHE: tuple[type[Exception], ...] | None = None
+
+
+def is_permanent_extraction_error(exc: Exception) -> bool:
+    """True for deterministic-permanent local failures (corrupt image, bad PDF,
+    zero-byte download).
+
+    Used by per-message and backfill paths to decide: post extraction-failed
+    + ACK (permanent) vs. leave unacked for retry (transient).
+
+    Network errors, HTTP 5xx, and model-load/generate errors are deliberately
+    NOT permanent — those are environmental and may resolve on retry.
+    """
+    if isinstance(exc, PermanentExtractionFailure):
+        return True
+    global _PERMANENT_TYPES_CACHE
+    if _PERMANENT_TYPES_CACHE is None:
+        _PERMANENT_TYPES_CACHE = _build_permanent_exception_types()
+    permanent = _PERMANENT_TYPES_CACHE
+    if permanent and isinstance(exc, permanent):
+        return True
+    # Safety net: pymupdf errors sometimes nest under fitz.errors in newer
+    # versions; match by class name so we don't miss them.
+    name = exc.__class__.__name__
+    return name in ("FileDataError", "EmptyFileError", "UnidentifiedImageError")
+
+
+def _format_failure_reason(exc: Exception) -> str:
+    """Build the reason string for post_extraction_failed."""
+    if isinstance(exc, PermanentExtractionFailure):
+        return exc.reason[:1000]
+    return f"{exc.__class__.__name__}: {exc}"[:1000]
+
+
 # ─── Backfill drain (--backfill mode) ────────────────────────────────────────
 # Recovery path for receipts stranded in a pending extraction_state — typically
 # because the queue consumer acked a 4xx poison pill (409 locked, 422 no OCR)
@@ -316,8 +432,18 @@ def _sql_escape(v: str | None) -> str:
 def pull_pending_rows(only_id: str | None = None) -> list[dict[str, Any]]:
     """Pending-extraction rows from D1 (extraction_state captured/queued/processing).
 
-    Excludes 'failed' (the user's check query matches this set) and soft-deleted
-    rows. Matches listPendingProcessingReceipts in lib/receipts/db.ts.
+    Excludes 'failed' and soft-deleted rows. Matches listPendingProcessingReceipts
+    in lib/receipts/db.ts.
+
+    Why 'failed' is excluded: 'failed' is terminal-until-operator-action. A
+    receipt reaches 'failed' either via the no-OCR-text path in /extract (422)
+    or via the consumer's permanent-failure classifier (POST extraction-failed).
+    Both paths mean "retrying the same bytes will produce the same outcome" —
+    so backfill must NOT pick them back up. They are operator-visible in the
+    review queue (red 'extraction failed' pill) and require manual intervention
+    (replace the file, or enter fields by hand and advance status). To re-attempt
+    extraction on a failed row, the operator must first reset extraction_state
+    to 'captured' (or re-upload); backfill deliberately won't do that for them.
     """
     where_id = f" AND id = {_sql_escape(only_id)}" if only_id else ""
     return _d1_query(
@@ -402,6 +528,8 @@ def process_backfill(dry_run: bool, only_id: str | None = None) -> None:
         try:
             image_path = fetch_image(rid, r2_key)
             try:
+                if os.path.getsize(image_path) == 0:
+                    raise PermanentExtractionFailure("downloaded file is zero bytes")
                 result = run_mlx(image_path)
             finally:
                 try:
@@ -417,8 +545,20 @@ def process_backfill(dry_run: bool, only_id: str | None = None) -> None:
             print(f"  [fail-http{status_code}] {label} body={body!r}", file=sys.stderr)
             stats["extract_fail"] += 1
         except Exception as exc:  # noqa: BLE001
-            print(f"  [fail]        {label}: {exc}", file=sys.stderr)
-            stats["extract_fail"] += 1
+            if is_permanent_extraction_error(exc):
+                # Same logic as the queue path: permanent local failure →
+                # mark the receipt failed in the UI, count as extract_fail
+                # (no queue to ack here — backfill reads D1 directly).
+                reason = _format_failure_reason(exc)
+                post_extraction_failed(rid, reason)
+                stats["extract_fail"] += 1
+                print(
+                    f"  [fail-perm]   {label}: {reason} — marked extraction-failed",
+                    file=sys.stderr,
+                )
+            else:
+                print(f"  [fail]        {label}: {exc}", file=sys.stderr)
+                stats["extract_fail"] += 1
 
     print(
         f"\nDone. stale-state cleanup: {stats['stale_state']}, "
@@ -440,7 +580,13 @@ def process_once() -> int:
             job = msg["body"] if isinstance(msg["body"], dict) else json.loads(msg["body"])
             receipt_id, r2_key = job["receiptId"], job["r2Key"]
             image_path = fetch_image(receipt_id, r2_key)
+            # Zero-byte downloads are deterministic-permanent: a 200 OK with
+            # an empty body means R2 has nothing for this key. MLX would
+            # either crash or produce gibberish; either way retrying won't
+            # help. Post failure + ack.
             try:
+                if os.path.getsize(image_path) == 0:
+                    raise PermanentExtractionFailure("downloaded file is zero bytes")
                 result = run_mlx(image_path)
             finally:
                 try:
@@ -461,8 +607,23 @@ def process_once() -> int:
                 print(f"[drop] {receipt_id}: HTTP {status} — permanent, acking. body={body!r}", file=sys.stderr)
             else:
                 print(f"[retry] {msg.get('id')} ({receipt_id}): {exc}", file=sys.stderr)
-        except Exception as exc:  # noqa: BLE001 — leave unacked for redelivery
-            print(f"[retry] {msg.get('id')} ({receipt_id}): {exc}", file=sys.stderr)
+        except Exception as exc:  # noqa: BLE001
+            if is_permanent_extraction_error(exc):
+                # Deterministic-permanent local failure (corrupt image / PDF,
+                # zero-byte file). Mark the receipt failed so the operator
+                # sees it in the review UI, then ack so the message doesn't
+                # retry into the DLQ. Transient errors (network, model load,
+                # generate) fall through to the unacked-retry path.
+                reason = _format_failure_reason(exc)
+                post_extraction_failed(receipt_id, reason)
+                acked.append(lease_id)
+                print(
+                    f"[fail-perm] {msg.get('id')} ({receipt_id}): {reason} "
+                    "— marked extraction-failed + acked",
+                    file=sys.stderr,
+                )
+            else:
+                print(f"[retry] {msg.get('id')} ({receipt_id}): {exc}", file=sys.stderr)
     ack(acked)
     return len(acked)
 

--- a/scripts/receipts-consumer/test_permanent_failure.py
+++ b/scripts/receipts-consumer/test_permanent_failure.py
@@ -1,0 +1,131 @@
+"""Tests for the permanent-failure classifier in consumer.py.
+
+Run:
+  cd scripts/receipts-consumer && \\
+  CF_ACCOUNT_ID=d CF_QUEUE_ID=d CF_API_TOKEN=d \\
+  RECEIPTS_EXTRACT_URL=http://d RECEIPTS_PROCESSOR_KEY=d MLX_MODEL=d \\
+  .venv/bin/python3 -m unittest test_permanent_failure -v
+"""
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+# Need to import consumer AFTER setting dummy env vars. The conftest pattern
+# isn't worth it for one test file — set env via the runner documented above,
+# or via the test_loads_import helper.
+import os
+os.environ.setdefault("CF_ACCOUNT_ID", "d")
+os.environ.setdefault("CF_QUEUE_ID", "d")
+os.environ.setdefault("CF_API_TOKEN", "d")
+os.environ.setdefault("RECEIPTS_EXTRACT_URL", "http://d")
+os.environ.setdefault("RECEIPTS_PROCESSOR_KEY", "d")
+os.environ.setdefault("MLX_MODEL", "d")
+
+import consumer  # type: ignore
+
+
+class TestPermanentFailureClassifier(unittest.TestCase):
+    def test_permanent_extraction_failure_is_permanent(self):
+        """Self-raised PermanentExtractionFailure → True."""
+        exc = consumer.PermanentExtractionFailure("downloaded file is zero bytes")
+        self.assertTrue(consumer.is_permanent_extraction_error(exc))
+        # Reason accessor preserves the clean message.
+        self.assertEqual(
+            consumer._format_failure_reason(exc),
+            "downloaded file is zero bytes",
+        )
+
+    def test_fitz_file_data_error_is_permanent(self):
+        """Real pymupdf FileDataError (raised on truncated PDFs) → True."""
+        import fitz
+        import tempfile
+        # Truncated PDF: header + EOF marker, no actual page data. pymupdf
+        # raises FileDataError ("Failed to open file ... as type pdf").
+        fd, path = tempfile.mkstemp(suffix=".pdf")
+        os.write(fd, b"%PDF-1.4\n%%EOF\n")
+        os.close(fd)
+        try:
+            with self.assertRaises(Exception) as ctx:
+                fitz.open(path)
+            self.assertTrue(
+                consumer.is_permanent_extraction_error(ctx.exception),
+                f"expected permanent, got {type(ctx.exception).__name__}: {ctx.exception}",
+            )
+        finally:
+            os.unlink(path)
+
+    def test_fitz_empty_file_is_permanent(self):
+        """Empty file → fitz.EmptyFileError (subclass of FileDataError) → True."""
+        import fitz
+        import tempfile
+        fd, path = tempfile.mkstemp(suffix=".pdf")
+        os.close(fd)  # leave the file empty
+        try:
+            with self.assertRaises(Exception) as ctx:
+                fitz.open(path)
+            self.assertTrue(consumer.is_permanent_extraction_error(ctx.exception))
+        finally:
+            os.unlink(path)
+
+    def test_pil_unidentified_image_error_is_permanent(self):
+        """PIL.UnidentifiedImageError on a non-image blob → True."""
+        from PIL import UnidentifiedImageError
+        import io
+        from PIL import Image
+        # 100 bytes of garbage — not a recognizable image format.
+        try:
+            Image.open(io.BytesIO(b"not an image at all" * 10))
+            self.fail("Image.open should have raised")
+        except Exception as exc:
+            # PIL raises UnidentifiedImageError for unknown formats. The
+            # exact subclass can vary; the classifier should catch the
+            # canonical name even if isinstance fails.
+            self.assertIsInstance(exc, UnidentifiedImageError)
+            self.assertTrue(consumer.is_permanent_extraction_error(exc))
+
+    def test_network_error_is_transient(self):
+        """requests.ConnectionError must NOT be permanent — retry should follow."""
+        import requests
+        exc = requests.ConnectionError("network down")
+        self.assertFalse(consumer.is_permanent_extraction_error(exc))
+
+    def test_timeout_is_transient(self):
+        """requests.Timeout must NOT be permanent."""
+        import requests
+        exc = requests.Timeout("read timed out")
+        self.assertFalse(consumer.is_permanent_extraction_error(exc))
+
+    def test_generic_runtime_error_is_transient(self):
+        """Model generate() / generic RuntimeError must NOT be permanent.
+
+        MLX inference failures are typically RuntimeError or torch errors;
+        they're environmental and may resolve on retry. Misclassifying them
+        as permanent would silently ack recoverable failures.
+        """
+        exc = RuntimeError("mlx generate failed: CUDA OOM")
+        self.assertFalse(consumer.is_permanent_extraction_error(exc))
+
+    def test_value_error_is_transient(self):
+        """ValueError must NOT be permanent (model output shape, dtype, etc.)."""
+        exc = ValueError("expected 4D tensor")
+        self.assertFalse(consumer.is_permanent_extraction_error(exc))
+
+    def test_format_reason_truncates_to_1000_chars(self):
+        """Reason longer than 1000 chars is truncated (endpoint enforces)."""
+        long_reason = "x" * 2000
+        exc = consumer.PermanentExtractionFailure(long_reason)
+        truncated = consumer._format_failure_reason(exc)
+        self.assertEqual(len(truncated), 1000)
+
+    def test_post_extraction_failed_swallows_network_error(self):
+        """A failed POST to extraction-failed must NOT raise — caller will
+        ACK regardless, and the alternative (re-raising) would leak a
+        network error into the ack-decision path."""
+        with patch("consumer.requests.post", side_effect=__import__("requests").RequestException("network down")):
+            # Should not raise.
+            consumer.post_extraction_failed("r1", "test reason")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/receipts/queue-items-failed.test.ts
+++ b/tests/receipts/queue-items-failed.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildQueueItems } from "@/lib/receipts/queue-items";
+import type { ReceiptRecord } from "@/lib/receipts/types";
+
+function receipt(partial: Partial<ReceiptRecord>): ReceiptRecord {
+  return {
+    id: "r1",
+    status: "captured",
+    captured_at: "2026-07-05T10:00:00.000Z",
+    merchant: null,
+    amount_minor: null,
+    currency: "JPY",
+    expense_category_code: null,
+    business_purpose: null,
+    transaction_date: null,
+    extraction_state: "captured",
+    extraction_json: null,
+    ...partial,
+  } as unknown as ReceiptRecord;
+}
+
+test("buildQueueItems: extraction-failed receipt is flagged with reason from extraction_json", () => {
+  const items = buildQueueItems([
+    receipt({
+      id: "failed-with-reason",
+      extraction_state: "failed",
+      extraction_json: JSON.stringify({
+        failed: true,
+        reason: "UnidentifiedImageError: cannot identify image file",
+        model: "mlx_local:qwen3-vl-32b",
+        failedAt: "2026-07-05T10:05:00.000Z",
+      }),
+    }),
+  ]);
+  assert.equal(items.length, 1);
+  assert.equal(items[0].extractionFailed, true);
+  assert.equal(
+    items[0].failureReason,
+    "UnidentifiedImageError: cannot identify image file",
+  );
+  // Pending extraction never went stale in this fixture, so stuck stays false.
+  assert.equal(items[0].stuck, false);
+});
+
+test("buildQueueItems: extraction-failed with missing/malformed JSON still flags the pill", () => {
+  const items = buildQueueItems([
+    receipt({
+      id: "failed-no-json",
+      extraction_state: "failed",
+      extraction_json: null,
+    }),
+    receipt({
+      id: "failed-malformed-json",
+      extraction_state: "failed",
+      extraction_json: "{not json",
+    }),
+  ]);
+  assert.equal(items[0].extractionFailed, true);
+  assert.equal(items[0].failureReason, null);
+  assert.equal(items[1].extractionFailed, true);
+  assert.equal(items[1].failureReason, null);
+});
+
+test("buildQueueItems: non-failed receipts never show the failed pill", () => {
+  const items = buildQueueItems([
+    receipt({ id: "captured", extraction_state: "captured" }),
+    receipt({ id: "queued", extraction_state: "queued" }),
+    receipt({ id: "processing", extraction_state: "processing" }),
+    receipt({ id: "processed", extraction_state: "processed" }),
+    // Even if extraction_json somehow has {failed:true}, the pill is gated
+    // on extraction_state === 'failed' so a stale payload on a recovered
+    // receipt doesn't keep rendering red.
+    receipt({
+      id: "recovered",
+      extraction_state: "processed",
+      extraction_json: JSON.stringify({ failed: true }),
+    }),
+  ]);
+  for (const item of items) {
+    assert.equal(item.extractionFailed, false, `${item.id} should not be flagged`);
+    assert.equal(item.failureReason, null);
+  }
+});
+
+test("buildQueueItems: failure reason is truncated to 300 chars (tooltip sanity)", () => {
+  const longReason = "x".repeat(500);
+  const items = buildQueueItems([
+    receipt({
+      id: "long-reason",
+      extraction_state: "failed",
+      extraction_json: JSON.stringify({ failed: true, reason: longReason }),
+    }),
+  ]);
+  assert.equal(items[0].failureReason?.length, 300);
+});


### PR DESCRIPTION
## Summary

Worker-side support for terminal extraction failures so the operator can see broken files in the review queue instead of watching receipts sit in `processing` forever or get silently DLQ'd.

- **`POST /api/receipts/[id]/extraction-failed`** — new endpoint. Auth mirrors `/extract`: processor key (constant-time) OR Clerk human actor. Body `{reason, model?}`. Writes `extraction_state='failed'` + persists reason into `extraction_json` (no migration needed). 409 if receipt is in a locked status. Reuses the existing `receipt.extraction_failed` audit action. Clerk middleware gets the same isPublicRoute exemption as `/extract` so processor-key requests aren't 404-rewritten.
- **Queue UI** — red "extraction failed" pill on each failed row in the review rail, with the reason in the tooltip. Pill is gated on `extraction_state === 'failed'` (not the JSON payload) so a recovered receipt doesn't keep rendering red.
- **`consumer.py` classifier** — wraps the fetch→rasterize→run_mlx path. Permanent exception types (pymupdf `FileDataError`/`EmptyFileError`, PIL `UnidentifiedImageError`, zero-byte download) → POST extraction-failed + ACK. Transient errors (network, HTTP 5xx, model load RuntimeError, ValueError) keep the existing unacked-retry-DLQ behavior. Same handling in `--backfill` mode.
- **Backfill compat** — `pull_pending_rows` already excludes `'failed'` (terminal-until-operator-action); docstring updated to spell that out.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `node --test` — 215 tests pass (incl. 4 new in `tests/receipts/queue-items-failed.test.ts` covering: failed-with-reason, missing/malformed JSON, non-failed receipts stay unflagged, 300-char reason truncation)
- [x] `python3 -m unittest test_permanent_failure` — 10/10 pass (covers real fitz FileDataError on truncated PDF, EmptyFileError, PIL UnidentifiedImageError, transient ConnectionError/Timeout/RuntimeError/ValueError, reason truncation, post-failure network-error swallow)
- [x] `npm run build:cf` clean
- [x] `npm run deploy` succeeded (Worker `de160cca`)
- [x] launchd consumer restarted cleanly
- [x] **End-to-end corrupt-PDF test:** uploaded truncated PDF (`%PDF-1.4\n%%EOF`) to a fresh test receipt → ran `./run.sh --backfill --once` → consumer log showed `[fail-perm] ... FileDataError: Failed to open file '...' — marked extraction-failed` → D1 verification showed `extraction_state='failed'` + `extraction_json={failed:true, reason:"FileDataError: Failed to open file ...", model:"mlx_local:Qwen3-VL-32B-Instruct-4bit", failedAt:"2026-07-05T08:29:20.266Z"}`
- [x] Test receipt + R2 object + audit entries cleaned up
- [x] `bash scripts/check-deployment.sh https://dazbeez.com` passes