### PR TITLE
chore(receipts): labeling + eslint hygiene + statement-month context

### DIFF
--- a/app/(receipt-system)/receipts/export/page.tsx
+++ b/app/(receipt-system)/receipts/export/page.tsx
@@ -28,6 +28,7 @@ import {
 } from "@/lib/receipts/settings";
 import { buildExportBundle } from "@/lib/receipts/month-closing";
 import { buildMonthlyExportCsv } from "@/lib/receipts/export";
+import { deriveStatementWindow } from "@/lib/receipts/statement-window";
 
 export const dynamic = "force-dynamic";
 
@@ -93,6 +94,11 @@ export default async function ExportPage({
   // drives the pending / unreviewed / unknown counts.
   const blockers = computeExportBlockers(monthReceipts, monthLines, bundle.receipts);
   const warnings = computeExportWarnings(monthLines);
+  // Statement window (transaction-date range the statement covers) for the
+  // manifest-preview header — the operator conflated 2026-06 and 2026-07 rows
+  // partly because the preview didn't restate which month/dates it belongs to.
+  const statementWindow =
+    monthLines.length > 0 ? deriveStatementWindow(monthLines, month) : null;
 
   const draftStats = computeDraftStats(bundle.rows);
   const breakdown = computeBreakdown(bundle.rows);
@@ -127,6 +133,7 @@ export default async function ExportPage({
         breakdown={breakdown}
         manifestSample={manifestSample}
         manifestSize={manifestSize}
+        statementWindow={statementWindow}
       />
       <div className="border-t border-amber-100 bg-amber-50 px-8 py-4 text-xs text-amber-900">
         <p className="font-semibold">Accountant review boundary</p>

--- a/components/receipts/export/export-screen.tsx
+++ b/components/receipts/export/export-screen.tsx
@@ -18,6 +18,7 @@ import {
   buildManifestPreviewCsv,
   type ManifestSampleRow,
 } from "@/lib/receipts/manifest-preview";
+import type { StatementWindow } from "@/lib/receipts/statement-window";
 
 export type { Blocker } from "@/lib/receipts/blockers";
 
@@ -47,6 +48,7 @@ export interface ExportScreenProps {
   breakdown: CategoryBreakdownRow[];
   manifestSample: ManifestSampleRow[];
   manifestSize: { rowsTotal: number; sizeBytes: number; sha256: string | null };
+  statementWindow: StatementWindow | null;
 }
 
 export function ExportScreen(props: ExportScreenProps) {
@@ -168,6 +170,8 @@ export function ExportScreen(props: ExportScreenProps) {
         <div className="px-8 pb-12">
           <ReportFormat
             month={props.month}
+            monthLabel={props.monthLabel}
+            statementWindow={props.statementWindow}
             manifestSample={props.manifestSample}
             manifestSize={props.manifestSize}
             finalized={finalized}
@@ -678,13 +682,21 @@ function ReportFormat({
   manifestSize,
   finalized,
   sha256,
+  monthLabel,
+  statementWindow,
 }: {
   month: string;
   manifestSample: ManifestSampleRow[];
   manifestSize: { rowsTotal: number; sizeBytes: number; sha256: string | null };
   finalized: boolean;
   sha256: string | null;
+  monthLabel: string;
+  statementWindow: StatementWindow | null;
 }) {
+  const windowLabel =
+    statementWindow && statementWindow.start && statementWindow.end
+      ? `${statementWindow.start.slice(0, 10)} – ${statementWindow.end.slice(0, 10)}`
+      : null;
   const [view, setView] = useState<"table" | "raw" | "json">("table");
 
   return (
@@ -724,7 +736,7 @@ function ReportFormat({
             Manifest preview
           </span>
           <span className="text-[11px] text-gray-400">
-            showing first {manifestSample.length} of {manifestSize.rowsTotal} rows
+            {monthLabel} statement{windowLabel ? ` · ${windowLabel}` : ""} · {manifestSize.rowsTotal} rows · showing first {manifestSample.length}
           </span>
           <span className="flex-1" />
           <div className="flex gap-1">

--- a/components/receipts/reconcile/reconcile-screen.tsx
+++ b/components/receipts/reconcile/reconcile-screen.tsx
@@ -645,7 +645,7 @@ function LinesPane({
         {tab === "lines" && (
           <>
             {groupReview.length > 0 && (
-              <SectionHeader label="Needs review" count={groupReview.length} dot="bg-red-500" />
+              <SectionHeader label="Needs attention" count={groupReview.length} dot="bg-red-500" />
             )}
             {groupReview.map((l) => (
               <LineRow

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,6 +5,20 @@ import nextTs from "eslint-config-next/typescript";
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
+  {
+    rules: {
+      // Honor the _-prefix convention for intentionally-unused params/vars,
+      // so stubbed auth/db seams (e.g. _actor, _requestHeaders) don't warn.
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+        },
+      ],
+    },
+  },
   // Override default ignores of eslint-config-next.
   globalIgnores([
     // Default ignores of eslint-config-next:
@@ -15,6 +29,8 @@ const eslintConfig = defineConfig([
     "build/**",
     "cloudflare-env.d.ts",
     "next-env.d.ts",
+    // Local-only scaffolding/templates not part of the app build.
+    ".agents/**",
   ]),
 ]);
 


### PR DESCRIPTION
Task 8 (part 1). Rename reconcile 'Needs review' → 'Needs attention' (collision with /receipts/review). Add month + statement-window + row-count context to the export manifest-preview header. eslint: ignore .agents/** + honor _-prefix → clears all 6 pre-existing warnings. tsc 0 / lint 0 warnings / 288 tests.