### PR TITLE
fix(receipts/export): unscoped matched receipts in blockers tile + UNKNOWN path

### DIFF
--- a/app/(receipt-system)/receipts/export/page.tsx
+++ b/app/(receipt-system)/receipts/export/page.tsx
@@ -83,7 +83,15 @@ export default async function ExportPage({
       getExport(month),
     ]);
 
-  const blockers = computeExportBlockers(monthReceipts, monthLines);
+  // bundle.receipts is the ID-fetched matched-receipt set (unscoped by month)
+  // plus in-month CASH/DIGITAL receipts — the same authority the finalize
+  // gate (validateMonthReadyForExport) builds its receiptMap from. Passing it
+  // lets computeExportBlockers resolve a line matched to a receipt dated in a
+  // different statement month, eliminating the tile-vs-gate drift where the
+  // tile over-reported "uncategorized" lines the gate accepted (2026-06's 27
+  // were all matched to April/May receipts). monthReceipts (month-scoped) still
+  // drives the pending / unreviewed / unknown counts.
+  const blockers = computeExportBlockers(monthReceipts, monthLines, bundle.receipts);
   const warnings = computeExportWarnings(monthLines);
 
   const draftStats = computeDraftStats(bundle.rows);

--- a/lib/receipts/blockers.ts
+++ b/lib/receipts/blockers.ts
@@ -29,6 +29,15 @@ export type Blocker = {
 export function computeExportBlockers(
   receipts: ReceiptRecord[],
   lines: AmexStatementLine[],
+  // Receipts fetched by matched_receipt_id, unscoped by month (a line may be
+  // matched to a receipt dated in a different statement month). Used ONLY for
+  // category resolution: unioned into the receipt map so a cross-month matched
+  // receipt's category resolves the line — matching the finalize gate, which
+  // builds its receiptMap from bundle.receipts (the same ID-fetched set).
+  // `receipts` (month-scoped) still drives the pending / unreviewed / unknown
+  // counts below. Kept pure: callers do the DB fetch (listReceiptRecordsByIds
+  // or reuse bundle.receipts); this function does no I/O.
+  matchedReceipts: ReceiptRecord[] = [],
 ): Blocker[] {
   const blockers: Blocker[] = [];
 
@@ -37,7 +46,12 @@ export function computeExportBlockers(
   // validateAmexLinesForSignoff / month-closing use). Counting the raw line
   // field over-reported "uncategorized" whenever a matched receipt already
   // carried the category, desynchronizing this tile from the finalize gate.
-  const receiptMap = new Map(receipts.map((r) => [r.id, r]));
+  // The map unions the month-scoped receipts with the ID-fetched matched
+  // receipts so cross-month matches resolve (the fix for the 2026-06 "27
+  // uncategorized" that were all matched to April/May receipts).
+  const receiptMap = new Map<string, ReceiptRecord>();
+  for (const r of receipts) receiptMap.set(r.id, r);
+  for (const r of matchedReceipts) receiptMap.set(r.id, r);
   const uncategorized = lines.filter((l) => {
     const receipt = l.matched_receipt_id
       ? receiptMap.get(l.matched_receipt_id)
@@ -52,6 +66,24 @@ export function computeExportBlockers(
       detail: "Pick an expense category for each line.",
       href: "/receipts/reconcile",
       ctaLabel: "Fix in Reconcile",
+    });
+  }
+
+  // payment_path='UNKNOWN' receipts are excluded from the export bundle by
+  // design (their export month is ambiguous) and block finalize at
+  // validateMonthReadyForExport gate 2. Surface them here so the tile and the
+  // gate agree in this direction too — previously a month could read "clear"
+  // on the tile yet 422 on finalize. `receipts` is month-scoped, matching the
+  // gate's `transaction_date LIKE month%` filter.
+  const unknownPath = receipts.filter((r) => r.payment_path === "UNKNOWN").length;
+  if (unknownPath > 0) {
+    blockers.push({
+      severity: "blocker",
+      count: unknownPath,
+      label: "Receipts with unknown payment path",
+      detail: "Classify as AMEX, CASH, or DIGITAL before sealing.",
+      href: "/receipts/review",
+      ctaLabel: "Fix in Review",
     });
   }
 

--- a/tests/receipts/blockers.test.ts
+++ b/tests/receipts/blockers.test.ts
@@ -147,3 +147,53 @@ test("blockers: dangling match (receipt id set but receipt absent) falls back to
   const blockers = computeExportBlockers([], [line]);
   assert.equal(uncategorizedCount(blockers), 0);
 });
+
+test("blockers: line matched to a receipt dated a DIFFERENT month resolves via matchedReceipts", () => {
+  // The 2026-06 bug: the matched receipt is dated 2026-04, so it is absent
+  // from the month-scoped `receipts` set the page used to pass alone. With the
+  // matchedReceipts param (the ID-fetched set the finalize gate uses), the
+  // line's category resolves from the receipt and is NOT uncategorized.
+  const line = makeLine({
+    matched_receipt_id: "r-apr",
+    match_status: "confirmed",
+    receipt_status: "matched",
+    expense_category_code: null,
+  });
+  // The matched receipt is NOT in the month-scoped receipts array...
+  const monthReceipts: ReceiptRecord[] = [];
+  // ...but IS supplied via matchedReceipts, carrying a category.
+  const matchedReceipts = [
+    makeReceipt({
+      id: "r-apr",
+      transaction_date: "2026-04-20",
+      expense_category_code: "office_supplies",
+    }),
+  ];
+
+  const blockers = computeExportBlockers(monthReceipts, [line], matchedReceipts);
+  assert.equal(
+    uncategorizedCount(blockers),
+    0,
+    `expected 0 uncategorized with matchedReceipts, got: ${JSON.stringify(blockers)}`,
+  );
+
+  // Contrast: without matchedReceipts the same line IS uncategorized — the
+  // param is what resolves it.
+  const withoutFix = computeExportBlockers(monthReceipts, [line]);
+  assert.equal(uncategorizedCount(withoutFix), 1);
+});
+
+test("blockers: receipt with unknown payment path is reported (finalize gate 2)", () => {
+  // The finalize gate blocks on payment_path='UNKNOWN' (the receipt is
+  // excluded from the bundle because its export month is ambiguous). The tile
+  // must surface the same blocker so a month can't read "clear" yet 422 on
+  // finalize.
+  const receipt = makeReceipt({ id: "r-unk", payment_path: "UNKNOWN" });
+
+  const blockers = computeExportBlockers([receipt], []);
+  const unknown = blockers.find(
+    (b) => b.label === "Receipts with unknown payment path",
+  );
+  assert.ok(unknown, `expected an unknown-payment-path blocker, got: ${JSON.stringify(blockers)}`);
+  assert.equal(unknown!.count, 1);
+});


### PR DESCRIPTION
## Problem

The export blocker **tile** and the finalize **gate** disagreed on uncategorized lines (tile-vs-gate drift):

- `computeExportBlockers` built its category-resolution `receiptMap` from the **month-scoped** `listReceiptRecords({month})` the page passed. A line matched to a receipt dated in a *different* statement month (e.g. a 2026-06 line matched to an April receipt) found no receipt in the map → counted as uncategorized.
- The finalize gate (`validateMonthReadyForExport`) fetches matched receipts **by ID** (`listReceiptRecordsByIds`, unscoped) and resolves them → 0 uncategorized.

For 2026-06 this showed as **27 "uncategorized" lines** in the tile that the gate accepted — all 27 were matched to receipts dated 2026-04 (17) and 2026-05 (10). Also, the tile never reported `payment_path='UNKNOWN'` receipts, which **do** block finalize at gate 2 — so a month could read "clear" on the tile yet 422 on finalize.

## Fix

1. **`computeExportBlockers` gains a `matchedReceipts` param** (pure — no DB; default `[]` for backward compat). The category-resolution map unions the month-scoped `receipts` with `matchedReceipts` so cross-month matches resolve. `receipts` (month-scoped) still drives the pending / unreviewed / unknown counts.
2. **Call site (`page.tsx`)** passes `bundle.receipts` — the ID-fetched matched-receipt set the gate already builds its `receiptMap` from (month-closing.ts:284). No extra DB round-trip; the tile's category resolution now matches the gate's.
3. **`payment_path='UNKNOWN'` receipts** are now a blocker entry in the tile, matching gate 2 (`receipts` is month-scoped, matching the gate's `transaction_date LIKE month%`).

## Result

Tile and gate agree in both directions: cross-month matched lines no longer over-report as uncategorized, and UNKNOWN-path receipts surface before finalize.

## Verification

- `tsc --noEmit` ✅
- `npm run lint` ✅ (0 errors; 6 pre-existing warnings unrelated)
- `npm run test` ✅ (261 pass, +2: cross-month matched receipt resolves; UNKNOWN path → blocker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)