### PR TITLE
feat(receipts/export): add invoice_registration_number to manifest preview

### DIFF
--- a/app/(receipt-system)/receipts/export/page.tsx
+++ b/app/(receipt-system)/receipts/export/page.tsx
@@ -14,8 +14,8 @@ import { assertReceiptsPageAccess } from "@/lib/receipts/auth-request";
 import {
   ExportScreen,
   type CategoryBreakdownRow,
-  type ManifestSampleRow,
 } from "@/components/receipts/export/export-screen";
+import type { ManifestSampleRow } from "@/lib/receipts/manifest-preview";
 import { MonthSwitcher, type MonthOption } from "@/components/receipts/month-switcher";
 import { formatMonth } from "@/lib/receipts/format";
 import {
@@ -230,6 +230,7 @@ function buildManifestSample(rows: ExportRowLike[]): ManifestSampleRow[] {
       archivePath: r.originalR2Key
         ? `r2://.../${r.originalR2Key.slice(-12)}`
         : "—",
+      invoiceRegistrationNumber: r.invoiceRegistrationNumber ?? "",
     };
   });
 }
@@ -248,4 +249,5 @@ type ExportRowLike = {
   matchStatus: string | null;
   taxAmountMinor: number | null;
   originalR2Key: string | null;
+  invoiceRegistrationNumber: string | null;
 };

--- a/components/receipts/export/export-screen.tsx
+++ b/components/receipts/export/export-screen.tsx
@@ -13,6 +13,10 @@ import {
 } from "@/components/ui/icons";
 import type { ReceiptExport } from "@/lib/receipts/types";
 import type { Blocker } from "@/lib/receipts/blockers";
+import {
+  buildManifestPreviewCsv,
+  type ManifestSampleRow,
+} from "@/lib/receipts/manifest-preview";
 
 export type { Blocker } from "@/lib/receipts/blockers";
 
@@ -42,17 +46,6 @@ export interface ExportScreenProps {
   breakdown: CategoryBreakdownRow[];
   manifestSample: ManifestSampleRow[];
   manifestSize: { rowsTotal: number; sizeBytes: number; sha256: string | null };
-}
-
-export interface ManifestSampleRow {
-  receiptId: string;
-  merchant: string;
-  txnDate: string;
-  amountMinor: number;
-  categoryLabel: string;
-  payment: string;
-  alcohol: boolean;
-  archivePath: string;
 }
 
 export function ExportScreen(props: ExportScreenProps) {
@@ -869,7 +862,7 @@ function ReportFormat({
             <ManifestTable rows={manifestSample} />
           ) : view === "raw" ? (
             <pre className="overflow-auto bg-white px-3 py-2 font-mono text-[11.5px] text-gray-700">
-              {rawCsv(manifestSample)}
+              {buildManifestPreviewCsv(manifestSample)}
             </pre>
           ) : (
             <pre className="overflow-auto bg-white px-3 py-2 font-mono text-[11.5px] text-gray-700">
@@ -1004,33 +997,6 @@ function SchemaTable() {
       ))}
     </div>
   );
