### PR TITLE
feat(receipts): add invoice_registration_number to reconciliation manifest

### DIFF
--- a/lib/receipts/reconciliation-signoff.ts
+++ b/lib/receipts/reconciliation-signoff.ts
@@ -31,6 +31,7 @@ const MANIFEST_HEADERS = [
   "business_trip_status",
   "business_trip_id",
   "re_review_needed",
+  "invoice_registration_number",
 ];
 
 export function buildReconciliationManifestCsv(
@@ -80,6 +81,9 @@ export function buildReconciliationManifestCsv(
         csvEscape(line.business_trip_status),
         csvEscape(line.business_trip_id),
         csvEscape(String(line.re_review_needed)),
+        // 適格請求書 registration number (T-number) from the linked receipt;
+        // empty when no receipt is linked or the receipt carries none.
+        csvEscape(receipt?.invoice_registration_number),
       ].join(","),
     );
   }

--- a/tests/receipts/manifest-csv.test.ts
+++ b/tests/receipts/manifest-csv.test.ts
@@ -174,3 +174,36 @@ test("manifest CSV: category column uses line value when no receipt linked", () 
   const dataCols = csvLines[1]!.split(",");
   assert.equal(dataCols[catIdx], "office_supplies");
 });
+
+test("manifest CSV: invoice_registration_number comes from the linked receipt", () => {
+  const lines = [makeLine()];
+  const receipts = [
+    makeReceipt({ invoice_registration_number: "T1234567890123" }),
+  ];
+
+  const csv = buildReconciliationManifestCsv(lines, receipts, {}, {});
+  const csvLines = csv.split("\n");
+  const headers = csvLines[0]!.split(",");
+  const idx = headers.indexOf("invoice_registration_number");
+  assert.ok(idx >= 0, "missing invoice_registration_number header");
+  const dataCols = csvLines[1]!.split(",");
+  assert.equal(dataCols[idx], "T1234567890123");
+});
+
+test("manifest CSV: invoice_registration_number empty when no receipt linked", () => {
+  const lines = [
+    makeLine({
+      matched_receipt_id: null,
+      match_status: "no_receipt",
+      receipt_status: "no_receipt_required",
+      receipt_missing_reason: "lost",
+    }),
+  ];
+  const csv = buildReconciliationManifestCsv(lines, [], {}, {});
+  const csvLines = csv.split("\n");
+  const headers = csvLines[0]!.split(",");
+  const idx = headers.indexOf("invoice_registration_number");
+  assert.ok(idx >= 0, "missing invoice_registration_number header");
+  const dataCols = csvLines[1]!.split(",");
+  assert.equal(dataCols[idx], "");
+});


### PR DESCRIPTION
## What

Append `invoice_registration_number` as the final column of the AMEX **reconciliation manifest** CSV (`buildReconciliationManifestCsv` in `lib/receipts/reconciliation-signoff.ts`), sourced from the linked receipt's `invoice_registration_number` (適格請求書 T-number). Empty when no receipt is linked or the receipt carries none.

**Column only — no validation, no blocker, no warning.** Append-only placement preserves existing column indices.

## Why

The T-number is captured on the receipt (Extraction already pulls it) but not surfaced on the per-line reconciliation manifest that ships to accounting. Adding it as a manifest column makes the registration number available alongside each line for the accountant, with zero gating.

## Scope notes

- **`receipt_export_items` / manifest sha flows untouched.** The column changes manifest *content*, which regenerates automatically on the next reconciliation signoff; the export manifest references the reconciliation manifest by sha + r2 key (not by parsing content). Already-finalized reconciliations (e.g. 2026-06) keep their immutable stored manifest — the new column appears on future signoffs.
- **Export screen "manifest preview" intentionally not touched.** It renders a simplified preview of the **export bundle** CSV (`receipts-{month}.csv`) — a different schema from this reconciliation manifest — so adding this column there would misrepresent the bundle CSV. Happy to add it to the bundle CSV too if that's wanted, as a separate change.

## Verification

- `tsc --noEmit` ✅
- `npm run lint` ✅ (0 errors; 6 pre-existing warnings unrelated)
- `npm run test` ✅ (265 pass, +2: invoice_registration_number from linked receipt; empty when no receipt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)