### PR TITLE
chore: ignore d1-backup-*.sql (local prod D1 backups)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ venv/
 
 # legacy local contact form artifacts
 /data/
+
+# D1 database backups (local only — never commit prod financial data)
+d1-backup-*.sql


### PR DESCRIPTION
## Summary
`wrangler d1 export` writes `d1-backup-*.sql` to the repo root. A multi-MB dump of **prod financial data** shouldn't sit one `git add -A` away from a commit. This ignores the pattern so backups stay local-only.

Operators should park backups outside the repo tree (e.g. `~/backups/dazbeez/`) — the ignore is a safety net, not an invitation to keep them in-tree.

## Verification
`git check-ignore -v d1-backup-20260712-1936.sql` → `.gitignore:60:d1-backup-*.sql` (rule matches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
