### PR TITLE
feat(receipts/export): review page — business trips section

### DIFF
--- a/app/(receipt-system)/receipts/export/[month]/review/page.tsx
+++ b/app/(receipt-system)/receipts/export/[month]/review/page.tsx
@@ -7,6 +7,8 @@ import {
   getExport,
   getFinalizedReconciliationForMonth,
   listAmexLines,
+  listAmexLinesForBusinessTripReports,
+  listBusinessTripReports,
   listReceiptRecords,
 } from "@/lib/receipts/db";
 import { assertReceiptsPageAccess } from "@/lib/receipts/auth-request";
@@ -32,14 +34,18 @@ export default async function ReviewPage({ params }: { params: Params }) {
   // receipts (never month-scoped receipts for line-category resolution — see
   // PR #72). monthReceipts (month-scoped) feeds only the tile's pending /
   // unreviewed / unknown counts.
-  const [bundle, currentExport, reconciliation, monthLines, monthReceipts] =
+  const [bundle, currentExport, reconciliation, monthLines, monthReceipts, tripReports] =
     await Promise.all([
       buildExportBundle(month),
       getExport(month),
       getFinalizedReconciliationForMonth(month),
       listAmexLines(month),
       listReceiptRecords({ month, limit: 1000 }),
+      listBusinessTripReports(month),
     ]);
+  const tripLines = await listAmexLinesForBusinessTripReports(
+    tripReports.map((r) => r.id),
+  );
 
   const window =
     monthLines.length > 0 ? deriveStatementWindow(monthLines, month) : null;
@@ -70,6 +76,8 @@ export default async function ReviewPage({ params }: { params: Params }) {
       gateBlockers={gateBlockers}
       tileBlockers={tileBlockers}
       warnings={warnings}
+      tripReports={tripReports}
+      tripLines={tripLines}
     />
   );
 }

--- a/components/receipts/export/review-screen.tsx
+++ b/components/receipts/export/review-screen.tsx
@@ -8,6 +8,8 @@ import {
 import { formatCategoryLabel } from "@/lib/receipts/categories";
 import type { Blocker } from "@/lib/receipts/blockers";
 import type {
+  AmexStatementLine,
+  BusinessTripReport,
   ExportRow,
   ReceiptExport,
   ReceiptRecord,
@@ -26,6 +28,8 @@ export interface ReviewScreenProps {
   gateBlockers: string[];
   tileBlockers: Blocker[];
   warnings: Blocker[];
+  tripReports: BusinessTripReport[];
+  tripLines: Map<string, AmexStatementLine[]>;
 }
 
 export function ReviewScreen(props: ReviewScreenProps) {
@@ -62,6 +66,13 @@ export function ReviewScreen(props: ReviewScreenProps) {
         <SummarySection rows={props.rows} receipts={props.receipts} />
         <SideBySideSection amexRows={amexRows} receipts={props.receipts} />
         <AdditionalChargesSection chargeRows={chargeRows} />
+        <BusinessTripsSection
+          tripReports={props.tripReports}
+          tripLines={props.tripLines}
+          candidateRows={amexRows.filter(
+            (r) => r.businessTripStatus === "candidate",
+          )}
+        />
       </div>
     </div>
   );
@@ -457,6 +468,89 @@ function AdditionalChargesSection({ chargeRows }: { chargeRows: ExportRow[] }) {
           ))
         )}
       </Card>
