### PR TITLE
fix(receipts/export): deep-link review blockers + gate review-status check

### DIFF
--- a/app/(receipt-system)/receipts/review/page.tsx
+++ b/app/(receipt-system)/receipts/review/page.tsx
@@ -38,9 +38,17 @@ async function renderReviewPage(
 
   const params = await searchParams;
   const filter = String(params.filter ?? "");
+  // Deep-link filters from export blocker hrefs (e.g.
+  // /receipts/review?status=needs_review, ?payment_path=UNKNOWN). Applied in
+  // JS on top of the existing `filter` view param so the page's metrics
+  // (capturedThisMonth, ocrHealth) still reflect the full fetched set.
+  const statusFilter =
+    typeof params.status === "string" ? params.status : undefined;
+  const paymentPathFilter =
+    typeof params.payment_path === "string" ? params.payment_path : undefined;
 
   const receipts = await listReceiptRecords({ limit: 200 });
-  const queue = filterQueue(receipts, filter);
+  const queue = filterQueue(receipts, filter, statusFilter, paymentPathFilter);
   const amexFlags = await getAmexMatchFlagsByReceiptIds(queue.map((r) => r.id));
   const reReviewIds = new Set(
     [...amexFlags.entries()]
@@ -111,21 +119,36 @@ async function renderReviewPage(
   );
 }
 
-function filterQueue(receipts: ReceiptRecord[], filter: string) {
+function filterQueue(
+  receipts: ReceiptRecord[],
+  filter: string,
+  statusFilter?: string,
+  paymentPathFilter?: string,
+) {
+  // Deep-link filters (status / payment_path) narrow the set first; the
+  // existing `filter` view param (reviewed / needs / attendees / purpose) is
+  // then applied on top.
+  let queue = receipts;
+  if (statusFilter) {
+    queue = queue.filter((r) => r.status === statusFilter);
+  }
+  if (paymentPathFilter) {
+    queue = queue.filter((r) => r.payment_path === paymentPathFilter);
+  }
   if (filter === "reviewed") {
-    return receipts.filter((r) => r.status === "reviewed");
+    return queue.filter((r) => r.status === "reviewed");
   }
   if (filter === "needs") {
-    return receipts.filter(
+    return queue.filter(
       (r) => r.status === "needs_review" || r.status === "captured",
     );
   }
   if (filter === "attendees" || filter === "purpose") {
-    return receipts.filter(
+    return queue.filter(
       (r) =>
         (r.status === "needs_review" || r.status === "captured") &&
         !r.business_purpose,
     );
   }
-  return receipts;
+  return queue;
 }

--- a/lib/receipts/blockers.ts
+++ b/lib/receipts/blockers.ts
@@ -82,7 +82,7 @@ export function computeExportBlockers(
       count: unknownPath,
       label: "Receipts with unknown payment path",
       detail: "Classify as AMEX, CASH, or DIGITAL before sealing.",
-      href: "/receipts/review",
+      href: "/receipts/review?payment_path=UNKNOWN",
       ctaLabel: "Fix in Review",
     });
   }
@@ -113,7 +113,7 @@ export function computeExportBlockers(
       count: unreviewed,
       label: "Unreviewed receipts",
       detail: "These receipts must be reviewed before sealing.",
-      href: "/receipts/review",
+      href: "/receipts/review?status=needs_review",
       ctaLabel: "Fix in Review",
     });
   }

--- a/lib/receipts/month-closing.ts
+++ b/lib/receipts/month-closing.ts
@@ -18,6 +18,7 @@ import type {
   ReceiptRecord,
 } from "@/lib/receipts/types";
 import { validateAmexLinesForSignoff } from "@/lib/receipts/reconciliation-signoff";
