### PR TITLE
audit(receipts): write export.generated entry on rebuild

### DIFF
--- a/app/api/receipts/export/month/route.ts
+++ b/app/api/receipts/export/month/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
 import { requireReceiptsActor } from "@/lib/receipts/auth";
+import { createAuditEntry } from "@/lib/receipts/audit";
+import { stringifyJson } from "@/lib/receipts/db-utils";
 import {
   createExport,
   finalizeExport,
@@ -245,6 +247,22 @@ export async function POST(request: Request) {
         sha256,
         manifestSha256,
       );
+      // Audit the rebuild (finalize:false) — "export.generated" was defined
+      // for this. The finalize:true path is audited by finalizeExport
+      // ("export.finalized"); recordExportBundle runs inside it there, so we
+      // only audit the standalone rebuild here.
+      await createAuditEntry(getReceiptsDb(), {
+        actor,
+        action: "export.generated",
+        objectType: "export",
+        objectId: exportId,
+        newValueJson: stringifyJson({
+          archiveKey,
+          sha256,
+          manifestSha256,
+          rowCount: bundle.rows.length,
+        }),
+      });
     }
 
     return NextResponse.json(


### PR DESCRIPTION
Task 7. The rebuild path (finalize:false) wrote no audit entry — bundle rebuilds weren't auditable. Add `export.generated` (action existed, unused) at the route rebuild path. finalize:true already audited via export.finalized. Coverage table + 5 backlog gaps in the overnight log. tsc 0 / lint 0 / 288 tests.