### PR TITLE
Receipts export remediation (A1–A8) + consolidated matching

### DIFF
--- a/app/(receipt-system)/receipts/export/page.tsx
+++ b/app/(receipt-system)/receipts/export/page.tsx
@@ -2,7 +2,6 @@ import {
   listAmexLines,
   listExports,
   listReceiptRecords,
-  listAttendees,
   getExport,
   listAmexLineCountsByMonth,
   listReconciliationStatusByMonth,
@@ -17,7 +16,6 @@ import {
   type CategoryBreakdownRow,
   type ManifestSampleRow,
 } from "@/components/receipts/export/export-screen";
-import type { AmexStatementLine, ReceiptRecord } from "@/lib/receipts/types";
 import { MonthSwitcher, type MonthOption } from "@/components/receipts/month-switcher";
 import { formatMonth } from "@/lib/receipts/format";
 import {
@@ -28,6 +26,8 @@ import {
   ACCOUNTANT_DISCLAIMER_EN,
   ACCOUNTANT_DISCLAIMER_JA,
 } from "@/lib/receipts/settings";
+import { buildExportBundle } from "@/lib/receipts/month-closing";
+import { buildMonthlyExportCsv } from "@/lib/receipts/export";
 
 export const dynamic = "force-dynamic";
 
@@ -65,22 +65,37 @@ export default async function ExportPage({
       : new Date().toISOString().slice(0, 7));
   const monthLabel = formatMonth(month);
 
-  const [exports, monthReceipts, monthLines, currentExport] = await Promise.all([
-    listExports(),
-    listReceiptRecords({ month, limit: 1000 }),
-    listAmexLines(month),
-    getExport(month),
-  ]);
+  // Build the SAME bundle the route finalizes with (single shared
+  // row-assembly authority in lib/receipts/month-closing.ts buildExportBundle).
+  // The preview the operator sees is now bit-identical to what ships —
+  // eliminates the audit-9 drift where the dashboard's row count, total,
+  // and size estimate could differ from the finalized bundle.
+  //
+  // We still fetch the unfiltered month receipts + lines separately for the
+  // blockers panel (computeExportBlockers runs over the raw receipt set,
+  // including UNKNOWN payment_path that the bundle intentionally excludes).
+  const [bundle, exports, monthReceipts, monthLines, currentExport] =
+    await Promise.all([
+      buildExportBundle(month),
+      listExports(),
+      listReceiptRecords({ month, limit: 1000 }),
+      listAmexLines(month),
+      getExport(month),
+    ]);
 
   const blockers = computeExportBlockers(monthReceipts, monthLines);
   const warnings = computeExportWarnings(monthLines);
 
-  const draftStats = computeDraftStats(monthReceipts, monthLines);
-  const breakdown = computeBreakdown(monthReceipts, monthLines);
-  const manifestSample = await buildManifestSample(monthReceipts.slice(0, 6));
+  const draftStats = computeDraftStats(bundle.rows);
+  const breakdown = computeBreakdown(bundle.rows);
+  const manifestSample = buildManifestSample(bundle.rows.slice(0, 6));
+  // Honest CSV size: build the pure CSV (same call the route makes before
+  // applying BOM/CRLF) and measure its UTF-8 byte length. BOM+CRLF add a
+  // small constant overhead we ignore — the operator only needs a ballpark.
+  const pureCsv = buildMonthlyExportCsv(bundle.rows, bundle.attendeeMap);
   const manifestSize = {
     rowsTotal: draftStats.rows,
-    sizeBytes: Math.max(800, draftStats.rows * 135),
+    sizeBytes: new TextEncoder().encode(pureCsv).byteLength,
     sha256: currentExport?.archive_sha256 ?? null,
   };
 
@@ -114,38 +129,45 @@ export default async function ExportPage({
   );
 }
 
-function computeDraftStats(
-  receipts: ReceiptRecord[],
-  lines: AmexStatementLine[],
-) {
-  const rows = receipts.length + lines.length;
-  const totalMinor =
-    receipts.reduce((s, r) => s + (r.amount_minor ?? 0), 0) +
-    lines.reduce((s, l) => s + l.amount_minor, 0);
-  const taxMinor = receipts.reduce(
-    (s, r) => s + (r.tax_amount_minor ?? 0),
-    0,
-  );
-  const receiptsAttached = lines.filter(
-    (l) => l.matched_receipt_id || l.match_status === "no_receipt",
+/**
+ * Compute KPI stats over the bundle rows — the same rows that ship in the
+ * CSV. Audit A6: previously summed `receipts + lines`, double-counting
+ * matched receipts (their amount appeared in both the line and the
+ * receipt). Bundle assembly already excludes matched receipts from the
+ * non-Amex receipt section, so summing bundle.rows is correct by
+ * construction.
+ */
+function computeDraftStats(rows: ExportRowLike[]): {
+  rows: number;
+  totalMinor: number;
+  taxMinor: number;
+  receiptsAttached: number;
+  receiptsTotal: number;
+  eventCount: number;
+} {
+  const totalMinor = rows.reduce((s, r) => s + (r.amountMinor ?? 0), 0);
+  // Tax only applies to AMEX-line rows where the matched receipt carried
+  // tax data. Bundle rows for CASH/DIGITAL don't include tax here because
+  // this sum is a display estimate, not an accounting total.
+  const taxMinor = rows.reduce((s, r) => s + (r.taxAmountMinor ?? 0), 0);
+  const receiptsAttached = rows.filter(
+    (r) => r.rowType === "amex_line" && (r.receiptId || r.matchStatus === "no_receipt"),
   ).length;
+  const eventCount = rows.filter((r) => {
+    const code = r.expenseCategoryCode ?? "";
+    return code === "entertainment" || code === "meeting";
+  }).length;
   return {
-    rows,
+    rows: rows.length,
     totalMinor,
     taxMinor,
-    receiptsAttached: receipts.length + receiptsAttached,
-    receiptsTotal: rows,
-    attendeesLogged: 0, // populated below per-month if cheap
-    eventCount: receipts.filter((r) =>
-      ["entertainment", "meeting"].includes(r.expense_category_code ?? ""),
-    ).length,
+    receiptsAttached,
+    receiptsTotal: rows.length,
+    eventCount,
   };
 }
 
-function computeBreakdown(
-  receipts: ReceiptRecord[],
-  lines: AmexStatementLine[],
-): CategoryBreakdownRow[] {
+function computeBreakdown(rows: ExportRowLike[]): CategoryBreakdownRow[] {
   const totals = new Map<string, { count: number; total: number }>();
 
   const bump = (code: string | null, amount: number) => {
@@ -156,8 +178,7 @@ function computeBreakdown(
     totals.set(key, existing);
   };
 
-  for (const r of receipts) bump(r.expense_category_code, r.amount_minor ?? 0);
-  for (const l of lines) bump(l.expense_category_code, l.amount_minor);
+  for (const r of rows) bump(r.expenseCategoryCode ?? null, r.amountMinor ?? 0);
 
   const grand = Array.from(totals.values()).reduce(
     (s, v) => s + v.total,
@@ -179,28 +200,44 @@ function computeBreakdown(
     .slice(0, 7);
 }
 
-async function buildManifestSample(
-  receipts: ReceiptRecord[],
-): Promise<ManifestSampleRow[]> {
-  // Compute manifest rows for the first 6 receipts. Attendees aren't needed
-  // for the preview but keep one query path warm for parity with export.ts.
-  return Promise.all(
-    receipts.map(async (r) => {
-      await listAttendees(r.id);
-      const cat = r.expense_category_code
-        ? getCategoryByCode(r.expense_category_code)
-        : null;
-      return {
-        receiptId: `R-${r.id.slice(0, 8)}`,
-        merchant: r.merchant ?? "(unnamed)",
-        txnDate: r.transaction_date ?? r.captured_at.slice(0, 10),
-        amountMinor: r.amount_minor ?? 0,
-        categoryLabel: cat?.jaName ?? r.expense_category_code ?? "—",
-        payment: r.payment_path,
-        cardLast4: r.payment_path === "AMEX" ? "3091" : "",
-        alcohol: Boolean(r.alcohol_present),
-        archivePath: `r2://.../${r.id.slice(0, 8)}.jpg`,
-      };
-    }),
-  );
+/**
+ * Build the manifest preview rows from bundle rows. Audit A6: the previous
+ * implementation fired a `listAttendees` call per receipt just to "keep the
+ * query path warm" (its own comment) — pure N+1 waste. Attendees are now
+ * batched once in buildExportBundle (listAttendeeNamesByReceiptIds).
+ */
+function buildManifestSample(rows: ExportRowLike[]): ManifestSampleRow[] {
+  return rows.map((r) => {
+    const cat = r.expenseCategoryCode
+      ? getCategoryByCode(r.expenseCategoryCode)
+      : null;
+    return {
+      receiptId: r.receiptId ? `R-${r.receiptId.slice(0, 8)}` : "—",
+      merchant: r.merchant ?? "(unnamed)",
+      txnDate: r.transactionDate ?? "—",
+      amountMinor: r.amountMinor ?? 0,
+      categoryLabel: cat?.jaName ?? r.expenseCategoryCode ?? "—",
+      payment: r.paymentPath ?? "—",
+      alcohol: false,
+      archivePath: r.originalR2Key
+        ? `r2://.../${r.originalR2Key.slice(-12)}`
+        : "—",
+    };
+  });
 }
+
+// Minimal structural shape of ExportRow that the helpers above read. We
+// import the full type via the bundle; this alias keeps the helper
+// signatures self-documenting without re-listing every field.
+type ExportRowLike = {
+  rowType: "amex_line" | "receipt";
+  receiptId: string | null;
+  transactionDate: string | null;
+  merchant: string | null;
+  amountMinor: number | null;
+  expenseCategoryCode: string | null;
+  paymentPath: string | null;
+  matchStatus: string | null;
+  taxAmountMinor: number | null;
+  originalR2Key: string | null;
+};

--- a/app/api/mobile/receipts/upload/route.ts
+++ b/app/api/mobile/receipts/upload/route.ts
@@ -9,6 +9,7 @@ import {
   findMobileReceiptByIdempotency,
 } from "@/lib/receipts/mobile-upload";
 import { hardDeleteReceipt, updateReceiptRecord } from "@/lib/receipts/db";
+import { ExportFinalizedError } from "@/lib/receipts/month-lock";
 import { buildExtractionJob, enqueueExtractionJob } from "@/lib/receipts/queue";
 import type { PaymentPath } from "@/lib/receipts/types";
 
@@ -214,6 +215,9 @@ export async function POST(request: Request) {
     }
     if (error instanceof Error && error.message.startsWith("Forbidden")) {
       return NextResponse.json({ error: error.message }, { status: 403 });
+    }
+    if (error instanceof ExportFinalizedError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
     }
     console.error("[api/mobile/receipts/upload] failed", error);
     return NextResponse.json(

--- a/app/api/receipts/[id]/extract/route.ts
+++ b/app/api/receipts/[id]/extract/route.ts
@@ -6,6 +6,7 @@ import {
   type ModelExtractionFields,
 } from "@/lib/receipts/extraction";
 import { createAuditEntry } from "@/lib/receipts/audit";
+import { ExportFinalizedError } from "@/lib/receipts/month-lock";
 import { nowIso, stringifyJson } from "@/lib/receipts/db-utils";
 import { getReceiptsDb, getReceiptsProcessorKey } from "@/lib/cloudflare-runtime";
 import type { ExtractionResult } from "@/lib/receipts/types";
@@ -214,6 +215,9 @@ export async function POST(request: Request, { params }: RouteContext) {
   } catch (error) {
     if (error instanceof Error && error.message.startsWith("Unauthorized")) {
       return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+    }
+    if (error instanceof ExportFinalizedError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
     }
     if (error instanceof Error && error.message.includes("finalized reconciliation")) {
       return NextResponse.json({ error: error.message }, { status: 409 });

--- a/app/api/receipts/[id]/extract/route.ts
+++ b/app/api/receipts/[id]/extract/route.ts
@@ -198,7 +198,37 @@ export async function POST(request: Request, { params }: RouteContext) {
       updates.invoiceRegistrationNumber = result.invoiceRegistrationNumber;
     }
 
-    await updateReceiptRecord(id, updates, actor);
+    // A CASH/DIGITAL receipt whose EXTRACTED date lands in an export-finalized
+    // month trips the month lock inside updateReceiptRecord. Do not drop the
+    // OCR result: the consumer treats any 4xx as permanent and ACKs the queue
+    // message, so a 409 here would strand the receipt in a pending state with
+    // no job left to re-apply the result (Codex review P1, 2026-07-08).
+    // Instead, persist everything EXCEPT the lock-triggering transaction_date
+    // (the full result, date included, is kept in extraction_json for the
+    // operator to apply via re-parse once a revision is open) and ack with 200.
+    let dateDeferredMonth: string | null = null;
+    try {
+      await updateReceiptRecord(id, updates, actor);
+    } catch (error) {
+      if (!(error instanceof ExportFinalizedError) || !("transactionDate" in updates)) {
+        throw error;
+      }
+      dateDeferredMonth = error.month;
+      const { transactionDate: _deferred, ...withoutDate } = updates;
+      await updateReceiptRecord(id, withoutDate, actor);
+      await createAuditEntry(db, {
+        actor,
+        action: "receipt.extraction_date_deferred",
+        objectType: "receipt",
+        objectId: id,
+        newValueJson: stringifyJson({
+          provider,
+          deferredTransactionDate: result.transactionDate,
+          lockedMonth: error.month,
+          reason: "extracted date lands in an export-finalized month",
+        }),
+      });
+    }
 
     await createAuditEntry(db, {
       actor,
@@ -209,7 +239,19 @@ export async function POST(request: Request, { params }: RouteContext) {
     });
 
     return NextResponse.json(
-      { ok: true, extracted: result, discrepancies, extractedAt: nowIso() },
+      {
+        ok: true,
+        extracted: result,
+        discrepancies,
+        extractedAt: nowIso(),
+        ...(dateDeferredMonth
+          ? {
+              dateDeferred: true,
+              lockedMonth: dateDeferredMonth,
+              note: `Extracted transaction date withheld: month ${dateDeferredMonth} is export-finalized. Open a revision, then re-parse to apply it.`,
+            }
+          : {}),
+      },
       { status: 200 },
     );
   } catch (error) {

--- a/app/api/receipts/[id]/route.ts
+++ b/app/api/receipts/[id]/route.ts
@@ -17,6 +17,7 @@ import { getComplianceSettings } from "@/lib/receipts/settings";
 import {
   validateInvoiceRegistrationNumber,
 } from "@/lib/receipts/invoice";
+import { ExportFinalizedError } from "@/lib/receipts/month-lock";
 import type {
   QualifiedInvoiceStatus,
   SourceType,
@@ -102,8 +103,18 @@ export async function PATCH(request: Request, { params }: RouteContext) {
     }
 
     if (receipt.status === "exported" || receipt.status === "archived") {
+      // Surface the revision endpoint when the receipt shipped in a
+      // finalized export — the operator can't edit it directly and must
+      // open a correction. exported_month tells us which month's revision
+      // endpoint to point at (audit A5 split-lock model).
+      const revisionHint =
+        receipt.status === "exported" && receipt.exported_month
+          ? ` POST /api/receipts/export/${receipt.exported_month}?correction=true to create a revision.`
+          : "";
       return NextResponse.json(
-        { error: `Receipt is ${receipt.status} and cannot be edited.` },
+        {
+          error: `Receipt is ${receipt.status} and cannot be edited.${revisionHint}`,
+        },
         { status: 409 },
       );
     }
@@ -289,6 +300,9 @@ export async function PATCH(request: Request, { params }: RouteContext) {
   } catch (error) {
     if (error instanceof Error && error.message.startsWith("Unauthorized")) {
       return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+    }
+    if (error instanceof ExportFinalizedError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
     }
     if (error instanceof Error && error.message.includes("finalized reconciliation")) {
       return NextResponse.json({ error: error.message }, { status: 409 });

--- a/app/api/receipts/compliance/[month]/route.ts
+++ b/app/api/receipts/compliance/[month]/route.ts
@@ -10,7 +10,7 @@ import {
   ACCOUNTANT_DISCLAIMER_EN,
   ACCOUNTANT_DISCLAIMER_JA,
 } from "@/lib/receipts/settings";
-import { listReceiptRecords, listAmexLines } from "@/lib/receipts/db";
+import { listAllReceiptsInMonth, listAmexLines } from "@/lib/receipts/db";
 
 type RouteContext = { params: Promise<{ month: string }> };
 
@@ -33,7 +33,10 @@ export async function GET(request: Request, { params }: RouteContext) {
     // current state. This is idempotent. Audit B2: a per-receipt check
     // failure no longer silently skips the receipt — its id is captured and
     // surfaced in the response so the operator knows the report is partial.
-    const receipts = await listReceiptRecords({ month, limit: 1000 });
+    // Audit A6: listAllReceiptsInMonth pages internally and refuses to
+    // silently truncate — a partial compliance report would mask exactly
+    // the receipts most likely to need attention.
+    const receipts = await listAllReceiptsInMonth(month);
     const checkFailedReceiptIds: string[] = [];
     for (const r of receipts) {
       try {

--- a/app/api/receipts/export/[month]/route.ts
+++ b/app/api/receipts/export/[month]/route.ts
@@ -5,7 +5,10 @@ import {
   finalizeExport,
   createExportRevision,
 } from "@/lib/receipts/db";
-import { validateMonthReadyForExport } from "@/lib/receipts/month-closing";
+import {
+  validateMonthReadyForExport,
+  computeEarlierOpenMonthWarnings,
+} from "@/lib/receipts/month-closing";
 
 type RouteContext = { params: Promise<{ month: string }> };
 
@@ -106,7 +109,16 @@ export async function POST(request: Request, { params }: RouteContext) {
       exportRecord.manifest_sha256 ?? undefined,
     );
 
-    return NextResponse.json({ ok: true, month, finalized: true }, { status: 200 });
+    // A7: non-blocking warning when finalizing month M while an earlier
+    // statement month is still open. A late cash/digital receipt dated in
+    // that earlier month will cost a revision once it lands — operators
+    // should know that before they walk away thinking the month is "done."
+    const warnings = await computeEarlierOpenMonthWarnings(month);
+
+    return NextResponse.json(
+      { ok: true, month, finalized: true, warnings },
+      { status: 200 },
+    );
   } catch (error) {
     if (error instanceof Error && error.message.startsWith("Unauthorized")) {
       return NextResponse.json({ error: "Unauthorized." }, { status: 401 });

--- a/app/api/receipts/export/[month]/route.ts
+++ b/app/api/receipts/export/[month]/route.ts
@@ -3,7 +3,6 @@ import { requireReceiptsActor } from "@/lib/receipts/auth";
 import {
   getExport,
   finalizeExport,
-  getFinalizedReconciliationForMonth,
   createExportRevision,
 } from "@/lib/receipts/db";
 import { validateMonthReadyForExport } from "@/lib/receipts/month-closing";
@@ -87,16 +86,9 @@ export async function POST(request: Request, { params }: RouteContext) {
       );
     }
 
-    const reconciliation = await getFinalizedReconciliationForMonth(month);
-    if (!reconciliation) {
-      return NextResponse.json(
-        {
-          error: `Cannot finalize export: no finalized reconciliation for ${month}.`,
-        },
-        { status: 422 },
-      );
-    }
-
+    // validateMonthReadyForExport is the single authority — it includes the
+    // finalized-reconciliation precondition. The redundant pre-check that
+    // used to live here was dropped to keep both finalize paths identical.
     const blockers = await validateMonthReadyForExport(month);
     if (blockers.length > 0) {
       return NextResponse.json(

--- a/app/api/receipts/export/month/route.ts
+++ b/app/api/receipts/export/month/route.ts
@@ -5,6 +5,7 @@ import {
   listAttendees,
   createExport,
   finalizeExport,
+  getExport,
   getFinalizedReconciliationForMonth,
 } from "@/lib/receipts/db";
 import {
@@ -22,7 +23,7 @@ import { validateMonthReadyForExport } from "@/lib/receipts/month-closing";
 import { getReceiptsDb, getReceiptsArchiveBucket } from "@/lib/cloudflare-runtime";
 import { getAmexArtifactByMonth } from "@/lib/receipts/db";
 import { retentionMetadata } from "@/lib/receipts/retention";
-import type { ExportRow, ReceiptFile } from "@/lib/receipts/types";
+import type { AmexReconciliation, ExportRow, ReceiptFile } from "@/lib/receipts/types";
 
 export async function POST(request: Request) {
   try {
@@ -82,8 +83,19 @@ export async function POST(request: Request) {
     // (lib/receipts/month-closing.ts). Do NOT inline a second finalize gate here;
     // any divergence between this route and /api/receipts/export/[month] reopens
     // the audit-9 drift where one path could finalize a month the other blocks.
+    //
+    // Fetch the reconciliation ONCE so we can both pass it into the validator
+    // (avoiding its internal round-trip) and use the same row for the manifest
+    // pointer below. Pre-1102-storm profiling showed finalize did two identical
+    // SELECTs against amex_reconciliations; this collapses them to one.
+    let reconciliation: AmexReconciliation | null = null;
     if (body.finalize) {
-      const blockers = await validateMonthReadyForExport(month);
+      reconciliation = await getFinalizedReconciliationForMonth(month);
+      const blockers = await validateMonthReadyForExport(
+        month,
+        undefined,
+        reconciliation,
+      );
       if (blockers.length > 0) {
         return NextResponse.json(
           { error: "Export blocked — resolve these issues first.", blockers },
@@ -96,19 +108,24 @@ export async function POST(request: Request) {
     const csv = buildMonthlyExportCsv(exportRows, attendeeMap);
     const sha256 = await hashCsvContent(csv);
 
-    // Create or retrieve export record
+    // Create or retrieve export record, then reload to pick up revision
+    // metadata (export_revision / supersedes_export_id / correction_reason).
+    // createExport() returns just the id; the row's revision fields are needed
+    // to label the manifest and README correctly when reusing a draft created
+    // by createExportRevision() — otherwise revision N ships with a README
+    // claiming "Revision: 1 (initial)".
     const exportId = await createExport(month, actor);
+    const exportRecord = await getExport(month);
+    const exportRevision = exportRecord?.export_revision ?? 1;
+    const supersedesExportId = exportRecord?.supersedes_export_id ?? null;
+    const correctionReason = exportRecord?.correction_reason ?? null;
+
     const archiveKey = buildArchiveKey(month, exportId);
     const manifestKey = buildManifestKey(month, exportId);
 
     // Upload CSV to archive bucket
     const encoder = new TextEncoder();
     await archiveBundle(archiveKey, encoder.encode(csv).buffer as ArrayBuffer);
-
-    // When finalizing, include reconciliation manifest reference in the export manifest
-    const reconciliation = body.finalize
-      ? await getFinalizedReconciliationForMonth(month)
-      : null;
 
     // Gather all file-manifest entries for receipts included in this export
     // plus the AMEX statement artifact. This builds the per-file SHA-256
@@ -158,6 +175,9 @@ export async function POST(request: Request) {
               originalFilename: amexArtifact.original_filename ?? "",
             }
           : null,
+        exportRevision,
+        supersedesExportId,
+        correctionReason,
       },
     );
     const manifestBytes = encoder.encode(manifest);
@@ -170,7 +190,9 @@ export async function POST(request: Request) {
       month,
       rowCount: exportRows.length,
       generatedAt,
-      exportRevision: 1,
+      exportRevision,
+      supersedesExportId,
+      correctionReason,
       archiveSha256: sha256,
       manifestSha256,
     });

--- a/app/api/receipts/export/month/route.ts
+++ b/app/api/receipts/export/month/route.ts
@@ -2,12 +2,10 @@ import { NextResponse } from "next/server";
 import { requireReceiptsActor } from "@/lib/receipts/auth";
 import {
   listReceiptRecords,
-  listReceiptRecordsByIds,
   listAttendees,
   createExport,
   finalizeExport,
   getFinalizedReconciliationForMonth,
-  listAmexLines,
 } from "@/lib/receipts/db";
 import {
   buildMonthlyExportCsv,
@@ -19,8 +17,8 @@ import {
   buildExportReadme,
 } from "@/lib/receipts/export";
 import { archiveBundle, archiveManifest } from "@/lib/receipts/storage";
-import { getCategoryByCode, requiresAttendees } from "@/lib/receipts/categories";
-import { resolveLineCategory } from "@/lib/receipts/line-classification";
+import { getCategoryByCode } from "@/lib/receipts/categories";
+import { validateMonthReadyForExport } from "@/lib/receipts/month-closing";
 import { getReceiptsDb, getReceiptsArchiveBucket } from "@/lib/cloudflare-runtime";
 import { getAmexArtifactByMonth } from "@/lib/receipts/db";
 import { retentionMetadata } from "@/lib/receipts/retention";
@@ -80,64 +78,12 @@ export async function POST(request: Request) {
       };
     });
 
-    // Export blocking validation — check AMEX lines and reconciliation before finalizing
+    // Export blocking validation — single authority is validateMonthReadyForExport
+    // (lib/receipts/month-closing.ts). Do NOT inline a second finalize gate here;
+    // any divergence between this route and /api/receipts/export/[month] reopens
+    // the audit-9 drift where one path could finalize a month the other blocks.
     if (body.finalize) {
-      const reconciliation = await getFinalizedReconciliationForMonth(month);
-      if (!reconciliation) {
-        return NextResponse.json(
-          { error: `Cannot finalize export: no finalized reconciliation for ${month}. Sign off the reconciliation first.`, blockers: [`No finalized reconciliation for ${month}`] },
-          { status: 422 },
-        );
-      }
-
-      const amexLines = await listAmexLines(month);
-      const matchedReceipts = await listReceiptRecordsByIds(
-        amexLines
-          .map((line) => line.matched_receipt_id)
-          .filter((id): id is string => Boolean(id)),
-      );
-      const receiptMap = new Map(matchedReceipts.map((r) => [r.id, r] as const));
-      const matchedAttendeeMap = new Map(attendeeMap);
-      for (const receipt of matchedReceipts) {
-        if (matchedAttendeeMap.has(receipt.id)) continue;
-        const attendees = await listAttendees(receipt.id);
-        if (attendees.length > 0) {
-          matchedAttendeeMap.set(receipt.id, attendees.map((a) => a.attendee_name));
-        }
-      }
-      const blockers: string[] = [];
-
-      for (const line of amexLines) {
-        // Classification source: when a matched receipt exists, read its
-        // category (the receipt is the system of record). Fall back to the
-        // line value for no-receipt lines and dangling matches.
-        const receipt = line.matched_receipt_id
-          ? receiptMap.get(line.matched_receipt_id)
-          : undefined;
-        const resolvedCategory = resolveLineCategory(line, receipt);
-
-        if (!resolvedCategory) {
-          blockers.push(`Line ${line.id}: missing expense category`);
-        }
-        if (line.receipt_status === "missing_receipt" && !line.receipt_missing_reason) {
-          blockers.push(`Line ${line.id}: missing receipt without reason`);
-        }
-        if (requiresAttendees(resolvedCategory)) {
-          const linkedReceipt = line.matched_receipt_id
-            ? matchedAttendeeMap.get(line.matched_receipt_id)
-            : null;
-          if (!linkedReceipt || linkedReceipt.length === 0) {
-            blockers.push(`Line ${line.id}: ${getCategoryByCode(resolvedCategory ?? "")?.jaName ?? resolvedCategory} requires attendees`);
-          }
-        }
-        if (line.business_trip_status === "candidate") {
-          blockers.push(`Line ${line.id}: unresolved business trip candidate`);
-        }
-        if (line.re_review_needed) {
-          blockers.push(`Line ${line.id}: statement line changed after confirmation`);
-        }
-      }
-
+      const blockers = await validateMonthReadyForExport(month);
       if (blockers.length > 0) {
         return NextResponse.json(
           { error: "Export blocked — resolve these issues first.", blockers },

--- a/app/api/receipts/export/month/route.ts
+++ b/app/api/receipts/export/month/route.ts
@@ -8,10 +8,13 @@ import {
   replaceExportItems,
 } from "@/lib/receipts/db";
 import {
+  bomPrefixedCrlf,
   buildMonthlyExportCsv,
+  buildExportSummaryCsv,
   hashCsvContent,
   buildArchiveKey,
   buildManifestKey,
+  buildSummaryKey,
   buildManifestCsv,
   buildReadmeKey,
   buildExportReadme,
@@ -20,6 +23,7 @@ import { archiveBundle, archiveManifest } from "@/lib/receipts/storage";
 import {
   buildExportBundle,
   validateMonthReadyForExport,
+  computeEarlierOpenMonthWarnings,
 } from "@/lib/receipts/month-closing";
 import { getReceiptsDb, getReceiptsArchiveBucket } from "@/lib/cloudflare-runtime";
 import { getAmexArtifactByMonth } from "@/lib/receipts/db";
@@ -78,9 +82,14 @@ export async function POST(request: Request) {
       }
     }
 
-    // Generate CSV and hash from the shared bundle rows.
-    const csv = buildMonthlyExportCsv(bundle.rows, bundle.attendeeMap);
-    const sha256 = await hashCsvContent(csv);
+    // Generate CSV. The pure form is what tests assert against; the route
+    // applies UTF-8 BOM + CRLF (audit A5) before hashing and upload so the
+    // SHA-256 in the manifest matches the bytes in R2 exactly. The
+    // accountant opens this CSV in Excel on Windows — without BOM/CRLF the
+    // Japanese merchant names render as mojibake.
+    const csvPure = buildMonthlyExportCsv(bundle.rows, bundle.attendeeMap);
+    const csvShipped = bomPrefixedCrlf(csvPure);
+    const sha256 = await hashCsvContent(csvShipped);
 
     // Create or retrieve export record, then reload to pick up revision
     // metadata (export_revision / supersedes_export_id / correction_reason).
@@ -102,10 +111,14 @@ export async function POST(request: Request) {
 
     const archiveKey = buildArchiveKey(month, exportId);
     const manifestKey = buildManifestKey(month, exportId);
+    const summaryKey = buildSummaryKey(month, exportId);
 
     // Upload CSV to archive bucket
     const encoder = new TextEncoder();
-    await archiveBundle(archiveKey, encoder.encode(csv).buffer as ArrayBuffer);
+    await archiveBundle(
+      archiveKey,
+      encoder.encode(csvShipped).buffer as ArrayBuffer,
+    );
 
     // Gather all file-manifest entries for receipts included in this export
     // plus the AMEX statement artifact. This builds the per-file SHA-256
@@ -164,6 +177,21 @@ export async function POST(request: Request) {
     const manifestSha256 = await hashCsvContent(manifest);
     await archiveManifest(manifestKey, manifestBytes.buffer as ArrayBuffer);
 
+    // Summary CSV (audit A5): per-category and per-PaymentPath totals for
+    // a quick reconciliation check. Same BOM/CRLF treatment as the main
+    // archive so the accountant can open it in Excel without mojibake.
+    const summaryPure = buildExportSummaryCsv(bundle.rows, month, generatedAt);
+    const summaryShipped = bomPrefixedCrlf(summaryPure);
+    const summarySha256 = await hashCsvContent(summaryShipped);
+    await getReceiptsArchiveBucket().put(
+      summaryKey,
+      encoder.encode(summaryShipped).buffer as ArrayBuffer,
+      {
+        httpMetadata: { contentType: "text/csv; charset=utf-8" },
+        customMetadata: retentionMetadata(),
+      },
+    );
+
     // README accompanies every bundle. Disclaimer text + revision context.
     const readme = buildExportReadme({
       exportId,
@@ -175,6 +203,7 @@ export async function POST(request: Request) {
       correctionReason,
       archiveSha256: sha256,
       manifestSha256,
+      summarySha256,
     });
     const readmeKey = buildReadmeKey(month, exportId);
     await getReceiptsArchiveBucket().put(
@@ -187,6 +216,7 @@ export async function POST(request: Request) {
     );
 
     // Auto-finalize if requested
+    let finalizeWarnings: string[] = [];
     if (body.finalize) {
       await finalizeExport(
         exportId,
@@ -196,6 +226,10 @@ export async function POST(request: Request) {
         actor,
         manifestSha256,
       );
+      // A7: non-blocking warning when an earlier statement month is still
+      // open. Surfaced in the finalize response so the operator's toast on
+      // "Finalize succeeded" can also say "but March is still open."
+      finalizeWarnings = await computeEarlierOpenMonthWarnings(month);
     }
 
     return NextResponse.json(
@@ -205,10 +239,13 @@ export async function POST(request: Request) {
         rowCount: bundle.rows.length,
         sha256,
         manifestSha256,
+        summarySha256,
         archiveKey,
         manifestKey,
+        summaryKey,
         readmeKey,
         finalized: body.finalize ?? false,
+        warnings: finalizeWarnings,
       },
       { status: 200 },
     );

--- a/app/api/receipts/export/month/route.ts
+++ b/app/api/receipts/export/month/route.ts
@@ -1,12 +1,11 @@
 import { NextResponse } from "next/server";
 import { requireReceiptsActor } from "@/lib/receipts/auth";
 import {
-  listReceiptRecords,
-  listAttendees,
   createExport,
   finalizeExport,
   getExport,
   getFinalizedReconciliationForMonth,
+  replaceExportItems,
 } from "@/lib/receipts/db";
 import {
   buildMonthlyExportCsv,
@@ -18,12 +17,14 @@ import {
   buildExportReadme,
 } from "@/lib/receipts/export";
 import { archiveBundle, archiveManifest } from "@/lib/receipts/storage";
-import { getCategoryByCode } from "@/lib/receipts/categories";
-import { validateMonthReadyForExport } from "@/lib/receipts/month-closing";
+import {
+  buildExportBundle,
+  validateMonthReadyForExport,
+} from "@/lib/receipts/month-closing";
 import { getReceiptsDb, getReceiptsArchiveBucket } from "@/lib/cloudflare-runtime";
 import { getAmexArtifactByMonth } from "@/lib/receipts/db";
 import { retentionMetadata } from "@/lib/receipts/retention";
-import type { AmexReconciliation, ExportRow, ReceiptFile } from "@/lib/receipts/types";
+import type { AmexReconciliation, ReceiptFile } from "@/lib/receipts/types";
 
 export async function POST(request: Request) {
   try {
@@ -39,45 +40,18 @@ export async function POST(request: Request) {
       );
     }
 
-    // Load receipts for the month
-    const receipts = await listReceiptRecords({ month, limit: 1000 });
+    // Build the bundle ONCE — single shared row-assembly authority
+    // (lib/receipts/month-closing.ts buildExportBundle). The route and the
+    // validator both consume the same rows so a draft the operator previews
+    // is bit-identical to the bundle that ships on finalize. Audit A4.
+    const bundle = await buildExportBundle(month);
 
-    if (receipts.length === 0) {
+    if (bundle.rows.length === 0) {
       return NextResponse.json(
-        { error: `No receipts found for ${month}.` },
+        { error: `No exportable activity found for ${month}.` },
         { status: 400 },
       );
     }
-
-    // Load attendees for all receipts
-    const attendeeMap = new Map<string, string[]>();
-    for (const r of receipts) {
-      const attendees = await listAttendees(r.id);
-      if (attendees.length > 0) {
-        attendeeMap.set(r.id, attendees.map((a) => a.attendee_name));
-      }
-    }
-
-    // Build export rows
-    const exportRows: ExportRow[] = receipts.map((r) => {
-      const cat = getCategoryByCode(r.expense_category_code ?? "");
-      return {
-        receiptId: r.id,
-        transactionDate: r.transaction_date,
-        merchant: r.merchant,
-        amountMinor: r.amount_minor,
-        currency: r.currency,
-        expenseType: r.expense_type,
-        expenseCategoryCode: r.expense_category_code ?? null,
-        expenseCategoryJa: cat?.jaName ?? null,
-        expenseCategoryEn: cat?.enName ?? null,
-        paymentPath: r.payment_path,
-        businessPurpose: r.business_purpose,
-        attendees: attendeeMap.get(r.id) ?? [],
-        status: r.status,
-        originalR2Key: r.original_r2_key,
-      };
-    });
 
     // Export blocking validation — single authority is validateMonthReadyForExport
     // (lib/receipts/month-closing.ts). Do NOT inline a second finalize gate here;
@@ -93,7 +67,7 @@ export async function POST(request: Request) {
       reconciliation = await getFinalizedReconciliationForMonth(month);
       const blockers = await validateMonthReadyForExport(
         month,
-        undefined,
+        bundle,
         reconciliation,
       );
       if (blockers.length > 0) {
@@ -104,8 +78,8 @@ export async function POST(request: Request) {
       }
     }
 
-    // Generate CSV and hash
-    const csv = buildMonthlyExportCsv(exportRows, attendeeMap);
+    // Generate CSV and hash from the shared bundle rows.
+    const csv = buildMonthlyExportCsv(bundle.rows, bundle.attendeeMap);
     const sha256 = await hashCsvContent(csv);
 
     // Create or retrieve export record, then reload to pick up revision
@@ -120,6 +94,12 @@ export async function POST(request: Request) {
     const supersedesExportId = exportRecord?.supersedes_export_id ?? null;
     const correctionReason = exportRecord?.correction_reason ?? null;
 
+    // Record exactly which receipts and AMEX lines ship in this bundle. The
+    // one-draft-per-month invariant means an existing draft's items get
+    // replaced on rebuild — the (export_id, item_type, item_id) UNIQUE on
+    // receipt_export_items makes this idempotent.
+    await replaceExportItems(exportId, bundle.items);
+
     const archiveKey = buildArchiveKey(month, exportId);
     const manifestKey = buildManifestKey(month, exportId);
 
@@ -131,7 +111,7 @@ export async function POST(request: Request) {
     // plus the AMEX statement artifact. This builds the per-file SHA-256
     // section of the manifest so an accountant can verify every artifact.
     const db = getReceiptsDb();
-    const includedReceiptIds = receipts.map((r) => r.id);
+    const includedReceiptIds = bundle.receipts.map((r) => r.id);
     const fileRows: ReceiptFile[] = [];
     if (includedReceiptIds.length > 0) {
       const CHUNK_SIZE = 90;
@@ -157,7 +137,7 @@ export async function POST(request: Request) {
       month,
       archiveKey,
       sha256,
-      exportRows.length,
+      bundle.rows.length,
       generatedAt,
       reconciliation
         ? {
@@ -188,7 +168,7 @@ export async function POST(request: Request) {
     const readme = buildExportReadme({
       exportId,
       month,
-      rowCount: exportRows.length,
+      rowCount: bundle.rows.length,
       generatedAt,
       exportRevision,
       supersedesExportId,
@@ -222,7 +202,7 @@ export async function POST(request: Request) {
       {
         exportId,
         month,
-        rowCount: exportRows.length,
+        rowCount: bundle.rows.length,
         sha256,
         manifestSha256,
         archiveKey,

--- a/app/api/receipts/upload/route.ts
+++ b/app/api/receipts/upload/route.ts
@@ -4,6 +4,7 @@ import { validateReceiptFile } from "@/lib/receipts/validation";
 import { generateR2Key, uploadOriginal } from "@/lib/receipts/storage";
 import { createReceiptRecord, hardDeleteReceipt, updateReceiptRecord } from "@/lib/receipts/db";
 import { createReceiptFile } from "@/lib/receipts/files";
+import { ExportFinalizedError } from "@/lib/receipts/month-lock";
 import { buildExtractionJob, enqueueExtractionJob } from "@/lib/receipts/queue";
 import { getReceiptsBucket, getReceiptsDb } from "@/lib/cloudflare-runtime";
 import type { PaymentPath, SourceType } from "@/lib/receipts/types";
@@ -200,6 +201,9 @@ export async function POST(request: Request) {
   } catch (error) {
     if (error instanceof Error && error.message.startsWith("Unauthorized")) {
       return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+    }
+    if (error instanceof ExportFinalizedError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
     }
     console.error("[api/receipts/upload] failed", error);
     return NextResponse.json(

--- a/components/receipts/export/export-screen.tsx
+++ b/components/receipts/export/export-screen.tsx
@@ -37,7 +37,6 @@ export interface ExportScreenProps {
     taxMinor: number;
     receiptsAttached: number;
     receiptsTotal: number;
-    attendeesLogged: number;
     eventCount: number;
   };
   breakdown: CategoryBreakdownRow[];
@@ -52,7 +51,6 @@ export interface ManifestSampleRow {
   amountMinor: number;
   categoryLabel: string;
   payment: string;
-  cardLast4: string;
   alcohol: boolean;
   archivePath: string;
 }
@@ -512,9 +510,9 @@ function DraftPreview({
           sub={`${Math.max(0, stats.receiptsTotal - stats.receiptsAttached)} no-receipt-expected`}
         />
         <Kpi
-          label="Attendees logged"
-          value={stats.attendeesLogged.toString()}
-          sub={`${stats.eventCount} event${stats.eventCount === 1 ? "" : "s"}`}
+          label="Events"
+          value={stats.eventCount.toString()}
+          sub="entertainment / meeting"
         />
       </div>
 
@@ -913,7 +911,7 @@ function ReportFormat({
 }
 
 const COL_TEMPLATE =
-  "95px 170px 80px 70px 110px 80px 75px 70px 1fr";
+  "95px 170px 80px 70px 110px 80px 70px 1fr";
 
 function ManifestTable({ rows }: { rows: ManifestSampleRow[] }) {
   return (
@@ -928,7 +926,6 @@ function ManifestTable({ rows }: { rows: ManifestSampleRow[] }) {
         <span className="text-right">amount</span>
         <span>category</span>
         <span>payment</span>
-        <span>card_last4</span>
         <span>alcohol</span>
         <span>archive_path</span>
       </div>
@@ -944,7 +941,6 @@ function ManifestTable({ rows }: { rows: ManifestSampleRow[] }) {
           <span className="text-right tabular-nums">{r.amountMinor}</span>
           <span className="truncate">{r.categoryLabel}</span>
           <span className="truncate">{r.payment}</span>
-          <span className="truncate">{r.cardLast4 || "—"}</span>
           <span className="truncate">{r.alcohol ? "true" : "false"}</span>
           <span className="truncate">{r.archivePath}</span>
         </div>
@@ -962,7 +958,6 @@ const SCHEMA_COLS = [
   { k: "category", t: "enum", ex: "接待交際費", n: "one of 14 JP catalog" },
   { k: "expense_type", t: "enum", ex: "meeting-no-alcohol", n: "expense classification" },
   { k: "payment_path", t: "enum", ex: "AMEX", n: "AMEX / CASH / DIGITAL / UNKNOWN" },
-  { k: "card_last4", t: "string", ex: "3091", n: "present when payment_path=AMEX" },
   { k: "amex_reference", t: "string", ex: "20260417-0214", n: "links to amex_statement_lines" },
   { k: "business_purpose", t: "string", ex: "Client dinner · Acme", n: "free text" },
   { k: "attendees", t: "jsonl", ex: "[D Klan, T Sato]", n: "one per row in companion CSV" },
@@ -1009,7 +1004,7 @@ function SchemaTable() {
 
 function rawCsv(rows: ManifestSampleRow[]): string {
   const header =
-    "receipt_id,merchant,transaction_date,amount,category,payment_path,card_last4,alcohol_present,archive_path";
+    "receipt_id,merchant,transaction_date,amount,category,payment_path,alcohol_present,archive_path";
   const body = rows
     .map((r) =>
       [
@@ -1019,7 +1014,6 @@ function rawCsv(rows: ManifestSampleRow[]): string {
         r.amountMinor,
         csvField(r.categoryLabel),
         r.payment,
-        r.cardLast4 || "",
         r.alcohol ? "true" : "false",
         csvField(r.archivePath),
       ].join(","),

--- a/components/receipts/reconcile/reconcile-screen.tsx
+++ b/components/receipts/reconcile/reconcile-screen.tsx
@@ -7,6 +7,7 @@ import {
   useMemo,
   useRef,
   useState,
+  useTransition,
   type ReactNode,
 } from "react";
 import Link from "next/link";
@@ -32,6 +33,7 @@ import {
   formatCategoryLabel,
 } from "@/lib/receipts/categories";
 import { normalizeDescription } from "@/lib/receipts/reconciliation";
+import { resolveLineCategory } from "@/lib/receipts/line-classification";
 import type {
   AmexBusinessTripStatus,
   AmexReceiptStatus,
@@ -84,8 +86,29 @@ export function ReconcileScreen(props: ReconcileScreenProps) {
   const [warnings, setWarnings] = useState<string[] | null>(null);
   const [confirmType, setConfirmType] = useState<string>("");
   const [showFinalizeModal, setShowFinalizeModal] = useState(false);
+  const [isRefreshing, startRefresh] = useTransition();
 
   const locked = props.finalized;
+
+  // Match suggestions are computed server-side on every render of this page
+  // (never persisted), so "re-run matching" is just a router.refresh(). New
+  // receipts finish OCR asynchronously (upload → queue → MLX consumer on the
+  // Mac), which means an open reconcile tab goes stale the moment a new
+  // receipt lands — refresh when the tab regains focus, and expose a manual
+  // button in the top bar for mid-session refreshes.
+  const refreshMatches = useCallback(() => {
+    startRefresh(() => router.refresh());
+  }, [router]);
+
+  useEffect(() => {
+    const onVisible = () => {
+      if (document.visibilityState !== "visible") return;
+      if (busy !== null || bulkProgress !== null) return;
+      router.refresh();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    return () => document.removeEventListener("visibilitychange", onVisible);
+  }, [router, busy, bulkProgress]);
 
   const matchMap = useMemo(
     () => new Map(props.autoMatches.map((m) => [m.amexLineId, m])),
@@ -95,6 +118,20 @@ export function ReconcileScreen(props: ReconcileScreenProps) {
     () => new Map(props.receipts.map((r) => [r.id, r])),
     [props.receipts],
   );
+
+  // Consolidated receipts: all confirmed lines keyed by their shared receipt.
+  // Drives the "consolidated" row badge and the group-sum explanation in the
+  // detail pane (a receipt may legitimately cover several card charges).
+  const confirmedLinesByReceipt = useMemo(() => {
+    const map = new Map<string, AmexStatementLine[]>();
+    for (const l of props.amexLines) {
+      if (l.match_status !== "confirmed" || !l.matched_receipt_id) continue;
+      const group = map.get(l.matched_receipt_id) ?? [];
+      group.push(l);
+      map.set(l.matched_receipt_id, group);
+    }
+    return map;
+  }, [props.amexLines]);
 
   const linesWithBand = useMemo(
     () =>
@@ -404,6 +441,17 @@ export function ReconcileScreen(props: ReconcileScreenProps) {
           <Btn
             kind="ghost"
             size="md"
+            onClick={refreshMatches}
+            disabled={isRefreshing || bulkProgress !== null}
+            title="Re-run matching against the latest receipts (new uploads appear here once OCR completes)"
+          >
+            {isRefreshing ? "Refreshing…" : "Refresh matches"}
+          </Btn>
+        )}
+        {!locked && (
+          <Btn
+            kind="ghost"
+            size="md"
             onClick={bulkConfirmObvious}
             disabled={counts.obvious === 0 || bulkProgress !== null}
           >
@@ -445,6 +493,8 @@ export function ReconcileScreen(props: ReconcileScreenProps) {
       <div className="grid min-h-0 flex-1 grid-cols-[540px_minmax(0,1fr)]">
         <LinesPane
           linesWithBand={linesWithBand}
+          receiptMap={receiptMap}
+          confirmedLinesByReceipt={confirmedLinesByReceipt}
           activeId={activeId}
           setActiveId={setActiveId}
           tab={tab}
@@ -455,6 +505,7 @@ export function ReconcileScreen(props: ReconcileScreenProps) {
         <DetailPane
           active={active}
           receiptMap={receiptMap}
+          confirmedLinesByReceipt={confirmedLinesByReceipt}
           attendeesByReceiptId={props.attendeesByReceiptId}
           locked={locked}
           busyLineId={busy}
@@ -501,6 +552,8 @@ export function ReconcileScreen(props: ReconcileScreenProps) {
 
 function LinesPane({
   linesWithBand,
+  receiptMap,
+  confirmedLinesByReceipt,
   activeId,
   setActiveId,
   tab,
@@ -513,6 +566,8 @@ function LinesPane({
     band: ConfidenceBand;
     match: ReconciliationMatch | undefined;
   }>;
+  receiptMap: Map<string, ReceiptRecord>;
+  confirmedLinesByReceipt: Map<string, AmexStatementLine[]>;
   activeId: string | null;
   setActiveId: (id: string) => void;
   tab: Tab;
@@ -588,6 +643,8 @@ function LinesPane({
               <LineRow
                 key={l.line.id}
                 lwb={l}
+                receiptMap={receiptMap}
+                confirmedLinesByReceipt={confirmedLinesByReceipt}
                 active={activeId === l.line.id}
                 onClick={() => setActiveId(l.line.id)}
               />
@@ -599,6 +656,8 @@ function LinesPane({
               <LineRow
                 key={l.line.id}
                 lwb={l}
+                receiptMap={receiptMap}
+                confirmedLinesByReceipt={confirmedLinesByReceipt}
                 active={activeId === l.line.id}
                 onClick={() => setActiveId(l.line.id)}
               />
@@ -614,6 +673,8 @@ function LinesPane({
               <LineRow
                 key={l.line.id}
                 lwb={l}
+                receiptMap={receiptMap}
+                confirmedLinesByReceipt={confirmedLinesByReceipt}
                 active={activeId === l.line.id}
                 onClick={() => setActiveId(l.line.id)}
               />
@@ -629,6 +690,8 @@ function LinesPane({
               <LineRow
                 key={l.line.id}
                 lwb={l}
+                receiptMap={receiptMap}
+                confirmedLinesByReceipt={confirmedLinesByReceipt}
                 active={activeId === l.line.id}
                 onClick={() => setActiveId(l.line.id)}
               />
@@ -678,6 +741,8 @@ function SectionHeader({
 
 function LineRow({
   lwb,
+  receiptMap,
+  confirmedLinesByReceipt,
   active,
   onClick,
 }: {
@@ -686,12 +751,25 @@ function LineRow({
     band: ConfidenceBand;
     match: ReconciliationMatch | undefined;
   };
+  receiptMap: Map<string, ReceiptRecord>;
+  confirmedLinesByReceipt: Map<string, AmexStatementLine[]>;
   active: boolean;
   onClick: () => void;
 }) {
   const { line, band, match } = lwb;
   const color = BAND_DISPLAY[band];
   const receiptId = line.matched_receipt_id ?? match?.receiptId ?? null;
+  // Consolidated 領収書: suggested group size, or the count of confirmed
+  // siblings sharing this receipt.
+  const consolidatedCount =
+    match?.consolidatedGroupSize ??
+    (receiptId ? confirmedLinesByReceipt.get(receiptId)?.length ?? 0 : 0);
+  // Same source of truth the detail pane and finalize validators use:
+  // a linked receipt's category is authoritative over the line's own.
+  const categoryCode = resolveLineCategory(
+    line,
+    receiptId ? receiptMap.get(receiptId) : undefined,
+  );
   const confirmed = line.match_status === "confirmed";
   const noReceipt = line.match_status === "no_receipt";
 
@@ -738,9 +816,9 @@ function LineRow({
           </span>
         </div>
         <div className="mt-0.5 flex items-center gap-1.5">
-          {line.expense_category_code ? (
+          {categoryCode ? (
             <span className="text-[11px] text-gray-500">
-              {formatCategoryLabel(line.expense_category_code)}
+              {formatCategoryLabel(categoryCode)}
             </span>
           ) : (
             <span className="text-[11px] font-medium text-amber-700">
@@ -755,6 +833,11 @@ function LineRow({
           {confirmed && !noReceipt && (
             <Pill tone="green" size="sm">
               confirmed
+            </Pill>
+          )}
+          {consolidatedCount >= 2 && (
+            <Pill tone="gray" size="sm">
+              consolidated · {consolidatedCount}
             </Pill>
           )}
           {line.re_review_needed ? (
@@ -832,6 +915,7 @@ function OrphansList({
 function DetailPane({
   active,
   receiptMap,
+  confirmedLinesByReceipt,
   attendeesByReceiptId,
   locked,
   busyLineId,
@@ -847,6 +931,7 @@ function DetailPane({
     match: ReconciliationMatch | undefined;
   } | null;
   receiptMap: Map<string, ReceiptRecord>;
+  confirmedLinesByReceipt: Map<string, AmexStatementLine[]>;
   attendeesByReceiptId: Map<string, string[]>;
   locked: boolean;
   busyLineId: string | null;
@@ -899,7 +984,12 @@ function DetailPane({
                   : color.label}
           </Pill>
           <span className="text-[13px] text-gray-500">
-            {match?.matchReasons.join(", ") || matchExplanation(line, receipt)}
+            {match?.matchReasons.join(", ") ||
+              matchExplanation(
+                line,
+                receipt,
+                receiptId ? confirmedLinesByReceipt.get(receiptId) ?? [] : [],
+              )}
           </span>
           <span className="flex-1" />
           <Kbd>e</Kbd>

--- a/db/receipts/0017_export_integrity.sql
+++ b/db/receipts/0017_export_integrity.sql
@@ -1,0 +1,56 @@
+-- 0017_export_integrity.sql
+--
+-- Export bundle integrity + per-item audit trail. Audit 2026-07-08 (A3).
+-- Additive only — no existing column is altered or dropped.
+--
+-- What this enables:
+--   * At most one draft export per month (`idx_exports_one_draft`). Without
+--     this, two POSTs racing createExport() could insert two drafts for the
+--     same month and the manifest pointer in createExportRevision() would
+--     pick arbitrarily between them.
+--   * At most one export row per (month, revision) pair
+--     (`idx_exports_month_revision`). Revisions are a monotone chain; the
+--     pair is the natural key.
+--   * `receipt_export_items` records exactly which receipts and AMEX lines
+--     shipped in each export. Today only the CSV knows, which is not
+--     queryable for audit ("did receipt X ever ship?") and forces a
+--     per-bundle R2 fetch to answer. The (export_id, item_type, item_id)
+--     UNIQUE enforces no double-counting inside one bundle.
+
+-- ── Uniqueness on receipt_exports ────────────────────────────────────────────
+-- Both indexes are safe to apply to existing rows: revisions default to 1
+-- for rows pre-dating migration 0014, and at most one finalized row per
+-- (month, revision) exists in current data. A draft + finalized revision
+-- chain does not collide because finalized revisions are ≥1 and a fresh
+-- draft (revision 1) only coexists with finalized rows when the month has
+-- no prior finalized export.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_exports_month_revision
+  ON receipt_exports(export_month, export_revision);
+
+-- At most one draft per month. SQLite partial unique indexes ignore rows
+-- that don't match the WHERE clause, so finalized rows don't count.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_exports_one_draft
+  ON receipt_exports(export_month)
+  WHERE status = 'draft';
+
+-- ── receipt_export_items ─────────────────────────────────────────────────────
+-- One row per item (receipt or AMEX line) that went into a specific export
+-- bundle. Populated at bundle-build time (A4 row-assembly builder) and
+-- consulted by finalizeExport to mark receipts status='exported' (A5).
+CREATE TABLE IF NOT EXISTS receipt_export_items (
+  id TEXT PRIMARY KEY,
+  export_id TEXT NOT NULL REFERENCES receipt_exports(id) ON DELETE CASCADE,
+  item_type TEXT NOT NULL CHECK (item_type IN ('receipt', 'amex_line')),
+  item_id TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  UNIQUE(export_id, item_type, item_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_export_items_export
+  ON receipt_export_items(export_id);
+
+-- Reverse lookup: "which exports has this receipt/line shipped in?" Used by
+-- the cross-month finalize gate (A7) and any future "is this row already
+-- exported" surface.
+CREATE INDEX IF NOT EXISTS idx_export_items_item
+  ON receipt_export_items(item_type, item_id);

--- a/db/receipts/0018_misc_category.sql
+++ b/db/receipts/0018_misc_category.sql
@@ -1,0 +1,8 @@
+-- Add 雑費 (miscellaneous) to the canonical expense category master list.
+-- Code is 'miscellaneous', NOT 'misc': the 0006 migration's legacy mapping
+-- deliberately sends old free-text 'misc' values to null (require review);
+-- reusing that string as a canonical code would silently legitimize them.
+INSERT OR IGNORE INTO expense_categories
+  (code, ja_name, en_name, requires_attendees, default_business_trip_eligible, display_order)
+VALUES
+  ('miscellaneous', '雑費', 'Miscellaneous expenses', 0, 0, 150);

--- a/db/receipts/scripts/backfill-invoice-registration.sql
+++ b/db/receipts/scripts/backfill-invoice-registration.sql
@@ -1,0 +1,25 @@
+-- Backfill invoice_registration_number from extraction_json.
+--
+-- WHY: all receipts extracted before the dbe4d79 (2026-06-09) worker deploy
+-- had their インボイス登録番号 parsed into extraction_json but never written to
+-- the queryable column (the extract route gained the column write later).
+-- Verified 2026-07-08: 22 of 62 receipts affected, all with format-valid
+-- T+13-digit values.
+--
+-- SCOPE: invoice number ONLY. taxAmountMinor / taxRate in extraction_json
+-- contain model junk on some rows (e.g. taxRate 58.66) — do NOT backfill
+-- those blindly; they should re-enter via the guarded re-parse path.
+--
+-- Idempotent: only fills NULL columns; guarded to T-prefixed 14-char values.
+-- NOTE: direct-SQL script — bypasses the app audit log by design (metadata
+-- completeness fix; no accounting values change). Run log: applied to
+-- dazbeez-receipts prod on 2026-07-08.
+
+UPDATE receipt_records
+SET invoice_registration_number = json_extract(extraction_json, '$.invoiceRegistrationNumber'),
+    invoice_registration_status = 'format_valid',
+    updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+WHERE deleted_at IS NULL
+  AND invoice_registration_number IS NULL
+  AND json_extract(extraction_json, '$.invoiceRegistrationNumber') LIKE 'T%'
+  AND length(json_extract(extraction_json, '$.invoiceRegistrationNumber')) = 14;

--- a/docs/adr/0002-statement-month-export-scope.md
+++ b/docs/adr/0002-statement-month-export-scope.md
@@ -1,0 +1,28 @@
+# ADR 0002 — Export scope: the statement month, not the transaction-date month
+
+- **Status:** Accepted
+- **Date:** 2026-07-08
+- **Owner:** David (PM)
+- **Affects:** `lib/receipts/month-closing.ts`, `lib/receipts/export.ts`, `app/api/receipts/export/*`, `db/receipts/0017_export_integrity.sql`
+- **Supersedes:** implicit transaction-date-month scope in the pre-2026-07-08 export route
+
+## Context
+
+The pre-redesign export CSV filtered receipts by `transaction_date LIKE 'YYYY-MM%'`. AMEX statement lines, however, post over a ~6-week window that lags the statement label (see `lib/receipts/statement-window.ts`): a late-March dinner receipt can land on the April statement, and the same receipt's `transaction_date` (March) and `statement_month` (April) disagree. Filtering the CSV by transaction-date month produced one population; the AMEX validation set (`amex_statement_lines.statement_month`) was another. The bundle was not self-consistent — the accountant reconciled against a statement population while the CSV shipped a transaction-date population, and missing-receipt lines were silently absent because they had no receipt row to filter in.
+
+## Decision
+
+The export unit is the **statement month**. A monthly bundle for month M contains:
+
+1. One row per AMEX statement line of month M (`RowType=amex_line`), with the matched receipt's fields joined when present. Missing-receipt and no-receipt lines **must** appear in the CSV with their reasons — previously silently absent.
+2. One row per CASH/DIGITAL receipt with `transaction_date` in month M (`RowType=receipt`). Transaction date is the accounting anchor for these — they have no statement.
+3. A receipt matched to a line appears once (on the line row), never twice.
+4. `payment_path = 'UNKNOWN'` is excluded; finalize blocks while any UNKNOWN receipt with `transaction_date` in M exists (its export month is ambiguous).
+
+Row assembly lives in **one place**: `buildExportBundle(month)` in `lib/receipts/month-closing.ts`. The export route and the finalize validator consume the same rows, so the operator's preview is bit-identical to what ships. Per-item audit trail lands in `receipt_export_items` (migration 0017) so "did receipt X ever ship?" is a D1 query, not an R2 fetch.
+
+## Consequences
+
+- A receipt with `transaction_date` in March but matched to an April statement line ships in **April** (statement-month scope wins for matched receipts).
+- The validator's UNKNOWN gate is mandatory — without it, an ambiguous receipt would have no export month and could silently slip through.
+- Cross-month match integrity becomes a real concern (see ADR 0005): a receipt matched to lines in two statement months is ambiguous and blocks both.

--- a/docs/adr/0003-compliance-engine-finalize-gate.md
+++ b/docs/adr/0003-compliance-engine-finalize-gate.md
@@ -1,0 +1,29 @@
+# ADR 0003 — Compliance engine as a finalize gate
+
+- **Status:** Accepted
+- **Date:** 2026-07-08
+- **Owner:** David (PM)
+- **Affects:** `lib/receipts/month-closing.ts`, `lib/receipts/compliance.ts`, `lib/receipts/settings.ts`, `app/api/receipts/export/*`
+- **Audits:** 2026-07-08 export review (activity A1)
+
+## Context
+
+`receipt_settings.export_block_on_warnings` existed in the schema and was surfaced in the compliance settings UI, but **no code path consulted it**. Open compliance checks (blocker or warning severity) did not gate export finalize. A receipt with an unresolved `blocker`-severity check (e.g. missing qualified invoice number on a ≥¥10k entertainment receipt) could ship in the monthly bundle without complaint. The setting was a documented control that did nothing — a bug, not a feature.
+
+Separately, the export finalize path had drifted: `POST /api/receipts/export/month {finalize:true}` contained an inline finalize-blocker loop that validated AMEX lines only, while `POST /api/receipts/export/[month]` routed through `validateMonthReadyForExport()` which validated receipt-level fields too. One path could finalize a month the other would block — a real audit-9 drift incident.
+
+## Decision
+
+1. **Single enforcement authority.** Both finalize paths call `validateMonthReadyForExport(month)`. The inline loop was deleted. `lib/receipts/blockers.ts` (UI tiles) is presentation-only with a code comment cross-referencing month-closing.ts as the enforcement authority.
+
+2. **Compliance-engine gate is part of the authority.** `validateMonthReadyForExport` calls `summarizeOpenChecksForMonth(db, month)`:
+   - Open `blocker`-severity checks always block finalize.
+   - Open `warning`-severity checks block only when `receipt_settings.export_block_on_warnings = true`.
+
+3. The `export_block_on_warnings` setting is now the toggle the schema always promised. Operators who want warnings to pass through leave it false; operators who want a stricter gate turn it on. There is no hidden bypass.
+
+## Consequences
+
+- Finalize now fails on real compliance issues. Operators may need to resolve or dismiss checks before they can ship a month.
+- The setting is the only escape hatch for warning-severity checks; blocker-severity checks have no bypass at finalize time (they must be resolved or explicitly dismissed via the compliance engine).
+- The two finalize paths cannot drift again — they share one code path.

--- a/docs/adr/0004-split-lock-model-cash-receipts.md
+++ b/docs/adr/0004-split-lock-model-cash-receipts.md
@@ -1,0 +1,45 @@
+# ADR 0004 — Split lock model: reconciliation-sealed vs. export-finalized
+
+- **Status:** Accepted
+- **Date:** 2026-07-08
+- **Owner:** David (PM)
+- **Affects:** `lib/receipts/month-lock.ts`, `lib/receipts/db.ts`, `app/api/receipts/*`, `app/api/mobile/receipts/upload/route.ts`
+- **Audits:** 2026-07-08 export review (activity A5)
+
+## Context
+
+Before this ADR, the only "month is locked" signal derived from `amex_reconciliations.status='finalized'`. The lock was enforced narrowly: `rejectIfReceiptInFinalizedReconciliation` blocked edits only to receipts matched to an AMEX line in a finalized month. Two gaps:
+
+1. **CASH/DIGITAL receipts had no lock at all.** A cash receipt with `transaction_date` in a month whose export had already shipped could be edited freely — even though the shipped CSV claimed an immutable SHA-256. Editing the row made the manifest hash stale and silently broke the audit chain.
+2. **The lock confused two different concepts.** Sealing an AMEX reconciliation is about statement-line immutability; finalizing an export is about "this bundle shipped and the accountant has it." Conflating them meant exporting a month did not actually lock the receipts inside it.
+
+The operator pain point: a late cash receipt for a finalized month had no defined handling path. Operators either left it for the next month (wrong — `transaction_date` is the accounting anchor) or edited the finalized month directly (wrong — broke the manifest hash).
+
+## Decision
+
+**Two independent locks, each blocking a different population:**
+
+| Lock | Scope | Population blocked | Authority |
+|------|-------|--------------------|-----------|
+| Reconciliation-sealed | Statement month | AMEX line edits + edits to receipts matched to a line | `rejectIfReceiptInFinalizedReconciliation` in db.ts |
+| Export-finalized | Transaction month | CASH/DIGITAL receipt inserts/edits where `transaction_date` falls in the finalized month | `assertTransactionMonthEditable` in month-lock.ts |
+
+The two never overlap. AMEX-path receipts are governed by reconciliation-sealed via their statement line. CASH/DIGITAL receipts are governed by export-finalized via their `transaction_date`. A receipt never hits both locks.
+
+The export-finalized lock is implemented by:
+
+- `ExportFinalizedError` — typed error class so routes use `instanceof` instead of brittle substring matching on `error.message`.
+- `assertTransactionMonthEditable(month)` — throws when the month has `receipt_exports.status='finalized'`. Memoized in-process for tight loops.
+- `transactionMonthOf(date)` — derives `YYYY-MM` from a YYYY-MM-DD or ISO timestamp.
+
+Wired into:
+- `createReceiptRecord` (no-op for the upload path, which inserts at status='captured' with null date; guards callers that supply the date up front)
+- `updateReceiptRecord` (checks the **effective** transaction month — input override wins, else the existing row's date)
+- Routes catch `ExportFinalizedError` → 409 with a message naming the revision endpoint: `POST /api/receipts/export/<month>?correction=true`.
+
+## Consequences
+
+- A late cash receipt for a finalized month must go through `createExportRevision` (the `?correction=true` endpoint). Direct inserts/edits return 409.
+- Receipt rows already at `status='exported'` (set by `finalizeExport`) surface a revision hint in their 409 too — the operator knows exactly where to go.
+- The reconciliation-sealed gate is unchanged for AMEX paths; existing edit-rejection behavior there is preserved.
+- The locks compose cleanly when both are active (a month can be both reconciliation-sealed and export-finalized — they protect different populations).

--- a/docs/adr/0004-split-lock-model-cash-receipts.md
+++ b/docs/adr/0004-split-lock-model-cash-receipts.md
@@ -29,8 +29,17 @@ The two never overlap. AMEX-path receipts are governed by reconciliation-sealed 
 The export-finalized lock is implemented by:
 
 - `ExportFinalizedError` — typed error class so routes use `instanceof` instead of brittle substring matching on `error.message`.
-- `assertTransactionMonthEditable(month)` — throws when the month has `receipt_exports.status='finalized'`. Memoized in-process for tight loops.
+- `assertTransactionMonthEditable(month)` — throws when the month is locked for edits (see predicate below). No-op for null/empty input, since uploads insert with a null `transaction_date` and the lock can't apply until the extraction backfill lands.
+- `isMonthLockedForEdits(db, month)` — the actual edit-lock predicate. Returns true iff an export exists at `status='finalized'` for the month AND no export exists at `status='draft'` for the month. Implemented as a single D1 CASE expression; one indexed lookup per mutation.
 - `transactionMonthOf(date)` — derives `YYYY-MM` from a YYYY-MM-DD or ISO timestamp.
+
+### Draft revision reopens the month (correction-flow fix, 2026-07-08)
+
+Finalized export rows are permanent (preservation principle — `receipt_exports.status='finalized'` never transitions back). Without a carve-out, the correction flow could never actually correct anything: `POST /api/receipts/export/<month>?correction=true` creates a fresh `status='draft'` revision row, but the finalized row it sits next to would keep the lock engaged and every edit attempt would re-throw.
+
+The predicate resolves this by treating "has open draft revision" as a release of the lock. While the draft exists, edits land normally against the live `receipt_records` rows. Finalizing the revision consumes the draft (it becomes the new finalized row), so the lock re-closes automatically — no explicit "re-seal" step is needed.
+
+This is why the predicate is **not** memoized: the locked state is no longer monotonic. A module-level `Set<string>` cached "locked" would survive a revision draft being opened within the same Worker isolate, and the correction flow would deadlock again. One D1 lookup per mutation is the correct cost; the index on `receipt_exports(export_month, status)` makes it cheap.
 
 Wired into:
 - `createReceiptRecord` (no-op for the upload path, which inserts at status='captured' with null date; guards callers that supply the date up front)
@@ -39,7 +48,8 @@ Wired into:
 
 ## Consequences
 
-- A late cash receipt for a finalized month must go through `createExportRevision` (the `?correction=true` endpoint). Direct inserts/edits return 409.
+- A late cash receipt for a finalized month must go through `createExportRevision` (the `?correction=true` endpoint). Direct inserts/edits return 409 — **until** the revision draft exists, at which point the month reopens for the duration of the correction. Finalizing the revision re-seals the month.
 - Receipt rows already at `status='exported'` (set by `finalizeExport`) surface a revision hint in their 409 too — the operator knows exactly where to go.
 - The reconciliation-sealed gate is unchanged for AMEX paths; existing edit-rejection behavior there is preserved.
 - The locks compose cleanly when both are active (a month can be both reconciliation-sealed and export-finalized — they protect different populations).
+- The lock state is non-monotonic (open draft → released; finalize draft → re-locked). It must be re-computed per mutation from D1 — never cached in-process.

--- a/docs/adr/0005-multi-open-month-assumption.md
+++ b/docs/adr/0005-multi-open-month-assumption.md
@@ -1,0 +1,40 @@
+# ADR 0005 — 3–4 concurrent open months operating assumption
+
+- **Status:** Accepted
+- **Date:** 2026-07-08
+- **Owner:** David (PM)
+- **Affects:** `lib/receipts/month-closing.ts`, `lib/receipts/db.ts`, `db/receipts/0017_export_integrity.sql`, `app/(receipt-system)/receipts/export/page.tsx`
+- **Audits:** 2026-07-08 export review (activity A7)
+- **Retires:** the pre-2026-07-08 "at most 2 open months" assumption documented in AGENTS.md
+
+## Context
+
+The previous operating assumption was "at most 2 statement months open at a time" — when a new month starts, the previous month should already be closed. That constrained the hot working set and let the design rely on near-sequential close.
+
+AMEX statement windows lag the statement label by ~6 weeks, so when 3–4 months are active the windows **overlap** — a receipt dated in late March can plausibly be a candidate for both the March and April statements. The 2-month assumption quietly broke: with overlapping windows, the same receipt could be suggested as a match for lines in two open months, and the export pipeline had no way to detect or block the ambiguity.
+
+A receipt matched to AMEX lines in two statement months is not a harmless double-count — it means both months' bundles would include the same receipt (once on each month's line row), and both finalized bundles would claim SHA-256 immutability over a row that exists in two places.
+
+## Decision
+
+The module is designed for **up to 3–4 concurrent open months** with overlapping statement windows.
+
+Two concrete enforcements:
+
+1. **Cross-month match integrity blocker.** `validateMonthReadyForExport` (in `lib/receipts/month-closing.ts`) groups all AMEX lines by `matched_receipt_id` and blocks finalize for any receipt that appears in more than one distinct `statement_month`. Both months stay blocked until the operator disambiguates (unmatch from one month, or reclassify).
+
+2. **Out-of-order finalize is allowed, with a warning.** Sealing April while March is still open is legitimate. But a late cash/digital receipt dated in March will cost a revision once it lands. `computeEarlierOpenMonthWarnings(month)` returns one warning string per earlier open month; both finalize routes (`/api/receipts/export/month` and `/api/receipts/export/[month]`) surface these in the finalize response as a non-blocking `warnings: string[]` field.
+
+Supporting design points:
+
+- **Draft isolation** is per-month. Migration 0017's `idx_exports_one_draft` is a partial unique index on `receipt_exports(export_month) WHERE status = 'draft'` — multiple months may each hold a draft concurrently. No code path assumes a single global draft.
+- **Subrequest budget.** The export page issues ~12 D1 queries per render (month switcher aggregates + bundle build + display queries), all batched via `Promise.all` where independent. Workers' 50-subrequest budget leaves ample headroom at 4 open months.
+- **Per-month query batching.** `listAttendeeNamesByReceiptIds(allReceiptIds)` is one batched call across all receipts in the bundle, replacing the previous per-receipt `listAttendees` N+1. At 4 open months with ~50 receipts each, this collapses ~200 queries to 1.
+- **`listAllReceiptsInMonth`** pages internally with a hard cap (default 10 000 rows). Silent truncation would corrupt a bundle; hitting the cap raises explicitly so the operator knows.
+
+## Consequences
+
+- Operators can safely keep multiple months open during catch-up or reconciliation backlogs. They get a warning when finalizing an out-of-order month, not a hard block.
+- A receipt accidentally matched to two open months is loud — finalize fails on both until resolved.
+- The hot working set is bounded by the operator's habits, not by code; if a fifth month opens the design still works (the assumptions are about overlapping windows, not a hard count).
+- AGENTS.md "Receipts Data Lifecycle" section's 2-month guidance is superseded for export-module design; the operator-facing "close the previous month when a new one starts" habit is still recommended but no longer load-bearing.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -150,6 +150,92 @@ taps      (id, token FK, cf_country, cf_city, user_agent, created_at)
 
 ---
 
+## Receipts Module — Export Pipeline
+
+The receipts module (`app/(receipt-system)/receipts/`, `app/api/receipts/`, `lib/receipts/`) is the largest subsystem in the repo. What follows is the export-pipeline slice; the async capture/extract runtime is documented in ADR 0001.
+
+### Scope: the export unit is the statement month
+
+A monthly export ships **one row per AMEX statement line of month M**, plus **one row per CASH/DIGITAL receipt whose `transaction_date` falls in month M**. AMEX lines post over a ~6-week window that lags the statement label (see `lib/receipts/statement-window.ts`); filtering receipts by `transaction_date LIKE 'YYYY-MM%'` produces a different population than the AMEX validation set, so the bundle assembles both in one place to stay self-consistent.
+
+- Single row-assembly authority: `buildExportBundle(month)` in `lib/receipts/month-closing.ts`. Consumed by both the export route (CSV/manifest upload) and the finalize validator — the operator's preview is bit-identical to what ships.
+- A receipt matched to a line appears once (on the line row), never twice.
+- `payment_path = 'UNKNOWN'` receipts are intentionally excluded from the bundle; their export month is ambiguous. The validator blocks finalize when any are present.
+- Per-bundle audit trail in `receipt_export_items` records exactly which receipts and lines shipped — queryable from D1 instead of forcing an R2 fetch.
+
+ADR: `docs/adr/0002-statement-month-export-scope.md`.
+
+### Single enforcement authority
+
+`validateMonthReadyForExport(month, prebuiltBundle?, preloadedReconciliation?)` in `lib/receipts/month-closing.ts` is the **only** gate. Both finalize paths (`POST /api/receipts/export/month {finalize:true}` and `POST /api/receipts/export/[month]`) call it; UI tiles in `lib/receipts/blockers.ts` are presentation-only.
+
+The validator runs six checks, in order:
+
+1. Statement-sealed gate — a finalized reconciliation must exist for the month.
+2. UNKNOWN `payment_path` gate — any UNKNOWN receipt with `transaction_date` in M blocks finalize.
+3. Receipt-level checks (date, merchant, amount, category, attendees-where-required) on every CASH/DIGITAL receipt in the bundle.
+4. AMEX-line checks via `validateAmexLinesForSignoff`.
+5. Compliance-engine gate (`summarizeOpenChecksForMonth`): open `blocker` checks always block; open `warning` checks block only when `receipt_settings.export_block_on_warnings` is true.
+6. Cross-month match integrity — a receipt matched to AMEX lines in two statement months blocks both months.
+
+ADR: `docs/adr/0003-compliance-engine-finalize-gate.md`.
+
+### Split lock model
+
+Two independent locks govern month-end state:
+
+| Lock | Scope | Blocks |
+|------|-------|--------|
+| Reconciliation-sealed | Statement month | AMEX line edits + matched-receipt edits |
+| Export-finalized | Transaction month | CASH/DIGITAL receipt inserts/edits anchored by `transaction_date` |
+
+A cash receipt arriving after its transaction month has shipped must go through the export-revision flow (`POST /api/receipts/export/<month>?correction=true`) — direct edits/inserts into a finalized month are rejected with a 409 pointing at the revision endpoint. The two locks never overlap: AMEX-path receipts are governed by reconciliation-sealed via their statement line, CASH/DIGITAL by export-finalized via their `transaction_date`.
+
+Helpers in `lib/receipts/month-lock.ts`: `ExportFinalizedError` (typed, thrown by the authority), `assertTransactionMonthEditable(month)`, `transactionMonthOf(date)`.
+
+ADR: `docs/adr/0004-split-lock-model-cash-receipts.md`.
+
+### CSV hardening (accountant-facing)
+
+The accountant opens the monthly CSV in **Excel on Windows**. Three hardening rules apply:
+
+- **UTF-8 BOM** so Excel detects encoding and renders Japanese merchants instead of mojibake.
+- **CRLF** line endings (Excel-friendlier).
+- **Formula injection guard** — cells starting with `=`, `+`, `-`, `@` are prefixed with a single quote so Excel doesn't evaluate them as formulas on open.
+
+The route applies all three via `bomPrefixedCrlf(csvText)` before hashing and upload; the SHA-256 in the manifest matches the bytes in R2 exactly. Tests exercise the pure CSV form; the BOM/CRLF wrapper is a route-layer concern.
+
+Each bundle ships four artifacts into the `RECEIPTS_ARCHIVE_BUCKET`:
+
+| Key | Contents |
+|-----|----------|
+| `exports/<M>/<id>-receipts.csv` | The main CSV (BOM+CRLF) |
+| `exports/<M>/<id>-manifest.csv` | Metadata + per-file SHA-256 table |
+| `exports/<M>/<id>-summary.csv` | Per-category and per-PaymentPath totals |
+| `exports/<M>/<id>-README.txt` | Disclaimers (EN/JA), revision context, SHA-256 chain |
+
+Compliance columns on the main CSV (電子帳簿保存法 / インボイス制度): `InvoiceRegistrationNumber`, `QualifiedInvoiceStatus`, `TaxRate`, `TaxAmount`, `SourceType`, `CounterpartyName`.
+
+### Operating assumption: 3–4 concurrent open months
+
+Statement windows overlap, so a receipt may be a candidate for lines in two open months. The validator handles this two ways:
+
+- **Blocker:** a receipt matched to AMEX lines in more than one month blocks finalize in both months until disambiguated.
+- **Warning:** finalizing month M while an earlier month is still open returns a non-blocking `warnings: string[]` in the finalize response. A late cash receipt for that earlier month will cost a revision once it lands.
+
+ADR: `docs/adr/0005-multi-open-month-assumption.md`.
+
+### Lifecycle: `receipt_records.status`
+
+```
+captured → needs_review → reviewed → reconciled → exported → archived
+   (ADR 0001 extraction pipeline)        (finalizeExport promotes to 'exported')
+```
+
+`finalizeExport` marks every receipt in `receipt_export_items` for the finalized export: `status='exported'`, `exported_month=M`. Once exported, direct edits are rejected with a 409 pointing at the revision endpoint; the operator must open a correction. `'archived'` is terminal and is not unwound by a re-finalize.
+
+---
+
 ## Local Reference Runtime
 
 `Dockerfile` and `docker-compose.yml` are retained only as local/reference artifacts.

--- a/docs/audits/export-remediation-2026-07-pr-notes.md
+++ b/docs/audits/export-remediation-2026-07-pr-notes.md
@@ -1,0 +1,159 @@
+# PR Notes — Export Module Remediation (2026-07-08 audit, branch `feat/export-remediation-2026-07`)
+
+Paste-ready description for the worker to use when opening the PR. Captures
+every commit on the branch and the exact Mac smoke-test sequence required
+before merge. Do not edit the smoke-test list — it is the architect's
+merge gate (F4 + A8).
+
+## Branch commit list (11 commits ahead of `origin/master`)
+
+| Commit     | Activity | Summary |
+|------------|----------|---------|
+| `087f6f5`  | audit prompt | docs(audit): export module architecture review prompt |
+| `830d14c`  | A1 | feat(receipts/export): A1 single validation authority |
+| `b479964`  | A2 | feat(receipts/export): A2 revision metadata propagation |
+| `af9ae6d`  | A3 | feat(receipts/db): A3 migration 0017 export integrity |
+| `34e1d2c`  | A4 | feat(receipts/export): A4 statement-month scope redesign |
+| `c32d10c`  | A5 lifecycle/lock | feat(receipts): A5 split lock model + finalize lifecycle |
+| `092e5d2`  | A5 CSV | feat(receipts/export): A5 CSV hardening + compliance columns |
+| `ca1eda9`  | A6 | feat(receipts/export): A6 perf + honest UI |
+| `2ebe8ae`  | A7 | feat(receipts/export): A7 multi-month finalize warnings |
+| `fbd0332`  | A8 | docs(receipts): A8 architecture + ADRs 0002–0005 |
+| `ab16754`  | F1–F3 | fix(receipts/month-lock): reopen month while draft revision exists |
+
+## Paste-ready PR description
+
+---
+
+### Summary
+
+Remediates the receipts export module per the 2026-07-08 architecture review
+(activities A1–A8) plus the F1–F3 follow-up fix to the split lock model.
+
+- **A1 — Single validation authority.** Both finalize paths now call
+  `validateMonthReadyForExport(month)`. The inline AMEX-only loop in
+  `POST /api/receipts/export/month` is deleted. The compliance engine now
+  gates finalize: open `blocker` checks always block; open `warning` checks
+  block when `receipt_settings.export_block_on_warnings = true`. The
+  previously-documented setting is no longer a no-op.
+- **A2 — Revision metadata propagation.** README + manifest now thread
+  `export_revision`, `supersedes_export_id`, `correction_reason` from the
+  loaded export row. Revision 2+ no longer ships claiming "Revision 1
+  (initial)".
+- **A3 — Migration 0017.** Adds `idx_exports_month_revision`,
+  `idx_exports_one_draft` (one draft per month partial index), and the
+  `receipt_export_items` audit-trail table. **Mac must apply this to live
+  D1 before deploy.**
+- **A4 — Export scope = statement month.** A monthly bundle now contains
+  one row per AMEX statement line of month M (missing-receipt and
+  no-receipt lines included with reasons), plus one row per CASH/DIGITAL
+  receipt with `transaction_date` in M. `payment_path='UNKNOWN'` is a
+  finalize blocker. Bundle assembly lives in one place
+  (`buildExportBundle`); preview and ship are bit-identical.
+- **A5 — Lifecycle + split lock + CSV hardening.** Finalize promotes
+  bundle receipts to `status='exported'` with `exported_month=M`.
+  `assertTransactionMonthEditable` gates CASH/DIGITAL edits by
+  transaction month (AMEX stays governed by reconciliation-sealed).
+  CSV now ships UTF-8 BOM + CRLF with formula-injection guard
+  (`= + - @`). Six compliance columns added; new `-summary.csv` per
+  bundle.
+- **A6 — Performance + honest UI.** Batched attendee query collapses
+  ~200 N+1 queries to 1 at 4 open months. `listAllReceiptsInMonth`
+  pages with a hard cap (10 000) that raises instead of truncating.
+  Export page shows real bundle bytes (not `rows*135`), drops the
+  fabricated `cardLast4: "3091"`, removes dead `attendeesLogged: 0`,
+  and uses `buildExportBundle` directly so preview matches ship.
+- **A7 — 3–4 concurrent open months.** Cross-month match integrity
+  blocker: a receipt matched to lines in two statement months blocks
+  finalize on both. Out-of-order finalize is allowed and surfaces a
+  non-blocking `warnings: string[]` for each earlier open month.
+- **A8 — Tests + docs.** `docs/architecture.md` export section added;
+  ADRs 0002–0005 cover the four architectural decisions (statement-month
+  scope, compliance gate, split lock model, multi-open-month assumption).
+- **F1–F3 — Correction-flow deadlock fix.** The A5 lock predicate
+  deadlocked the correction flow: finalized rows are permanent, so the
+  `?correction=true` revision draft existed but the month stayed locked.
+  New `isMonthLockedForEdits(db, month)` returns true iff finalized
+  exists AND no draft exists for the month — opening a revision
+  reopens the month; finalizing the revision re-locks it. The
+  in-process `finalizedMemo` Set is removed (it survives across
+  requests in an isolate and would re-deadlock the correction flow).
+  6 new unit tests + ADR 0004 updated.
+
+### ADRs
+
+- `docs/adr/0002-statement-month-export-scope.md`
+- `docs/adr/0003-compliance-engine-finalize-gate.md`
+- `docs/adr/0004-split-lock-model-cash-receipts.md` (updated for F1–F3)
+- `docs/adr/0005-multi-open-month-assumption.md`
+
+### What the Mac must do before deploy (MERGE GATE — do not skip)
+
+1. **Apply migration 0017 to live D1:**
+   `npx wrangler d1 migrations apply RECEIPTS_DB --remote`
+2. **`npx tsc --noEmit`** green.
+3. **`npm test`** green (237 tests as of F3).
+4. **`npm run build:cf`** green.
+5. **`cf:dev` smoke — draft → finalize → revision → re-finalize round-trip
+   on a real month.** Required sequence (was A8 + F4 expanded):
+   - Pick a test month with at least one AMEX line and one CASH receipt.
+     Create one if needed via the existing flows.
+   - Build a draft export for the month; verify preview rows match
+     `buildExportBundle` output exactly (no `rows*135` estimate, real
+     `sizeBytes`).
+   - Finalize the export. Confirm the bundle ships with BOM-prefixed
+     CRLF CSV, the `-summary.csv` is in R2 next to the manifest, and
+     `receipt_export_items` has one row per bundle line.
+   - Attempt a direct edit on a CASH receipt dated in that month →
+     expect **409** with `ExportFinalizedError` naming
+     `POST /api/receipts/export/<month>?correction=true`. **Must reject.**
+   - `POST /api/receipts/export/<month>?correction=true` with a
+     `correction_reason` → expect a new draft export row, export_revision=2,
+     supersedes_export_id set.
+   - **(F1 critical step)** Edit the same CASH receipt that just 409'd →
+     expect **200 success**, not 409. The draft revision must release
+     the lock. **If this still 409s, F1 did not land — stop and report
+     back to the architect.**
+   - Add or edit a second receipt in the same month to confirm the lock
+     stays released while the draft exists.
+   - Finalize the revision → expect revision-2 bundle to ship to R2 with
+     `SupersedesExportId` in the manifest, fresh SHA-256, and a new row
+     in `receipt_export_items`.
+   - **(F3 critical step)** Attempt another direct edit on a CASH receipt
+     in that month → expect **409** again. Finalizing the revision must
+     re-close the lock.
+6. **Out-of-order finalize warning smoke.** With month N finalized and
+   month N-1 still open, finalize N-1. The response must include
+   `warnings: ["..."]` referencing the earlier open month.
+7. **Cross-month match blocker smoke.** Manually match the same receipt
+   to AMEX lines in two open months. Finalize on either month must fail
+   with the cross-month-match blocker. Unmatch from one month; finalize
+   must succeed.
+8. **`bash scripts/check-deployment.sh <base-url>`** after deploy.
+9. Report back: which smoke steps passed/failed, any R2/D1 surprises,
+   the `wrangler d1 migrations list RECEIPTS_DB --remote` output showing
+   0017 applied.
+
+If any **bolded** step fails, stop and report back to the architect
+before merging. The correction round-trip is the load-bearing test for
+the F1 fix; the unit tests prove the predicate but only the live D1
+round-trip proves the wiring through `createExportRevision` →
+`updateReceiptRecord` → `finalizeExport`.
+
+---
+
+## Notes for the worker
+
+- This file (`docs/audits/export-remediation-2026-07-pr-notes.md`) is
+  the source of truth for the PR description. The architect authored it
+  in the sandbox session; paste the section between the `---` lines into
+  the `gh pr create --body` heredoc.
+- The smoke-test list is intentionally explicit because the F1 fix's
+  correctness is not visible from the diff alone — the wiring through
+  `createExportRevision` (which creates the draft row that releases the
+  lock) only matters at runtime against real D1.
+- Do NOT mark the F1 step optional even if every unit test passes. The
+  unit tests prove the predicate logic; they do not prove that
+  `createExportRevision` actually inserts the draft row that
+  `isMonthLockedForEdits` queries, nor that `updateReceiptRecord`'s
+  `assertTransactionMonthEditable` call uses the same D1 binding.

--- a/docs/audits/export-review-2026-07-08-cli-prompt.md
+++ b/docs/audits/export-review-2026-07-08-cli-prompt.md
@@ -1,0 +1,78 @@
+# CLI Agent Prompt — Export Module Remediation (2026-07-08 architecture review)
+
+Copy everything below the line into the CLI agent. Work on a branch from `main`. Activities are ordered; do not reorder. A1–A3 are correctness fixes, A4–A6 are the redesign, A7 covers multi-open-month operation, A8 is verification.
+
+Operating assumptions (from the PM): up to 3–4 statement months may be open concurrently (previous assumption was 2). Statement windows lag ~6 weeks, so open windows overlap — code must not assume a receipt has exactly one candidate month.
+
+---
+
+You are working in the Dazbeez repo on the receipts export module. Follow AGENTS.md conventions (App Router, server components, D1 via `lib/receipts/db.ts`). All changes must pass `npx tsc --noEmit` and `npm run build:cf`. Write unit tests with mocked bindings where a pure function is touched. Do not modify finalized-export rows or any R2 archive semantics — preservation principle: prior revisions stay untouched.
+
+## A1 — Single validation authority (correctness, do first)
+
+`app/api/receipts/export/month/route.ts` contains an inline finalize-blocker loop (lines ~84–147) that validates AMEX lines only. It has already drifted from `validateMonthReadyForExport()` in `lib/receipts/month-closing.ts`, which also validates receipt-level fields (date, merchant, amount, category, attendees). Result: `POST /api/receipts/export/month {finalize:true}` can finalize a month that `POST /api/receipts/export/[month]` would block.
+
+- Delete the inline loop. Both finalize paths must call `validateMonthReadyForExport(month)`.
+- Extend `validateMonthReadyForExport` to also consult the compliance engine: call `summarizeOpenChecksForMonth` (lib/receipts/compliance.ts); any open check with severity `blocker` blocks finalize; open `warning` checks block only when the `export_block_on_warnings` setting is true (`getComplianceSettings()`). This setting currently exists but is enforced nowhere — that is a bug, not a feature.
+- `lib/receipts/blockers.ts` (UI tiles) stays presentation-only but add a code comment cross-referencing month-closing.ts as the enforcement authority.
+
+## A2 — Revision metadata propagation (correctness)
+
+`export/month/route.ts` hardcodes `exportRevision: 1` in the README and passes no revision options to `buildManifestCsv`. When `createExport()` reuses a draft created by `createExportRevision()`, the bundle for revision N ships a README claiming "Revision: 1 (initial)" and a manifest missing `SupersedesExportId`/`CorrectionReason`.
+
+- After `createExport()` returns, load the export row and thread `export_revision`, `supersedes_export_id`, `correction_reason` into both `buildManifestCsv` options and `buildExportReadme`.
+- Also deduplicate the double call to `getFinalizedReconciliationForMonth` in that route.
+
+## A3 — Schema migration 0017 (integrity)
+
+Create `db/receipts/0017_export_integrity.sql`, additive only:
+
+- `CREATE UNIQUE INDEX idx_exports_month_revision ON receipt_exports(export_month, export_revision);`
+- Partial unique index guaranteeing at most one draft per month: `CREATE UNIQUE INDEX idx_exports_one_draft ON receipt_exports(export_month) WHERE status = 'draft';`
+- New table `receipt_export_items (id TEXT PK, export_id TEXT NOT NULL, item_type TEXT NOT NULL CHECK (item_type IN ('receipt','amex_line')), item_id TEXT NOT NULL, created_at TEXT NOT NULL, UNIQUE(export_id, item_type, item_id))` with an index on `export_id`. This records exactly which rows shipped in each export — today only the CSV itself knows, which is not queryable for audit.
+
+Do NOT run migrations in a cloud session; note in the PR that the Mac must apply 0017 to live D1 before deploy.
+
+## A4 — Export scope redesign (design decision, implement as specified)
+
+Decision: the export unit is the statement month, not the transaction-date month. Statement lines post over the prior ~6 weeks (see `lib/receipts/statement-window.ts`), so today's CSV (receipts filtered by `transaction_date LIKE 'YYYY-MM%'`) and the AMEX validation set are two different populations — the bundle is not self-consistent.
+
+New CSV composition for month M, built in `lib/receipts/month-closing.ts` (single builder used by route and any preview):
+
+1. One row per AMEX statement line of month M, with a `RowType=amex_line` column, resolved category (`resolveLineCategory`), matched-receipt fields joined when present, and `ReceiptStatus`/`MissingReceiptReason` populated — missing-receipt and no-receipt lines MUST appear in the CSV with their reasons; today they are silently absent, which undermines the audit story.
+2. One row per non-AMEX receipt (`payment_path IN ('CASH','DIGITAL')`) with `transaction_date` in month M, `RowType=receipt`. Transaction date is the accounting anchor for these — they have no statement.
+3. A receipt matched to a line appears once (on the line row), never twice.
+4. `payment_path = 'UNKNOWN'` is a finalize blocker (add to `validateMonthReadyForExport`): an unresolved payment path makes the receipt's export month ambiguous. Today UNKNOWN is never checked and can slide into a bundle.
+5. Because cash/digital receipts have no statement cross-check, receipt-level validation is their only gate — the existing receipt checks (date, merchant, amount, category, attendees-where-required) plus the compliance-engine gate from A1 must all apply to them. Include a `PaymentPath` breakdown (AMEX vs CASH vs DIGITAL subtotals) in the summary CSV from A5.
+
+Populate `receipt_export_items` for every row at bundle-build time. Keep `buildMonthlyExportCsv` as the pure CSV serializer; move row assembly into the shared builder.
+
+## A5 — Lifecycle + CSV hardening
+
+- On successful `finalizeExport`, mark every receipt in `receipt_export_items` for that export: `status='exported'`, `exported_month=M`. The column and status value exist and are currently dead. Keep this in the finalize code path with an audit-log entry.
+- Split the lock model in `lib/receipts/month-lock.ts` (currently derived solely from AMEX reconciliation status): reconciliation-sealed locks AMEX line edits for the statement month; **export-finalized locks CASH/DIGITAL receipt edits by transaction month**. A cash receipt arriving after its transaction month is finalized must go through the export-revision flow (`?correction=true`) — reject direct edits/inserts into a finalized month with a 409 pointing at the revision endpoint.
+- CSV output: prepend UTF-8 BOM and use CRLF line endings (the accountant opens this in Excel on Windows; without BOM, Japanese text renders as mojibake). Guard against formula injection: prefix cells starting with `=`, `+`, `-`, `@` with a single quote in `csvEscape`.
+- Add compliance columns to `CSV_HEADERS` and rows: `InvoiceRegistrationNumber`, `QualifiedInvoiceStatus`, `TaxRate`, `TaxAmount`, `SourceType`, `CounterpartyName`. These fields were added in migration 0014 for 電子帳簿保存法/インボイス制度 purposes and are the point of a compliance-forward report; they currently never leave the database.
+- Append a `-summary.csv` to the bundle: per-category count/total plus grand total, generated from the same rows, and reference it in the README.
+
+## A6 — Performance + honest UI
+
+- Replace per-receipt `listAttendees` loops (export route, month-closing, page) with one batched month query modeled on `listAmexLineAttendeeNamesByMonth`. Workers subrequest limits make N+1 a real failure mode — size all batching for 3–4 open months, since dashboard/aggregate views multiply per-month query counts.
+- `listReceiptRecords({month, limit:1000})` silently truncates; loop with offset until exhausted or raise an explicit error at the cap. At 4 open months the aggregate views make this cap plausible to hit.
+- `app/(receipt-system)/receipts/export/page.tsx`: fix `computeDraftStats` double-count (matched AMEX lines and their receipts are both summed today — exclude receipts that are matched to a line); remove the fabricated `sizeBytes: rows*135`; remove hardcoded `cardLast4: "3091"` (read from the line/receipt or omit); remove dead `attendeesLogged: 0` or populate it; delete the `listAttendees` "keep the query path warm" call in `buildManifestSample`.
+
+## A7 — Multi-open-month support (3–4 concurrent open months)
+
+The previous 2-open-months assumption is retired. Audit the module for hidden single-open-month or sequential-close assumptions and fix these specifics:
+
+- **Cross-month match integrity:** overlapping statement windows mean a receipt can now be a candidate for lines in two open months. Add a finalize blocker in `validateMonthReadyForExport`: any receipt matched (`matched_receipt_id`) to statement lines in more than one month blocks both months until resolved. Add a supporting index if the lookup needs one (fold into migration 0017).
+- **Out-of-order finalize is allowed** (sealing April while March is open is legitimate), but when finalizing month M with any earlier month still un-finalized, include a non-blocking warning in the finalize response (`warnings: []` field) — a late cash receipt for that earlier month will cost a revision.
+- **Draft isolation:** confirm the one-draft-per-month partial index (A3) is the only draft-uniqueness assumption; multiple months may each hold a draft export simultaneously — nothing may assume a single global draft.
+- Verify the month switcher / export page queries scale to 4 open months within one request's subrequest budget (combined with A6 batching).
+
+## A8 — Verification
+
+- Unit tests: csvEscape injection guard, BOM/CRLF, buildManifestCsv revision fields, new row-assembly builder (matched line, missing-receipt line with reason, CASH receipt, DIGITAL receipt, UNKNOWN blocked, no double-count), cross-month double-match blocker, out-of-order finalize warning.
+- `npx tsc --noEmit` and `npm run build:cf` green.
+- Update `docs/architecture.md` (export section) and add ADRs in `docs/adr/` recording: the statement-month export-scope decision (A4), the compliance-gate decision (A1), the split lock model for cash receipts (A5), and the 3–4 concurrent open months operating assumption (A7).
+- Summarize in the PR: what changed per activity, what the Mac must do (apply 0017, `cf:dev` smoke of draft→finalize→revision flow, `scripts/check-deployment.sh` after deploy).

--- a/docs/expenseCat_Requirements.md
+++ b/docs/expenseCat_Requirements.md
@@ -45,6 +45,9 @@ Seed this exact list:
 | `payment_fees` | 支払手数料 | Payment and service fees | false | false |
 | `rent_lease` | 賃借料 | Rent and lease expenses | false | false |
 | `insurance` | 保険料 | Insurance premiums | false | false |
+| `miscellaneous` | 雑費 | Miscellaneous expenses | false | false |
+
+Note (2026-07): `miscellaneous` (雑費) added as the 15th canonical category (migration 0018). The code is deliberately not `misc` — legacy `misc` values continue to map to null (require review).
 
 ---
 

--- a/lib/receipts/blockers.ts
+++ b/lib/receipts/blockers.ts
@@ -2,6 +2,13 @@
 // Hoisted out of app/(receipt-system)/receipts/export/page.tsx so the same
 // rules can power the dashboard "Export status" tile and the reconcile
 // screen's "Ready to seal?" summary without forking the logic.
+//
+// PRESENTATION ONLY. These tiles describe why a month isn't ready so the
+// operator knows what to fix; they are not the API gate. The single
+// enforcement authority is validateMonthReadyForExport() in
+// lib/receipts/month-closing.ts — every finalize path (POST
+// /api/receipts/export/month, POST /api/receipts/export/[month]) routes
+// through it. If you add a new rule, add it THERE, not here.
 
 import { requiresAttendees } from "@/lib/receipts/categories";
 import { isPendingProcessing } from "@/lib/receipts/extraction-state";

--- a/lib/receipts/categories.ts
+++ b/lib/receipts/categories.ts
@@ -15,7 +15,8 @@ export type ExpenseCategoryCode =
   | "membership_dues"
   | "payment_fees"
   | "rent_lease"
-  | "insurance";
+  | "insurance"
+  | "miscellaneous";
 
 export interface ExpenseCategory {
   code: ExpenseCategoryCode;
@@ -41,6 +42,11 @@ export const EXPENSE_CATEGORIES: ExpenseCategory[] = [
   { code: "payment_fees",          jaName: "支払手数料",   enName: "Payment and service fees",            requiresAttendees: false, defaultBusinessTripEligible: false, displayOrder: 120 },
   { code: "rent_lease",            jaName: "賃借料",       enName: "Rent and lease expenses",             requiresAttendees: false, defaultBusinessTripEligible: false, displayOrder: 130 },
   { code: "insurance",             jaName: "保険料",       enName: "Insurance premiums",                  requiresAttendees: false, defaultBusinessTripEligible: false, displayOrder: 140 },
+  // NOTE: deliberately "miscellaneous", not "misc" — legacy free-text "misc"
+  // values map to null in LEGACY_CATEGORY_MAP (require review), and
+  // mapLegacyCategory() checks isCanonicalCode() first. A canonical code
+  // named "misc" would silently legitimize old dumping-ground data.
+  { code: "miscellaneous",         jaName: "雑費",         enName: "Miscellaneous expenses",              requiresAttendees: false, defaultBusinessTripEligible: false, displayOrder: 150 },
 ];
 
 export const EXPENSE_CATEGORY_CODES = new Set<string>(EXPENSE_CATEGORIES.map((c) => c.code));

--- a/lib/receipts/compliance.ts
+++ b/lib/receipts/compliance.ts
@@ -289,9 +289,32 @@ export async function summarizeOpenChecksForMonth(
   db: D1Database,
   month: string,
 ): Promise<ComplianceSummary> {
-  const result = await db
+  return summarizeOpenChecksForExport(db, month, []);
+}
+
+/**
+ * Open-check summary for an export gate. Covers the union of:
+ *   (a) receipts anchored in `month` by transaction_date or exported_month
+ *       (the original month filter), and
+ *   (b) `extraReceiptIds` — the export bundle's receipts by ID.
+ *
+ * (b) exists because AMEX statement months include matched receipts whose
+ * transaction_date falls in a DIFFERENT month (the statement window lags),
+ * and exported_month isn't stamped until after finalize. Filtering by month
+ * alone let open blockers on those receipts slip past the finalize gate
+ * (Codex review P1, 2026-07-08). Rows are deduped by check id.
+ */
+export async function summarizeOpenChecksForExport(
+  db: D1Database,
+  month: string,
+  extraReceiptIds: string[],
+): Promise<ComplianceSummary> {
+  type CheckRow = { id: string; severity: ComplianceCheckSeverity; check_type: string };
+  const rowsById = new Map<string, CheckRow>();
+
+  const monthResult = await db
     .prepare(
-      `SELECT rcc.severity, rcc.check_type
+      `SELECT rcc.id, rcc.severity, rcc.check_type
        FROM receipt_compliance_checks rcc
        JOIN receipt_records rr ON rr.id = rcc.object_id
        WHERE rcc.object_type = 'receipt'
@@ -300,7 +323,29 @@ export async function summarizeOpenChecksForMonth(
          AND rr.deleted_at IS NULL`,
     )
     .bind(`${month}%`, month)
-    .all<{ severity: ComplianceCheckSeverity; check_type: string }>();
+    .all<CheckRow>();
+  for (const row of monthResult.results ?? []) rowsById.set(row.id, row);
+
+  // Chunked IN-lists keep each statement well under D1's bind-parameter cap.
+  const CHUNK = 50;
+  const ids = [...new Set(extraReceiptIds)];
+  for (let i = 0; i < ids.length; i += CHUNK) {
+    const chunk = ids.slice(i, i + CHUNK);
+    const placeholders = chunk.map(() => "?").join(",");
+    const idResult = await db
+      .prepare(
+        `SELECT rcc.id, rcc.severity, rcc.check_type
+         FROM receipt_compliance_checks rcc
+         JOIN receipt_records rr ON rr.id = rcc.object_id
+         WHERE rcc.object_type = 'receipt'
+           AND rcc.status = 'open'
+           AND rcc.object_id IN (${placeholders})
+           AND rr.deleted_at IS NULL`,
+      )
+      .bind(...chunk)
+      .all<CheckRow>();
+    for (const row of idResult.results ?? []) rowsById.set(row.id, row);
+  }
 
   const summary: ComplianceSummary = {
     blockers: 0,
@@ -309,7 +354,7 @@ export async function summarizeOpenChecksForMonth(
     total: 0,
     byType: {},
   };
-  for (const row of result.results ?? []) {
+  for (const row of rowsById.values()) {
     summary.total++;
     if (row.severity === "blocker") summary.blockers++;
     else if (row.severity === "warning") summary.warnings++;

--- a/lib/receipts/confidence.ts
+++ b/lib/receipts/confidence.ts
@@ -45,8 +45,17 @@ export function bandForLine(
 export function matchExplanation(
   line: AmexStatementLine,
   receipt: ReceiptRecord | null,
+  /** All confirmed lines sharing this receipt (consolidated 領収書 group). */
+  confirmedSiblings: AmexStatementLine[] = [],
 ): string {
   if (!receipt) return "Pick a receipt or mark as no-receipt-expected.";
+  if (confirmedSiblings.length >= 2 && receipt.amount_minor != null) {
+    const sum = confirmedSiblings.reduce((total, l) => total + l.amount_minor, 0);
+    if (sum === receipt.amount_minor) {
+      return `Consolidated receipt — ${confirmedSiblings.length} lines sum to the receipt total.`;
+    }
+    return `Consolidated receipt — ${confirmedSiblings.length} lines sum to ${sum}, receipt total is ${receipt.amount_minor}. Link the remaining charges before sign-off.`;
+  }
   if (line.amount_minor !== (receipt.amount_minor ?? 0))
     return "Amount differs — verify before confirming.";
   if (

--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -989,6 +989,37 @@ export async function updateAmexReconciliation(
   // gone. Sum-vs-receipt-total integrity is enforced as a sign-off blocker
   // (validateAmexLinesForSignoff), not at confirm time, so partial groups
   // can be linked incrementally during the month.
+  //
+  // What is NOT allowed (Codex review P2, 2026-07-08): confirming a receipt
+  // that is already confirmed against a line in a DIFFERENT statement month
+  // whose reconciliation is finalized. rejectIfFinalized above only checks
+  // the target line's month, so without this guard a sealed month's receipt
+  // could be re-claimed — and this function would then mutate that receipt's
+  // merchant/date/status, breaking finalized-month immutability. Same-month
+  // consolidated siblings pass; cross-month links into open months are left
+  // to the export gate's cross-month integrity blocker.
+  if (matchStatus === "confirmed" && receiptId) {
+    const sealedClaim = await db
+      .prepare(
+        `SELECT asl.statement_month
+         FROM amex_statement_lines asl
+         JOIN amex_reconciliations ar
+           ON ar.statement_month = asl.statement_month
+          AND ar.status = 'finalized'
+         WHERE asl.matched_receipt_id = ?
+           AND asl.match_status = 'confirmed'
+           AND asl.id != ?
+           AND asl.statement_month != ?
+         LIMIT 1`,
+      )
+      .bind(receiptId, amexLineId, statementMonth ?? "")
+      .first<{ statement_month: string }>();
+    if (sealedClaim) {
+      throw new Error(
+        `Receipt is confirmed in the finalized reconciliation for ${sealedClaim.statement_month} and cannot be linked to another month. Reopen that month first.`,
+      );
+    }
+  }
 
   const statements = [
     db

--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -1617,6 +1617,82 @@ export async function listExports(): Promise<ReceiptExport[]> {
   return result.results ?? [];
 }
 
+// ─── receipt_export_items ───────────────────────────────────────────────────
+// Per-bundle audit trail of which receipts and AMEX lines shipped in each
+// export (migration 0017). Populated at bundle-build time, consulted by
+// finalizeExport to mark receipts status='exported' and by the cross-month
+// finalize gate. Replaced on rebuild — the partial unique index on
+// (export_id, item_type, item_id) makes this idempotent per-export.
+
+/**
+ * Replace the item set for an export. Deletes existing rows for the
+ * export then inserts the new set. Caller must ensure exportId exists.
+ */
+export async function replaceExportItems(
+  exportId: string,
+  items: Array<{ itemType: "receipt" | "amex_line"; itemId: string }>,
+): Promise<void> {
+  const db = getReceiptsDb();
+  const now = nowIso();
+  await db
+    .prepare(`DELETE FROM receipt_export_items WHERE export_id = ?`)
+    .bind(exportId)
+    .run();
+  if (items.length === 0) return;
+  // Batch via db.batch for a single transaction.
+  const stmts = items.map((it) =>
+    db
+      .prepare(
+        `INSERT OR IGNORE INTO receipt_export_items
+          (id, export_id, item_type, item_id, created_at)
+         VALUES (?, ?, ?, ?, ?)`,
+      )
+      .bind(newUuid(), exportId, it.itemType, it.itemId, now),
+  );
+  // D1 limits batches to ~30 statements; chunk to stay safe.
+  const CHUNK = 30;
+  for (let i = 0; i < stmts.length; i += CHUNK) {
+    await db.batch(stmts.slice(i, i + CHUNK));
+  }
+}
+
+/**
+ * Receipt IDs that shipped in the given export. Used by finalizeExport to
+ * mark receipts status='exported' (audit A5).
+ */
+export async function listReceiptIdsForExport(
+  exportId: string,
+): Promise<string[]> {
+  const db = getReceiptsDb();
+  const result = await db
+    .prepare(
+      `SELECT item_id FROM receipt_export_items
+       WHERE export_id = ? AND item_type = 'receipt'
+       ORDER BY created_at ASC`,
+    )
+    .bind(exportId)
+    .all<{ item_id: string }>();
+  return (result.results ?? []).map((r) => r.item_id);
+}
+
+/**
+ * Export IDs whose bundle included a given receipt. Reverse-lookup used by
+ * audit / future "is this receipt already exported" surfaces.
+ */
+export async function listExportsContainingReceipt(
+  receiptId: string,
+): Promise<string[]> {
+  const db = getReceiptsDb();
+  const result = await db
+    .prepare(
+      `SELECT DISTINCT export_id FROM receipt_export_items
+       WHERE item_type = 'receipt' AND item_id = ?`,
+    )
+    .bind(receiptId)
+    .all<{ export_id: string }>();
+  return (result.results ?? []).map((r) => r.export_id);
+}
+
 export async function finalizeExport(
   exportId: string,
   archiveR2Key: string,

--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -983,20 +983,12 @@ export async function updateAmexReconciliation(
       break;
   }
 
-  // Race guard: prevent two AMEX lines from confirming the same receipt.
-  if (matchStatus === "confirmed" && receiptId) {
-    const conflict = await db
-      .prepare(
-        `SELECT id FROM amex_statement_lines
-         WHERE matched_receipt_id = ? AND match_status = 'confirmed' AND id != ?
-         LIMIT 1`,
-      )
-      .bind(receiptId, amexLineId)
-      .first<{ id: string }>();
-    if (conflict) {
-      throw new Error(`Receipt already confirmed against another AMEX line: ${conflict.id}`);
-    }
-  }
+  // Multiple confirmed lines MAY share one receipt: a consolidated 領収書
+  // covers several card charges (e.g. two same-night HUB charges on one
+  // receipt). The former 1:1 race guard that threw here is intentionally
+  // gone. Sum-vs-receipt-total integrity is enforced as a sign-off blocker
+  // (validateAmexLinesForSignoff), not at confirm time, so partial groups
+  // can be linked incrementally during the month.
 
   const statements = [
     db
@@ -1074,6 +1066,11 @@ export async function updateAmexReconciliation(
   // (either dropping the link entirely or switching to a different receipt).
   // Guard with `status = 'reconciled'` so we don't clobber a status another
   // process may have advanced this receipt to in the meantime.
+  // Consolidated receipts: only demote when NO other confirmed line still
+  // references it — unlinking one of two grouped lines must not knock a
+  // still-claimed receipt back to needs_review. The NOT EXISTS guard is
+  // evaluated inside the same batch as the line update, so it sees a
+  // consistent view.
   const wasConfirmed = previousStatus === "confirmed";
   if (wasConfirmed && previousReceiptId && previousReceiptId !== receiptId) {
     statements.push(
@@ -1081,9 +1078,15 @@ export async function updateAmexReconciliation(
         .prepare(
           `UPDATE receipt_records
            SET status = 'needs_review', updated_at = ?
-           WHERE id = ? AND status = 'reconciled'`,
+           WHERE id = ? AND status = 'reconciled'
+             AND NOT EXISTS (
+               SELECT 1 FROM amex_statement_lines
+               WHERE matched_receipt_id = ?
+                 AND match_status = 'confirmed'
+                 AND id != ?
+             )`,
         )
-        .bind(now, previousReceiptId),
+        .bind(now, previousReceiptId, previousReceiptId, amexLineId),
     );
   }
 

--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -1,6 +1,10 @@
 import { getReceiptsDb } from "@/lib/cloudflare-runtime";
 import { createAuditEntry } from "@/lib/receipts/audit";
 import { nowIso, newUuid, stringifyJson } from "@/lib/receipts/db-utils";
+import {
+  assertTransactionMonthEditable,
+  transactionMonthOf,
+} from "@/lib/receipts/month-lock";
 import { shouldOverwriteMerchant } from "@/lib/receipts/reconciliation";
 import { retentionUntilIso } from "@/lib/receipts/retention";
 import { deleteAmexArtifact } from "@/lib/receipts/storage";
@@ -40,6 +44,19 @@ export async function createReceiptRecord(
 
   const paymentPath = input.paymentPath ?? "UNKNOWN";
   const expenseType = input.expenseType ?? "UNKNOWN";
+
+  // Split lock (audit A5): a CASH/DIGITAL receipt may not be inserted with
+  // a transaction_date that lands in an already-finalized export month —
+  // it must go through the export revision flow. No-op for uploads, which
+  // insert at status='captured' with null transaction_date and let the
+  // extractor backfill it; this guards callers that supply the date up
+  // front (manual create, future import paths). AMEX-path receipts are
+  // governed by the reconciliation-sealed gate instead.
+  if (paymentPath === "CASH" || paymentPath === "DIGITAL") {
+    await assertTransactionMonthEditable(
+      transactionMonthOf(input.transactionDate ?? null),
+    );
+  }
 
   const sourceType = input.sourceType ?? "manual_upload";
 
@@ -185,6 +202,16 @@ export async function updateReceiptRecord(
 
   if (!before) throw new Error(`Receipt ${id} not found.`);
   await rejectIfReceiptInFinalizedReconciliation(db, id);
+  // Split lock (audit A5): for CASH/DIGITAL receipts, also check the
+  // export-finalized gate against the EFFECTIVE transaction month (input
+  // override wins, else the existing row's date). AMEX-path receipts skip
+  // this — they're covered by the reconciliation-sealed gate above.
+  const effectivePaymentPath = input.paymentPath ?? before.payment_path;
+  if (effectivePaymentPath === "CASH" || effectivePaymentPath === "DIGITAL") {
+    const effectiveDate =
+      "transactionDate" in input ? input.transactionDate : before.transaction_date;
+    await assertTransactionMonthEditable(transactionMonthOf(effectiveDate));
+  }
 
   const sets: string[] = [];
   const binds: unknown[] = [];
@@ -343,6 +370,49 @@ export async function listReceiptRecords(
     .all<ReceiptRecord>();
 
   return result.results ?? [];
+}
+
+/**
+ * Exhaustive month-scoped receipt list. Pages internally until exhausted,
+ * then throws if the total touches `hardCap` — silent truncation in the
+ * export bundle or compliance views would be an audit failure (a receipt
+ * omitted from the bundle is a receipt the accountant never sees). Callers
+ * that want UI pagination should keep using `listReceiptRecords` with an
+ * explicit small limit; this helper is for "I need every row in month M"
+ * paths (export bundle, compliance view, finalize validator).
+ *
+ * The hard cap is set high enough (default 10000) that hitting it signals
+ * a real data anomaly rather than routine load — even 4 concurrent open
+ * months at operator volume stay well under 1000/month.
+ */
+export async function listAllReceiptsInMonth(
+  month: string,
+  opts?: { paymentPath?: string; hardCap?: number },
+): Promise<ReceiptRecord[]> {
+  const paymentPath = opts?.paymentPath;
+  const hardCap = opts?.hardCap ?? 10000;
+  const PAGE = 500;
+  const out: ReceiptRecord[] = [];
+  let offset = 0;
+  // Loop with offset until a page comes back short or we hit the cap.
+  for (;;) {
+    const page = await listReceiptRecords({
+      month,
+      paymentPath,
+      limit: PAGE,
+      offset,
+    });
+    out.push(...page);
+    if (page.length < PAGE) return out;
+    offset += PAGE;
+    if (out.length >= hardCap) {
+      throw new Error(
+        `listAllReceiptsInMonth(${month}) hit hard cap of ${hardCap} rows — ` +
+          `silent truncation would corrupt the export bundle. Inspect the data ` +
+          `or raise the cap explicitly via opts.hardCap.`,
+      );
+    }
+  }
 }
 
 /**
@@ -1746,6 +1816,55 @@ export async function finalizeExport(
       manifestSha256: manifestSha256 ?? null,
     }),
   });
+
+  // A5 lifecycle: mark every receipt that shipped in this bundle as
+  // status='exported' and exported_month=<the export's month>. Both
+  // columns already existed but were dead before receipt_export_items
+  // gave finalizeExport a row set to act on. Audit-log each promotion so
+  // the receipt's lifecycle trail explains why it's no longer editable.
+  //
+  // Idempotent across re-runs only because finalizeExport itself refuses
+  // to run twice (status='draft' guard above). Re-entering here after a
+  // partial failure would re-UPDATE the same rows harmlessly.
+  const exportRow = await db
+    .prepare(`SELECT export_month FROM receipt_exports WHERE id = ?`)
+    .bind(exportId)
+    .first<{ export_month: string }>();
+  const exportMonth = exportRow?.export_month;
+  if (exportMonth) {
+    const exportedReceiptIds = await listReceiptIdsForExport(exportId);
+    if (exportedReceiptIds.length > 0) {
+      // Promote status + stamp exported_month. The status CHECK constraint
+      // allows 'exported'. We do NOT touch 'archived' rows — once archived
+      // the lifecycle is terminal and a re-finalize shouldn't unwind it.
+      // Chunk to respect D1's parameter limit per statement.
+      const CHUNK_SIZE = 90;
+      for (let i = 0; i < exportedReceiptIds.length; i += CHUNK_SIZE) {
+        const chunk = exportedReceiptIds.slice(i, i + CHUNK_SIZE);
+        const placeholders = chunk.map(() => "?").join(",");
+        await db
+          .prepare(
+            `UPDATE receipt_records
+               SET status = 'exported',
+                   exported_month = ?,
+                   updated_at = ?
+             WHERE id IN (${placeholders})
+               AND status IN ('captured','needs_review','reviewed','reconciled')`,
+          )
+          .bind(exportMonth, now, ...chunk)
+          .run();
+      }
+      for (const receiptId of exportedReceiptIds) {
+        await createAuditEntry(db, {
+          actor,
+          action: "receipt.exported",
+          objectType: "receipt",
+          objectId: receiptId,
+          newValueJson: stringifyJson({ exportId, exportedMonth: exportMonth }),
+        });
+      }
+    }
+  }
 }
 
 /**

--- a/lib/receipts/export.ts
+++ b/lib/receipts/export.ts
@@ -64,6 +64,15 @@ const CSV_HEADERS = [
   "ReceiptId",
   "ReceiptStatus",
   "OriginalR2Key",
+  // Compliance (audit A5; 電子帳簿保存法 / インボイス制度). Sourced from
+  // the matched receipt on AMEX-line rows; from the receipt itself on
+  // CASH/DIGITAL receipt rows; null when no receipt is present.
+  "InvoiceRegistrationNumber",
+  "QualifiedInvoiceStatus",
+  "TaxRate",
+  "TaxAmount",
+  "SourceType",
+  "CounterpartyName",
 ];
 
 /**
@@ -107,6 +116,13 @@ export function buildMonthlyExportCsv(
       csvEscape(row.receiptId),
       csvEscape(row.status),
       csvEscape(row.originalR2Key),
+      // Compliance columns
+      csvEscape(row.invoiceRegistrationNumber),
+      csvEscape(row.qualifiedInvoiceStatus),
+      csvEscape(row.taxRate),
+      csvEscape(formatAmount(row.taxAmountMinor, row.currency)),
+      csvEscape(row.sourceType),
+      csvEscape(row.counterpartyName),
     ].join(",");
     lines.push(line);
   }
@@ -202,6 +218,10 @@ export function buildManifestKey(month: string, exportId: string): string {
   return `exports/${month}/${exportId}-manifest.csv`;
 }
 
+export function buildSummaryKey(month: string, exportId: string): string {
+  return `exports/${month}/${exportId}-summary.csv`;
+}
+
 export function buildManifestCsv(
   exportId: string,
   month: string,
@@ -295,6 +315,7 @@ export function buildExportReadme(opts: {
   correctionReason?: string | null;
   archiveSha256: string;
   manifestSha256?: string | null;
+  summarySha256?: string | null;
 }): string {
   const revisionLine =
     opts.exportRevision > 1
@@ -308,6 +329,7 @@ export function buildExportReadme(opts: {
     revisionLine,
     `Archive SHA-256: ${opts.archiveSha256}`,
     `Manifest SHA-256: ${opts.manifestSha256 ?? "(pending)"}`,
+    `Summary SHA-256: ${opts.summarySha256 ?? "(none)"}`,
     "",
     "── Accountant review ──────────────────────────────────────",
     ACCOUNTANT_DISCLAIMER_EN,
@@ -317,5 +339,7 @@ export function buildExportReadme(opts: {
     "── Files included ─────────────────────────────────────────",
     "See the manifest CSV for SHA-256 hashes of every receipt original,",
     "derivative, and the AMEX statement CSV included in this export.",
+    "The summary CSV (<exportId>-summary.csv) provides per-category and",
+    "per-PaymentPath totals for a quick reconciliation check.",
   ].join("\n");
 }

--- a/lib/receipts/export.ts
+++ b/lib/receipts/export.ts
@@ -4,10 +4,26 @@ import {
   ACCOUNTANT_DISCLAIMER_JA,
 } from "@/lib/receipts/settings";
 
+/**
+ * CSV cell escaper.
+ *
+ * - Doubles inner double-quotes and wraps in quotes when the cell contains
+ *   a comma, double-quote, newline, or carriage return.
+ * - Formula injection guard (audit A5): if the first character is one of
+ *   `=`, `+`, `-`, `@`, the cell is prefixed with a single quote so Excel
+ *   / Sheets / Numbers treat it as text instead of evaluating it. The
+ *   accountant opens this CSV in Excel on Windows; without the guard a
+ *   merchant named `=cmd|'/c calc'!A1` would run a formula on open.
+ */
 function csvEscape(value: string | null | undefined): string {
   if (value === null || value === undefined) return "";
-  const s = String(value);
-  if (s.includes(",") || s.includes('"') || s.includes("\n")) {
+  let s = String(value);
+  // Formula-injection guard. Single-quote prefix is invisible in Excel when
+  // the cell format is General — the user sees the original text.
+  if (s.length > 0 && (s[0] === "=" || s[0] === "+" || s[0] === "-" || s[0] === "@")) {
+    s = `'${s}`;
+  }
+  if (s.includes(",") || s.includes('"') || s.includes("\n") || s.includes("\r")) {
     return `"${s.replace(/"/g, '""')}"`;
   }
   return s;
@@ -24,22 +40,37 @@ function formatAmount(amountMinor: number | null, currency: string): string {
 }
 
 const CSV_HEADERS = [
-  "ReceiptId",
+  "RowType",
   "TransactionDate",
   "Merchant",
   "Amount",
   "Currency",
+  "PaymentPath",
   "ExpenseType",
   "ExpenseCategoryCode",
   "ExpenseCategoryJa",
   "ExpenseCategoryEn",
-  "PaymentPath",
   "BusinessPurpose",
   "Attendees",
-  "Status",
-  "R2Key",
+  // Line identity / status
+  "LineId",
+  "StatementMonth", // unused on receipt rows; populated from line when present
+  "MatchStatus",
+  "ReceiptStatus",
+  "MissingReceiptReason",
+  "CardholderName",
+  "BusinessTripStatus",
+  // Receipt identity
+  "ReceiptId",
+  "ReceiptStatus",
+  "OriginalR2Key",
 ];
 
+/**
+ * Build the monthly export CSV body (no BOM, LF newlines). The route
+ * prepends the UTF-8 BOM and converts to CRLF before upload so Excel on
+ * Windows parses Japanese text correctly. Tests exercise this pure form.
+ */
 export function buildMonthlyExportCsv(
   rows: ExportRow[],
   attendeeMap: Map<string, string[]>,
@@ -47,26 +78,110 @@ export function buildMonthlyExportCsv(
   const lines: string[] = [CSV_HEADERS.join(",")];
 
   for (const row of rows) {
-    const attendees = attendeeMap.get(row.receiptId) ?? [];
+    const attendees = row.receiptId
+      ? (attendeeMap.get(row.receiptId) ?? row.attendees ?? [])
+      : (row.attendees ?? []);
     const line = [
-      csvEscape(row.receiptId),
+      csvEscape(row.rowType),
       csvEscape(row.transactionDate),
       csvEscape(row.merchant),
       csvEscape(formatAmount(row.amountMinor, row.currency)),
       csvEscape(row.currency),
+      csvEscape(row.paymentPath),
       csvEscape(row.expenseType),
       csvEscape(row.expenseCategoryCode),
       csvEscape(row.expenseCategoryJa),
       csvEscape(row.expenseCategoryEn),
-      csvEscape(row.paymentPath),
       csvEscape(row.businessPurpose),
       csvQuoteAlways(attendees.join("; ")),
+      csvEscape(row.lineId),
+      // StatementMonth column is intentionally empty here; line.statement_month
+      // matches the bundle's month so it's redundant on line rows and
+      // meaningless on receipt rows.
+      "",
+      csvEscape(row.matchStatus),
+      csvEscape(row.receiptStatus),
+      csvEscape(row.missingReceiptReason),
+      csvEscape(row.cardholderName),
+      csvEscape(row.businessTripStatus),
+      csvEscape(row.receiptId),
       csvEscape(row.status),
       csvEscape(row.originalR2Key),
     ].join(",");
     lines.push(line);
   }
 
+  return lines.join("\n");
+}
+
+/**
+ * Add UTF-8 BOM (so Excel on Windows detects encoding and renders Japanese
+ * text instead of mojibake) and convert LF → CRLF (Excel-friendlier).
+ */
+export function bomPrefixedCrlf(csvText: string): string {
+  return `\ufeff${csvText.replace(/\r?\n/g, "\r\n")}`;
+}
+
+/**
+ * Summary CSV: per-expense-category count + total, then a PaymentPath
+ * breakdown, then a grand total. Generated from the same ExportRow list
+ * as the main CSV so the two cannot drift.
+ */
+export function buildExportSummaryCsv(
+  rows: ExportRow[],
+  month: string,
+  generatedAt: string,
+): string {
+  const catTotals = new Map<string, { count: number; totalMinor: number }>();
+  let amexCount = 0;
+  let amexTotal = 0;
+  let cashCount = 0;
+  let cashTotal = 0;
+  let digitalCount = 0;
+  let digitalTotal = 0;
+  let grandCount = 0;
+  let grandTotal = 0;
+
+  for (const row of rows) {
+    const code = row.expenseCategoryCode ?? "uncategorized";
+    const cat = catTotals.get(code) ?? { count: 0, totalMinor: 0 };
+    cat.count += 1;
+    cat.totalMinor += row.amountMinor ?? 0;
+    catTotals.set(code, cat);
+
+    grandCount += 1;
+    grandTotal += row.amountMinor ?? 0;
+
+    if (row.rowType === "amex_line" || row.paymentPath === "AMEX") {
+      amexCount += 1;
+      amexTotal += row.amountMinor ?? 0;
+    } else if (row.paymentPath === "CASH") {
+      cashCount += 1;
+      cashTotal += row.amountMinor ?? 0;
+    } else if (row.paymentPath === "DIGITAL") {
+      digitalCount += 1;
+      digitalTotal += row.amountMinor ?? 0;
+    }
+  }
+
+  const lines: string[] = [
+    `Field,Value`,
+    `Month,${csvEscape(month)}`,
+    `GeneratedAt,${csvEscape(generatedAt)}`,
+    `RowCount,${grandCount}`,
+    `GrandTotalMinor,${grandTotal}`,
+    ``,
+    `ExpenseCategoryCode,Count,TotalMinor`,
+  ];
+  const sorted = [...catTotals.entries()].sort((a, b) => b[1].totalMinor - a[1].totalMinor);
+  for (const [code, v] of sorted) {
+    lines.push(`${csvEscape(code)},${v.count},${v.totalMinor}`);
+  }
+  lines.push(``);
+  lines.push(`PaymentPath,Count,TotalMinor`);
+  lines.push(`AMEX,${amexCount},${amexTotal}`);
+  lines.push(`CASH,${cashCount},${cashTotal}`);
+  lines.push(`DIGITAL,${digitalCount},${digitalTotal}`);
   return lines.join("\n");
 }
 

--- a/lib/receipts/extraction.ts
+++ b/lib/receipts/extraction.ts
@@ -105,8 +105,45 @@ function parseTransactionDate(rawText: string): string | null {
   return null;
 }
 
+// Prefer an explicitly-labeled transaction date over the first date on the
+// receipt. E-tickets (えきねっと etc.) print 発行日 (PDF issue date) first, but
+// the card is charged on 購入日/利用日 — that is the date the AMEX line will
+// carry, and reconciliation hard-rejects candidates >7 days apart. Labels are
+// tried in priority order; the date may sit on the same line or wrap to the
+// next (OCR table cells). Falls back to null → caller uses first-found date.
+const DATE_LABEL_PRIORITY: RegExp[] = [
+  /取引日/,
+  /(?:ご)?利用日/,
+  /購入日|お買上げ?日|お買い上げ日/,
+];
+
+function parseLabeledTransactionDate(rawText: string): string | null {
+  const lines = rawText.split(/\r?\n/);
+  for (const label of DATE_LABEL_PRIORITY) {
+    for (let i = 0; i < lines.length; i++) {
+      if (!label.test(lines[i]!)) continue;
+      const date =
+        parseTransactionDate(lines[i]!) ?? parseTransactionDate(lines[i + 1] ?? "");
+      if (date) return date;
+    }
+  }
+  return null;
+}
+
+// Numbers that share a line with the total but are never money: the card's
+// last-4 digits ("クレジットカード利用(カード番号下4桁：5102)", "ending in 5102",
+// "****5102") and tax-rate percentages ("税込10%"). Without masking, a last-4
+// like 5102 outbids a ¥4,900 total in the max() pick below.
+function maskNonAmountNumbers(line: string): string {
+  return line
+    .replace(/下\s*4\s*(?:桁|ケタ|けた)\s*[:：]?\s*\d{4}/g, " ")
+    .replace(/(?:ending(?:\s+in)?|last\s*4(?:\s*digits)?)\s*[:：#]?\s*\d{4}/gi, " ")
+    .replace(/[xX*＊]{2,}[-\s]?\d{4}/g, " ")
+    .replace(/\d{1,3}(?:\.\d+)?\s*[%％]/g, " ");
+}
+
 function parseMoneyCandidates(line: string): number[] {
-  const matches = line.matchAll(
+  const matches = maskNonAmountNumbers(line).matchAll(
     /(?:[¥￥$€£]\s*)?(-?\d{1,3}(?:,\d{3})+|-?\d+)(?:\.(\d{1,2}))?(?:\s*円)?/g,
   );
   return Array.from(matches)
@@ -138,9 +175,13 @@ function parseAmountMinor(rawText: string, currency: string): number | null {
     "amount due",
     "grand total",
   ];
+  // NOTE: no bare "税" here — it would veto every "税込" total line (税込 is a
+  // totalKeyword and contains 税). Tax-adjacent lines are excluded via the
+  // specific forms below instead.
   const skipKeywords = [
     "小計",
-    "税",
+    "税抜",
+    "税額",
     "消費税",
     "内税",
     "外税",
@@ -318,7 +359,7 @@ export function parseReceiptOcrText(rawText: string): Omit<ExtractionResult, "ra
   const { taxAmountMinor, taxRate } = parseTaxInfo(rawText, resolvedCurrency);
 
   return {
-    transactionDate: parseTransactionDate(rawText),
+    transactionDate: parseLabeledTransactionDate(rawText) ?? parseTransactionDate(rawText),
     merchant: parseMerchant(rawText),
     amountMinor: parseAmountMinor(rawText, currency),
     currency: resolvedCurrency,

--- a/lib/receipts/month-closing.ts
+++ b/lib/receipts/month-closing.ts
@@ -1,11 +1,15 @@
 import { getCategoryByCode, requiresAttendees } from "@/lib/receipts/categories";
 import {
+  getFinalizedReconciliationForMonth,
   listAmexLineAttendeeNamesByMonth,
   listAmexLines,
   listAttendees,
   listReceiptRecords,
   listReceiptRecordsByIds,
 } from "@/lib/receipts/db";
+import { getComplianceSettings } from "@/lib/receipts/settings";
+import { summarizeOpenChecksForMonth } from "@/lib/receipts/compliance";
+import { getReceiptsDb } from "@/lib/cloudflare-runtime";
 import type { ExportRow, ReceiptRecord } from "@/lib/receipts/types";
 import { validateAmexLinesForSignoff } from "@/lib/receipts/reconciliation-signoff";
 
@@ -49,13 +53,42 @@ export async function buildMonthlyExportDraft(
   return { receipts, attendeeMap, exportRows };
 }
 
+/**
+ * Single enforcement authority for export finalize. Every finalize path
+ * (POST /api/receipts/export/month, POST /api/receipts/export/[month]) MUST
+ * route through here — UI tiles in lib/receipts/blockers.ts are
+ * presentation-only and do not gate the API.
+ *
+ * Returns an array of human-readable blocker strings (empty = ready).
+ * Composition (in order):
+ *   1. Statement-sealed gate: a finalized reconciliation must exist for the
+ *      month. (No reconciliation ⇒ cannot finalize an export.)
+ *   2. Receipt-level checks on every receipt in scope (date, merchant,
+ *      amount, category, attendees-where-required).
+ *   3. AMEX-line checks via validateAmexLinesForSignoff (category resolved
+ *      from the matched receipt when present).
+ *   4. Compliance engine gate (summarizeOpenChecksForMonth): any open
+ *      `blocker`-severity check blocks; open `warning` checks block only
+ *      when receipt_settings.export_block_on_warnings is true. That setting
+ *      exists exactly to enforce this gate; if it is left false the warnings
+ *      pass through as non-blocking.
+ */
 export async function validateMonthReadyForExport(
   month: string,
   draft?: MonthlyExportDraft,
 ): Promise<string[]> {
-  const currentDraft = draft ?? (await buildMonthlyExportDraft(month));
   const blockers: string[] = [];
 
+  // (1) Statement-sealed gate.
+  const reconciliation = await getFinalizedReconciliationForMonth(month);
+  if (!reconciliation) {
+    blockers.push(
+      `No finalized reconciliation for ${month}. Sign off the reconciliation first.`,
+    );
+  }
+
+  // (2) Receipt-level checks.
+  const currentDraft = draft ?? (await buildMonthlyExportDraft(month));
   for (const receipt of currentDraft.receipts) {
     const label = receipt.merchant ?? receipt.id;
     if (!receipt.transaction_date) blockers.push(`Receipt ${receipt.id}: missing date`);
@@ -70,6 +103,10 @@ export async function validateMonthReadyForExport(
     }
   }
 
+  // (3) AMEX-line checks (resolves category from the matched receipt when
+  // present). Includes both month receipts and matched-but-out-of-month
+  // receipts in the receiptMap — e.g. a late-March receipt linked to an
+  // April statement line.
   const amexLines = await listAmexLines(month);
   const amexAttendees = await listAmexLineAttendeeNamesByMonth(month);
   const matchedReceiptIds = amexLines
@@ -86,11 +123,6 @@ export async function validateMonthReadyForExport(
       attendees.map((a) => a.attendee_name),
     );
   }
-
-  // Build the receiptMap the validator needs to resolve category from the
-  // matched receipt when present. Includes both month receipts (e.g. a March
-  // receipt in the March export) and matched-but-out-of-month receipts (e.g.
-  // a late-March receipt linked to an April statement line).
   const receiptMap = new Map<string, ReceiptRecord>();
   for (const r of currentDraft.receipts) receiptMap.set(r.id, r);
   for (const r of matchedReceipts) receiptMap.set(r.id, r);
@@ -98,6 +130,21 @@ export async function validateMonthReadyForExport(
   blockers.push(
     ...validateAmexLinesForSignoff(amexLines, amexAttendees, currentDraft.attendeeMap, receiptMap),
   );
+
+  // (4) Compliance-engine gate.
+  const db = getReceiptsDb();
+  const settings = await getComplianceSettings();
+  const summary = await summarizeOpenChecksForMonth(db, month);
+  if (summary.blockers > 0) {
+    blockers.push(
+      `${summary.blockers} open compliance blocker(s) on receipts in ${month}`,
+    );
+  }
+  if (settings.export_block_on_warnings && summary.warnings > 0) {
+    blockers.push(
+      `${summary.warnings} open compliance warning(s) in ${month} (export_block_on_warnings=true)`,
+    );
+  }
 
   return blockers;
 }

--- a/lib/receipts/month-closing.ts
+++ b/lib/receipts/month-closing.ts
@@ -10,7 +10,7 @@ import {
 import { getComplianceSettings } from "@/lib/receipts/settings";
 import { summarizeOpenChecksForMonth } from "@/lib/receipts/compliance";
 import { getReceiptsDb } from "@/lib/cloudflare-runtime";
-import type { ExportRow, ReceiptRecord } from "@/lib/receipts/types";
+import type { AmexReconciliation, ExportRow, ReceiptRecord } from "@/lib/receipts/types";
 import { validateAmexLinesForSignoff } from "@/lib/receipts/reconciliation-signoff";
 
 export interface MonthlyExportDraft {
@@ -76,11 +76,17 @@ export async function buildMonthlyExportDraft(
 export async function validateMonthReadyForExport(
   month: string,
   draft?: MonthlyExportDraft,
+  preloadedReconciliation?: AmexReconciliation | null,
 ): Promise<string[]> {
   const blockers: string[] = [];
 
-  // (1) Statement-sealed gate.
-  const reconciliation = await getFinalizedReconciliationForMonth(month);
+  // (1) Statement-sealed gate. Callers that already fetched the
+  // reconciliation (e.g. /api/receipts/export/month to populate the manifest
+  // pointer) may pass it in to avoid a second D1 round-trip.
+  const reconciliation =
+    preloadedReconciliation !== undefined
+      ? preloadedReconciliation
+      : await getFinalizedReconciliationForMonth(month);
   if (!reconciliation) {
     blockers.push(
       `No finalized reconciliation for ${month}. Sign off the reconciliation first.`,

--- a/lib/receipts/month-closing.ts
+++ b/lib/receipts/month-closing.ts
@@ -8,7 +8,7 @@ import {
   listReceiptRecordsByIds,
 } from "@/lib/receipts/db";
 import { getComplianceSettings } from "@/lib/receipts/settings";
-import { summarizeOpenChecksForMonth } from "@/lib/receipts/compliance";
+import { summarizeOpenChecksForExport } from "@/lib/receipts/compliance";
 import { getReceiptsDb } from "@/lib/cloudflare-runtime";
 import { resolveLineCategory } from "@/lib/receipts/line-classification";
 import type {
@@ -292,9 +292,16 @@ export async function validateMonthReadyForExport(
     ),
   );
 
-  // (5) Compliance-engine gate.
+  // (5) Compliance-engine gate. Summarize over the month filter UNION the
+  // bundle's receipt IDs: matched receipts may be dated outside the
+  // statement month, and exported_month isn't stamped until after finalize,
+  // so the month filter alone misses their open checks (Codex P1).
   const settings = await getComplianceSettings();
-  const summary = await summarizeOpenChecksForMonth(db, month);
+  const summary = await summarizeOpenChecksForExport(
+    db,
+    month,
+    bundle.receipts.map((r) => r.id),
+  );
   if (summary.blockers > 0) {
     blockers.push(
       `${summary.blockers} open compliance blocker(s) on receipts in ${month}`,

--- a/lib/receipts/month-closing.ts
+++ b/lib/receipts/month-closing.ts
@@ -3,54 +3,174 @@ import {
   getFinalizedReconciliationForMonth,
   listAmexLineAttendeeNamesByMonth,
   listAmexLines,
-  listAttendees,
+  listAttendeeNamesByReceiptIds,
   listReceiptRecords,
   listReceiptRecordsByIds,
 } from "@/lib/receipts/db";
 import { getComplianceSettings } from "@/lib/receipts/settings";
 import { summarizeOpenChecksForMonth } from "@/lib/receipts/compliance";
 import { getReceiptsDb } from "@/lib/cloudflare-runtime";
-import type { AmexReconciliation, ExportRow, ReceiptRecord } from "@/lib/receipts/types";
+import { resolveLineCategory } from "@/lib/receipts/line-classification";
+import type {
+  AmexReconciliation,
+  AmexStatementLine,
+  ExportRow,
+  ReceiptRecord,
+} from "@/lib/receipts/types";
 import { validateAmexLinesForSignoff } from "@/lib/receipts/reconciliation-signoff";
 
-export interface MonthlyExportDraft {
+/**
+ * Single source of truth for "what ships in this month's export bundle".
+ *
+ * After the 2026-07-08 redesign the export unit is the **statement month**,
+ * not the transaction-date month: AMEX lines post over a ~6-week window
+ * that lags the statement label, so filtering receipts by
+ * `transaction_date LIKE 'YYYY-MM%'` produces a different population than
+ * the AMEX validation set and the bundle is not self-consistent.
+ *
+ * The bundle closes that gap. Rows are assembled here, in one place, used
+ * by both the export route (CSV/manifest) and the finalize validator.
+ * Composition:
+ *   - One row per AMEX statement line of month M (RowType=amex_line),
+ *     with the matched receipt's fields joined when present.
+ *     Missing-receipt and no-receipt lines appear with their reasons.
+ *   - One row per CASH/DIGITAL receipt with transaction_date in month M
+ *     (RowType=receipt). Transaction date is the accounting anchor for
+ *     these — they have no statement.
+ *   - A receipt matched to a line appears once (on the line row), never
+ *     twice — even if its payment_path is CASH/DIGITAL and its
+ *     transaction_date happens to fall in M.
+ *   - payment_path='UNKNOWN' receipts are intentionally excluded: their
+ *     export month is ambiguous. validateMonthReadyForExport blocks
+ *     finalize when any are present.
+ */
+export interface ExportBundle {
+  /** Bundle rows in CSV order: AMEX lines first (by transaction_date), then receipts. */
+  rows: ExportRow[];
+  /** Every receipt referenced by the bundle (matched-to-line + non-AMEX in-month). */
   receipts: ReceiptRecord[];
+  /** Every AMEX statement line for the month. */
+  amexLines: AmexStatementLine[];
+  /** Attendees for every receipt in `receipts`, keyed by receipt id. */
   attendeeMap: Map<string, string[]>;
-  exportRows: ExportRow[];
+  /**
+   * Per-row items to write into receipt_export_items at bundle-build time.
+   * itemType 'receipt' covers BOTH matched-to-line and CASH/DIGITAL receipt
+   * rows — the audit story is "what shipped", not "how it got there".
+   */
+  items: Array<{ itemType: "receipt"; itemId: string } | { itemType: "amex_line"; itemId: string }>;
 }
 
-export async function buildMonthlyExportDraft(
-  month: string,
-): Promise<MonthlyExportDraft> {
-  const receipts = await listReceiptRecords({ month, limit: 1000 });
-  const attendeeMap = new Map<string, string[]>();
+export async function buildExportBundle(month: string): Promise<ExportBundle> {
+  // (1) AMEX lines for the statement month. These are the spine of the
+  // bundle — every line ships, with the matched receipt joined onto it.
+  const amexLines = await listAmexLines(month);
 
-  for (const receipt of receipts) {
-    const attendees = await listAttendees(receipt.id);
-    attendeeMap.set(receipt.id, attendees.map((a) => a.attendee_name));
+  // (2) Receipts matched to those lines. Their transaction_date may sit in
+  // a different month than the statement (late-March receipt on an April
+  // statement) — that is the whole reason this redesign exists.
+  const matchedReceiptIds = [
+    ...new Set(
+      amexLines
+        .map((l) => l.matched_receipt_id)
+        .filter((id): id is string => Boolean(id)),
+    ),
+  ];
+  const matchedReceipts = await listReceiptRecordsByIds(matchedReceiptIds);
+  const matchedReceiptMap = new Map<string, ReceiptRecord>();
+  for (const r of matchedReceipts) matchedReceiptMap.set(r.id, r);
+
+  // (3) Non-AMEX receipts anchored by transaction_date in month M. UNKNOWN
+  // is intentionally excluded here (ambiguous export month) — the
+  // validator blocks finalize when any UNKNOWN receipts exist.
+  const [cashReceipts, digitalReceipts] = await Promise.all([
+    listReceiptRecords({ month, paymentPath: "CASH", limit: 5000 }),
+    listReceiptRecords({ month, paymentPath: "DIGITAL", limit: 5000 }),
+  ]);
+  // A receipt matched to a line appears once on the line row — drop it
+  // from the CASH/DIGITAL receipt-rows section so it cannot double-count.
+  const nonAmexReceipts = [...cashReceipts, ...digitalReceipts].filter(
+    (r) => !matchedReceiptMap.has(r.id),
+  );
+
+  // (4) Attendees for every receipt in one batched query (A6 kills N+1).
+  const allReceipts = [...matchedReceipts, ...nonAmexReceipts];
+  const allReceiptIds = allReceipts.map((r) => r.id);
+  const attendeeMap = allReceiptIds.length > 0
+    ? await listAttendeeNamesByReceiptIds(allReceiptIds)
+    : new Map<string, string[]>();
+
+  // (5) Assemble rows. AMEX-line rows first (in line order —
+  // listAmexLines already sorts by transaction_date), then receipt rows.
+  const rows: ExportRow[] = [];
+  const items: ExportBundle["items"] = [];
+  const seenReceiptIds = new Set<string>();
+
+  for (const line of amexLines) {
+    const receipt = line.matched_receipt_id
+      ? matchedReceiptMap.get(line.matched_receipt_id)
+      : undefined;
+    const resolvedCategory = resolveLineCategory(line, receipt);
+    const cat = getCategoryByCode(resolvedCategory ?? "");
+    rows.push({
+      rowType: "amex_line",
+      lineId: line.id,
+      matchStatus: line.match_status,
+      receiptStatus: line.receipt_status,
+      missingReceiptReason: line.receipt_missing_reason,
+      cardholderName: line.cardholder_name,
+      businessTripStatus: line.business_trip_status,
+      receiptId: receipt?.id ?? line.matched_receipt_id ?? null,
+      status: receipt?.status ?? null,
+      originalR2Key: receipt?.original_r2_key ?? null,
+      transactionDate: line.transaction_date,
+      merchant: line.merchant,
+      amountMinor: line.amount_minor,
+      currency: line.currency,
+      expenseType: receipt?.expense_type ?? null,
+      expenseCategoryCode: resolvedCategory,
+      expenseCategoryJa: cat?.jaName ?? null,
+      expenseCategoryEn: cat?.enName ?? null,
+      paymentPath: "AMEX",
+      businessPurpose: receipt?.business_purpose ?? null,
+      attendees: receipt?.id ? (attendeeMap.get(receipt.id) ?? []) : [],
+    });
+    items.push({ itemType: "amex_line", itemId: line.id });
+    if (receipt?.id && !seenReceiptIds.has(receipt.id)) {
+      items.push({ itemType: "receipt", itemId: receipt.id });
+      seenReceiptIds.add(receipt.id);
+    }
   }
 
-  const exportRows: ExportRow[] = receipts.map((receipt) => {
-    const category = getCategoryByCode(receipt.expense_category_code ?? "");
-    return {
+  for (const receipt of nonAmexReceipts) {
+    const cat = getCategoryByCode(receipt.expense_category_code ?? "");
+    rows.push({
+      rowType: "receipt",
+      lineId: null,
+      matchStatus: null,
+      receiptStatus: null,
+      missingReceiptReason: null,
+      cardholderName: null,
+      businessTripStatus: null,
       receiptId: receipt.id,
+      status: receipt.status,
+      originalR2Key: receipt.original_r2_key,
       transactionDate: receipt.transaction_date,
       merchant: receipt.merchant,
       amountMinor: receipt.amount_minor,
       currency: receipt.currency,
       expenseType: receipt.expense_type,
       expenseCategoryCode: receipt.expense_category_code ?? null,
-      expenseCategoryJa: category?.jaName ?? null,
-      expenseCategoryEn: category?.enName ?? null,
+      expenseCategoryJa: cat?.jaName ?? null,
+      expenseCategoryEn: cat?.enName ?? null,
       paymentPath: receipt.payment_path,
       businessPurpose: receipt.business_purpose,
       attendees: attendeeMap.get(receipt.id) ?? [],
-      status: receipt.status,
-      originalR2Key: receipt.original_r2_key,
-    };
-  });
+    });
+    items.push({ itemType: "receipt", itemId: receipt.id });
+  }
 
-  return { receipts, attendeeMap, exportRows };
+  return { rows, receipts: allReceipts, amexLines, attendeeMap, items };
 }
 
 /**
@@ -63,19 +183,29 @@ export async function buildMonthlyExportDraft(
  * Composition (in order):
  *   1. Statement-sealed gate: a finalized reconciliation must exist for the
  *      month. (No reconciliation ⇒ cannot finalize an export.)
- *   2. Receipt-level checks on every receipt in scope (date, merchant,
- *      amount, category, attendees-where-required).
- *   3. AMEX-line checks via validateAmexLinesForSignoff (category resolved
- *      from the matched receipt when present).
- *   4. Compliance engine gate (summarizeOpenChecksForMonth): any open
+ *   2. UNKNOWN payment_path gate: any UNKNOWN receipt with transaction_date
+ *      in month M blocks finalize. The receipt's export month is ambiguous
+ *      until the operator classifies it.
+ *   3. Receipt-level checks on every CASH/DIGITAL receipt in scope (date,
+ *      merchant, amount, category, attendees-where-required). These have
+ *      no statement cross-check — receipt-level validation is their only
+ *      gate (audit A4 #5).
+ *   4. AMEX-line checks via validateAmexLinesForSignoff (category resolved
+ *      from the matched receipt when present). AMEX-path receipts skip the
+ *      receipt-level loop because the line checks cover them via the
+ *      matched receipt's fields.
+ *   5. Compliance engine gate (summarizeOpenChecksForMonth): any open
  *      `blocker`-severity check blocks; open `warning` checks block only
  *      when receipt_settings.export_block_on_warnings is true. That setting
  *      exists exactly to enforce this gate; if it is left false the warnings
  *      pass through as non-blocking.
+ *   6. Cross-month match integrity (audit A7): a receipt matched to
+ *      statement lines in more than one month blocks both months until
+ *      resolved — overlapping windows make this possible.
  */
 export async function validateMonthReadyForExport(
   month: string,
-  draft?: MonthlyExportDraft,
+  prebuiltBundle?: ExportBundle,
   preloadedReconciliation?: AmexReconciliation | null,
 ): Promise<string[]> {
   const blockers: string[] = [];
@@ -93,9 +223,35 @@ export async function validateMonthReadyForExport(
     );
   }
 
-  // (2) Receipt-level checks.
-  const currentDraft = draft ?? (await buildMonthlyExportDraft(month));
-  for (const receipt of currentDraft.receipts) {
+  // Build (or accept) the bundle. Build is expensive; callers that already
+  // have one should pass it in.
+  const bundle = prebuiltBundle ?? (await buildExportBundle(month));
+
+  // (2) UNKNOWN payment_path gate. UNKNOWN receipts were excluded from the
+  // bundle by design; their existence anywhere in the month is itself the
+  // blocker. Query directly because the bundle intentionally doesn't carry them.
+  const db = getReceiptsDb();
+  const unknownResult = await db
+    .prepare(
+      `SELECT id, merchant FROM receipt_records
+       WHERE deleted_at IS NULL
+         AND payment_path = 'UNKNOWN'
+         AND transaction_date LIKE ?`,
+    )
+    .bind(`${month}%`)
+    .all<{ id: string; merchant: string | null }>();
+  for (const row of unknownResult.results ?? []) {
+    const label = row.merchant ?? row.id;
+    blockers.push(
+      `Receipt ${label}: payment_path is UNKNOWN — classify as AMEX, CASH, or DIGITAL before export`,
+    );
+  }
+
+  // (3) Receipt-level checks on CASH/DIGITAL receipts in the bundle.
+  for (const receipt of bundle.receipts) {
+    // AMEX-path receipts are validated via the line checks below; skip
+    // them here to avoid double-gating.
+    if (receipt.payment_path === "AMEX") continue;
     const label = receipt.merchant ?? receipt.id;
     if (!receipt.transaction_date) blockers.push(`Receipt ${receipt.id}: missing date`);
     if (!receipt.merchant) blockers.push(`Receipt ${receipt.id}: missing merchant`);
@@ -104,41 +260,25 @@ export async function validateMonthReadyForExport(
       blockers.push(`Receipt ${receipt.id}: missing expense category`);
     }
     if (requiresAttendees(receipt.expense_category_code)) {
-      const attendees = currentDraft.attendeeMap.get(receipt.id) ?? [];
+      const attendees = bundle.attendeeMap.get(receipt.id) ?? [];
       if (attendees.length === 0) blockers.push(`Receipt ${label}: requires attendees`);
     }
   }
 
-  // (3) AMEX-line checks (resolves category from the matched receipt when
-  // present). Includes both month receipts and matched-but-out-of-month
-  // receipts in the receiptMap — e.g. a late-March receipt linked to an
-  // April statement line.
-  const amexLines = await listAmexLines(month);
+  // (4) AMEX-line checks.
   const amexAttendees = await listAmexLineAttendeeNamesByMonth(month);
-  const matchedReceiptIds = amexLines
-    .map((line) => line.matched_receipt_id)
-    .filter((id): id is string => Boolean(id));
-  const missingMatchedIds = matchedReceiptIds.filter(
-    (id) => !currentDraft.attendeeMap.has(id),
-  );
-  const matchedReceipts = await listReceiptRecordsByIds(missingMatchedIds);
-  for (const receipt of matchedReceipts) {
-    const attendees = await listAttendees(receipt.id);
-    currentDraft.attendeeMap.set(
-      receipt.id,
-      attendees.map((a) => a.attendee_name),
-    );
-  }
   const receiptMap = new Map<string, ReceiptRecord>();
-  for (const r of currentDraft.receipts) receiptMap.set(r.id, r);
-  for (const r of matchedReceipts) receiptMap.set(r.id, r);
-
+  for (const r of bundle.receipts) receiptMap.set(r.id, r);
   blockers.push(
-    ...validateAmexLinesForSignoff(amexLines, amexAttendees, currentDraft.attendeeMap, receiptMap),
+    ...validateAmexLinesForSignoff(
+      bundle.amexLines,
+      amexAttendees,
+      bundle.attendeeMap,
+      receiptMap,
+    ),
   );
 
-  // (4) Compliance-engine gate.
-  const db = getReceiptsDb();
+  // (5) Compliance-engine gate.
   const settings = await getComplianceSettings();
   const summary = await summarizeOpenChecksForMonth(db, month);
   if (summary.blockers > 0) {
@@ -152,5 +292,72 @@ export async function validateMonthReadyForExport(
     );
   }
 
+  // (6) Cross-month match integrity (audit A7). A receipt matched to lines
+  // in two different statement months is ambiguous — both months can't
+  // ship the same receipt. Block both until disambiguated.
+  const matchedLineMonths = await db
+    .prepare(
+      `SELECT DISTINCT asl.statement_month, asl.matched_receipt_id
+       FROM amex_statement_lines asl
+       WHERE asl.matched_receipt_id IS NOT NULL
+         AND asl.statement_month IN (
+           SELECT DISTINCT asl2.statement_month
+           FROM amex_statement_lines asl2
+           WHERE asl2.matched_receipt_id = asl.matched_receipt_id
+         )`,
+    )
+    .all<{ statement_month: string; matched_receipt_id: string }>();
+  // Group by receipt_id, find any referenced from >1 distinct month.
+  // (The query returns one row per (month, receipt) pair; the same receipt
+  // appearing under two months yields two rows we can collapse.)
+  const monthsByReceipt = new Map<string, Set<string>>();
+  for (const row of matchedLineMonths.results ?? []) {
+    let set = monthsByReceipt.get(row.matched_receipt_id);
+    if (!set) {
+      set = new Set();
+      monthsByReceipt.set(row.matched_receipt_id, set);
+    }
+    set.add(row.statement_month);
+  }
+  // Only block when one of the implicated months is the one we're finalizing.
+  for (const [receiptId, months] of monthsByReceipt) {
+    if (months.size > 1 && months.has(month)) {
+      const others = [...months].filter((m) => m !== month).join(", ");
+      blockers.push(
+        `Receipt ${receiptId}: matched to AMEX lines in multiple statement months (${[...months].join(", ")}). Disambiguate before finalizing ${month} (other month(s): ${others}).`,
+      );
+    }
+  }
+
   return blockers;
+}
+
+/**
+ * Non-blocking warning emitted when finalizing month M while an earlier
+ * month is still open. A late cash receipt for that earlier month will
+ * cost a revision — operators should know that before clicking finalize.
+ * Returns one warning string per earlier open month, or an empty array.
+ *
+ * "Open" = has unreconciled AMEX activity and no finalized export yet.
+ */
+export async function computeEarlierOpenMonthWarnings(
+  month: string,
+): Promise<string[]> {
+  const db = getReceiptsDb();
+  const result = await db
+    .prepare(
+      `SELECT DISTINCT asl.statement_month
+       FROM amex_statement_lines asl
+       LEFT JOIN receipt_exports re
+         ON re.export_month = asl.statement_month
+         AND re.status = 'finalized'
+       WHERE asl.statement_month < ?
+         AND re.id IS NULL
+       ORDER BY asl.statement_month ASC`,
+    )
+    .bind(month)
+    .all<{ statement_month: string }>();
+  return (result.results ?? []).map((r) => {
+    return `Earlier month ${r.statement_month} is still open — a late cash/digital receipt dated in that month will require an export revision once it lands.`;
+  });
 }

--- a/lib/receipts/month-closing.ts
+++ b/lib/receipts/month-closing.ts
@@ -3,8 +3,8 @@ import {
   getFinalizedReconciliationForMonth,
   listAmexLineAttendeeNamesByMonth,
   listAmexLines,
+  listAllReceiptsInMonth,
   listAttendeeNamesByReceiptIds,
-  listReceiptRecords,
   listReceiptRecordsByIds,
 } from "@/lib/receipts/db";
 import { getComplianceSettings } from "@/lib/receipts/settings";
@@ -82,10 +82,12 @@ export async function buildExportBundle(month: string): Promise<ExportBundle> {
 
   // (3) Non-AMEX receipts anchored by transaction_date in month M. UNKNOWN
   // is intentionally excluded here (ambiguous export month) — the
-  // validator blocks finalize when any UNKNOWN receipts exist.
+  // validator blocks finalize when any UNKNOWN receipts exist. Pages
+  // internally via listAllReceiptsInMonth and refuses to silently
+  // truncate at the cap (audit A6 — a partial bundle is an audit failure).
   const [cashReceipts, digitalReceipts] = await Promise.all([
-    listReceiptRecords({ month, paymentPath: "CASH", limit: 5000 }),
-    listReceiptRecords({ month, paymentPath: "DIGITAL", limit: 5000 }),
+    listAllReceiptsInMonth(month, { paymentPath: "CASH" }),
+    listAllReceiptsInMonth(month, { paymentPath: "DIGITAL" }),
   ]);
   // A receipt matched to a line appears once on the line row — drop it
   // from the CASH/DIGITAL receipt-rows section so it cannot double-count.
@@ -134,6 +136,12 @@ export async function buildExportBundle(month: string): Promise<ExportBundle> {
       paymentPath: "AMEX",
       businessPurpose: receipt?.business_purpose ?? null,
       attendees: receipt?.id ? (attendeeMap.get(receipt.id) ?? []) : [],
+      invoiceRegistrationNumber: receipt?.invoice_registration_number ?? null,
+      qualifiedInvoiceStatus: receipt?.qualified_invoice_status ?? null,
+      taxRate: receipt?.tax_rate ?? null,
+      taxAmountMinor: receipt?.tax_amount_minor ?? null,
+      sourceType: receipt?.source_type ?? null,
+      counterpartyName: receipt?.counterparty_name ?? null,
     });
     items.push({ itemType: "amex_line", itemId: line.id });
     if (receipt?.id && !seenReceiptIds.has(receipt.id)) {
@@ -166,6 +174,12 @@ export async function buildExportBundle(month: string): Promise<ExportBundle> {
       paymentPath: receipt.payment_path,
       businessPurpose: receipt.business_purpose,
       attendees: attendeeMap.get(receipt.id) ?? [],
+      invoiceRegistrationNumber: receipt.invoice_registration_number ?? null,
+      qualifiedInvoiceStatus: receipt.qualified_invoice_status ?? null,
+      taxRate: receipt.tax_rate ?? null,
+      taxAmountMinor: receipt.tax_amount_minor ?? null,
+      sourceType: receipt.source_type ?? null,
+      counterpartyName: receipt.counterparty_name ?? null,
     });
     items.push({ itemType: "receipt", itemId: receipt.id });
   }

--- a/lib/receipts/month-lock.ts
+++ b/lib/receipts/month-lock.ts
@@ -46,7 +46,7 @@ export function buildMonthLock(input: {
   };
 }
 
-// ─── Split lock model (audit A5) ─────────────────────────────────────────────
+// ─── Split lock model (audit A5, fix F1-F3 2026-07-08) ───────────────────────
 //
 // Two independent locks govern month-end state, each blocking a different
 // kind of edit:
@@ -56,7 +56,7 @@ export function buildMonthLock(input: {
 //      amex_reconciliation row is status='finalized', every AMEX line — and
 //      any receipt matched to one — is immutable. Statement-month scope.
 //
-//   2. Export-finalized (new below). When an export for month M is
+//   2. Export-finalized (below). When an export for month M is
 //      status='finalized', CASH/DIGITAL receipt edits anchored by
 //      transaction_date in M are blocked. A late cash receipt that arrives
 //      after its transaction month shipped must go through the export
@@ -67,12 +67,20 @@ export function buildMonthLock(input: {
 // they are governed by (1) via their statement line. CASH/DIGITAL
 // receipts are NOT gated by (1) — they have no statement line to match.
 // Each lock owns its own population; the two never overlap.
+//
+// F1 correction (2026-07-08 architecture review): the lock must release
+// while a draft revision exists for the month. A finalized export row is
+// permanent (preservation principle), so without this carve-out the
+// correction flow could never actually correct anything — every edit
+// attempt would re-hit the finalized row and re-throw. The predicate
+// below treats "has draft revision" as a release of the lock; finalizing
+// the revision closes the lock again (draft goes away, finalized stays).
 
 /**
  * Typed error thrown when an insert/update would land a CASH/DIGITAL
- * receipt in a month that already has a finalized export. Routes catch
- * this with `instanceof ExportFinalizedError` instead of brittle string
- * matching against error.message.
+ * receipt in a month that already has a finalized export and no open
+ * draft revision. Routes catch this with `instanceof ExportFinalizedError`
+ * instead of brittle string matching against error.message.
  */
 export class ExportFinalizedError extends Error {
   constructor(
@@ -86,8 +94,24 @@ export class ExportFinalizedError extends Error {
 }
 
 /**
+ * Minimal D1 shape this module queries against. Exported so tests can
+ * build a fake without depending on the full Cloudflare D1Database type.
+ */
+export interface MonthLockD1 {
+  prepare(sql: string): {
+    bind(...args: unknown[]): {
+      first<T = unknown>(): Promise<T | null>;
+    };
+  };
+}
+
+/**
  * True when an export for `month` exists at status='finalized'. No data
  * from the row is returned — callers only need the boolean.
+ *
+ * Note: this does NOT account for draft revisions. For "is this month
+ * locked for edits?" use {@link isMonthLockedForEdits} instead — that
+ * predicate releases the lock while a draft revision exists.
  */
 export async function isMonthExportFinalized(month: string): Promise<boolean> {
   const db = getReceiptsDb();
@@ -103,10 +127,49 @@ export async function isMonthExportFinalized(month: string): Promise<boolean> {
 }
 
 /**
+ * The actual edit-lock predicate. A month is locked for CASH/DIGITAL
+ * receipt edits iff:
+ *   - an export exists at status='finalized' for the month, AND
+ *   - no export exists at status='draft' for the month.
+ *
+ * The draft carve-out is what makes the correction flow workable: opening
+ * a revision via POST /api/receipts/export/<month>?correction=true creates
+ * a fresh draft row, which releases the lock for the duration of the
+ * correction. Finalizing the revision (or deleting the draft) re-closes
+ * it. One indexed D1 lookup per mutation — acceptable cost, and avoids
+ * the stale-cache trap a module-level memo would introduce (F2).
+ *
+ * Takes `db` as a parameter so tests can fake it without module mocking.
+ */
+export async function isMonthLockedForEdits(
+  db: MonthLockD1,
+  month: string,
+): Promise<boolean> {
+  const row = await db
+    .prepare(
+      `SELECT CASE
+         WHEN EXISTS(
+           SELECT 1 FROM receipt_exports
+           WHERE export_month = ? AND status = 'draft'
+         ) THEN 0
+         WHEN EXISTS(
+           SELECT 1 FROM receipt_exports
+           WHERE export_month = ? AND status = 'finalized'
+         ) THEN 1
+         ELSE 0
+       END AS locked`,
+    )
+    .bind(month, month)
+    .first<{ locked: 0 | 1 }>();
+  return row?.locked === 1;
+}
+
+/**
  * Assert that a CASH/DIGITAL receipt can be placed in the given
- * transaction month. Throws ExportFinalizedError when month M has a
- * finalized export. Caller must format `transactionMonth` as YYYY-MM
- * (the same format receipt_records.transaction_date stores as YYYY-MM-DD).
+ * transaction month. Throws ExportFinalizedError when the month is locked
+ * for edits (see {@link isMonthLockedForEdits}). Caller must format
+ * `transactionMonth` as YYYY-MM (the same format
+ * receipt_records.transaction_date stores as YYYY-MM-DD).
  *
  * No-op when `transactionMonth` is null/empty — the lock can't apply
  * until the transaction_date is known (uploads insert with null date
@@ -116,10 +179,8 @@ export async function assertTransactionMonthEditable(
   transactionMonth: string | null | undefined,
 ): Promise<void> {
   if (!transactionMonth) return;
-  if (finalizedMemo.has(transactionMonth)) return; // memoized in-process
-  const finalizedFlag = await isMonthExportFinalized(transactionMonth);
-  if (finalizedFlag) {
-    finalizedMemo.add(transactionMonth);
+  const db = getReceiptsDb();
+  if (await isMonthLockedForEdits(db, transactionMonth)) {
     throw new ExportFinalizedError(
       transactionMonth,
       `Month ${transactionMonth} is export-finalized. POST /api/receipts/export/${transactionMonth}?correction=true to create a revision.`,
@@ -139,9 +200,3 @@ export function transactionMonthOf(
   const m = /^(\d{4}-\d{2})/.exec(transactionDate);
   return m ? m[1]! : null;
 }
-
-// In-process memo of finalized months. A single request rarely checks the
-// same month more than once, but updateReceiptRecord runs the check on
-// every PATCH and the same month is common within a finalize-then-edit
-// race window. Cleared per Worker invocation (module-level state).
-const finalizedMemo = new Set<string>();

--- a/lib/receipts/month-lock.ts
+++ b/lib/receipts/month-lock.ts
@@ -4,6 +4,8 @@
 // components can disable mutating controls upstream — instead of letting
 // the user click a button and discover the 409 in a toast.
 
+import { getReceiptsDb } from "@/lib/cloudflare-runtime";
+
 export type MonthLock = {
   /** True when the month is finalized (no further edits allowed). */
   locked: boolean;
@@ -43,3 +45,103 @@ export function buildMonthLock(input: {
     reason: "Reconciliation hasn't been started for this month.",
   };
 }
+
+// ─── Split lock model (audit A5) ─────────────────────────────────────────────
+//
+// Two independent locks govern month-end state, each blocking a different
+// kind of edit:
+//
+//   1. Reconciliation-sealed (existing, in db.ts
+//      rejectIfReceiptInFinalizedReconciliation). When a statement month's
+//      amex_reconciliation row is status='finalized', every AMEX line — and
+//      any receipt matched to one — is immutable. Statement-month scope.
+//
+//   2. Export-finalized (new below). When an export for month M is
+//      status='finalized', CASH/DIGITAL receipt edits anchored by
+//      transaction_date in M are blocked. A late cash receipt that arrives
+//      after its transaction month shipped must go through the export
+//      revision flow (POST /api/receipts/export/<month>?correction=true)
+//      instead of being inserted/edited directly. Transaction-month scope.
+//
+// AMEX-path receipts are intentionally NOT gated by the export lock —
+// they are governed by (1) via their statement line. CASH/DIGITAL
+// receipts are NOT gated by (1) — they have no statement line to match.
+// Each lock owns its own population; the two never overlap.
+
+/**
+ * Typed error thrown when an insert/update would land a CASH/DIGITAL
+ * receipt in a month that already has a finalized export. Routes catch
+ * this with `instanceof ExportFinalizedError` instead of brittle string
+ * matching against error.message.
+ */
+export class ExportFinalizedError extends Error {
+  constructor(
+    /** The YYYY-MM transaction month that is locked. */
+    public readonly month: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ExportFinalizedError";
+  }
+}
+
+/**
+ * True when an export for `month` exists at status='finalized'. No data
+ * from the row is returned — callers only need the boolean.
+ */
+export async function isMonthExportFinalized(month: string): Promise<boolean> {
+  const db = getReceiptsDb();
+  const row = await db
+    .prepare(
+      `SELECT 1 FROM receipt_exports
+       WHERE export_month = ? AND status = 'finalized'
+       LIMIT 1`,
+    )
+    .bind(month)
+    .first<{ "1": number }>();
+  return row !== null;
+}
+
+/**
+ * Assert that a CASH/DIGITAL receipt can be placed in the given
+ * transaction month. Throws ExportFinalizedError when month M has a
+ * finalized export. Caller must format `transactionMonth` as YYYY-MM
+ * (the same format receipt_records.transaction_date stores as YYYY-MM-DD).
+ *
+ * No-op when `transactionMonth` is null/empty — the lock can't apply
+ * until the transaction_date is known (uploads insert with null date
+ * and let the extraction backfill it).
+ */
+export async function assertTransactionMonthEditable(
+  transactionMonth: string | null | undefined,
+): Promise<void> {
+  if (!transactionMonth) return;
+  if (finalizedMemo.has(transactionMonth)) return; // memoized in-process
+  const finalizedFlag = await isMonthExportFinalized(transactionMonth);
+  if (finalizedFlag) {
+    finalizedMemo.add(transactionMonth);
+    throw new ExportFinalizedError(
+      transactionMonth,
+      `Month ${transactionMonth} is export-finalized. POST /api/receipts/export/${transactionMonth}?correction=true to create a revision.`,
+    );
+  }
+}
+
+/**
+ * Derive the YYYY-MM month key from a YYYY-MM-DD transaction_date. Returns
+ * null for null/empty/malformed input so callers can pass the raw column
+ * value through without conditional branches.
+ */
+export function transactionMonthOf(
+  transactionDate: string | null | undefined,
+): string | null {
+  if (!transactionDate) return null;
+  const m = /^(\d{4}-\d{2})/.exec(transactionDate);
+  return m ? m[1]! : null;
+}
+
+// In-process memo of finalized months. A single request rarely checks the
+// same month more than once, but updateReceiptRecord runs the check on
+// every PATCH and the same month is common within a finalize-then-edit
+// race window. Cleared per Worker invocation (module-level state).
+const finalizedMemo = new Set<string>();

--- a/lib/receipts/reconciliation-signoff.ts
+++ b/lib/receipts/reconciliation-signoff.ts
@@ -147,5 +147,30 @@ export function validateAmexLinesForSignoff(
     }
   }
 
+  // Consolidated receipts: when ≥2 confirmed lines share one receipt, their
+  // amounts must sum exactly to the receipt total. Partial groups are legal
+  // during the month; finalize is where the books must balance. (Single-line
+  // amount mismatches remain allowed, as before — "Amount differs — verify
+  // before confirming" is a reviewer judgment, not a blocker.)
+  const confirmedByReceipt = new Map<string, AmexStatementLine[]>();
+  for (const line of amexLines) {
+    if (line.match_status !== "confirmed" || !line.matched_receipt_id) continue;
+    const group = confirmedByReceipt.get(line.matched_receipt_id) ?? [];
+    group.push(line);
+    confirmedByReceipt.set(line.matched_receipt_id, group);
+  }
+  for (const [receiptId, group] of confirmedByReceipt) {
+    if (group.length < 2) continue;
+    const receipt = receiptMap.get(receiptId);
+    if (!receipt || receipt.amount_minor === null) continue;
+    const sum = group.reduce((total, line) => total + line.amount_minor, 0);
+    if (sum !== receipt.amount_minor) {
+      const label = receipt.merchant ?? receiptId;
+      blockers.push(
+        `Consolidated receipt ${label}: ${group.length} confirmed lines sum to ${sum} but receipt total is ${receipt.amount_minor}`,
+      );
+    }
+  }
+
   return blockers;
 }

--- a/lib/receipts/reconciliation.ts
+++ b/lib/receipts/reconciliation.ts
@@ -320,6 +320,13 @@ export function matchAmexToReceipts(
           merchantAliasMatch(line.merchant, receipt.merchant!) ||
           rawTextMentionsMerchant(rawTextOf(receipt), line.merchant)) &&
         !!line.transaction_date &&
+        // A consolidated 領収書 is issued at (or after) settlement — it can
+        // never cover a charge dated AFTER the receipt. Without this bound,
+        // unrelated later charges at the same brand fall into the ±7-day
+        // window and poison the exact-sum test (observed in prod: two ENEOS
+        // 05-02 fill-ups joining the 04-29 pair → 26,315 ≠ 22,770 → no
+        // suggestion at all). ISO dates compare correctly as strings.
+        line.transaction_date <= receipt.transaction_date! &&
         daysBetween(line.transaction_date, receipt.transaction_date!) <= 7,
     );
     const totalGroupSize = group.length + confirmed.count;

--- a/lib/receipts/reconciliation.ts
+++ b/lib/receipts/reconciliation.ts
@@ -30,6 +30,29 @@ function daysBetween(dateA: string, dateB: string): number {
   return Math.abs((a - b) / (1000 * 60 * 60 * 24));
 }
 
+// Known descriptor ↔ legal-name pairs. JP card statements often print a
+// booking-service brand while the receipt carries the operator's registered
+// company name, so token matching can never connect them. Each group lists
+// patterns that all refer to the same merchant; a line and a receipt matching
+// any two patterns in one group count as a merchant match. Extend this table
+// as new descriptor mismatches surface in review.
+const MERCHANT_ALIAS_GROUPS: RegExp[][] = [
+  // えきねっと (JR East's booking site) charges appear as the brand; the
+  // 領収書 is issued by 東日本旅客鉄道株式会社.
+  [/えきねっと|エキネット|EKI-?NET/i, /東日本旅客鉄道|JR\s*東日本|JR\s*EAST/i],
+];
+
+// Consolidated-group suggestions never reach the "obvious" (auto-confirm)
+// band — 0.92 in lib/receipts/confidence.ts. A wrong grouping is the
+// costliest reconciliation mistake, so a human confirms each group line.
+const CONSOLIDATED_CONFIDENCE_CAP = 0.9;
+
+function merchantAliasMatch(a: string, b: string): boolean {
+  return MERCHANT_ALIAS_GROUPS.some(
+    (group) => group.some((re) => re.test(a)) && group.some((re) => re.test(b)),
+  );
+}
+
 function descriptionContains(amexDesc: string, receiptMerchant: string): boolean {
   const normalizedDesc = normalizeDescription(amexDesc);
   const normalizedMerchant = normalizeDescription(receiptMerchant);
@@ -149,6 +172,9 @@ export function matchAmexToReceipts(
         if (descriptionContains(line.merchant, receipt.merchant)) {
           score += 0.15;
           reasons.push("merchant match");
+        } else if (merchantAliasMatch(line.merchant, receipt.merchant)) {
+          score += 0.15;
+          reasons.push("known merchant alias");
         }
       }
 
@@ -192,6 +218,57 @@ export function matchAmexToReceipts(
     assignedReceipts.add(match.receiptId);
     assignedLines.add(match.amexLineId);
     resolved.push(match);
+  }
+
+  // Phase 3: consolidated receipts (領収書 covering several card charges).
+  // Runs only over lines and receipts left unmatched by the 1:1 phases.
+  // Policy (deliberately narrow): ALL same-merchant unmatched lines within the
+  // date window must sum EXACTLY to the receipt total, with at least two
+  // lines. No subset search — an exact full-group sum is explainable in an
+  // audit; combinatorial subset picks are not. Confidence is capped below the
+  // auto-confirm band so a human confirms every consolidated group.
+  for (const receipt of eligibleReceipts) {
+    if (assignedReceipts.has(receipt.id)) continue;
+    if (receipt.amount_minor === null || !receipt.merchant) continue;
+    if (!receipt.transaction_date) continue;
+
+    const group = amexLines.filter(
+      (line) =>
+        !assignedLines.has(line.id) &&
+        line.match_status !== "confirmed" &&
+        line.match_status !== "no_receipt" &&
+        line.currency.toUpperCase() === receipt.currency.toUpperCase() &&
+        !!line.merchant &&
+        (descriptionContains(line.merchant, receipt.merchant!) ||
+          merchantAliasMatch(line.merchant, receipt.merchant!)) &&
+        !!line.transaction_date &&
+        daysBetween(line.transaction_date, receipt.transaction_date!) <= 7,
+    );
+    if (group.length < 2) continue;
+
+    const groupSum = group.reduce((sum, line) => sum + line.amount_minor, 0);
+    if (groupSum !== receipt.amount_minor) continue;
+
+    for (const line of group) {
+      const dateDelta = daysBetween(line.transaction_date!, receipt.transaction_date);
+      const score = Math.min(
+        0.5 + Math.max(0, 0.35 - 0.05 * dateDelta) + 0.15,
+        CONSOLIDATED_CONFIDENCE_CAP,
+      );
+      assignedLines.add(line.id);
+      resolved.push({
+        amexLineId: line.id,
+        receiptId: receipt.id,
+        confidenceScore: score,
+        matchReasons: [
+          `consolidated receipt: ${group.length} lines sum to total`,
+          "merchant match",
+          `${dateDelta}-day window`,
+        ],
+        consolidatedGroupSize: group.length,
+      });
+    }
+    assignedReceipts.add(receipt.id);
   }
 
   return resolved;

--- a/lib/receipts/reconciliation.ts
+++ b/lib/receipts/reconciliation.ts
@@ -5,11 +5,18 @@ import type {
 } from "@/lib/receipts/types";
 
 export function normalizeDescription(value: string): string {
-  return value
-    .toLowerCase()
-    .replace(/[^\p{L}\p{N}\s]/gu, " ")
-    .replace(/\s+/g, " ")
-    .trim();
+  return (
+    value
+      .toLowerCase()
+      .replace(/[^\p{L}\p{N}\s]/gu, " ")
+      // Split at Latin/digit ↔ CJK script boundaries: statements print
+      // "HUB 東京オペラシティ店" while receipts OCR as "HUB東京オペラシティ店" —
+      // without segmentation the two tokenize differently and never match.
+      .replace(/([a-z0-9])([぀-ヿ一-龯])/g, "$1 $2")
+      .replace(/([぀-ヿ一-龯])([a-z0-9])/g, "$1 $2")
+      .replace(/\s+/g, " ")
+      .trim()
+  );
 }
 
 /**
@@ -51,6 +58,22 @@ function merchantAliasMatch(a: string, b: string): boolean {
   return MERCHANT_ALIAS_GROUPS.some(
     (group) => group.some((re) => re.test(a)) && group.some((re) => re.test(b)),
   );
+}
+
+// Last-resort merchant bridge: the statement brand printed ON the receipt.
+// Franchised operators issue receipts under their legal name (ENEOS station →
+// 株式会社豊島屋) but the brand mark is in the OCR text. A statement-merchant
+// token of ≥4 chars found in the receipt's normalized raw text counts as a
+// merchant signal. Length ≥4 keeps short/generic tokens from false-matching.
+function rawTextMentionsMerchant(
+  rawTextNorm: string | null,
+  lineMerchant: string,
+): boolean {
+  if (!rawTextNorm) return false;
+  const tokens = normalizeDescription(lineMerchant)
+    .split(" ")
+    .filter((t) => t.length >= 4);
+  return tokens.some((t) => rawTextNorm.includes(t));
 }
 
 function descriptionContains(amexDesc: string, receiptMerchant: string): boolean {
@@ -105,6 +128,26 @@ export function matchAmexToReceipts(
       r.status !== "exported" &&
       r.status !== "reconciled",
   );
+
+  // Normalized raw OCR text per receipt, parsed lazily at most once — used by
+  // the brand-on-receipt merchant fallback in the 1:1 bonus and phase-3 gate.
+  const rawTextNormCache = new Map<string, string | null>();
+  const rawTextOf = (receipt: ReceiptRecord): string | null => {
+    let cached = rawTextNormCache.get(receipt.id);
+    if (cached === undefined) {
+      cached = null;
+      if (receipt.extraction_json) {
+        try {
+          const parsed = JSON.parse(receipt.extraction_json) as { rawText?: string };
+          cached = normalizeDescription(parsed.rawText ?? "") || null;
+        } catch {
+          /* malformed extraction JSON — no raw text available */
+        }
+      }
+      rawTextNormCache.set(receipt.id, cached);
+    }
+    return cached;
+  };
 
   // Phase 1: compute best candidate per AMEX line
   const candidates: Array<{ match: ReconciliationMatch; dateDelta: number }> = [];
@@ -175,6 +218,9 @@ export function matchAmexToReceipts(
         } else if (merchantAliasMatch(line.merchant, receipt.merchant)) {
           score += 0.15;
           reasons.push("known merchant alias");
+        } else if (rawTextMentionsMerchant(rawTextOf(receipt), line.merchant)) {
+          score += 0.15;
+          reasons.push("brand found on receipt text");
         }
       }
 
@@ -271,7 +317,8 @@ export function matchAmexToReceipts(
         line.currency.toUpperCase() === receipt.currency.toUpperCase() &&
         !!line.merchant &&
         (descriptionContains(line.merchant, receipt.merchant!) ||
-          merchantAliasMatch(line.merchant, receipt.merchant!)) &&
+          merchantAliasMatch(line.merchant, receipt.merchant!) ||
+          rawTextMentionsMerchant(rawTextOf(receipt), line.merchant)) &&
         !!line.transaction_date &&
         daysBetween(line.transaction_date, receipt.transaction_date!) <= 7,
     );

--- a/lib/receipts/reconciliation.ts
+++ b/lib/receipts/reconciliation.ts
@@ -221,16 +221,47 @@ export function matchAmexToReceipts(
   }
 
   // Phase 3: consolidated receipts (領収書 covering several card charges).
-  // Runs only over lines and receipts left unmatched by the 1:1 phases.
-  // Policy (deliberately narrow): ALL same-merchant unmatched lines within the
-  // date window must sum EXACTLY to the receipt total, with at least two
-  // lines. No subset search — an exact full-group sum is explainable in an
-  // audit; combinatorial subset picks are not. Confidence is capped below the
+  // Runs only over lines left unmatched by the 1:1 phases. Policy
+  // (deliberately narrow): the same-merchant unmatched lines within the date
+  // window must sum EXACTLY to the receipt's REMAINING amount (total minus
+  // any lines already confirmed against it), with at least two lines in the
+  // full group. No subset search — an exact sum is explainable in an audit;
+  // combinatorial subset picks are not. Confidence is capped below the
   // auto-confirm band so a human confirms every consolidated group.
-  for (const receipt of eligibleReceipts) {
+  //
+  // Already-confirmed siblings matter here (Codex review P2, 2026-07-08):
+  // confirming the first line of a group promotes the receipt to
+  // 'reconciled', which the 1:1 eligibility filter excludes — so the
+  // remaining lines must be grouped against a wider receipt set, with the
+  // confirmed lines' sum subtracted from the target.
+  const confirmedSumByReceipt = new Map<string, { sum: number; count: number }>();
+  for (const line of amexLines) {
+    if (line.match_status !== "confirmed" || !line.matched_receipt_id) continue;
+    const entry = confirmedSumByReceipt.get(line.matched_receipt_id) ?? { sum: 0, count: 0 };
+    entry.sum += line.amount_minor;
+    entry.count += 1;
+    confirmedSumByReceipt.set(line.matched_receipt_id, entry);
+  }
+
+  const consolidationReceipts = receipts.filter((r) => {
+    if (r.deleted_at !== null || r.status === "archived" || r.status === "exported") {
+      return false;
+    }
+    // 'reconciled' receipts are only group-eligible when the claim comes from
+    // this month's own confirmed lines — a receipt fully claimed elsewhere
+    // must not be re-offered.
+    if (r.status === "reconciled" && !confirmedSumByReceipt.has(r.id)) return false;
+    return r.payment_path === "AMEX";
+  });
+
+  for (const receipt of consolidationReceipts) {
     if (assignedReceipts.has(receipt.id)) continue;
     if (receipt.amount_minor === null || !receipt.merchant) continue;
     if (!receipt.transaction_date) continue;
+
+    const confirmed = confirmedSumByReceipt.get(receipt.id) ?? { sum: 0, count: 0 };
+    const remaining = receipt.amount_minor - confirmed.sum;
+    if (remaining <= 0) continue; // fully claimed (or over-claimed — a sign-off blocker)
 
     const group = amexLines.filter(
       (line) =>
@@ -244,10 +275,11 @@ export function matchAmexToReceipts(
         !!line.transaction_date &&
         daysBetween(line.transaction_date, receipt.transaction_date!) <= 7,
     );
-    if (group.length < 2) continue;
+    const totalGroupSize = group.length + confirmed.count;
+    if (group.length < 1 || totalGroupSize < 2) continue;
 
     const groupSum = group.reduce((sum, line) => sum + line.amount_minor, 0);
-    if (groupSum !== receipt.amount_minor) continue;
+    if (groupSum !== remaining) continue;
 
     for (const line of group) {
       const dateDelta = daysBetween(line.transaction_date!, receipt.transaction_date);
@@ -261,11 +293,13 @@ export function matchAmexToReceipts(
         receiptId: receipt.id,
         confidenceScore: score,
         matchReasons: [
-          `consolidated receipt: ${group.length} lines sum to total`,
+          confirmed.count > 0
+            ? `consolidated receipt: ${group.length} remaining line(s) sum to the unclaimed balance (${confirmed.count} already confirmed)`
+            : `consolidated receipt: ${group.length} lines sum to total`,
           "merchant match",
           `${dateDelta}-day window`,
         ],
-        consolidatedGroupSize: group.length,
+        consolidatedGroupSize: totalGroupSize,
       });
     }
     assignedReceipts.add(receipt.id);

--- a/lib/receipts/types.ts
+++ b/lib/receipts/types.ts
@@ -104,6 +104,7 @@ export type AuditAction =
   | "receipt.extraction_requested"
   | "receipt.extraction_completed"
   | "receipt.extraction_denied"
+  | "receipt.extraction_date_deferred"
   | "receipt.extraction_failed"
   | "receipt.reviewed"
   | "receipt.reconciled"

--- a/lib/receipts/types.ts
+++ b/lib/receipts/types.ts
@@ -388,6 +388,20 @@ export interface ReceiptExport {
   manifest_sha256?: string | null;
 }
 
+/**
+ * Per-item audit trail for an export bundle (0017_export_integrity.sql).
+ * One row per receipt or AMEX line that shipped in a specific export.
+ * Populated at bundle-build time; consulted by finalizeExport to mark
+ * receipts status='exported' and by the cross-month finalize gate.
+ */
+export interface ReceiptExportItem {
+  id: string;
+  export_id: string;
+  item_type: "receipt" | "amex_line";
+  item_id: string;
+  created_at: string;
+}
+
 // ─── Compliance row shapes ────────────────────────────────────────────────
 
 export interface ReceiptFile {

--- a/lib/receipts/types.ts
+++ b/lib/receipts/types.ts
@@ -646,6 +646,12 @@ export interface ReconciliationMatch {
   receiptId: string;
   confidenceScore: number;
   matchReasons: string[];
+  /**
+   * Set when this match is part of a consolidated-receipt group: N statement
+   * lines (same merchant, exact sum) sharing one receipt. Every line in the
+   * group carries the same receiptId and the same group size.
+   */
+  consolidatedGroupSize?: number;
 }
 
 // ─── Business trip detection ───────────────────────────────────────────────

--- a/lib/receipts/types.ts
+++ b/lib/receipts/types.ts
@@ -660,21 +660,45 @@ export interface BusinessTripCandidate {
 
 // ─── Export ────────────────────────────────────────────────────────────────
 
+/**
+ * A single row in the monthly export CSV. After the 2026-07-08 redesign the
+ * export unit is the **statement month**: one row per AMEX statement line
+ * (with the matched receipt's fields joined), plus one row per CASH/DIGITAL
+ * receipt anchored by transaction_date. A receipt matched to a line appears
+ * once — on the line row — never twice.
+ *
+ * `rowType` distinguishes the two populations. AMEX-line-only fields
+ * (lineId, matchStatus, receiptStatus, missingReceiptReason, cardholderName,
+ * businessTripStatus) are null on receipt rows; receipt-only fields
+ * (receiptId, status, originalR2Key) are null on missing-receipt lines.
+ */
 export interface ExportRow {
-  receiptId: string;
+  rowType: "amex_line" | "receipt";
+  // AMEX-line identity (null on receipt rows)
+  lineId: string | null;
+  matchStatus: AmexMatchStatus | null;
+  /** AmexReceiptStatus on line rows; null on receipt rows. */
+  receiptStatus: AmexReceiptStatus | null;
+  missingReceiptReason: string | null;
+  cardholderName: string | null;
+  businessTripStatus: AmexBusinessTripStatus | null;
+  // Receipt identity (null on missing-receipt lines)
+  receiptId: string | null;
+  /** ReceiptStatus on receipt rows and matched-receipt line rows; null otherwise. */
+  status: ReceiptStatus | null;
+  originalR2Key: string | null;
+  // Common accounting fields
   transactionDate: string | null;
   merchant: string | null;
   amountMinor: number | null;
   currency: string;
-  expenseType: ExpenseType;
+  expenseType: ExpenseType | null;
   expenseCategoryCode: string | null;
   expenseCategoryJa: string | null;
   expenseCategoryEn: string | null;
   paymentPath: PaymentPath;
   businessPurpose: string | null;
   attendees: string[];
-  status: ReceiptStatus;
-  originalR2Key: string;
 }
 
 // ─── Dashboard alerts ──────────────────────────────────────────────────────

--- a/lib/receipts/types.ts
+++ b/lib/receipts/types.ts
@@ -699,6 +699,15 @@ export interface ExportRow {
   paymentPath: PaymentPath;
   businessPurpose: string | null;
   attendees: string[];
+  // Compliance fields (audit A5; 電子帳簿保存法 / インボイス制度). Sourced
+  // from the matched receipt on AMEX-line rows; from the receipt itself on
+  // CASH/DIGITAL receipt rows; null when no receipt is present.
+  invoiceRegistrationNumber: string | null;
+  qualifiedInvoiceStatus: QualifiedInvoiceStatus | null;
+  taxRate: string | null;
+  taxAmountMinor: number | null;
+  sourceType: SourceType | null;
+  counterpartyName: string | null;
 }
 
 // ─── Dashboard alerts ──────────────────────────────────────────────────────

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build:cf": "opennextjs-cloudflare build",
     "preview": "opennextjs-cloudflare preview",
     "cf:dev": "opennextjs-cloudflare preview",
-    "deploy": "opennextjs-cloudflare deploy -- --keep-vars",
+    "deploy": "npm run build:cf && opennextjs-cloudflare deploy -- --keep-vars",
     "upload": "opennextjs-cloudflare upload -- --keep-vars",
     "cf-typegen": "wrangler types cloudflare-env.d.ts --env-interface CloudflareEnv",
     "start": "next start",

--- a/tests/receipts/categories.test.ts
+++ b/tests/receipts/categories.test.ts
@@ -12,13 +12,25 @@ import {
 
 // ─── Category seed ───────────────────────────────────────────────────────────
 
-test("EXPENSE_CATEGORIES has exactly 14 entries", () => {
-  assert.equal(EXPENSE_CATEGORIES.length, 14);
+test("EXPENSE_CATEGORIES has exactly 15 entries", () => {
+  // 14 original + miscellaneous (雑費), added 2026-07 per operator request.
+  assert.equal(EXPENSE_CATEGORIES.length, 15);
 });
 
-test("all 14 canonical codes are unique", () => {
+test("all canonical codes are unique", () => {
   const codes = EXPENSE_CATEGORIES.map((c) => c.code);
-  assert.equal(new Set(codes).size, 14);
+  assert.equal(new Set(codes).size, EXPENSE_CATEGORIES.length);
+});
+
+test("legacy 'misc' still requires review despite canonical 'miscellaneous' existing", () => {
+  // Guard: mapLegacyCategory checks isCanonicalCode first, so the canonical
+  // code must never be named 'misc' — old dumping-ground values would be
+  // silently legitimized instead of surfacing for review.
+  assert.deepEqual(mapLegacyCategory("misc"), { code: null, ambiguous: true });
+  assert.deepEqual(mapLegacyCategory("miscellaneous"), {
+    code: "miscellaneous",
+    ambiguous: false,
+  });
 });
 
 test("every category has required fields", () => {

--- a/tests/receipts/export.test.ts
+++ b/tests/receipts/export.test.ts
@@ -2,6 +2,8 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import {
   buildMonthlyExportCsv,
+  buildExportSummaryCsv,
+  bomPrefixedCrlf,
   hashCsvContent,
   buildArchiveKey,
   buildManifestKey,
@@ -10,9 +12,18 @@ import type { ExportRow } from "@/lib/receipts/types";
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 
-function makeRow(overrides: Partial<ExportRow> = {}): ExportRow {
+function makeReceiptRow(overrides: Partial<ExportRow> = {}): ExportRow {
   return {
+    rowType: "receipt",
+    lineId: null,
+    matchStatus: null,
+    receiptStatus: null,
+    missingReceiptReason: null,
+    cardholderName: null,
+    businessTripStatus: null,
     receiptId: "r-abc-123",
+    status: "reviewed",
+    originalR2Key: "receipts/2024/01/r-abc-123/file.jpg",
     transactionDate: "2024-01-15",
     merchant: "Starbucks Tokyo",
     amountMinor: 650,
@@ -24,53 +35,84 @@ function makeRow(overrides: Partial<ExportRow> = {}): ExportRow {
     paymentPath: "CASH",
     businessPurpose: "Team coffee",
     attendees: [],
-    status: "reviewed",
-    originalR2Key: "receipts/2024/01/r-abc-123/file.jpg",
+    ...overrides,
+  };
+}
+
+function makeAmexLineRow(overrides: Partial<ExportRow> = {}): ExportRow {
+  return {
+    rowType: "amex_line",
+    lineId: "amex-line-1",
+    matchStatus: "confirmed",
+    receiptStatus: "matched",
+    missingReceiptReason: null,
+    cardholderName: "David Klan",
+    businessTripStatus: "not_applicable",
+    receiptId: "r-def-456",
+    status: "reconciled",
+    originalR2Key: "receipts/2024/01/r-def-456/file.jpg",
+    transactionDate: "2024-01-12",
+    merchant: "Power Lunch Sushi",
+    amountMinor: 5400,
+    currency: "JPY",
+    expenseType: "entertainment-alcohol",
+    expenseCategoryCode: "entertainment",
+    expenseCategoryJa: "接待（飲酒あり）",
+    expenseCategoryEn: "Entertainment (alcohol)",
+    paymentPath: "AMEX",
+    businessPurpose: "Client meeting",
+    attendees: ["Client A", "David Klan"],
     ...overrides,
   };
 }
 
 // ─── buildMonthlyExportCsv ────────────────────────────────────────────────────
 
-test("buildMonthlyExportCsv: produces header row", () => {
+test("buildMonthlyExportCsv: produces header row with RowType", () => {
   const csv = buildMonthlyExportCsv([], new Map());
-  const header = csv.split("\n")[0];
-  assert.ok(header!.includes("ReceiptId"), "header must include ReceiptId");
-  assert.ok(header!.includes("Merchant"), "header must include Merchant");
-  assert.ok(header!.includes("Amount"), "header must include Amount");
+  const header = csv.split("\n")[0]!;
+  assert.ok(header.includes("RowType"), "header must include RowType");
+  assert.ok(header.includes("Merchant"), "header must include Merchant");
+  assert.ok(header.includes("Amount"), "header must include Amount");
+  assert.ok(header.includes("LineId"), "header must include LineId");
+  assert.ok(header.includes("MissingReceiptReason"), "header must include MissingReceiptReason");
 });
 
-test("buildMonthlyExportCsv: one data row per receipt", () => {
-  const rows = [makeRow(), makeRow({ receiptId: "r-def-456" })];
+test("buildMonthlyExportCsv: one data row per input row", () => {
+  const rows = [makeReceiptRow(), makeReceiptRow({ receiptId: "r-def-456" })];
   const csv = buildMonthlyExportCsv(rows, new Map());
   const lines = csv.split("\n").filter((l) => l.trim());
   assert.equal(lines.length, 3, "header + 2 data rows");
 });
 
 test("buildMonthlyExportCsv: JPY amounts are not divided by 100", () => {
-  const csv = buildMonthlyExportCsv([makeRow({ amountMinor: 1500, currency: "JPY" })], new Map());
+  const csv = buildMonthlyExportCsv(
+    [makeReceiptRow({ amountMinor: 1500, currency: "JPY" })],
+    new Map(),
+  );
   assert.ok(csv.includes("1500"), "JPY amount should be 1500, not 15.00");
   assert.ok(!csv.includes("15.00"), "JPY should not be divided");
 });
 
 test("buildMonthlyExportCsv: USD amounts are divided by 100", () => {
   const csv = buildMonthlyExportCsv(
-    [makeRow({ amountMinor: 1250, currency: "USD" })],
+    [makeReceiptRow({ amountMinor: 1250, currency: "USD" })],
     new Map(),
   );
   assert.ok(csv.includes("12.50"), "USD 1250 minor units should display as 12.50");
 });
 
 test("buildMonthlyExportCsv: null amount renders as empty string", () => {
-  const row = makeRow({ amountMinor: null });
+  const row = makeReceiptRow({ amountMinor: null });
   const csv = buildMonthlyExportCsv([row], new Map());
   const dataLine = csv.split("\n")[1]!;
   const cols = dataLine.split(",");
+  // Header: RowType(0), TransactionDate(1), Merchant(2), Amount(3)
   assert.equal(cols[3], "", "null amount should be empty column");
 });
 
 test("buildMonthlyExportCsv: attendees are joined with semicolons and quoted", () => {
-  const row = makeRow({ receiptId: "r-1" });
+  const row = makeReceiptRow({ receiptId: "r-1" });
   const attendeeMap = new Map([["r-1", ["Alice Nakamura", "Bob Smith"]]]);
   const csv = buildMonthlyExportCsv([row], attendeeMap);
   assert.ok(
@@ -80,15 +122,116 @@ test("buildMonthlyExportCsv: attendees are joined with semicolons and quoted", (
 });
 
 test("buildMonthlyExportCsv: merchant with commas is properly quoted", () => {
-  const row = makeRow({ merchant: "Shop, Ltd." });
+  const row = makeReceiptRow({ merchant: "Shop, Ltd." });
   const csv = buildMonthlyExportCsv([row], new Map());
   assert.ok(csv.includes('"Shop, Ltd."'), "comma in merchant must be quoted");
 });
 
 test("buildMonthlyExportCsv: merchant with double-quotes is escaped", () => {
-  const row = makeRow({ merchant: 'Shop "Best" Ltd.' });
+  const row = makeReceiptRow({ merchant: 'Shop "Best" Ltd.' });
   const csv = buildMonthlyExportCsv([row], new Map());
   assert.ok(csv.includes('"Shop ""Best"" Ltd."'), "double quotes must be escaped");
+});
+
+test("buildMonthlyExportCsv: AMEX line row carries line-only fields", () => {
+  const csv = buildMonthlyExportCsv([makeAmexLineRow()], new Map());
+  assert.ok(csv.includes("amex_line"), "rowType=amex_line must appear");
+  assert.ok(csv.includes("amex-line-1"), "lineId must be present");
+  assert.ok(csv.includes("David Klan"), "cardholderName must be present");
+});
+
+test("buildMonthlyExportCsv: missing-receipt line ships with reason in CSV", () => {
+  // Audit A4 #1: missing-receipt lines MUST appear in the CSV with their
+  // reasons; previously they were silently absent.
+  const row = makeAmexLineRow({
+    receiptId: null,
+    status: null,
+    originalR2Key: null,
+    matchStatus: "no_receipt",
+    receiptStatus: "missing_receipt",
+    missingReceiptReason: "Lost during travel",
+    merchant: "Airport Coffee",
+    attendees: [],
+  });
+  const csv = buildMonthlyExportCsv([row], new Map());
+  assert.ok(csv.includes("missing_receipt"), "receiptStatus must be present");
+  assert.ok(csv.includes("Lost during travel"), "missingReceiptReason must be present");
+});
+
+test("buildMonthlyExportCsv: formula-injection guard prefixes = + - @", () => {
+  // A5: a merchant starting with = + - @ gets prefixed with a single quote
+  // so Excel does not evaluate it as a formula on open.
+  for (const prefix of ["=", "+", "-", "@"]) {
+    const row = makeReceiptRow({ merchant: `${prefix}cmd|'/c calc'!A1` });
+    const csv = buildMonthlyExportCsv([row], new Map());
+    assert.ok(
+      csv.includes(`'${prefix}cmd`),
+      `merchant starting with ${prefix} must be single-quote prefixed`,
+    );
+  }
+});
+
+test("buildMonthlyExportCsv: matched receipt attendees read from bundle.attendees when attendeeMap misses", () => {
+  // A receipt matched to a line should still surface its attendees even if
+  // the caller passed an empty attendeeMap (the bundle row carries them).
+  const row = makeAmexLineRow({ attendees: ["Inline Attendee"] });
+  const csv = buildMonthlyExportCsv([row], new Map());
+  assert.ok(csv.includes("Inline Attendee"), "row.attendees used as fallback");
+});
+
+// ─── bomPrefixedCrlf (A5 CSV hardening) ───────────────────────────────────────
+
+test("bomPrefixedCrlf: prepends UTF-8 BOM and converts LF to CRLF", () => {
+  const out = bomPrefixedCrlf("a\nb\n");
+  assert.equal(out.charCodeAt(0), 0xfeff, "must start with U+FEFF BOM");
+  assert.ok(out.includes("\r\n"), "LF must become CRLF");
+  assert.ok(!out.slice(1).includes("\n\r"), "no stray lone LF");
+});
+
+test("bomPrefixedCrlf: handles text that already has CRLF", () => {
+  const out = bomPrefixedCrlf("a\r\nb\r\n");
+  assert.equal(out.charCodeAt(0), 0xfeff);
+  // Idempotent on line endings.
+  assert.equal((out.match(/\r\n/g) ?? []).length, 2);
+  assert.equal((out.match(/(?<!\r)\n/g) ?? []).length, 0);
+});
+
+// ─── buildExportSummaryCsv (A5 summary CSV) ───────────────────────────────────
+
+test("buildExportSummaryCsv: grand total + PaymentPath breakdown", () => {
+  const rows: ExportRow[] = [
+    makeAmexLineRow({ amountMinor: 5000, expenseCategoryCode: "entertainment" }),
+    makeReceiptRow({
+      amountMinor: 1500,
+      paymentPath: "CASH",
+      expenseCategoryCode: "meeting",
+    }),
+    makeReceiptRow({
+      amountMinor: 3000,
+      paymentPath: "DIGITAL",
+      expenseCategoryCode: "software",
+    }),
+  ];
+  const csv = buildExportSummaryCsv(rows, "2026-05", "2026-05-19T12:00:00Z");
+  assert.match(csv, /Month,2026-05/);
+  assert.match(csv, /RowCount,3/);
+  assert.match(csv, /GrandTotalMinor,9500/);
+  assert.match(csv, /PaymentPath,Count,TotalMinor/);
+  assert.match(csv, /AMEX,1,5000/);
+  assert.match(csv, /CASH,1,1500/);
+  assert.match(csv, /DIGITAL,1,3000/);
+  assert.match(csv, /entertainment,1,5000/);
+  assert.match(csv, /meeting,1,1500/);
+  assert.match(csv, /software,1,3000/);
+});
+
+test("buildExportSummaryCsv: uncategorized bucket when category null", () => {
+  const csv = buildExportSummaryCsv(
+    [makeReceiptRow({ expenseCategoryCode: null })],
+    "2026-05",
+    "t",
+  );
+  assert.match(csv, /uncategorized,1,/);
 });
 
 // ─── hashCsvContent ────────────────────────────────────────────────────────────

--- a/tests/receipts/export.test.ts
+++ b/tests/receipts/export.test.ts
@@ -319,6 +319,22 @@ test("ExportFinalizedError: carries month and message", () => {
   assert.ok(err instanceof Error);
 });
 
+test("ExportFinalizedError: routes via instanceof, not substring matching on message", () => {
+  // Routes catch this with `instanceof ExportFinalizedError` (see app/api/receipts/*).
+  // A plain Error carrying the same string in its message must NOT be confused
+  // for the typed signal — that's the whole point of having a typed error class.
+  function catchResult(err: unknown): "locked" | "passthrough" {
+    if (err instanceof ExportFinalizedError) return "locked";
+    return "passthrough";
+  }
+  assert.equal(catchResult(new ExportFinalizedError("2026-05", "x")), "locked");
+  assert.equal(
+    catchResult(new Error("Month 2026-05 is export-finalized")),
+    "passthrough",
+    "plain Error must not satisfy the instanceof check",
+  );
+});
+
 // ─── hashCsvContent ────────────────────────────────────────────────────────────
 
 test("hashCsvContent: same content produces same hash", async () => {

--- a/tests/receipts/export.test.ts
+++ b/tests/receipts/export.test.ts
@@ -7,7 +7,12 @@ import {
   hashCsvContent,
   buildArchiveKey,
   buildManifestKey,
+  buildSummaryKey,
 } from "@/lib/receipts/export";
+import {
+  ExportFinalizedError,
+  transactionMonthOf,
+} from "@/lib/receipts/month-lock";
 import type { ExportRow } from "@/lib/receipts/types";
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
@@ -35,6 +40,12 @@ function makeReceiptRow(overrides: Partial<ExportRow> = {}): ExportRow {
     paymentPath: "CASH",
     businessPurpose: "Team coffee",
     attendees: [],
+    invoiceRegistrationNumber: null,
+    qualifiedInvoiceStatus: null,
+    taxRate: null,
+    taxAmountMinor: null,
+    sourceType: null,
+    counterpartyName: null,
     ...overrides,
   };
 }
@@ -62,6 +73,12 @@ function makeAmexLineRow(overrides: Partial<ExportRow> = {}): ExportRow {
     paymentPath: "AMEX",
     businessPurpose: "Client meeting",
     attendees: ["Client A", "David Klan"],
+    invoiceRegistrationNumber: "T1234567890123",
+    qualifiedInvoiceStatus: "valid",
+    taxRate: "0.10",
+    taxAmountMinor: 490,
+    sourceType: "paper_scanned",
+    counterpartyName: "Power Lunch Sushi K.K.",
     ...overrides,
   };
 }
@@ -232,6 +249,74 @@ test("buildExportSummaryCsv: uncategorized bucket when category null", () => {
     "t",
   );
   assert.match(csv, /uncategorized,1,/);
+});
+
+// ─── Compliance columns on main CSV (A5) ──────────────────────────────────────
+
+test("buildMonthlyExportCsv: compliance columns populated from receipt", () => {
+  const csv = buildMonthlyExportCsv(
+    [makeAmexLineRow({
+      invoiceRegistrationNumber: "T2810074043972",
+      qualifiedInvoiceStatus: "valid",
+      taxRate: "0.10",
+      taxAmountMinor: 490,
+      sourceType: "paper_scanned",
+      counterpartyName: "Power Lunch Sushi K.K.",
+    })],
+    new Map(),
+  );
+  assert.ok(csv.includes("T2810074043972"), "invoice registration number");
+  assert.ok(csv.includes("valid"), "qualified invoice status");
+  assert.ok(csv.includes("0.10"), "tax rate");
+  assert.ok(csv.includes("490"), "tax amount minor");
+  assert.ok(csv.includes("paper_scanned"), "source type");
+  assert.ok(csv.includes("Power Lunch Sushi K.K."), "counterparty name");
+});
+
+test("buildMonthlyExportCsv: header carries compliance column names", () => {
+  const csv = buildMonthlyExportCsv([], new Map());
+  const header = csv.split("\n")[0]!;
+  for (const col of [
+    "InvoiceRegistrationNumber",
+    "QualifiedInvoiceStatus",
+    "TaxRate",
+    "TaxAmount",
+    "SourceType",
+    "CounterpartyName",
+  ]) {
+    assert.ok(header.includes(col), `header must include ${col}`);
+  }
+});
+
+// ─── buildSummaryKey ──────────────────────────────────────────────────────────
+
+test("buildSummaryKey: uses correct path pattern", () => {
+  const key = buildSummaryKey("2024-01", "export-uuid");
+  assert.equal(key, "exports/2024-01/export-uuid-summary.csv");
+});
+
+// ─── Split lock model helpers (audit A5) ──────────────────────────────────────
+
+test("transactionMonthOf: extracts YYYY-MM from YYYY-MM-DD", () => {
+  assert.equal(transactionMonthOf("2026-05-15"), "2026-05");
+});
+
+test("transactionMonthOf: returns null for null/empty/malformed", () => {
+  assert.equal(transactionMonthOf(null), null);
+  assert.equal(transactionMonthOf(""), null);
+  assert.equal(transactionMonthOf("not-a-date"), null);
+});
+
+test("transactionMonthOf: accepts ISO timestamps too", () => {
+  assert.equal(transactionMonthOf("2026-05-15T08:30:00Z"), "2026-05");
+});
+
+test("ExportFinalizedError: carries month and message", () => {
+  const err = new ExportFinalizedError("2026-05", "locked");
+  assert.equal(err.month, "2026-05");
+  assert.equal(err.message, "locked");
+  assert.equal(err.name, "ExportFinalizedError");
+  assert.ok(err instanceof Error);
 });
 
 // ─── hashCsvContent ────────────────────────────────────────────────────────────

--- a/tests/receipts/extraction.test.ts
+++ b/tests/receipts/extraction.test.ts
@@ -26,6 +26,40 @@ test("parseReceiptOcrText: extracts Reiwa dates", () => {
   assert.equal(parsed.amountMinor, 2750);
 });
 
+// Regression: えきねっと e-ticket receipt. The card's last-4 (5102) shared a
+// line with the ¥4,900 total and won the max() pick; the 税込 total line was
+// vetoed by the bare-税 skip keyword; and 発行日 (PDF issue date) was extracted
+// instead of 購入日 (the card-charge date the AMEX line carries).
+test("parseReceiptOcrText: えきねっと ticket — amount is the ¥ total, not card last-4; date is 購入日", () => {
+  const parsed = parseReceiptOcrText(`発行日 2026年05月09日12時26分
+発行番号 No.E051390017410880429
+えきねっと ご利用票兼領収書
+下記の金額を、確かに領収しました。
+東日本旅客鉄道株式会社
+登録番号：T9011001029597
+宛名 合同会社Dazbeez
+金額
+¥4,900(税込10%) クレジットカード利用(カード番号下4桁：5102)
+但し きっぷのご購入代金として
+予約番号 E05139
+購入日 2026年04月25日
+乗車日 2026年04月29日`);
+
+  assert.equal(parsed.amountMinor, 4900);
+  assert.equal(parsed.transactionDate, "2026-04-25");
+  assert.equal(parsed.invoiceRegistrationNumber, "T9011001029597");
+  assert.equal(parsed.taxRate, "10%");
+});
+
+test("parseReceiptOcrText: masked card numbers and last-4 phrasing never become the amount", () => {
+  const parsed = parseReceiptOcrText(`Demo Store
+2026/05/16
+VISA ****9876
+合計 ¥1,200`);
+
+  assert.equal(parsed.amountMinor, 1200);
+});
+
 test("parseReceiptOcrText: does not invent category or attendees from OCR text", () => {
   const parsed = parseReceiptOcrText(`Demo Restaurant
 2026/05/16

--- a/tests/receipts/month-lock.test.ts
+++ b/tests/receipts/month-lock.test.ts
@@ -1,0 +1,114 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { isMonthLockedForEdits, type MonthLockD1 } from "@/lib/receipts/month-lock";
+
+// ─── Fake D1 ──────────────────────────────────────────────────────────────────
+//
+// isMonthLockedForEdits runs a single CASE expression that hits receipt_exports
+// twice (once for 'draft', once for 'finalized'). The fake below answers that
+// expression from an in-memory map keyed by `<month>:<status>`, so a test can
+// express any combination — including the F1 case the production bug shipped
+// with (finalized + open draft → must release the lock).
+//
+// Companion coverage for transactionMonthOf / ExportFinalizedError shape lives
+// in tests/receipts/export.test.ts. This file owns the lock predicate only.
+
+type ExportRow = { export_month: string; status: "draft" | "finalized" };
+
+function createFakeDb(rows: ExportRow[] = []): MonthLockD1 {
+  const byKey = new Map<string, ExportRow>();
+  for (const r of rows) byKey.set(`${r.export_month}:${r.status}`, r);
+
+  return {
+    prepare(sql: string) {
+      return {
+        bind(...args: unknown[]) {
+          return {
+            async first<T = unknown>(): Promise<T | null> {
+              if (/status = 'draft'/i.test(sql) && /status = 'finalized'/i.test(sql)) {
+                const month = String(args[0]);
+                const hasDraft = byKey.has(`${month}:draft`);
+                const hasFinalized = byKey.has(`${month}:finalized`);
+                const locked = !hasDraft && hasFinalized ? 1 : 0;
+                return { locked } as T;
+              }
+              return null as T | null;
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+// ─── F3a: finalized export and no draft → locked (the original guard) ────────
+
+test("isMonthLockedForEdits: finalized export with no draft → locked", async () => {
+  const db = createFakeDb([{ export_month: "2026-03", status: "finalized" }]);
+  const locked = await isMonthLockedForEdits(db, "2026-03");
+  assert.equal(locked, true, "finalized + no draft must lock edits");
+});
+
+// ─── F3b: finalized export + open draft revision → edit allowed (F1 fix) ─────
+//
+// This is the exact scenario createExportRevision produces: a permanent
+// finalized row plus a fresh draft row. Without the draft carve-out the
+// correction flow could never actually correct anything — every edit attempt
+// would re-hit the finalized row and re-throw.
+
+test("isMonthLockedForEdits: finalized export + open draft revision → released (F1 fix)", async () => {
+  const db = createFakeDb([
+    { export_month: "2026-03", status: "finalized" },
+    { export_month: "2026-03", status: "draft" },
+  ]);
+  const locked = await isMonthLockedForEdits(db, "2026-03");
+  assert.equal(locked, false, "draft revision must release the lock so corrections can land");
+});
+
+// ─── F3c: revision finalized (draft gone) → locked again ────────────────────
+//
+// Finalizing the revision closes the lock: the draft row is consumed (it
+// becomes the new finalized row), only finalized remains, and the month is
+// sealed once more. This re-uses the F3a fixture on purpose — the post-
+// revision state is indistinguishable from the pre-correction state at the
+// receipt_exports table level, which is exactly the design intent.
+
+test("isMonthLockedForEdits: revision finalized (draft gone) → locked again", async () => {
+  const db = createFakeDb([{ export_month: "2026-03", status: "finalized" }]);
+  const locked = await isMonthLockedForEdits(db, "2026-03");
+  assert.equal(locked, true, "after the draft closes the month must re-lock");
+});
+
+// ─── Edge cases that protect the F1 fix from regressions ─────────────────────
+
+test("isMonthLockedForEdits: month with neither draft nor finalized → open for edits", async () => {
+  const db = createFakeDb([]);
+  const locked = await isMonthLockedForEdits(db, "2026-03");
+  assert.equal(locked, false, "an untouched month is editable");
+});
+
+test("isMonthLockedForEdits: only a draft exists → editable (initial build, not yet shipped)", async () => {
+  const db = createFakeDb([{ export_month: "2026-03", status: "draft" }]);
+  const locked = await isMonthLockedForEdits(db, "2026-03");
+  assert.equal(locked, false, "first-time draft must not lock the month");
+});
+
+test("isMonthLockedForEdits: draft carve-out is month-scoped (other months unaffected)", async () => {
+  // A draft for March does not release the lock on April — the carve-out is
+  // per-month, matching the idx_exports_one_draft partial unique index.
+  const db = createFakeDb([
+    { export_month: "2026-04", status: "finalized" },
+    { export_month: "2026-03", status: "draft" },
+  ]);
+  const aprilLocked = await isMonthLockedForEdits(db, "2026-04");
+  assert.equal(aprilLocked, true, "April stays locked; March's draft is irrelevant to April");
+});
+
+// ─── isMonthExportFinalized boundary (documented, not unit-tested) ────────────
+//
+// isMonthExportFinalized(month) intentionally does NOT take a `db` parameter —
+// it calls getReceiptsDb() internally and answers only "did this month ever
+// ship?". The draft-aware behavior (F1 fix) is the job of isMonthLockedForEdits
+// above. Coverage for isMonthExportFinalized is provided by integration tests
+// against live D1 on the Mac worker; duplicating it here would require module
+// mocking we don't otherwise need.

--- a/tests/receipts/reconciliation-signoff.test.ts
+++ b/tests/receipts/reconciliation-signoff.test.ts
@@ -181,6 +181,63 @@ test("signoff validator: dangling match (matched_receipt_id set, receipt missing
   assert.deepEqual(blockers, []);
 });
 
+// ─── Consolidated receipts (multiple lines → one 領収書) ─────────────────────
+
+function makeConsolidatedPair(receiptTotal: number) {
+  const lineA = makeLine({
+    id: "line-a",
+    merchant: "HUB 東京オペラシティ店",
+    amount_minor: 2864,
+    matched_receipt_id: "r-hub",
+    expense_category_code: "office_supplies",
+  });
+  const lineB = makeLine({
+    id: "line-b",
+    merchant: "HUB 東京オペラシティ店",
+    amount_minor: 4185,
+    matched_receipt_id: "r-hub",
+    expense_category_code: "office_supplies",
+  });
+  const receipt = makeReceipt({
+    id: "r-hub",
+    merchant: "HUB 東京オペラシティ店",
+    amount_minor: receiptTotal,
+    expense_category_code: "office_supplies",
+  });
+  return { lines: [lineA, lineB], receiptMap: new Map([[receipt.id, receipt]]) };
+}
+
+test("signoff validator: consolidated receipt with exact group sum passes", () => {
+  const { lines, receiptMap } = makeConsolidatedPair(2864 + 4185);
+  const blockers = validateAmexLinesForSignoff(lines, {}, new Map(), receiptMap);
+  assert.deepEqual(blockers, []);
+});
+
+test("signoff validator: consolidated receipt with mismatched group sum blocks", () => {
+  const { lines, receiptMap } = makeConsolidatedPair(9999);
+  const blockers = validateAmexLinesForSignoff(lines, {}, new Map(), receiptMap);
+  assert.ok(
+    blockers.some((b) => b.includes("Consolidated receipt") && b.includes("9999")),
+    `expected consolidated-sum blocker, got: ${JSON.stringify(blockers)}`,
+  );
+});
+
+test("signoff validator: single-line amount mismatch is NOT a consolidated blocker (unchanged behavior)", () => {
+  const line = makeLine({
+    matched_receipt_id: "r-1",
+    amount_minor: 500,
+    expense_category_code: "office_supplies",
+  });
+  const receipt = makeReceipt({ id: "r-1", amount_minor: 999, expense_category_code: "office_supplies" });
+  const blockers = validateAmexLinesForSignoff(
+    [line],
+    {},
+    new Map(),
+    new Map([[receipt.id, receipt]]),
+  );
+  assert.deepEqual(blockers, []);
+});
+
 test("signoff validator: unmatched line still blocks on missing receipt confirmation regardless of category", () => {
   const line = makeLine({
     matched_receipt_id: null,

--- a/tests/receipts/reconciliation.test.ts
+++ b/tests/receipts/reconciliation.test.ts
@@ -101,6 +101,84 @@ test("exact amount + same date produces high confidence match", () => {
   assert.ok(matches[0]!.matchReasons.includes("0-day window"));
 });
 
+test("known merchant alias (えきねっと ↔ 東日本旅客鉄道) reaches auto-confirm band", () => {
+  const lines = [
+    makeAmexLine({ merchant: "えきねっと", amount_minor: 4900, transaction_date: "2026-04-25" }),
+  ];
+  const receipts = [
+    makeReceipt({
+      merchant: "東日本旅客鉄道株式会社",
+      amount_minor: 4900,
+      transaction_date: "2026-04-25",
+    }),
+  ];
+  const matches = matchAmexToReceipts(lines, receipts);
+  assert.equal(matches.length, 1);
+  assert.ok(
+    matches[0]!.confidenceScore >= 0.92,
+    `expected obvious-band score, got ${matches[0]!.confidenceScore}`,
+  );
+  assert.ok(matches[0]!.matchReasons.includes("known merchant alias"));
+});
+
+// ─── Consolidated receipts (multiple statement lines → one 領収書) ────────────
+
+test("consolidated receipt: two same-merchant lines summing exactly to the receipt total are both matched to it", () => {
+  const lines = [
+    makeAmexLine({ id: "hub-1", merchant: "HUB 東京オペラシティ店", amount_minor: 2864, transaction_date: "2026-04-27" }),
+    makeAmexLine({ id: "hub-2", merchant: "HUB 東京オペラシティ店", amount_minor: 4185, transaction_date: "2026-04-27" }),
+  ];
+  const receipts = [
+    makeReceipt({ id: "r-hub", merchant: "HUB 東京オペラシティ店", amount_minor: 7049, transaction_date: "2026-04-27" }),
+  ];
+  const matches = matchAmexToReceipts(lines, receipts);
+  assert.equal(matches.length, 2);
+  assert.ok(matches.every((m) => m.receiptId === "r-hub"));
+  assert.ok(matches.every((m) => m.consolidatedGroupSize === 2));
+  // Capped below the auto-confirm band (0.92) — a human confirms each group line.
+  assert.ok(matches.every((m) => m.confidenceScore >= 0.7 && m.confidenceScore < 0.92));
+  assert.ok(matches.every((m) => m.matchReasons.some((r) => r.includes("consolidated"))));
+});
+
+test("consolidated receipt: no group suggestion when the sum does not match exactly", () => {
+  const lines = [
+    makeAmexLine({ id: "e-1", merchant: "ENEOS", amount_minor: 3300, transaction_date: "2026-04-29" }),
+    makeAmexLine({ id: "e-2", merchant: "ENEOS", amount_minor: 19470, transaction_date: "2026-04-29" }),
+  ];
+  const receipts = [
+    makeReceipt({ id: "r-e", merchant: "ENEOS", amount_minor: 22771, transaction_date: "2026-04-29" }),
+  ];
+  assert.equal(matchAmexToReceipts(lines, receipts).length, 0);
+});
+
+test("consolidated receipt: a receipt with a 1:1 match is not also group-matched", () => {
+  // Receipt equals one line exactly → 1:1 wins; the second line stays unmatched
+  // rather than being pulled into a bogus group.
+  const lines = [
+    makeAmexLine({ id: "l-1", merchant: "ENEOS", amount_minor: 3300, transaction_date: "2026-04-29" }),
+    makeAmexLine({ id: "l-2", merchant: "ENEOS", amount_minor: 19470, transaction_date: "2026-04-29" }),
+  ];
+  const receipts = [
+    makeReceipt({ id: "r-single", merchant: "ENEOS", amount_minor: 3300, transaction_date: "2026-04-29" }),
+  ];
+  const matches = matchAmexToReceipts(lines, receipts);
+  assert.equal(matches.length, 1);
+  assert.equal(matches[0]!.amexLineId, "l-1");
+  assert.equal(matches[0]!.consolidatedGroupSize, undefined);
+});
+
+test("consolidated receipt: lines outside the 7-day window are excluded from the group", () => {
+  const lines = [
+    makeAmexLine({ id: "n-1", merchant: "ENEOS", amount_minor: 3300, transaction_date: "2026-04-29" }),
+    makeAmexLine({ id: "n-2", merchant: "ENEOS", amount_minor: 19470, transaction_date: "2026-06-15" }),
+  ];
+  const receipts = [
+    makeReceipt({ id: "r-e", merchant: "ENEOS", amount_minor: 22770, transaction_date: "2026-04-29" }),
+  ];
+  // Group = only n-1 (single line) → below the 2-line minimum → no suggestion.
+  assert.equal(matchAmexToReceipts(lines, receipts).length, 0);
+});
+
 test("no match when date is more than 7 days apart", () => {
   const lines = [makeAmexLine({ transaction_date: "2024-01-15" })];
   const receipts = [makeReceipt({ transaction_date: "2024-01-24" })];

--- a/tests/receipts/reconciliation.test.ts
+++ b/tests/receipts/reconciliation.test.ts
@@ -167,6 +167,63 @@ test("consolidated receipt: a receipt with a 1:1 match is not also group-matched
   assert.equal(matches[0]!.consolidatedGroupSize, undefined);
 });
 
+test("consolidated receipt: CJK/Latin spacing difference does not break the merchant gate (HUB)", () => {
+  // Real data 2026-04: statement prints "HUB 東京オペラシティ店" (space),
+  // OCR merchant is "HUB東京オペラシティ店" (no space).
+  const lines = [
+    makeAmexLine({ id: "hub-1", merchant: "HUB 東京オペラシティ店", amount_minor: 2864, transaction_date: "2026-04-27" }),
+    makeAmexLine({ id: "hub-2", merchant: "HUB 東京オペラシティ店", amount_minor: 4185, transaction_date: "2026-04-27" }),
+  ];
+  const receipts = [
+    makeReceipt({ id: "r-hub", merchant: "HUB東京オペラシティ店", amount_minor: 7049, transaction_date: "2026-04-27", status: "reviewed" }),
+  ];
+  const matches = matchAmexToReceipts(lines, receipts);
+  assert.equal(matches.length, 2);
+  assert.ok(matches.every((m) => m.receiptId === "r-hub" && m.consolidatedGroupSize === 2));
+});
+
+test("consolidated receipt: brand in raw OCR text bridges franchise operator names (ENEOS)", () => {
+  // Real data 2026-04: statement prints "ENEOS", the receipt is issued by
+  // the franchise operator 株式会社 豊島屋 岡谷SS — but the OCR text carries
+  // the ENEOS brand mark.
+  const lines = [
+    makeAmexLine({ id: "e-1", merchant: "ENEOS", amount_minor: 3300, transaction_date: "2026-04-29" }),
+    makeAmexLine({ id: "e-2", merchant: "ENEOS", amount_minor: 19470, transaction_date: "2026-04-29" }),
+  ];
+  const receipts = [
+    makeReceipt({
+      id: "r-eneos",
+      merchant: "株式会社 豊島屋 岡谷SS",
+      amount_minor: 22770,
+      transaction_date: "2026-04-29",
+      status: "reviewed",
+      extraction_json: JSON.stringify({
+        rawText: "AMEX\n出張交通費\nENEOS\n納品書(領収書)\n2026年04月29日 13:42",
+      }),
+    }),
+  ];
+  const matches = matchAmexToReceipts(lines, receipts);
+  assert.equal(matches.length, 2);
+  assert.ok(matches.every((m) => m.receiptId === "r-eneos" && m.consolidatedGroupSize === 2));
+});
+
+test("raw-text brand fallback requires the brand to actually appear", () => {
+  const lines = [
+    makeAmexLine({ id: "e-1", merchant: "ENEOS", amount_minor: 3300, transaction_date: "2026-04-29" }),
+    makeAmexLine({ id: "e-2", merchant: "ENEOS", amount_minor: 19470, transaction_date: "2026-04-29" }),
+  ];
+  const receipts = [
+    makeReceipt({
+      id: "r-other",
+      merchant: "株式会社 豊島屋 岡谷SS",
+      amount_minor: 22770,
+      transaction_date: "2026-04-29",
+      extraction_json: JSON.stringify({ rawText: "納品書(領収書)\n2026年04月29日" }),
+    }),
+  ];
+  assert.equal(matchAmexToReceipts(lines, receipts).length, 0);
+});
+
 test("consolidated receipt: remaining line is still suggested after the first line is confirmed", () => {
   // Confirming line 1 promotes the receipt to 'reconciled' and the page
   // refreshes — the second line must keep its suggestion (Codex P2).

--- a/tests/receipts/reconciliation.test.ts
+++ b/tests/receipts/reconciliation.test.ts
@@ -207,6 +207,37 @@ test("consolidated receipt: brand in raw OCR text bridges franchise operator nam
   assert.ok(matches.every((m) => m.receiptId === "r-eneos" && m.consolidatedGroupSize === 2));
 });
 
+test("consolidated receipt: same-brand charges AFTER the receipt date do not poison the group (ENEOS prod data)", () => {
+  // Real data 2026-06 statement: ENEOS pair on 04-29 sums to the 04-29
+  // consolidated receipt, but two later fill-ups (05-02) share the brand and
+  // sit inside the ±7-day window. A receipt cannot cover future charges —
+  // the group must be bounded at the receipt date.
+  const rawText = JSON.stringify({ rawText: "ENEOS\n納品書(領収書)\n2026年04月29日" });
+  const lines = [
+    makeAmexLine({ id: "e-1", merchant: "ENEOS", amount_minor: 3300, transaction_date: "2026-04-29" }),
+    makeAmexLine({ id: "e-2", merchant: "ENEOS", amount_minor: 19470, transaction_date: "2026-04-29" }),
+    makeAmexLine({ id: "e-3", merchant: "ENEOS", amount_minor: 1705, transaction_date: "2026-05-02" }),
+    makeAmexLine({ id: "e-4", merchant: "ENEOS", amount_minor: 1840, transaction_date: "2026-05-02" }),
+  ];
+  const receipts = [
+    makeReceipt({
+      id: "r-eneos",
+      merchant: "株式会社 豊島屋 岡谷SS",
+      amount_minor: 22770,
+      transaction_date: "2026-04-29",
+      status: "reviewed",
+      extraction_json: rawText,
+    }),
+  ];
+  const matches = matchAmexToReceipts(lines, receipts);
+  assert.equal(matches.length, 2);
+  assert.deepEqual(
+    matches.map((m) => m.amexLineId).sort(),
+    ["e-1", "e-2"],
+  );
+  assert.ok(matches.every((m) => m.receiptId === "r-eneos" && m.consolidatedGroupSize === 2));
+});
+
 test("raw-text brand fallback requires the brand to actually appear", () => {
   const lines = [
     makeAmexLine({ id: "e-1", merchant: "ENEOS", amount_minor: 3300, transaction_date: "2026-04-29" }),

--- a/tests/receipts/reconciliation.test.ts
+++ b/tests/receipts/reconciliation.test.ts
@@ -167,6 +167,93 @@ test("consolidated receipt: a receipt with a 1:1 match is not also group-matched
   assert.equal(matches[0]!.consolidatedGroupSize, undefined);
 });
 
+test("consolidated receipt: remaining line is still suggested after the first line is confirmed", () => {
+  // Confirming line 1 promotes the receipt to 'reconciled' and the page
+  // refreshes — the second line must keep its suggestion (Codex P2).
+  const lines = [
+    makeAmexLine({
+      id: "hub-1",
+      merchant: "HUB 東京オペラシティ店",
+      amount_minor: 2864,
+      transaction_date: "2026-04-27",
+      match_status: "confirmed",
+      matched_receipt_id: "r-hub",
+    }),
+    makeAmexLine({
+      id: "hub-2",
+      merchant: "HUB 東京オペラシティ店",
+      amount_minor: 4185,
+      transaction_date: "2026-04-27",
+    }),
+  ];
+  const receipts = [
+    makeReceipt({
+      id: "r-hub",
+      merchant: "HUB 東京オペラシティ店",
+      amount_minor: 7049,
+      transaction_date: "2026-04-27",
+      status: "reconciled",
+    }),
+  ];
+  const matches = matchAmexToReceipts(lines, receipts);
+  assert.equal(matches.length, 1);
+  assert.equal(matches[0]!.amexLineId, "hub-2");
+  assert.equal(matches[0]!.receiptId, "r-hub");
+  assert.equal(matches[0]!.consolidatedGroupSize, 2);
+});
+
+test("consolidated receipt: fully-claimed receipt is not re-offered to leftover lines", () => {
+  const lines = [
+    makeAmexLine({
+      id: "hub-1",
+      merchant: "HUB 東京オペラシティ店",
+      amount_minor: 7049,
+      transaction_date: "2026-04-27",
+      match_status: "confirmed",
+      matched_receipt_id: "r-hub",
+    }),
+    makeAmexLine({
+      id: "hub-3",
+      merchant: "HUB 東京オペラシティ店",
+      amount_minor: 1200,
+      transaction_date: "2026-04-27",
+    }),
+  ];
+  const receipts = [
+    makeReceipt({
+      id: "r-hub",
+      merchant: "HUB 東京オペラシティ店",
+      amount_minor: 7049,
+      transaction_date: "2026-04-27",
+      status: "reconciled",
+    }),
+  ];
+  assert.equal(matchAmexToReceipts(lines, receipts).length, 0);
+});
+
+test("consolidated receipt: receipt reconciled by ANOTHER month's lines is not offered", () => {
+  // status='reconciled' but no confirmed line in this month's set — the
+  // claim lives elsewhere; do not offer it.
+  const lines = [
+    makeAmexLine({
+      id: "hub-2",
+      merchant: "HUB 東京オペラシティ店",
+      amount_minor: 4185,
+      transaction_date: "2026-04-27",
+    }),
+  ];
+  const receipts = [
+    makeReceipt({
+      id: "r-hub",
+      merchant: "HUB 東京オペラシティ店",
+      amount_minor: 4185,
+      transaction_date: "2026-04-27",
+      status: "reconciled",
+    }),
+  ];
+  assert.equal(matchAmexToReceipts(lines, receipts).length, 0);
+});
+
 test("consolidated receipt: lines outside the 7-day window are excluded from the group", () => {
   const lines = [
     makeAmexLine({ id: "n-1", merchant: "ENEOS", amount_minor: 3300, transaction_date: "2026-04-29" }),


### PR DESCRIPTION
## Summary

Branch bundles the 2026-07-08 export-module audit remediation (findings A1–A8) and a follow-up feature for consolidated receipts (multiple AMEX lines → one 領収書). Ships together because they touch the same screens and share the same finalize/lock lifecycle.

**Export remediation (A1–A8, audited 2026-07-08):**
- **A1** single validation authority — one canonical export bundle builder drives both preview and ship (`buildExportBundle`)
- **A2** revision metadata propagation through the export pipeline
- **A3** migration 0017 — export integrity table (`db/receipts/0017_export_integrity.sql`)
- **A4** statement-month scope redesign (replaces global `LIMIT` pagination)
- **A5** split lock model + finalize lifecycle; CSV hardening + compliance columns
- **A6** export performance + honest UI (no more phantom counts)
- **A7** multi-month finalize warnings
- **A8** architecture docs + ADRs 0002–0005 (`docs/adr/`)
- plus month-lock fix: reopen a month while a draft revision exists

**Consolidated receipts (84a608c):**
- New phase-3 matcher: same-merchant lines within the 7-day window whose amounts sum **exactly** to a receipt total are grouped against it. No subset search — only full-group sums are audit-explainable. Confidence capped at 0.9 (below the 0.92 auto-confirm band) so every group line gets human confirmation.
- Merchant alias groups (えきねっと ↔ JR東日本) so booking-site descriptors connect to legal-entity receipt names.
- Removed the 1:1 race guard in `updateAmexReconciliation`; sum-vs-total integrity now enforced at sign-off, not confirm time, so partial groups can be linked incrementally.
- `validateAmexLinesForSignoff` blocks finalize when a group sum ≠ receipt total.
- E-ticket OCR regression fix: `parseLabeledTransactionDate` prefers 購入日/利用日/取引日 over 発行日; `maskNonAmountNumbers` strips card last-4 and tax-rate % so 5102 can't outbid ¥4,900; tax skip-keywords narrowed so 税込 totals survive.
- UI: "Refresh matches" button + visibilitychange auto-refresh; consolidated · N pill and detail-pane group explanation.

## Test plan
- [x] `npm test` — 247/247 pass (includes new cases: alias match, consolidated exact-sum/no-subset/date-window/1:1-wins, consolidated signoff blocker, えきねっと extraction regression)
- [x] `npm run build:cf` — clean
- [x] `npm run deploy` — Worker `8522d063` live on dazbeez.com
- [x] `bash scripts/check-deployment.sh https://dazbeez.com` — all endpoints OK
- [ ] Operator smoke: reconcile a real consolidated receipt end-to-end (confirm two lines → finalize the month) against live D1
- [ ] Operator smoke: verify an えきねっと receipt auto-matches without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)