+import { isPendingProcessing } from "@/lib/receipts/extraction-state";
 
 /**
  * Single source of truth for "what ships in this month's export bundle".
@@ -258,6 +259,38 @@ export async function validateMonthReadyForExport(
     const label = row.merchant ?? row.id;
     blockers.push(
       `Receipt ${label}: payment_path is UNKNOWN — classify as AMEX, CASH, or DIGITAL before export`,
+    );
+  }
+
+  // (2.5) Unreviewed-receipt gate. Mirrors computeExportBlockers' "Unreviewed
+  // receipts" tile (status='needs_review' in-month, excluding pending
+  // processing) so the tile's BLOCKER label is enforced at finalize —
+  // previously the tile reported unreviewed receipts as blockers but the gate
+  // never checked review status, so a month could read "blocked" on the tile
+  // yet finalize successfully (reverse tile-vs-gate drift).
+  //
+  // Direct month-scoped query, NOT bundle.receipts: the tile counts receipts by
+  // transaction_date in the statement month (all payment paths), while
+  // bundle.receipts excludes in-month AMEX (validated via lines) and UNKNOWN
+  // (excluded above) and includes cross-month matched receipts. Iterating the
+  // bundle here would read a different set than the tile and re-open the drift.
+  const unreviewedResult = await db
+    .prepare(
+      `SELECT * FROM receipt_records
+       WHERE deleted_at IS NULL
+         AND status = 'needs_review'
+         AND transaction_date LIKE ?`,
+    )
+    .bind(`${month}%`)
+    .all<ReceiptRecord>();
+  for (const r of unreviewedResult.results ?? []) {
+    // Same exclusion the tile applies: a needs_review receipt still in the
+    // extraction queue is "pending processing", not "unreviewed" — it's
+    // surfaced separately and fixed by draining the queue, not by reviewing.
+    if (isPendingProcessing(r)) continue;
+    const label = r.merchant ?? r.id;
+    blockers.push(
+      `Receipt ${label}: unreviewed (status='needs_review') — mark reviewed before exporting`,
     );
   }
 

--- a/tests/receipts/blockers.test.ts
+++ b/tests/receipts/blockers.test.ts
@@ -197,3 +197,36 @@ test("blockers: receipt with unknown payment path is reported (finalize gate 2)"
   assert.ok(unknown, `expected an unknown-payment-path blocker, got: ${JSON.stringify(blockers)}`);
   assert.equal(unknown!.count, 1);
 });
+
+test("blockers: needs_review receipt (not pending) is an unreviewed blocker with a status deep-link", () => {
+  // The finalize gate now mirrors this (validateMonthReadyForExport gate 2.5),
+  // so the tile's BLOCKER label is true. The href deep-links into a
+  // status-filtered Review view.
+  const receipt = makeReceipt({ id: "r-needs", status: "needs_review" });
+
+  const blockers = computeExportBlockers([receipt], []);
+  const unreviewed = blockers.find((b) => b.label === "Unreviewed receipts");
+  assert.ok(unreviewed, `expected an unreviewed blocker, got: ${JSON.stringify(blockers)}`);
+  assert.equal(unreviewed!.count, 1);
+  assert.equal(unreviewed!.href, "/receipts/review?status=needs_review");
+});
+
+test("blockers: needs_review receipt still pending processing is NOT unreviewed", () => {
+  // isPendingProcessing wins: a needs_review receipt still in the extraction
+  // queue is surfaced as "pending processing", not "unreviewed" — the fix is
+  // to drain the queue, not to review. The finalize gate mirrors this
+  // exclusion (gate 2.5 skips isPendingProcessing rows).
+  const receipt = makeReceipt({
+    id: "r-pending",
+    status: "needs_review",
+    extraction_state: "queued",
+  });
+
+  const blockers = computeExportBlockers([receipt], []);
+  const unreviewed = blockers.find((b) => b.label === "Unreviewed receipts");
+  assert.equal(
+    unreviewed ?? null,
+    null,
+    `expected no unreviewed blocker for a pending receipt, got: ${JSON.stringify(blockers)}`,
+  );
+});


### PR DESCRIPTION
## Problem

The **"Unreviewed receipts"** tile blocker was a *false* blocker — `computeExportBlockers` reported `needs_review` receipts as blockers, but `validateMonthReadyForExport` (the finalize gate) **never checked review status**. A month could read "blocked" on the tile yet finalize successfully — the reverse of the drift PR #72 closed for categories.

Investigation (read-only, prod D1) also confirmed the data-feed asymmetry: the tile's unreviewed count is month-scoped (`transaction_date LIKE month%`, all payment paths), while the gate's existing receipt-level checks operate on `bundle.receipts` (excludes in-month AMEX + UNKNOWN, includes cross-month matched) — a different set.

## Fix

1. **Gate (gate 2.5)** — add a review-status check to `validateMonthReadyForExport`, mirroring the tile's unreviewed filter **exactly**: direct month-scoped query for `status='needs_review'` (all payment paths), excluding `isPendingProcessing`. Direct query (not `bundle.receipts`) so the gate reads the *same set* the tile counts — iterating the bundle would re-open the drift. Now the tile's BLOCKER label is true.
2. **Deep links** — "Unreviewed receipts" → `/receipts/review?status=needs_review`; "Receipts with unknown payment path" → `/receipts/review?payment_path=UNKNOWN`. The review list page gains `status` / `payment_path` query-param filtering (JS-level via `filterQueue`, preserving the page's full-set metrics like `capturedThisMonth`/`ocrHealth`).
3. **Tests** — needs_review receipt → unreviewed blocker with the status deep-link; pending `needs_review` → excluded (mirrors the gate's `isPendingProcessing` skip).

## Note on gate test coverage

`month-closing.ts` has no test harness — `validateMonthReadyForExport` calls `getReceiptsDb()` directly plus `buildExportBundle`/compliance/etc., so it isn't DI-friendly like `month-lock.ts` (which has a FakeD1). The new gate check itself isn't unit-tested; it mirrors the tile's exact filter (same `isPendingProcessing`, same month-scope) and the existing untested gate-2 (UNKNOWN) pattern. Structural consistency (tile ≡ gate) is the guarantee; the tile side is covered by the new blockers tests.

## Verification

- `tsc --noEmit` ✅
- `npm run lint` ✅ (0 errors; 6 pre-existing warnings unrelated)
- `npm run test` ✅ (263 pass, +2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)