### PR TITLE
test(receipts/api): amex line PATCH parse extraction + #67 contract tests

### DIFF
--- a/app/api/receipts/amex/lines/[id]/route.ts
+++ b/app/api/receipts/amex/lines/[id]/route.ts
@@ -1,46 +1,7 @@
 import { NextResponse } from "next/server";
 import { requireReceiptsActor } from "@/lib/receipts/auth";
 import { updateAmexLineCategory } from "@/lib/receipts/db";
-import { isCanonicalCode } from "@/lib/receipts/categories";
-import type {
-  AmexCategoryStatus,
-  AmexExpenseCategory,
-  AmexReceiptStatus,
-  AmexBusinessTripStatus,
-} from "@/lib/receipts/types";
-
-const VALID_EXPENSE_CATEGORIES: AmexExpenseCategory[] = [
-  "meeting_no_alcohol",
-  "entertainment_alcohol",
-  "transportation",
-  "books",
-  "research",
-  "insurance",
-  "software",
-  "telecom",
-  "office_supplies",
-  "travel",
-  "business_trip",
-  "misc",
-  "unknown",
-];
-const VALID_CATEGORY_STATUSES: AmexCategoryStatus[] = [
-  "uncategorized",
-  "suggested",
-  "confirmed",
-];
-const VALID_RECEIPT_STATUSES: AmexReceiptStatus[] = [
-  "missing_receipt",
-  "matched",
-  "no_receipt_required",
-  "receipt_not_available",
-];
-const VALID_BUSINESS_TRIP_STATUSES: AmexBusinessTripStatus[] = [
-  "not_applicable",
-  "candidate",
-  "confirmed",
-  "excluded",
-];
+import { parseAmexLinePatch, type AmexLinePatchBody } from "@/lib/receipts/api/amex-line-patch";
 
 type RouteContext = { params: Promise<{ id: string }> };
 
