### PR TITLE
fix(receipts/reconcile): sparse PATCH updates + revert for no-receipt lines

### DIFF
--- a/app/api/receipts/amex/lines/[id]/route.ts
+++ b/app/api/receipts/amex/lines/[id]/route.ts
@@ -126,19 +126,33 @@ export async function PATCH(request: Request, { params }: RouteContext) {
         ? body.receiptMissingReason.trim().slice(0, 500) || null
         : body.receiptMissingReason;
 
-    await updateAmexLineCategory(
-      id,
-      {
-        expenseCategory: body.expenseCategory as AmexExpenseCategory | undefined,
-        expenseCategoryCode:
-          body.expenseCategoryCode === undefined ? undefined : expenseCategoryCode,
-        categoryStatus: body.categoryStatus as AmexCategoryStatus | undefined,
-        receiptStatus: body.receiptStatus as AmexReceiptStatus | undefined,
-        receiptMissingReason,
-        businessTripStatus: body.businessTripStatus as AmexBusinessTripStatus | undefined,
-      },
-      actor,
-    );
+    // Build the update input sparsely: only include a key when it was present
+    // in the request body. The DB layer uses `"key" in input` checks for the
+    // nullable fields (expenseCategoryCode, receiptMissingReason) so that an
+    // explicit null clears the column — which means an always-present key with
+    // value undefined would NULL out sibling fields on every save.
+    const updateInput: Parameters<typeof updateAmexLineCategory>[1] = {};
+    if (body.expenseCategory !== undefined) {
+      updateInput.expenseCategory = body.expenseCategory as AmexExpenseCategory;
+    }
+    if ("expenseCategoryCode" in body) {
+      updateInput.expenseCategoryCode = expenseCategoryCode ?? null;
+    }
+    if (body.categoryStatus !== undefined) {
+      updateInput.categoryStatus = body.categoryStatus as AmexCategoryStatus;
+    }
+    if (body.receiptStatus !== undefined) {
+      updateInput.receiptStatus = body.receiptStatus as AmexReceiptStatus;
+    }
+    if ("receiptMissingReason" in body) {
+      updateInput.receiptMissingReason = receiptMissingReason ?? null;
+    }
+    if (body.businessTripStatus !== undefined) {
+      updateInput.businessTripStatus =
+        body.businessTripStatus as AmexBusinessTripStatus;
+    }
+
+    await updateAmexLineCategory(id, updateInput, actor);
 
     return NextResponse.json({ ok: true }, { status: 200 });
   } catch (error) {

--- a/components/receipts/reconcile/reconcile-screen.tsx
+++ b/components/receipts/reconcile/reconcile-screen.tsx
@@ -514,6 +514,7 @@ export function ReconcileScreen(props: ReconcileScreenProps) {
           }
           onUnlink={(line) => reconcile(line.id, null, "unmatched")}
           onNoReceipt={(line) => reconcile(line.id, null, "no_receipt")}
+          onUnmatch={(line) => reconcile(line.id, null, "unmatched")}
           onUpdateCategory={updateCategory}
           onUpdateLineDetails={updateLineDetails}
         />
@@ -922,6 +923,7 @@ function DetailPane({
   onConfirm,
   onUnlink,
   onNoReceipt,
+  onUnmatch,
   onUpdateCategory,
   onUpdateLineDetails,
 }: {
@@ -938,6 +940,7 @@ function DetailPane({
   onConfirm: (line: AmexStatementLine, receiptId: string) => void;
   onUnlink: (line: AmexStatementLine) => void;
   onNoReceipt: (line: AmexStatementLine) => void;
+  onUnmatch: (line: AmexStatementLine) => void;
   onUpdateCategory: (lineId: string, code: string) => void;
   onUpdateLineDetails: (
     lineId: string,
@@ -1120,6 +1123,21 @@ function DetailPane({
               </Btn>
               <span className="text-[11px] text-gray-400">
                 <Kbd>N</Kbd>
+              </span>
+            </>
+          )}
+          {!locked && line.match_status === "no_receipt" && (
+            <>
+              <Btn
+                kind="ghost"
+                size="md"
+                onClick={() => onUnmatch(line)}
+                disabled={busy}
+              >
+                Return to matching pool
+              </Btn>
+              <span className="text-[11px] text-gray-400">
+                <Kbd>U</Kbd>
               </span>
             </>
           )}


### PR DESCRIPTION
## Summary

Follow-up to the reconcile flow (PR #66 is already merged to `master`); these two fixes landed after that merge and ship separately.

### Sparse PATCH updates — `app/api/receipts/amex/lines/[id]/route.ts`
`PATCH /api/receipts/amex/lines/[id]` previously sent the full field set on every save. The DB layer uses `"key" in input` checks for the nullable fields (`expenseCategoryCode`, `receiptMissingReason`) so an explicit `null` clears the column — which meant an always-present key with value `undefined` NULLed sibling fields on every save. Saving a category wiped `receipt_missing_reason`, and vice versa, so edits appeared not to persist. The handler now builds the update input **sparsely**, including a key only when it was present in the request body.

### "Return to matching pool" — `components/receipts/reconcile/reconcile-screen.tsx`
Adds a **Return to matching pool** button (shortcut `U`) in the reconcile detail pane for `no_receipt` lines. Non-destructive revert: it only re-queues the line for matching (`match_status` → `unmatched`); any saved category / `receipt_missing_reason` is preserved.

## Verification
- `npx tsc --noEmit` — clean
- `npm test` — 255/255 pass
- `npm run lint` — both changed files lint clean

## Note on lint
`npm run lint` is currently red on `master` due to a **pre-existing** error in `components/receipts/review/form-pane.tsx` (`react-hooks/preserve-manual-memoization`: `router` is used in the `triggerSave` useCallback but missing from its dep array). It is unrelated to this diff and exists independently of this change. The fix follows in the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