+    </div>
+  );
+}
+
+// ─── Section 4: Business trips ────────────────────────────────────────────
+
+function BusinessTripsSection({
+  tripReports,
+  tripLines,
+  candidateRows,
+}: {
+  tripReports: BusinessTripReport[];
+  tripLines: Map<string, AmexStatementLine[]>;
+  candidateRows: ExportRow[];
+}) {
+  return (
+    <div>
+      <SectionTitle
+        title="Business trips"
+        sub="Trip reports overlapping this statement window"
+      />
+      {candidateRows.length > 0 && (
+        <div className="mb-3 rounded-lg border border-amber-200 bg-amber-50 px-4 py-2.5 text-[12.5px] text-amber-800">
+          <b>{candidateRows.length} unresolved business-trip candidate line(s)</b> — these block
+          finalize (gate 4). Confirm or dismiss the trip cluster in Reconcile.
+        </div>
+      )}
+      {tripReports.length === 0 ? (
+        <Card pad={20}>
+          <p className="text-[12.5px] text-gray-400">
+            No business trip reports for this month.
+          </p>
+        </Card>
+      ) : (
+        <div className="space-y-3">
+          {tripReports.map((trip) => {
+            const lines = tripLines.get(trip.id) ?? [];
+            const total = lines.reduce((s, l) => s + (l.amount_minor ?? 0), 0);
+            return (
+              <Card key={trip.id} pad={20}>
+                <div className="flex flex-wrap items-baseline justify-between gap-2">
+                  <div>
+                    <span className="text-[13.5px] font-semibold text-gray-900">
+                      {trip.trip_name ?? trip.primary_location ?? "Untitled trip"}
+                    </span>
+                    <span className="ml-2 text-[11.5px] text-gray-500">
+                      {trip.start_date} – {trip.end_date}
+                      {trip.primary_location ? ` · ${trip.primary_location}` : ""}
+                    </span>
+                  </div>
+                  <Pill tone={trip.status === "confirmed" ? "green" : "amber"} size="sm">
+                    {trip.status}
+                  </Pill>
+                </div>
+                {trip.purpose && (
+                  <p className="mt-1 text-[12px] text-gray-500">{trip.purpose}</p>
+                )}
+                <div className="mt-3">
+                  <div className="mb-1.5 text-[11px] font-semibold uppercase tracking-[0.05em] text-gray-500">
+                    Linked lines ({lines.length}) · {formatAmountMinor(total)}
+                  </div>
+                  {lines.length === 0 ? (
+                    <p className="text-[12px] text-gray-400">No linked AMEX lines.</p>
+                  ) : (
+                    <ul className="space-y-0.5 text-[12px] text-gray-700">
+                      {lines.map((l) => (
+                        <li key={l.id} className="flex justify-between gap-3">
+                          <span className="truncate">
+                            {l.transaction_date} · {l.merchant}
+                          </span>
+                          <span className="shrink-0 tabular-nums text-gray-500">
+                            {formatAmountMinor(l.amount_minor, l.currency)}
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              </Card>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }

--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -1622,6 +1622,41 @@ export async function listBusinessTripReports(
   return result.results ?? [];
 }
 
+/**
+ * AMEX statement lines linked to each business trip report (via
+ * business_trip_report_lines), keyed by report id. Empty map for no ids.
+ * Used by the export review page to render the lines behind each trip.
+ */
+export async function listAmexLinesForBusinessTripReports(
+  reportIds: string[],
+): Promise<Map<string, AmexStatementLine[]>> {
+  const out = new Map<string, AmexStatementLine[]>();
+  const unique = [...new Set(reportIds.filter(Boolean))];
+  if (unique.length === 0) return out;
+  const db = getReceiptsDb();
+  const CHUNK = 90;
+  for (let i = 0; i < unique.length; i += CHUNK) {
+    const chunk = unique.slice(i, i + CHUNK);
+    const placeholders = chunk.map(() => "?").join(",");
+    const result = await db
+      .prepare(
+        `SELECT btrl.business_trip_report_id AS report_id, asl.*
+         FROM business_trip_report_lines btrl
+         JOIN amex_statement_lines asl ON asl.id = btrl.amex_statement_line_id
+         WHERE btrl.business_trip_report_id IN (${placeholders})`,
+      )
+      .bind(...chunk)
+      .all<AmexStatementLine & { report_id: string }>();
+    for (const row of result.results ?? []) {
+      const { report_id, ...line } = row;
+      const arr = out.get(report_id) ?? [];
+      arr.push(line);
+      out.set(report_id, arr);
+    }
+  }
+  return out;
+}
+
 // ─── Expense categories ───────────────────────────────────────────────────────
 
 export interface ExpenseCategoryDbRow {


### PR DESCRIPTION
Section 4 of the pre-finalize review page: trip reports (listBusinessTripReports) with linked AMEX lines (new db.ts helper listAmexLinesForBusinessTripReports — joins business_trip_report_lines → amex_statement_lines, chunked, no new schema) + total per trip; flags unresolved business_trip_status='candidate' lines as a gate-4 blocker. tsc 0 / lint 0 errors / 267 tests pass.