### PR TITLE
refactor(receipts): month-closing DI-seam + gate test suite

### DIFF
--- a/lib/receipts/month-closing.ts
+++ b/lib/receipts/month-closing.ts
@@ -218,75 +218,70 @@ export async function buildExportBundle(month: string): Promise<ExportBundle> {
  *      statement lines in more than one month blocks both months until
  *      resolved — overlapping windows make this possible.
  */
-export async function validateMonthReadyForExport(
-  month: string,
-  prebuiltBundle?: ExportBundle,
-  preloadedReconciliation?: AmexReconciliation | null,
-): Promise<string[]> {
+/** Inputs the export-finalize gate needs, fetched by the async wrapper. */
+export interface ValidateMonthReadyInput {
+  month: string;
+  reconciliation: AmexReconciliation | null;
+  bundle: ExportBundle;
+  /** Gate 2: in-month UNKNOWN payment_path receipts (id + merchant). */
+  unknownReceipts: { id: string; merchant: string | null }[];
+  /** Gate 2.5: in-month needs_review receipts (raw; core applies the
+   * isPendingProcessing exclusion to match the tile). */
+  unreviewedReceipts: ReceiptRecord[];
+  /** Gate 4: attendees keyed by AMEX line id. */
+  amexAttendees: Record<string, string[]>;
+  /** Gate 5: open compliance checks summary. */
+  complianceSummary: { blockers: number; warnings: number };
+  /** Gate 5: compliance settings. */
+  complianceSettings: { export_block_on_warnings: boolean };
+  /** Gate 6: raw (statement_month, matched_receipt_id) rows for cross-month
+   * match integrity; core groups them. */
+  crossMonthMatchedLines: { statement_month: string; matched_receipt_id: string }[];
+}
+
+/**
+ * Pure synchronous core of the export-finalize gate. Given the data the gates
+ * need (fetched by {@link validateMonthReadyForExport}), returns the blocker
+ * strings in the gate's canonical order (1 → 2 → 2.5 → 3 → 4 → 5 → 6).
+ * Extracted verbatim from the former inline body so the gate is unit-testable
+ * without D1 and so the tile (Task 3) can share the exact same rule logic.
+ */
+export function validateMonthReadyForExportCore(
+  input: ValidateMonthReadyInput,
+): string[] {
+  const {
+    month,
+    reconciliation,
+    bundle,
+    unknownReceipts,
+    unreviewedReceipts,
+    amexAttendees,
+    complianceSummary,
+    complianceSettings,
+    crossMonthMatchedLines,
+  } = input;
   const blockers: string[] = [];
 
-  // (1) Statement-sealed gate. Callers that already fetched the
-  // reconciliation (e.g. /api/receipts/export/month to populate the manifest
-  // pointer) may pass it in to avoid a second D1 round-trip.
-  const reconciliation =
-    preloadedReconciliation !== undefined
-      ? preloadedReconciliation
-      : await getFinalizedReconciliationForMonth(month);
+  // (1) Statement-sealed gate.
   if (!reconciliation) {
     blockers.push(
       `No finalized reconciliation for ${month}. Sign off the reconciliation first.`,
     );
   }
 
-  // Build (or accept) the bundle. Build is expensive; callers that already
-  // have one should pass it in.
-  const bundle = prebuiltBundle ?? (await buildExportBundle(month));
-
-  // (2) UNKNOWN payment_path gate. UNKNOWN receipts were excluded from the
-  // bundle by design; their existence anywhere in the month is itself the
-  // blocker. Query directly because the bundle intentionally doesn't carry them.
-  const db = getReceiptsDb();
-  const unknownResult = await db
-    .prepare(
-      `SELECT id, merchant FROM receipt_records
-       WHERE deleted_at IS NULL
-         AND payment_path = 'UNKNOWN'
-         AND transaction_date LIKE ?`,
-    )
-    .bind(`${month}%`)
-    .all<{ id: string; merchant: string | null }>();
-  for (const row of unknownResult.results ?? []) {
+  // (2) UNKNOWN payment_path gate.
+  for (const row of unknownReceipts) {
     const label = row.merchant ?? row.id;
     blockers.push(
       `Receipt ${label}: payment_path is UNKNOWN — classify as AMEX, CASH, or DIGITAL before export`,
     );
   }
 
-  // (2.5) Unreviewed-receipt gate. Mirrors computeExportBlockers' "Unreviewed
-  // receipts" tile (status='needs_review' in-month, excluding pending
-  // processing) so the tile's BLOCKER label is enforced at finalize —
-  // previously the tile reported unreviewed receipts as blockers but the gate
-  // never checked review status, so a month could read "blocked" on the tile
-  // yet finalize successfully (reverse tile-vs-gate drift).
-  //
-  // Direct month-scoped query, NOT bundle.receipts: the tile counts receipts by
-  // transaction_date in the statement month (all payment paths), while
-  // bundle.receipts excludes in-month AMEX (validated via lines) and UNKNOWN
-  // (excluded above) and includes cross-month matched receipts. Iterating the
-  // bundle here would read a different set than the tile and re-open the drift.
-  const unreviewedResult = await db
-    .prepare(
-      `SELECT * FROM receipt_records
-       WHERE deleted_at IS NULL
-         AND status = 'needs_review'
-         AND transaction_date LIKE ?`,
-    )
-    .bind(`${month}%`)
-    .all<ReceiptRecord>();
-  for (const r of unreviewedResult.results ?? []) {
-    // Same exclusion the tile applies: a needs_review receipt still in the
-    // extraction queue is "pending processing", not "unreviewed" — it's
-    // surfaced separately and fixed by draining the queue, not by reviewing.
+  // (2.5) Unreviewed-receipt gate. isPendingProcessing exclusion matches the
+  // tile (a needs_review receipt still in the queue is "pending processing",
+  // not "unreviewed"). Direct month-scoped set, NOT bundle.receipts — see the
+  // tile-vs-gate drift note in the former inline body (PR #73).
+  for (const r of unreviewedReceipts) {
     if (isPendingProcessing(r)) continue;
     const label = r.merchant ?? r.id;
     blockers.push(
@@ -296,8 +291,6 @@ export async function validateMonthReadyForExport(
 
   // (3) Receipt-level checks on CASH/DIGITAL receipts in the bundle.
   for (const receipt of bundle.receipts) {
-    // AMEX-path receipts are validated via the line checks below; skip
-    // them here to avoid double-gating.
     if (receipt.payment_path === "AMEX") continue;
     const label = receipt.merchant ?? receipt.id;
     if (!receipt.transaction_date) blockers.push(`Receipt ${receipt.id}: missing date`);
@@ -313,7 +306,6 @@ export async function validateMonthReadyForExport(
   }
 
   // (4) AMEX-line checks.
-  const amexAttendees = await listAmexLineAttendeeNamesByMonth(month);
   const receiptMap = new Map<string, ReceiptRecord>();
   for (const r of bundle.receipts) receiptMap.set(r.id, r);
   blockers.push(
@@ -325,30 +317,94 @@ export async function validateMonthReadyForExport(
     ),
   );
 
-  // (5) Compliance-engine gate. Summarize over the month filter UNION the
-  // bundle's receipt IDs: matched receipts may be dated outside the
-  // statement month, and exported_month isn't stamped until after finalize,
-  // so the month filter alone misses their open checks (Codex P1).
+  // (5) Compliance-engine gate.
+  if (complianceSummary.blockers > 0) {
+    blockers.push(
+      `${complianceSummary.blockers} open compliance blocker(s) on receipts in ${month}`,
+    );
+  }
+  if (complianceSettings.export_block_on_warnings && complianceSummary.warnings > 0) {
+    blockers.push(
+      `${complianceSummary.warnings} open compliance warning(s) in ${month} (export_block_on_warnings=true)`,
+    );
+  }
+
+  // (6) Cross-month match integrity (audit A7). A receipt matched to lines in
+  // two different statement months is ambiguous — both months can't ship it.
+  const monthsByReceipt = new Map<string, Set<string>>();
+  for (const row of crossMonthMatchedLines) {
+    let set = monthsByReceipt.get(row.matched_receipt_id);
+    if (!set) {
+      set = new Set();
+      monthsByReceipt.set(row.matched_receipt_id, set);
+    }
+    set.add(row.statement_month);
+  }
+  for (const [receiptId, months] of monthsByReceipt) {
+    if (months.size > 1 && months.has(month)) {
+      const others = [...months].filter((m) => m !== month).join(", ");
+      blockers.push(
+        `Receipt ${receiptId}: matched to AMEX lines in multiple statement months (${[...months].join(", ")}). Disambiguate before finalizing ${month} (other month(s): ${others}).`,
+      );
+    }
+  }
+
+  return blockers;
+}
+
+export async function validateMonthReadyForExport(
+  month: string,
+  prebuiltBundle?: ExportBundle,
+  preloadedReconciliation?: AmexReconciliation | null,
+): Promise<string[]> {
+  // (1) Statement-sealed gate. Callers that already fetched the reconciliation
+  // (e.g. /api/receipts/export/month to populate the manifest pointer) may
+  // pass it in to avoid a second D1 round-trip.
+  const reconciliation =
+    preloadedReconciliation !== undefined
+      ? preloadedReconciliation
+      : await getFinalizedReconciliationForMonth(month);
+
+  // Build (or accept) the bundle. Build is expensive; callers that already
+  // have one should pass it in.
+  const bundle = prebuiltBundle ?? (await buildExportBundle(month));
+  const db = getReceiptsDb();
+
+  // (2) UNKNOWN payment_path — queried directly; the bundle excludes UNKNOWN.
+  const unknownResult = await db
+    .prepare(
+      `SELECT id, merchant FROM receipt_records
+       WHERE deleted_at IS NULL
+         AND payment_path = 'UNKNOWN'
+         AND transaction_date LIKE ?`,
+    )
+    .bind(`${month}%`)
+    .all<{ id: string; merchant: string | null }>();
+
+  // (2.5) Unreviewed receipts in-month (core applies the pending exclusion).
+  const unreviewedResult = await db
+    .prepare(
+      `SELECT * FROM receipt_records
+       WHERE deleted_at IS NULL
+         AND status = 'needs_review'
+         AND transaction_date LIKE ?`,
+    )
+    .bind(`${month}%`)
+    .all<ReceiptRecord>();
+
+  // (4) AMEX-line attendees.
+  const amexAttendees = await listAmexLineAttendeeNamesByMonth(month);
+
+  // (5) Compliance — month filter UNION bundle receipt IDs (matched receipts
+  // may be dated outside the statement month; Codex P1).
   const settings = await getComplianceSettings();
   const summary = await summarizeOpenChecksForExport(
     db,
     month,
     bundle.receipts.map((r) => r.id),
   );
-  if (summary.blockers > 0) {
-    blockers.push(
-      `${summary.blockers} open compliance blocker(s) on receipts in ${month}`,
-    );
-  }
-  if (settings.export_block_on_warnings && summary.warnings > 0) {
-    blockers.push(
-      `${summary.warnings} open compliance warning(s) in ${month} (export_block_on_warnings=true)`,
-    );
-  }
 
-  // (6) Cross-month match integrity (audit A7). A receipt matched to lines
-  // in two different statement months is ambiguous — both months can't
-  // ship the same receipt. Block both until disambiguated.
+  // (6) Cross-month match integrity.
   const matchedLineMonths = await db
     .prepare(
       `SELECT DISTINCT asl.statement_month, asl.matched_receipt_id
@@ -361,29 +417,18 @@ export async function validateMonthReadyForExport(
          )`,
     )
     .all<{ statement_month: string; matched_receipt_id: string }>();
-  // Group by receipt_id, find any referenced from >1 distinct month.
-  // (The query returns one row per (month, receipt) pair; the same receipt
-  // appearing under two months yields two rows we can collapse.)
-  const monthsByReceipt = new Map<string, Set<string>>();
-  for (const row of matchedLineMonths.results ?? []) {
-    let set = monthsByReceipt.get(row.matched_receipt_id);
-    if (!set) {
-      set = new Set();
-      monthsByReceipt.set(row.matched_receipt_id, set);
-    }
-    set.add(row.statement_month);
-  }
-  // Only block when one of the implicated months is the one we're finalizing.
-  for (const [receiptId, months] of monthsByReceipt) {
-    if (months.size > 1 && months.has(month)) {
-      const others = [...months].filter((m) => m !== month).join(", ");
-      blockers.push(
-        `Receipt ${receiptId}: matched to AMEX lines in multiple statement months (${[...months].join(", ")}). Disambiguate before finalizing ${month} (other month(s): ${others}).`,
-      );
-    }
-  }
 
-  return blockers;
+  return validateMonthReadyForExportCore({
+    month,
+    reconciliation,
+    bundle,
+    unknownReceipts: unknownResult.results ?? [],
+    unreviewedReceipts: unreviewedResult.results ?? [],
+    amexAttendees,
+    complianceSummary: summary,
+    complianceSettings: settings,
+    crossMonthMatchedLines: matchedLineMonths.results ?? [],
+  });
 }
 
 /**

--- a/tests/receipts/month-closing.test.ts
+++ b/tests/receipts/month-closing.test.ts
@@ -1,0 +1,290 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  validateMonthReadyForExportCore,
+  type ExportBundle,
+  type ValidateMonthReadyInput,
+} from "@/lib/receipts/month-closing";
+import type {
+  AmexReconciliation,
+  AmexStatementLine,
+  ReceiptRecord,
+} from "@/lib/receipts/types";
+
+const MONTH = "2026-06";
+
+function makeReceipt(overrides: Partial<ReceiptRecord> = {}): ReceiptRecord {
+  return {
+    id: "r-1",
+    captured_at: "2026-06-15T10:00:00Z",
+    captured_by: "test",
+    source: "mobile_capture",
+    original_filename: "r.jpg",
+    payment_path: "CASH",
+    expense_type: "misc",
+    transaction_date: "2026-06-15",
+    merchant: "Test Merchant",
+    amount_minor: 1000,
+    currency: "JPY",
+    tax_amount_minor: null,
+    business_purpose: null,
+    alcohol_present: 0,
+    attendees_required: 0,
+    status: "reviewed",
+    original_r2_key: "receipts/2026/06/r-1/f.jpg",
+    original_sha256: "abc",
+    original_content_type: "image/jpeg",
+    original_size_bytes: 1024,
+    processed_r2_key: null,
+    extraction_json: null,
+    legacy: 0,
+    exported_month: null,
+    expense_category_code: "supplies",
+    deleted_at: null,
+    deleted_by: null,
+    delete_reason: null,
+    created_at: "2026-06-15T10:00:00Z",
+    updated_at: "2026-06-15T10:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeLine(overrides: Partial<AmexStatementLine> = {}): AmexStatementLine {
+  return {
+    id: "line-1",
+    statement_month: MONTH,
+    transaction_date: "2026-06-15",
+    posting_date: null,
+    merchant: "TEST MERCHANT",
+    amount_minor: 1000,
+    currency: "JPY",
+    amex_reference: "REF001",
+    matched_receipt_id: null,
+    match_status: "confirmed",
+    raw_json: "{}",
+    created_at: "2026-06-15T00:00:00Z",
+    statement_artifact_id: null,
+    cardholder_name: null,
+    cardholder_flag: null,
+    payment_type: null,
+    prepayment_flag: null,
+    memo: null,
+    raw_csv_line_number: null,
+    source_file_sha256: null,
+    imported_at: null,
+    expense_category: "unknown",
+    category_status: "uncategorized",
+    receipt_status: "matched",
+    receipt_missing_reason: null,
+    business_trip_id: null,
+    business_trip_status: "not_applicable",
+    expense_category_code: "supplies",
+    re_review_needed: 0,
+    updated_at: null,
+    ...overrides,
+  };
+}
+
+function makeReconciliation(overrides: Partial<AmexReconciliation> = {}): AmexReconciliation {
+  return {
+    id: "recon-1",
+    statement_month: MONTH,
+    statement_artifact_id: null,
+    status: "finalized",
+    manifest_r2_key: "manifests/2026-06.csv",
+    manifest_sha256: "sha",
+    line_count: 1,
+    matched_count: 1,
+    no_receipt_count: 0,
+    created_by: "test",
+    created_at: "2026-06-15T00:00:00Z",
+    finalized_by: "test",
+    finalized_at: "2026-06-15T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeBundle(overrides: Partial<ExportBundle> = {}): ExportBundle {
+  return {
+    rows: [],
+    receipts: [],
+    amexLines: [],
+    attendeeMap: new Map(),
+    items: [],
+    ...overrides,
+  };
+}
+
+/** Clean input: every gate silent → core returns []. */
+function makeInput(overrides: Partial<ValidateMonthReadyInput> = {}): ValidateMonthReadyInput {
+  return {
+    month: MONTH,
+    reconciliation: makeReconciliation(),
+    bundle: makeBundle(),
+    unknownReceipts: [],
+    unreviewedReceipts: [],
+    amexAttendees: {},
+    complianceSummary: { blockers: 0, warnings: 0 },
+    complianceSettings: { export_block_on_warnings: false },
+    crossMonthMatchedLines: [],
+    ...overrides,
+  };
+}
+
+test("gate core: clean input returns no blockers", () => {
+  assert.deepEqual(validateMonthReadyForExportCore(makeInput()), []);
+});
+
+// (1) Statement-sealed
+test("gate 1: missing reconciliation blocks", () => {
+  const blockers = validateMonthReadyForExportCore(makeInput({ reconciliation: null }));
+  assert.equal(
+    blockers.some((b) => b.startsWith("No finalized reconciliation for 2026-06")),
+    true,
+  );
+});
+
+// (2) UNKNOWN payment_path
+test("gate 2: UNKNOWN payment_path receipts block", () => {
+  const blockers = validateMonthReadyForExportCore(
+    makeInput({ unknownReceipts: [{ id: "r-unk", merchant: "DAISO" }] }),
+  );
+  assert.ok(
+    blockers.some((b) => b.includes("DAISO") && b.includes("payment_path is UNKNOWN")),
+    JSON.stringify(blockers),
+  );
+});
+
+// (2.5) Unreviewed, incl. isPendingProcessing exclusion
+test("gate 2.5: needs_review receipt (not pending) blocks; pending is excluded", () => {
+  const blocking = validateMonthReadyForExportCore(
+    makeInput({
+      unreviewedReceipts: [makeReceipt({ id: "r-needs", status: "needs_review", merchant: "LAWSON" })],
+    }),
+  );
+  assert.ok(
+    blocking.some((b) => b.includes("LAWSON") && b.includes("unreviewed")),
+    JSON.stringify(blocking),
+  );
+
+  // A needs_review receipt still in the extraction queue is "pending
+  // processing", not "unreviewed" — must NOT block here.
+  const pending = validateMonthReadyForExportCore(
+    makeInput({
+      unreviewedReceipts: [
+        makeReceipt({ id: "r-pend", status: "needs_review", extraction_state: "queued" }),
+      ],
+    }),
+  );
+  assert.ok(
+    !pending.some((b) => b.includes("unreviewed")),
+    `pending needs_review must not produce an unreviewed blocker: ${JSON.stringify(pending)}`,
+  );
+});
+
+// (3) Receipt-level (CASH/DIGITAL) field completeness
+test("gate 3: CASH receipt missing expense category blocks; AMEX is skipped here", () => {
+  const blockers = validateMonthReadyForExportCore(
+    makeInput({
+      bundle: makeBundle({
+        receipts: [makeReceipt({ id: "r-cash", payment_path: "CASH", expense_category_code: null })],
+      }),
+    }),
+  );
+  assert.ok(
+    blockers.some((b) => b.includes("r-cash") && b.includes("missing expense category")),
+    JSON.stringify(blockers),
+  );
+
+  // AMEX receipts are validated via the line checks (gate 4), not here.
+  const amex = validateMonthReadyForExportCore(
+    makeInput({
+      bundle: makeBundle({
+        receipts: [makeReceipt({ id: "r-amex", payment_path: "AMEX", expense_category_code: null })],
+      }),
+    }),
+  );
+  assert.ok(
+    !amex.some((b) => b.includes("r-amex") && b.includes("missing expense category")),
+    `AMEX receipt must not hit gate 3: ${JSON.stringify(amex)}`,
+  );
+});
+
+// (4) AMEX-line checks (validateAmexLinesForSignoff)
+test("gate 4: unresolved AMEX line blocks via validateAmexLinesForSignoff", () => {
+  const blockers = validateMonthReadyForExportCore(
+    makeInput({
+      bundle: makeBundle({
+        amexLines: [makeLine({ match_status: "unmatched", merchant: "UNMATCHED CO" })],
+      }),
+    }),
+  );
+  assert.ok(
+    blockers.some((b) => b.includes("UNMATCHED CO") && b.includes("unresolved match status")),
+    JSON.stringify(blockers),
+  );
+  // NOTE: the consolidated-receipt sum rule (≥2 confirmed lines sharing a
+  // receipt must sum to the receipt total) lives in validateAmexLinesForSignoff
+  // and is covered by tests/receipts/reconciliation-signoff.test.ts.
+});
+
+// (5) Compliance
+test("gate 5: compliance blockers and (optional) warnings block", () => {
+  const withBlockers = validateMonthReadyForExportCore(
+    makeInput({ complianceSummary: { blockers: 2, warnings: 0 } }),
+  );
+  assert.ok(withBlockers.some((b) => b.includes("2 open compliance blocker(s)")));
+
+  const withWarnings = validateMonthReadyForExportCore(
+    makeInput({
+      complianceSummary: { blockers: 0, warnings: 1 },
+      complianceSettings: { export_block_on_warnings: true },
+    }),
+  );
+  assert.ok(withWarnings.some((b) => b.includes("1 open compliance warning(s)")));
+
+  // Warnings don't block when export_block_on_warnings is false.
+  const warningsOff = validateMonthReadyForExportCore(
+    makeInput({
+      complianceSummary: { blockers: 0, warnings: 1 },
+      complianceSettings: { export_block_on_warnings: false },
+    }),
+  );
+  assert.ok(!warningsOff.some((b) => b.includes("compliance warning")));
+});
+
+// (6) Cross-month match integrity
+test("gate 6: receipt matched across months blocks only when this month is implicated", () => {
+  const blocking = validateMonthReadyForExportCore(
+    makeInput({
+      crossMonthMatchedLines: [
+        { statement_month: "2026-06", matched_receipt_id: "r-x" },
+        { statement_month: "2026-07", matched_receipt_id: "r-x" },
+      ],
+    }),
+  );
+  assert.ok(
+    blocking.some((b) => b.includes("r-x") && b.includes("multiple statement months")),
+    JSON.stringify(blocking),
+  );
+
+  // Two months but neither is the one being finalized → no blocker.
+  const otherMonths = validateMonthReadyForExportCore(
+    makeInput({
+      month: "2026-06",
+      crossMonthMatchedLines: [
+        { statement_month: "2026-07", matched_receipt_id: "r-y" },
+        { statement_month: "2026-08", matched_receipt_id: "r-y" },
+      ],
+    }),
+  );
+  assert.ok(!otherMonths.some((b) => b.includes("r-y")));
+
+  // Only one month → not ambiguous → no blocker.
+  const single = validateMonthReadyForExportCore(
+    makeInput({
+      crossMonthMatchedLines: [{ statement_month: "2026-06", matched_receipt_id: "r-z" }],
+    }),
+  );
+  assert.ok(!single.some((b) => b.includes("r-z")));
+});


### PR DESCRIPTION
Extract pure `validateMonthReadyForExportCore(input)` from `validateMonthReadyForExport`; the async fn becomes a thin wrapper that fetches gate inputs and calls the core. **Zero behavior change** — verbatim logic move (same fetches, same blocker strings, same order 1→2→2.5→3→4→5→6). No call-site changes.

New `tests/receipts/month-closing.test.ts`: each gate fires on its trigger + stays silent on clean — gates 1, 2, 2.5 (incl. isPendingProcessing exclusion), 3, 4, 5, 6. Consolidated-sum rule lives in `validateAmexLinesForSignoff` (covered by `reconciliation-signoff.test.ts`, noted).

**Zero-drift evidence:** 2026-06 prod gate inputs captured read-only — reconciliation finalized, 0 UNKNOWN, 0 needs_review, 0 cross-month matches (gates 1/2/2.5/6 silent); gates 3/4/5 exercised via fixtures. A runtime before/after capture isn't possible from the CLI (gate runs only in the Clerk-gated Worker), so the proof is structural: verbatim extraction + 8 gate tests.

tsc 0 / lint 0 errors / 275 tests pass (+8). Enables Task 3 (unify tile with gate core).