@@ -48,111 +9,18 @@ export async function PATCH(request: Request, { params }: RouteContext) {
   try {
     const actor = await requireReceiptsActor(request.headers);
     const { id } = await params;
+    const body = (await request.json()) as AmexLinePatchBody;
 
-    const body = (await request.json()) as {
-      expenseCategory?: string;
-      expenseCategoryCode?: string;
-      categoryStatus?: string;
-      receiptStatus?: string;
-      receiptMissingReason?: string | null;
-      businessTripStatus?: string;
-    };
-
-    // Validate canonical category code if provided
-    const expenseCategoryCode =
-      body.expenseCategoryCode === "" ? null : body.expenseCategoryCode;
-
-    if (expenseCategoryCode && !isCanonicalCode(expenseCategoryCode)) {
-      return NextResponse.json(
-        { error: `Invalid expense category code: ${expenseCategoryCode}` },
-        { status: 400 },
-      );
+    // Parse+validate lives in a pure helper (lib/receipts/api/amex-line-patch)
+    // so the sparse-update contract the DB layer relies on is unit-tested
+    // without D1 — guards the #67 regression (always-present key NULLing
+    // sibling columns).
+    const parsed = parseAmexLinePatch(body);
+    if (!parsed.ok) {
+      return NextResponse.json({ error: parsed.error }, { status: 400 });
     }
 
-    // Validate each enum field if provided — previously these were cast
-    // straight from arbitrary string body input into typed enums and
-    // forwarded to the DB, where invalid values could silently land.
-    if (
-      body.expenseCategory !== undefined &&
-      !VALID_EXPENSE_CATEGORIES.includes(body.expenseCategory as AmexExpenseCategory)
-    ) {
-      return NextResponse.json(
-        { error: `Invalid expenseCategory: ${body.expenseCategory}` },
-        { status: 400 },
-      );
-    }
-    if (
-      body.categoryStatus !== undefined &&
-      !VALID_CATEGORY_STATUSES.includes(body.categoryStatus as AmexCategoryStatus)
-    ) {
-      return NextResponse.json(
-        { error: `Invalid categoryStatus: ${body.categoryStatus}` },
-        { status: 400 },
-      );
-    }
-    if (
-      body.receiptStatus !== undefined &&
-      !VALID_RECEIPT_STATUSES.includes(body.receiptStatus as AmexReceiptStatus)
-    ) {
-      return NextResponse.json(
-        { error: `Invalid receiptStatus: ${body.receiptStatus}` },
-        { status: 400 },
-      );
-    }
-    if (
-      body.businessTripStatus !== undefined &&
-      !VALID_BUSINESS_TRIP_STATUSES.includes(
-        body.businessTripStatus as AmexBusinessTripStatus,
-      )
-    ) {
-      return NextResponse.json(
-        { error: `Invalid businessTripStatus: ${body.businessTripStatus}` },
-        { status: 400 },
-      );
-    }
-    if (
-      body.receiptMissingReason !== undefined &&
-      body.receiptMissingReason !== null &&
-      typeof body.receiptMissingReason !== "string"
-    ) {
-      return NextResponse.json(
-        { error: "receiptMissingReason must be a string or null." },
-        { status: 400 },
-      );
-    }
-
-    const receiptMissingReason =
-      typeof body.receiptMissingReason === "string"
-        ? body.receiptMissingReason.trim().slice(0, 500) || null
-        : body.receiptMissingReason;
-
-    // Build the update input sparsely: only include a key when it was present
-    // in the request body. The DB layer uses `"key" in input` checks for the
-    // nullable fields (expenseCategoryCode, receiptMissingReason) so that an
-    // explicit null clears the column — which means an always-present key with
-    // value undefined would NULL out sibling fields on every save.
-    const updateInput: Parameters<typeof updateAmexLineCategory>[1] = {};
-    if (body.expenseCategory !== undefined) {
-      updateInput.expenseCategory = body.expenseCategory as AmexExpenseCategory;
-    }
-    if ("expenseCategoryCode" in body) {
-      updateInput.expenseCategoryCode = expenseCategoryCode ?? null;
-    }
-    if (body.categoryStatus !== undefined) {
-      updateInput.categoryStatus = body.categoryStatus as AmexCategoryStatus;
-    }
-    if (body.receiptStatus !== undefined) {
-      updateInput.receiptStatus = body.receiptStatus as AmexReceiptStatus;
-    }
-    if ("receiptMissingReason" in body) {
-      updateInput.receiptMissingReason = receiptMissingReason ?? null;
-    }
-    if (body.businessTripStatus !== undefined) {
-      updateInput.businessTripStatus =
-        body.businessTripStatus as AmexBusinessTripStatus;
-    }
-
-    await updateAmexLineCategory(id, updateInput, actor);
+    await updateAmexLineCategory(id, parsed.input, actor);
 
     return NextResponse.json({ ok: true }, { status: 200 });
   } catch (error) {

--- a/lib/receipts/api/amex-line-patch.ts
+++ b/lib/receipts/api/amex-line-patch.ts
@@ -1,0 +1,140 @@
+// Pure parse+validate for PATCH /api/receipts/amex/lines/[id].
+//
+// Extracted from the route so the contract the DB layer relies on — a SPARSE
+// update input carrying only fields the request actually sent — is unit-
+// testable without D1. The #67 regression (an always-present key with value
+// undefined NULLed out sibling columns on every save) is guarded by the
+// "only include a key when present" construction below + the DB layer's
+// `"key" in input` checks for nullable fields.
+
+import { isCanonicalCode } from "@/lib/receipts/categories";
+import type { updateAmexLineCategory } from "@/lib/receipts/db";
+import type {
+  AmexBusinessTripStatus,
+  AmexCategoryStatus,
+  AmexExpenseCategory,
+  AmexReceiptStatus,
+} from "@/lib/receipts/types";
+
+const VALID_EXPENSE_CATEGORIES: AmexExpenseCategory[] = [
+  "meeting_no_alcohol",
+  "entertainment_alcohol",
+  "transportation",
+  "books",
+  "research",
+  "insurance",
+  "software",
+  "telecom",
+  "office_supplies",
+  "travel",
+  "business_trip",
+  "misc",
+  "unknown",
+];
+const VALID_CATEGORY_STATUSES: AmexCategoryStatus[] = [
+  "uncategorized",
+  "suggested",
+  "confirmed",
+];
+const VALID_RECEIPT_STATUSES: AmexReceiptStatus[] = [
+  "missing_receipt",
+  "matched",
+  "no_receipt_required",
+  "receipt_not_available",
+];
+const VALID_BUSINESS_TRIP_STATUSES: AmexBusinessTripStatus[] = [
+  "not_applicable",
+  "candidate",
+  "confirmed",
+  "excluded",
+];
+
+export type AmexLinePatchInput = Parameters<typeof updateAmexLineCategory>[1];
+
+export type AmexLinePatchBody = {
+  expenseCategory?: string;
+  expenseCategoryCode?: string;
+  categoryStatus?: string;
+  receiptStatus?: string;
+  receiptMissingReason?: string | null;
+  businessTripStatus?: string;
+};
+
+export type AmexLinePatchResult =
+  | { ok: true; input: AmexLinePatchInput }
+  | { ok: false; error: string };
+
+/**
+ * Validate the PATCH body and build a SPARSE update input — only fields the
+ * request sent are included. Returns the first validation error, or the input.
+ */
+export function parseAmexLinePatch(body: AmexLinePatchBody): AmexLinePatchResult {
+  const expenseCategoryCode =
+    body.expenseCategoryCode === "" ? null : body.expenseCategoryCode;
+
+  if (expenseCategoryCode && !isCanonicalCode(expenseCategoryCode)) {
+    return { ok: false, error: `Invalid expense category code: ${expenseCategoryCode}` };
+  }
+  if (
+    body.expenseCategory !== undefined &&
+    !VALID_EXPENSE_CATEGORIES.includes(body.expenseCategory as AmexExpenseCategory)
+  ) {
+    return { ok: false, error: `Invalid expenseCategory: ${body.expenseCategory}` };
+  }
+  if (
+    body.categoryStatus !== undefined &&
+    !VALID_CATEGORY_STATUSES.includes(body.categoryStatus as AmexCategoryStatus)
+  ) {
+    return { ok: false, error: `Invalid categoryStatus: ${body.categoryStatus}` };
+  }
+  if (
+    body.receiptStatus !== undefined &&
+    !VALID_RECEIPT_STATUSES.includes(body.receiptStatus as AmexReceiptStatus)
+  ) {
+    return { ok: false, error: `Invalid receiptStatus: ${body.receiptStatus}` };
+  }
+  if (
+    body.businessTripStatus !== undefined &&
+    !VALID_BUSINESS_TRIP_STATUSES.includes(
+      body.businessTripStatus as AmexBusinessTripStatus,
+    )
+  ) {
+    return { ok: false, error: `Invalid businessTripStatus: ${body.businessTripStatus}` };
+  }
+  if (
+    body.receiptMissingReason !== undefined &&
+    body.receiptMissingReason !== null &&
+    typeof body.receiptMissingReason !== "string"
+  ) {
+    return { ok: false, error: "receiptMissingReason must be a string or null." };
+  }
+
+  const receiptMissingReason =
+    typeof body.receiptMissingReason === "string"
+      ? body.receiptMissingReason.trim().slice(0, 500) || null
+      : body.receiptMissingReason;
+
+  // Sparse: only include a key when present in the body. The DB layer uses
+  // `"key" in input` for the nullable fields so an explicit null clears the
+  // column — an always-present key with undefined would NULL siblings (#67).
+  const input: AmexLinePatchInput = {};
+  if (body.expenseCategory !== undefined) {
+    input.expenseCategory = body.expenseCategory as AmexExpenseCategory;
+  }
+  if ("expenseCategoryCode" in body) {
+    input.expenseCategoryCode = expenseCategoryCode ?? null;
+  }
+  if (body.categoryStatus !== undefined) {
+    input.categoryStatus = body.categoryStatus as AmexCategoryStatus;
+  }
+  if (body.receiptStatus !== undefined) {
+    input.receiptStatus = body.receiptStatus as AmexReceiptStatus;
+  }
+  if ("receiptMissingReason" in body) {
+    input.receiptMissingReason = receiptMissingReason ?? null;
+  }
+  if (body.businessTripStatus !== undefined) {
+    input.businessTripStatus = body.businessTripStatus as AmexBusinessTripStatus;
+  }
+  return { ok: true, input };
+}

--- a/tests/receipts/amex-line-patch.test.ts
+++ b/tests/receipts/amex-line-patch.test.ts
@@ -1,0 +1,76 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { parseAmexLinePatch } from "@/lib/receipts/api/amex-line-patch";
+
+// Contract tests for PATCH /api/receipts/amex/lines/[id]. The route's DB
+// layer uses `"key" in input` for nullable fields, so the parse helper MUST
+// build a sparse input (only keys the request sent). An always-present key
+// with undefined would NULL sibling columns on every save — the #67
+// regression. These guard that contract without D1.
+
+test("amex line PATCH: single field → sparse input that won't touch siblings (#67)", () => {
+  const r = parseAmexLinePatch({ expenseCategory: "misc" });
+  assert.ok(r.ok);
+  assert.deepEqual(r.input, { expenseCategory: "misc" });
+});
+
+test("amex line PATCH: only expenseCategoryCode sent → only that key present", () => {
+  const r = parseAmexLinePatch({ expenseCategoryCode: "supplies" });
+  assert.ok(r.ok);
+  assert.deepEqual(r.input, { expenseCategoryCode: "supplies" });
+});
+
+test("amex line PATCH: expenseCategoryCode empty string clears to null (key present)", () => {
+  const r = parseAmexLinePatch({ expenseCategoryCode: "" });
+  assert.ok(r.ok);
+  assert.deepEqual(r.input, { expenseCategoryCode: null });
+});
+
+test("amex line PATCH: receiptMissingReason null clears (key present)", () => {
+  const r = parseAmexLinePatch({ receiptMissingReason: null });
+  assert.ok(r.ok);
+  assert.deepEqual(r.input, { receiptMissingReason: null });
+});
+
+test("amex line PATCH: receiptMissingReason trimmed + sliced to 500 chars", () => {
+  const r = parseAmexLinePatch({ receiptMissingReason: "  lost   " });
+  assert.ok(r.ok);
+  assert.equal(r.input.receiptMissingReason, "lost");
+
+  const long = "x".repeat(600);
+  const r2 = parseAmexLinePatch({ receiptMissingReason: long });
+  assert.ok(r2.ok);
+  assert.equal(r2.input.receiptMissingReason?.length, 500);
+});
+
+test("amex line PATCH: multiple fields all included", () => {
+  const r = parseAmexLinePatch({
+    expenseCategory: "misc",
+    categoryStatus: "confirmed",
+    receiptStatus: "matched",
+  });
+  assert.ok(r.ok);
+  assert.deepEqual(r.input, {
+    expenseCategory: "misc",
+    categoryStatus: "confirmed",
+    receiptStatus: "matched",
+  });
+});
+
+test("amex line PATCH: invalid category code → error", () => {
+  const r = parseAmexLinePatch({ expenseCategoryCode: "definitely-not-a-code" });
+  assert.ok(!r.ok);
+  assert.match(r.error, /Invalid expense category code/);
+});
+
+test("amex line PATCH: invalid enum → error", () => {
+  const r = parseAmexLinePatch({ receiptStatus: "bogus_status" });
+  assert.ok(!r.ok);
+  assert.match(r.error, /Invalid receiptStatus/);
+});
+
+test("amex line PATCH: empty body → empty sparse input (no keys)", () => {
+  const r = parseAmexLinePatch({});
+  assert.ok(r.ok);
+  assert.deepEqual(r.input, {});
+});


### PR DESCRIPTION
Extract PATCH /api/receipts/amex/lines/[id] parse+validate into pure `parseAmexLinePatch`; route becomes thin. 9 contract tests guard the #67 regression (sparse update input — an always-present key with undefined NULLed sibling columns) plus enum validation, null/empty clearing, trimming. tsc 0 / lint 0 / 288 tests (+9). Pattern for the other 4 high-risk routes noted as follow-up.