### PR TITLE
fix(reconcile): bulk-confirm surfaces failed matches

### DIFF
--- a/components/receipts/reconcile/reconcile-screen.tsx
+++ b/components/receipts/reconcile/reconcile-screen.tsx
@@ -276,11 +276,12 @@ export function ReconcileScreen(props: ReconcileScreenProps) {
     );
     if (candidates.length === 0) return;
     setBulkProgress({ current: 0, total: candidates.length });
+    let failed = 0;
     for (let i = 0; i < candidates.length; i++) {
       setBulkProgress({ current: i + 1, total: candidates.length });
       const c = candidates[i]!;
       try {
-        await fetch("/api/receipts/reconcile", {
+        const res = await fetch("/api/receipts/reconcile", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -289,13 +290,19 @@ export function ReconcileScreen(props: ReconcileScreenProps) {
             matchStatus: "confirmed",
           }),
         });
+        if (!res.ok) failed++;
       } catch {
-        // continue
+        failed++;
       }
     }
     setBulkProgress(null);
     router.refresh();
-  }, [locked, linesWithBand, router]);
+    if (failed > 0) {
+      setError(
+        `${failed} of ${candidates.length} match(es) failed to confirm — retry or check those lines.`,
+      );
+    }
+  }, [locked, linesWithBand, router, setError]);
 
   const finalize = useCallback(async () => {
     if (locked) return;


### PR DESCRIPTION
Task 6 silent-failure sweep. bulkConfirmObvious silently skipped non-OK responses (bare await fetch + catch{continue}); now tracks failures and setError with the count. Audit of all mutating client fetches: this was the only true gap; the dismiss-alert is an intentional documented silent-fail (safe fallback); all others already surface errors. tsc 0 / lint 0 / 288 tests.