-}
-
-function rawCsv(rows: ManifestSampleRow[]): string {
-  const header =
-    "receipt_id,merchant,transaction_date,amount,category,payment_path,alcohol_present,archive_path";
-  const body = rows
-    .map((r) =>
-      [
-        r.receiptId,
-        csvField(r.merchant),
-        r.txnDate,
-        r.amountMinor,
-        csvField(r.categoryLabel),
-        r.payment,
-        r.alcohol ? "true" : "false",
-        csvField(r.archivePath),
-      ].join(","),
-    )
-    .join("\n");
-  return `${header}\n${body}`;
-}
-
-function csvField(s: string): string {
-  if (s.includes(",") || s.includes('"') || s.includes("\n")) {
-    return `"${s.replace(/"/g, '""')}"`;
-  }
-  return s;
 }
 
 function fmtRelative(iso: string): string {

--- a/lib/receipts/manifest-preview.ts
+++ b/lib/receipts/manifest-preview.ts
@@ -1,0 +1,59 @@
+// On-screen manifest preview helpers for the export screen.
+//
+// The preview renders a simplified CSV projection of the export bundle rows
+// (the same rows buildExportBundle produces — the single source of truth the
+// finalize gate and the shipped receipts-{month}.csv both consume). Hoisted
+// into a lib (out of the "use client" component) so the CSV projection is
+// unit-testable without importing React/Next.
+
+export interface ManifestSampleRow {
+  receiptId: string;
+  merchant: string;
+  txnDate: string;
+  amountMinor: number;
+  categoryLabel: string;
+  payment: string;
+  alcohol: boolean;
+  archivePath: string;
+  // 適格請求書 registration number (T-number) from the linked/own receipt;
+  // empty string when none. Mirrors the InvoiceRegistrationNumber column of
+  // the shipped export bundle CSV (buildMonthlyExportCsv) so the operator
+  // sees in the preview exactly what will ship.
+  invoiceRegistrationNumber: string;
+}
+
+/** Escape a CSV field; quote only when it contains a comma, quote, or newline. */
+function csvField(s: string): string {
+  if (s.includes(",") || s.includes('"') || s.includes("\n")) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}
+
+/**
+ * Build the simplified preview CSV shown in the export screen's "Raw CSV"
+ * view. A projection of the bundle rows — NOT the shipped CSV (which carries
+ * the full column set via buildMonthlyExportCsv) — but it includes the same
+ * invoice_registration_number column (appended) so the T-number visible in
+ * the preview matches the column that ships.
+ */
+export function buildManifestPreviewCsv(rows: ManifestSampleRow[]): string {
+  const header =
+    "receipt_id,merchant,transaction_date,amount,category,payment_path,alcohol_present,archive_path,invoice_registration_number";
+  const body = rows
+    .map((r) =>
+      [
+        r.receiptId,
+        csvField(r.merchant),
+        r.txnDate,
+        r.amountMinor,
+        csvField(r.categoryLabel),
+        r.payment,
+        r.alcohol ? "true" : "false",
+        csvField(r.archivePath),
+        csvField(r.invoiceRegistrationNumber),
+      ].join(","),
+    )
+    .join("\n");
+  return `${header}\n${body}`;
+}

--- a/tests/receipts/manifest-preview.test.ts
+++ b/tests/receipts/manifest-preview.test.ts
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildManifestPreviewCsv,
+  type ManifestSampleRow,
+} from "@/lib/receipts/manifest-preview";
+
+function makeRow(
+  overrides: Partial<ManifestSampleRow> = {},
+): ManifestSampleRow {
+  return {
+    receiptId: "R-abc12345",
+    merchant: "Test Merchant",
+    txnDate: "2026-06-15",
+    amountMinor: 1000,
+    categoryLabel: "supplies",
+    payment: "CASH",
+    alcohol: false,
+    archivePath: "r2://.../abc123def456",
+    invoiceRegistrationNumber: "",
+    ...overrides,
+  };
+}
+
+test("manifest preview CSV: invoice_registration_number column appended last", () => {
+  const csv = buildManifestPreviewCsv([
+    makeRow({ invoiceRegistrationNumber: "T1234567890123" }),
+  ]);
+  const lines = csv.split("\n");
+  const headers = lines[0]!.split(",");
+  const idx = headers.indexOf("invoice_registration_number");
+  assert.ok(idx >= 0, "missing invoice_registration_number header");
+  assert.equal(
+    idx,
+    headers.length - 1,
+    "column must be appended last (append-only)",
+  );
+  const dataCols = lines[1]!.split(",");
+  assert.equal(dataCols[idx], "T1234567890123");
+});
+
+test("manifest preview CSV: invoice_registration_number empty when none", () => {
+  const csv = buildManifestPreviewCsv([makeRow({ invoiceRegistrationNumber: "" })]);
+  const lines = csv.split("\n");
+  const headers = lines[0]!.split(",");
+  const idx = headers.indexOf("invoice_registration_number");
+  const dataCols = lines[1]!.split(",");
+  assert.equal(dataCols[idx], "");
+});


### PR DESCRIPTION
## Context

Two follow-ups from PR #74:

### 1. Investigation — preview month-mixing (read-only prod D1)

The operator reported the 2026-06 manifest preview showing BOTH 2026-06 rows (PC Depot 04-10) AND 2026-07 rows (PC Depot 05-10, Rooftop Butcher, MORETHAN TAPAS, Amazon JP) in one table headed "42 rows".

**Finding: no bug.** The preview path is `page.tsx: buildExportBundle(month) → buildManifestSample(bundle.rows.slice(0, 6))` — a 1:1 map of the first 6 bundle rows, no reordering/filtering. `buildExportBundle` uses `listAmexLines(month)` = `WHERE statement_month=?` (single statement, no window derivation). **The preview renders exactly the bundle rows — it cannot show cross-statement rows.**

Evidence (prod D1):
- **2026-06 preview (first 6 rows)** = PC Depot 04-10, Da808Lounge 04-11, 楽天モバイル 04-13, スポーツエントリー 04-14, ラクスル 04-14, EMot 04-16 — all `statement_month=2026-06`.
- **2026-07 bundle** contains exactly the operator's rows, in order: 楽天ペイ 05-05, **PC Depot 05-10**, **Rooftop Butcher 05-10**, **MORETHAN TAPAS 05-12**, **Amazon JP 05-13**, 楽天モバイル 05-13.

So the screenshot was **month=2026-07** (those rows live there). "42 rows" was the 2026-06 header — 2026-07 has 21 rows (20 lines + 1 CASH). No code change.

### 2. invoice_registration_number in the preview

The shipped export bundle CSV (`buildMonthlyExportCsv`) **already has** `InvoiceRegistrationNumber` (added in compliance A5 work, with tests at `export.test.ts:256`/`:276`). But the on-screen preview's "Raw CSV" view (`rawCsv`, a simplified projection) did **not** include it — so the operator couldn't see the T-number in the preview that ships in the CSV.

**Fix:** add `invoice_registration_number` as an append-only column to the preview CSV (from the linked/own receipt, empty when none) — same rule as the reconciliation manifest column from PR #74. No validation/blocker/warning.

To make the preview CSV projection unit-testable (it was component-local in a `"use client"` file), extract `ManifestSampleRow` + the builder into `lib/receipts/manifest-preview.ts` (`buildManifestPreviewCsv`). The component imports from there; behavior unchanged except the new column.

## Verification

- `tsc --noEmit` ✅
- `npm run lint` ✅ (0 errors; 6 pre-existing warnings unrelated)
- `npm run test` ✅ (267 pass, +2: preview column appended last; empty when none)
- Bundle CSV column already covered by `export.test.ts:256`/`:276` (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)