### PR TITLE
refactor(receipts): unify tile with gate via shared predicates

### DIFF
--- a/lib/receipts/blockers.ts
+++ b/lib/receipts/blockers.ts
@@ -15,6 +15,39 @@ import { isPendingProcessing } from "@/lib/receipts/extraction-state";
 import { resolveLineCategory } from "@/lib/receipts/line-classification";
 import type { AmexStatementLine, ReceiptRecord } from "@/lib/receipts/types";
 
+// ─── Shared predicates (tile ⇄ gate) ─────────────────────────────────────
+// Pure rules shared between the export tile (computeExportBlockers) and the
+// finalize gate (validateMonthReadyForExportCore + validateAmexLinesForSignoff)
+// so a rule can never exist in one and not the other. The gate is the
+// authority; the tile mirrors these exactly. Add a rule here AND wire it into
+// the gate if it should block finalize.
+
+/** A line is uncategorized when neither it nor its matched receipt carries a
+ * category (resolveLineCategory — the same authority the gate uses). */
+export function isUncategorizedLine(
+  line: Pick<AmexStatementLine, "matched_receipt_id" | "expense_category_code">,
+  receipt:
+    | Pick<ReceiptRecord, "expense_category_code" | "deleted_at">
+    | undefined
+    | null,
+): boolean {
+  return !resolveLineCategory(line, receipt);
+}
+
+/** A receipt blocks on unknown payment path (finalize gate 2). */
+export function isUnknownPathReceipt(
+  receipt: Pick<ReceiptRecord, "payment_path">,
+): boolean {
+  return receipt.payment_path === "UNKNOWN";
+}
+
+/** A receipt is an unreviewed blocker: needs review and not still pending
+ * extraction (gate 2.5). Pending receipts are a separate "drain the queue"
+ * nudge, not an unreviewed blocker. */
+export function isUnreviewedReceipt(receipt: ReceiptRecord): boolean {
+  return receipt.status === "needs_review" && !isPendingProcessing(receipt);
+}
+
 export type BlockerSeverity = "blocker" | "warn";
 
 export type Blocker = {
@@ -56,7 +89,7 @@ export function computeExportBlockers(
     const receipt = l.matched_receipt_id
       ? receiptMap.get(l.matched_receipt_id)
       : undefined;
-    return !resolveLineCategory(l, receipt);
+    return isUncategorizedLine(l, receipt);
   }).length;
   if (uncategorized > 0) {
     blockers.push({
@@ -75,7 +108,7 @@ export function computeExportBlockers(
   // gate agree in this direction too — previously a month could read "clear"
   // on the tile yet 422 on finalize. `receipts` is month-scoped, matching the
   // gate's `transaction_date LIKE month%` filter.
-  const unknownPath = receipts.filter((r) => r.payment_path === "UNKNOWN").length;
+  const unknownPath = receipts.filter(isUnknownPathReceipt).length;
   if (unknownPath > 0) {
     blockers.push({
       severity: "blocker",
@@ -104,9 +137,7 @@ export function computeExportBlockers(
     });
   }
 
-  const unreviewed = receipts.filter(
-    (r) => r.status === "needs_review" && !isPendingProcessing(r),
-  ).length;
+  const unreviewed = receipts.filter(isUnreviewedReceipt).length;
   if (unreviewed > 0) {
     blockers.push({
       severity: "blocker",

--- a/lib/receipts/month-closing.ts
+++ b/lib/receipts/month-closing.ts
@@ -18,7 +18,7 @@ import type {
   ReceiptRecord,
 } from "@/lib/receipts/types";
 import { validateAmexLinesForSignoff } from "@/lib/receipts/reconciliation-signoff";
-import { isPendingProcessing } from "@/lib/receipts/extraction-state";
+import { isUnreviewedReceipt } from "@/lib/receipts/blockers";
 
 /**
  * Single source of truth for "what ships in this month's export bundle".
@@ -282,7 +282,7 @@ export function validateMonthReadyForExportCore(
   // not "unreviewed"). Direct month-scoped set, NOT bundle.receipts — see the
   // tile-vs-gate drift note in the former inline body (PR #73).
   for (const r of unreviewedReceipts) {
-    if (isPendingProcessing(r)) continue;
+    if (!isUnreviewedReceipt(r)) continue;
     const label = r.merchant ?? r.id;
     blockers.push(
       `Receipt ${label}: unreviewed (status='needs_review') — mark reviewed before exporting`,

--- a/lib/receipts/reconciliation-signoff.ts
+++ b/lib/receipts/reconciliation-signoff.ts
@@ -1,6 +1,7 @@
 import type { AmexStatementLine, ReceiptRecord } from "@/lib/receipts/types";
 import { requiresAttendees } from "@/lib/receipts/categories";
 import { resolveLineCategory } from "@/lib/receipts/line-classification";
+import { isUncategorizedLine } from "@/lib/receipts/blockers";
 
 function csvEscape(value: string | null | undefined): string {
   if (value === null || value === undefined) return "";
@@ -117,7 +118,7 @@ export function validateAmexLinesForSignoff(
     if (line.match_status === "unmatched" || line.match_status === "matched") {
       blockers.push(`AMEX ${label}: unresolved match status (${line.match_status})`);
     }
-    if (!resolvedCategory) {
+    if (isUncategorizedLine(line, receipt)) {
       blockers.push(`AMEX ${label}: missing expense category`);
     }
     if (

--- a/tests/receipts/month-closing.test.ts
+++ b/tests/receipts/month-closing.test.ts
@@ -5,6 +5,7 @@ import {
   type ExportBundle,
   type ValidateMonthReadyInput,
 } from "@/lib/receipts/month-closing";
+import { computeExportBlockers } from "@/lib/receipts/blockers";
 import type {
   AmexReconciliation,
   AmexStatementLine,
@@ -287,4 +288,68 @@ test("gate 6: receipt matched across months blocks only when this month is impli
     }),
   );
   assert.ok(!single.some((b) => b.includes("r-z")));
+});
+
+// ─── Tile ⇄ gate parity ───────────────────────────────────────────────────
+// The tile (computeExportBlockers) and the gate (validateMonthReadyForExportCore)
+// must agree on the shared rules: a receipt/line the tile counts as a blocker
+// must also produce a gate blocker, and vice versa. These guard against the
+// PR #69→#72 / #73 drift class.
+
+test("parity: uncategorized line — tile count == gate verdict", () => {
+  const line = makeLine({
+    matched_receipt_id: null,
+    match_status: "no_receipt",
+    receipt_status: "no_receipt_required",
+    receipt_missing_reason: "lost",
+    expense_category_code: null,
+  });
+  const tile = computeExportBlockers([], [line], []);
+  const tileCount = tile.find((b) => b.label === "Uncategorized AMEX lines")?.count ?? 0;
+  const gate = validateMonthReadyForExportCore(
+    makeInput({ bundle: makeBundle({ amexLines: [line] }) }),
+  );
+  const gateCount = gate.filter((b) => b.includes("missing expense category")).length;
+  assert.equal(tileCount, gateCount, `tile=${tileCount} gate=${gateCount}`);
+  assert.equal(tileCount, 1);
+});
+
+test("parity: unreviewed receipt — tile count == gate verdict", () => {
+  const receipt = makeReceipt({ id: "r-needs", status: "needs_review", merchant: "LAWSON" });
+  const tile = computeExportBlockers([receipt], [], []);
+  const tileCount = tile.find((b) => b.label === "Unreviewed receipts")?.count ?? 0;
+  const gate = validateMonthReadyForExportCore(
+    makeInput({ unreviewedReceipts: [receipt] }),
+  );
+  const gateCount = gate.filter((b) => b.includes("unreviewed")).length;
+  assert.equal(tileCount, gateCount, `tile=${tileCount} gate=${gateCount}`);
+  assert.equal(tileCount, 1);
+});
+
+test("parity: unknown payment path — tile count == gate verdict", () => {
+  const receipt = makeReceipt({ id: "r-unk", payment_path: "UNKNOWN", merchant: "DAISO" });
+  const tile = computeExportBlockers([receipt], [], []);
+  const tileCount = tile.find((b) => b.label === "Receipts with unknown payment path")?.count ?? 0;
+  const gate = validateMonthReadyForExportCore(
+    makeInput({ unknownReceipts: [{ id: "r-unk", merchant: "DAISO" }] }),
+  );
+  const gateCount = gate.filter((b) => b.includes("payment_path is UNKNOWN")).length;
+  assert.equal(tileCount, gateCount, `tile=${tileCount} gate=${gateCount}`);
+  assert.equal(tileCount, 1);
+});
+
+test("parity: clean fixture — neither tile nor gate flags the shared rules", () => {
+  const tile = computeExportBlockers([], [], []);
+  const sharedLabels = [
+    "Uncategorized AMEX lines",
+    "Unreviewed receipts",
+    "Receipts with unknown payment path",
+  ];
+  for (const label of sharedLabels) {
+    assert.equal(tile.find((b) => b.label === label)?.count ?? 0, 0, `${label} should be 0`);
+  }
+  const gate = validateMonthReadyForExportCore(makeInput());
+  assert.ok(!gate.some((b) => b.includes("missing expense category")));
+  assert.ok(!gate.some((b) => b.includes("unreviewed")));
+  assert.ok(!gate.some((b) => b.includes("payment_path is UNKNOWN")));
 });


### PR DESCRIPTION
Extract shared pure predicates (`isUncategorizedLine`, `isUnreviewedReceipt`, `isUnknownPathReceipt`) used by BOTH the export tile (`computeExportBlockers`) and the finalize gate (gate 2.5 + gate 4 via `validateAmexLinesForSignoff`). A shared rule can no longer exist in one and not the other.

Directly addresses the two historical drifts: PR #72 (uncategorized) and PR #73 (unreviewed) — both sides now call the same predicate. Zero behavior change (predicates are the exact inline logic). Labels/hrefs/CTAs stay tile-only.

Parity tests: tile count == gate verdict for uncategorized/unreviewed/unknown fixtures; clean flags neither. tsc 0 / lint 0 errors / 279 tests (+4 parity).