### PR TITLE
fix(receipts/export): persist staged bundle on rebuild + bundle_built_at

### DIFF
--- a/app/api/receipts/export/month/route.ts
+++ b/app/api/receipts/export/month/route.ts
@@ -5,6 +5,7 @@ import {
   finalizeExport,
   getExport,
   getFinalizedReconciliationForMonth,
+  recordExportBundle,
   replaceExportItems,
 } from "@/lib/receipts/db";
 import {
@@ -215,7 +216,13 @@ export async function POST(request: Request) {
       },
     );
 
-    // Auto-finalize if requested
+    // Persist the staged bundle, then finalize if requested. On the rebuild
+    // path (finalize=false) recordExportBundle is the only row write — it
+    // stores the R2 keys + SHAs + bundle_built_at so the finalize-only route
+    // (/api/receipts/export/[month]) finds them present and "Last draft built"
+    // advances on every rebuild. On the finalize path finalizeExport calls
+    // recordExportBundle internally, so we do NOT call it here again (that
+    // would double-write the bundle columns).
     let finalizeWarnings: string[] = [];
     if (body.finalize) {
       await finalizeExport(
@@ -230,6 +237,14 @@ export async function POST(request: Request) {
       // open. Surfaced in the finalize response so the operator's toast on
       // "Finalize succeeded" can also say "but March is still open."
       finalizeWarnings = await computeEarlierOpenMonthWarnings(month);
+    } else {
+      await recordExportBundle(
+        exportId,
+        archiveKey,
+        manifestKey,
+        sha256,
+        manifestSha256,
+      );
     }
 
     return NextResponse.json(

--- a/components/receipts/export/export-screen.tsx
+++ b/components/receipts/export/export-screen.tsx
@@ -132,7 +132,11 @@ export function ExportScreen(props: ExportScreenProps) {
       <TopBar
         monthLabel={props.monthLabel}
         finalized={finalized}
-        builtAt={props.currentExport?.created_at ?? null}
+        builtAt={
+          props.currentExport?.bundle_built_at ??
+          props.currentExport?.created_at ??
+          null
+        }
         onRebuild={rebuildDraft}
         busy={busy === "build"}
       />

--- a/db/receipts/0019_export_bundle_built_at.sql
+++ b/db/receipts/0019_export_bundle_built_at.sql
@@ -1,0 +1,16 @@
+-- 0019_export_bundle_built_at.sql
+--
+-- Record when an export draft's bundle was last (re)built in R2.
+--
+-- Why: the export screen's "Last draft built" timestamp was sourced from
+-- receipt_exports.created_at, which is set once at row creation and never
+-- updated — createExport() returns the existing draft's id without any
+-- UPDATE on rebuild. So every "Rebuild draft" click left the displayed
+-- timestamp frozen at first creation, making a successful rebuild look like
+-- a no-op (the bundle WAS re-staged in R2 and items replaced, but nothing
+-- on the row advanced). bundle_built_at is written by recordExportBundle()
+-- on every rebuild, giving the UI a value that actually moves.
+--
+-- Additive only — nullable, no backfill. Pre-existing draft rows read as
+-- NULL and the UI falls back to created_at (see export-screen.tsx TopBar).
+ALTER TABLE receipt_exports ADD COLUMN bundle_built_at TEXT;

--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -1797,6 +1797,44 @@ export async function listExportsContainingReceipt(
   return (result.results ?? []).map((r) => r.export_id);
 }
 
+/**
+ * Persist the staged-bundle metadata onto a draft row: the R2 keys, the
+ * archive + manifest SHA-256s, and bundle_built_at (when the bundle was
+ * last (re)built). Shared between the rebuild path (POST
+ * /api/receipts/export/month with finalize=false) and finalizeExport so a
+ * draft built via the rebuild route carries the same persisted fields the
+ * finalize-only route (/api/receipts/export/[month]) checks before
+ * finalizing — without it, Rebuild→Finalize always 400s with
+ * "Export bundle has not been generated yet."
+ *
+ * Guarded on status='draft' so a finalized row is left untouched, matching
+ * finalizeExport's own guard (callers already reject finalized months with a
+ * 409 before reaching here). This also keeps the no-op-on-finalized behavior
+ * intact: if the row is already finalized, nothing is written.
+ */
+export async function recordExportBundle(
+  exportId: string,
+  archiveR2Key: string,
+  manifestR2Key: string,
+  archiveSha256: string,
+  manifestSha256?: string,
+): Promise<void> {
+  const db = getReceiptsDb();
+  const now = nowIso();
+  await db
+    .prepare(
+      `UPDATE receipt_exports
+       SET archive_r2_key = ?,
+           manifest_r2_key = ?,
+           archive_sha256 = ?,
+           manifest_sha256 = ?,
+           bundle_built_at = ?
+       WHERE id = ? AND status = 'draft'`,
+    )
+    .bind(archiveR2Key, manifestR2Key, archiveSha256, manifestSha256 ?? null, now, exportId)
+    .run();
+}
+
 export async function finalizeExport(
   exportId: string,
   archiveR2Key: string,
@@ -1808,29 +1846,30 @@ export async function finalizeExport(
   const db = getReceiptsDb();
   const now = nowIso();
 
+  // Record the staged bundle (R2 keys + SHAs + bundle_built_at) via the
+  // shared helper so the finalize:true path leaves the same persisted bundle
+  // metadata as the rebuild path. The UPDATE below flips only the
+  // finalize-specific fields — each column is written exactly once (no
+  // double-write) and the end-state is identical to the pre-refactor single
+  // UPDATE, plus the new bundle_built_at column.
+  await recordExportBundle(
+    exportId,
+    archiveR2Key,
+    manifestR2Key,
+    archiveSha256,
+    manifestSha256,
+  );
+
   const result = await db
     .prepare(
       `UPDATE receipt_exports
        SET status = 'finalized',
-           archive_r2_key = ?,
-           manifest_r2_key = ?,
-           archive_sha256 = ?,
-           manifest_sha256 = ?,
            finalization_hash = ?,
            finalized_by = ?,
            finalized_at = ?
        WHERE id = ? AND status = 'draft'`,
     )
-    .bind(
-      archiveR2Key,
-      manifestR2Key,
-      archiveSha256,
-      manifestSha256 ?? null,
-      manifestSha256 ?? archiveSha256,
-      actor,
-      now,
-      exportId,
-    )
+    .bind(manifestSha256 ?? archiveSha256, actor, now, exportId)
     .run();
 
   if ((result.meta.changes ?? 0) === 0) {

--- a/lib/receipts/types.ts
+++ b/lib/receipts/types.ts
@@ -387,6 +387,9 @@ export interface ReceiptExport {
   finalized_by?: string | null;
   finalization_hash?: string | null;
   manifest_sha256?: string | null;
+  // When the draft's bundle was last (re)built in R2 (0019). NULL on rows
+  // predating 0019; the UI falls back to created_at.
+  bundle_built_at?: string | null;
 }
 
 /**


### PR DESCRIPTION
## Problem

On `/receipts/export?month=2026-06`, **Rebuild draft** appeared to do nothing: "Last draft built" stayed frozen at first-creation time, no error banner, hard refresh unchanged. Root cause (investigated read-only against prod D1):

- The rebuild path (`POST /api/receipts/export/month`, `finalize=false`) staged the CSV/manifest in R2 and replaced `receipt_export_items` but **never wrote `archive_r2_key`/`manifest_r2_key`/`archive_sha256`/`manifest_sha256` back to the `receipt_exports` draft row**. The only `UPDATE receipt_exports` in the codebase was inside `finalizeExport`, which runs solely on the `finalize:true` path.
- "Last draft built" was sourced from `created_at`, which `createExport()` never updates for an existing draft (it `SELECT`s the draft and returns its id early — no UPDATE). So the timestamp froze at first creation (10:25:33) even though rebuilds succeeded (items re-stamped 10:53:34, HTTP 200).
- The finalize-only route (`/api/receipts/export/[month]`) checks `archive_r2_key`/`archive_sha256` and **400s when NULL** → Rebuild→Finalize via the UI was structurally broken.

Not a caching issue (`force-dynamic` + D1 binding reads). Not a unique-index collision (`createExport` reuses the existing draft, never INSERTs a second).

## Fix

1. **Migration 0019** — `ALTER TABLE receipt_exports ADD COLUMN bundle_built_at TEXT;` (nullable, no backfill).
2. **`recordExportBundle()`** extracted from the shared part of `finalizeExport` — UPDATEs `archive_r2_key`, `manifest_r2_key`, `archive_sha256`, `manifest_sha256`, `bundle_built_at` on the draft row (guarded `WHERE id=? AND status='draft'`).
3. **`/api/receipts/export/month`** calls it on the rebuild (`finalize:false`) path after R2 uploads. `finalizeExport` calls the helper internally then a focused UPDATE for finalize-specific fields — each column written once (no double-write); the rebuild path does **not** call it when finalizing. End-state identical to before, plus `bundle_built_at`.
4. **"Last draft built"** sourced from `bundle_built_at ?? created_at` (falls back to `created_at` for rows predating 0019).

## Result

- Rebuild visibly advances the "Last draft built" timestamp.
- The `[month]` finalize route's `archive_r2_key`/`archive_sha256` check passes after any rebuild.

A separate PR will address the tile-vs-gate drift on uncategorized lines (the "27 blockers" are phantom at the gate — cross-month matched receipts) and surface `payment_path=UNKNOWN` receipts in the tile.

## Verification

- `tsc --noEmit` ✅
- `npm run lint` ✅ (0 errors; 6 pre-existing warnings unrelated)
- `npm run test` ✅ (259 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)