### PR TITLE
fix(receipts/export): uncategorized tile resolves category via matched receipt

### DIFF
--- a/lib/receipts/blockers.ts
+++ b/lib/receipts/blockers.ts
@@ -12,6 +12,7 @@
 
 import { requiresAttendees } from "@/lib/receipts/categories";
 import { isPendingProcessing } from "@/lib/receipts/extraction-state";
+import { resolveLineCategory } from "@/lib/receipts/line-classification";
 import type { AmexStatementLine, ReceiptRecord } from "@/lib/receipts/types";
 
 export type BlockerSeverity = "blocker" | "warn";
@@ -31,7 +32,18 @@ export function computeExportBlockers(
 ): Blocker[] {
   const blockers: Blocker[] = [];
 
-  const uncategorized = lines.filter((l) => !l.expense_category_code).length;
+  // Category authority is the matched receipt, not the line, for confirmed
+  // matches (resolveLineCategory — the same authority
+  // validateAmexLinesForSignoff / month-closing use). Counting the raw line
+  // field over-reported "uncategorized" whenever a matched receipt already
+  // carried the category, desynchronizing this tile from the finalize gate.
+  const receiptMap = new Map(receipts.map((r) => [r.id, r]));
+  const uncategorized = lines.filter((l) => {
+    const receipt = l.matched_receipt_id
+      ? receiptMap.get(l.matched_receipt_id)
+      : undefined;
+    return !resolveLineCategory(l, receipt);
+  }).length;
   if (uncategorized > 0) {
     blockers.push({
       severity: "blocker",

--- a/tests/receipts/blockers.test.ts
+++ b/tests/receipts/blockers.test.ts
@@ -1,0 +1,149 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { computeExportBlockers, type Blocker } from "@/lib/receipts/blockers";
+import type { AmexStatementLine, ReceiptRecord } from "@/lib/receipts/types";
+
+// Fixture builders mirror tests/receipts/reconciliation-signoff.test.ts so the
+// shapes stay valid against AmexStatementLine / ReceiptRecord.
+
+function makeLine(overrides: Partial<AmexStatementLine> = {}): AmexStatementLine {
+  return {
+    id: "line-1",
+    statement_month: "2026-06",
+    transaction_date: "2026-06-15",
+    posting_date: null,
+    merchant: "TEST MERCHANT",
+    amount_minor: 1000,
+    currency: "JPY",
+    amex_reference: "REF001",
+    matched_receipt_id: null,
+    match_status: "confirmed",
+    raw_json: "{}",
+    created_at: "2026-06-15T00:00:00Z",
+    statement_artifact_id: null,
+    cardholder_name: null,
+    cardholder_flag: null,
+    payment_type: null,
+    prepayment_flag: null,
+    memo: null,
+    raw_csv_line_number: null,
+    source_file_sha256: null,
+    imported_at: null,
+    expense_category: "unknown",
+    category_status: "uncategorized",
+    receipt_status: "matched",
+    receipt_missing_reason: null,
+    business_trip_id: null,
+    business_trip_status: "not_applicable",
+    expense_category_code: null,
+    re_review_needed: 0,
+    updated_at: null,
+    ...overrides,
+  };
+}
+
+function makeReceipt(overrides: Partial<ReceiptRecord> = {}): ReceiptRecord {
+  return {
+    id: "r-1",
+    captured_at: "2026-06-15T10:00:00Z",
+    captured_by: "test",
+    source: "mobile_capture",
+    original_filename: "r.jpg",
+    payment_path: "AMEX",
+    expense_type: "misc",
+    transaction_date: "2026-06-15",
+    merchant: "Test Merchant",
+    amount_minor: 1000,
+    currency: "JPY",
+    tax_amount_minor: null,
+    business_purpose: null,
+    alcohol_present: 0,
+    attendees_required: 0,
+    status: "reviewed",
+    original_r2_key: "receipts/2026/06/r-1/f.jpg",
+    original_sha256: "abc",
+    original_content_type: "image/jpeg",
+    original_size_bytes: 1024,
+    processed_r2_key: null,
+    extraction_json: null,
+    legacy: 0,
+    exported_month: null,
+    expense_category_code: null,
+    deleted_at: null,
+    deleted_by: null,
+    delete_reason: null,
+    created_at: "2026-06-15T10:00:00Z",
+    updated_at: "2026-06-15T10:00:00Z",
+    ...overrides,
+  };
+}
+
+function uncategorizedCount(blockers: Blocker[]): number {
+  const b = blockers.find((x) => x.label === "Uncategorized AMEX lines");
+  return b ? b.count : 0;
+}
+
+test("blockers: matched line with category only on the receipt is NOT uncategorized", () => {
+  // The exact false-positive the fix targets: the line's own category is null
+  // (and the reconcile UI hides the dropdown for matched lines, so the operator
+  // can't set it anyway), but the matched receipt carries the category. The
+  // finalize gate (resolveLineCategory) accepts this; the tile must too.
+  const line = makeLine({
+    matched_receipt_id: "r-1",
+    match_status: "confirmed",
+    receipt_status: "matched",
+    expense_category_code: null,
+  });
+  const receipt = makeReceipt({ id: "r-1", expense_category_code: "office_supplies" });
+
+  const blockers = computeExportBlockers([receipt], [line]);
+  assert.equal(
+    uncategorizedCount(blockers),
+    0,
+    `expected 0 uncategorized, got: ${JSON.stringify(blockers)}`,
+  );
+});
+
+test("blockers: matched line where receipt ALSO lacks a category IS uncategorized", () => {
+  // Both null → genuinely unresolved. Don't let the fix swing too far the other
+  // way and hide real gaps.
+  const line = makeLine({
+    matched_receipt_id: "r-1",
+    match_status: "confirmed",
+    receipt_status: "matched",
+    expense_category_code: null,
+  });
+  const receipt = makeReceipt({ id: "r-1", expense_category_code: null });
+
+  const blockers = computeExportBlockers([receipt], [line]);
+  assert.equal(uncategorizedCount(blockers), 1);
+});
+
+test("blockers: unmatched no-receipt line with no category IS uncategorized", () => {
+  // No matched receipt → authority is the line's own (null) category.
+  const line = makeLine({
+    matched_receipt_id: null,
+    match_status: "no_receipt",
+    receipt_status: "no_receipt_required",
+    receipt_missing_reason: "lost",
+    expense_category_code: null,
+  });
+
+  const blockers = computeExportBlockers([], [line]);
+  assert.equal(uncategorizedCount(blockers), 1);
+});
+
+test("blockers: dangling match (receipt id set but receipt absent) falls back to line category", () => {
+  // matched_receipt_id points at a receipt not in the bundle (deleted
+  // out-of-band). resolveLineCategory falls back to the line's own category,
+  // matching the finalize gate — not uncategorized here.
+  const line = makeLine({
+    matched_receipt_id: "r-gone",
+    match_status: "confirmed",
+    receipt_status: "matched",
+    expense_category_code: "office_supplies",
+  });
+
+  const blockers = computeExportBlockers([], [line]);
+  assert.equal(uncategorizedCount(blockers), 0);
+});


### PR DESCRIPTION
## Summary
The export screen's **Uncategorized AMEX lines** tile over-counted: `computeExportBlockers` read the raw line `expense_category_code`, so any **confirmed match whose category lives on the receipt** (the line dropdown is hidden in the reconcile UI for matched lines, so the operator can't set it) showed as a false blocker. That desynchronized the presentation tile from the actual finalize gate (`validateAmexLinesForSignoff`), which already resolves category via the receipt.

### Fix (`lib/receipts/blockers.ts`)
Build a `receiptMap` from the `receipts[]` the function already receives and count uncategorized as lines where `resolveLineCategory(line, receipt)` is falsy — the same authority the finalize gate and `month-closing.ts` use. The tile now agrees with the gate.

### `attendeesMissing` — intentionally unchanged
It is scoped to `!matched_receipt_id` (unmatched lines only). For every line it considers there is no matched receipt whose category could be authoritative, so `resolveLineCategory(l, undefined) === l.expense_category_code` — resolving would be a no-op. No raw-field problem there.

## Tests (`tests/receipts/blockers.test.ts`)
- matched line with category **only on the receipt** → NOT uncategorized ✅ (the regression)
- matched line where receipt **also** lacks a category → still uncategorized (fix doesn't over-correct)
- unmatched no-receipt line with no category → uncategorized
- dangling match (receipt id set but receipt absent) → falls back to line category

## Verification
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (6 pre-existing warnings, unchanged)
- `npm test` — 259/259 pass (+4 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
