### PR TITLE
fix(receipts/review): add router to triggerSave useCallback deps

### DIFF
--- a/components/receipts/review/form-pane.tsx
+++ b/components/receipts/review/form-pane.tsx
@@ -228,6 +228,7 @@ export function FormPane(props: FormPaneProps) {
       currency,
       businessPurpose,
       attendees,
+      router,
     ],
   );
 


### PR DESCRIPTION
## Summary
Clears the pre-existing `npm run lint` error on `master`.

`FormPane`'s `triggerSave` useCallback calls `router.refresh()` (to refresh the server-rendered `CompliancePanel` after an autosave) but `router` was missing from the dependency array. The React Compiler therefore could not preserve the manual memoization, producing a `react-hooks/preserve-manual-memoization` **error** that made `npm run lint` red on `master`.

`router` (from `next/navigation`'s `useRouter`) is a stable reference, so adding it to the dep array is behaviorally safe — no extra re-renders or debounce retimings.

## Change
One line: add `router` to the `triggerSave` useCallback dependency array in `components/receipts/review/form-pane.tsx`. Nothing else changed.

## Verification
- `npm run lint` — **0 errors** (exit 0); the form-pane error and its companion `exhaustive-deps` warning are both gone. 6 pre-existing warnings remain (unused-vars in `lib/`, `_deferred` in the extract route, and a `no-head-element` in the untracked `.agents/` skill template) — none introduced by this PR.
- `npx tsc --noEmit` — clean
- `npm test` — 255/255 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
