### PR TITLE
ci: Node-24 actions (checkout@v7, setup-node@v6); keep app node on 22

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,10 +28,10 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
-          node-version: "24"
+          node-version: "22"
           cache: "npm"
       - run: npm ci
       - run: npx tsc --noEmit
@@ -45,10 +45,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch'
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
-          node-version: "24"
+          node-version: "22"
           cache: "npm"
       - run: npm ci
       - name: Probe D1 access (migrations list, read-only)
@@ -71,10 +71,10 @@ jobs:
     if: github.event_name == 'push' && vars.AUTO_DEPLOY == 'true'
     needs: verify
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
-          node-version: "24"
+          node-version: "22"
           cache: "npm"
       - run: npm ci
       - name: Apply D1 migrations (remote, before deploy)


### PR DESCRIPTION
Reverts PR #87's app node bump (22→24 → back to 22). The Node 20→24 change is the actions' runtime: checkout@v4/setup-node@v4 (Node 20, deprecated) → checkout@v7/setup-node@v6 (Node 24 native), clearing the deprecation annotation. App stays on Node 22. Latest majors confirmed via GitHub API (checkout v7.0.0 2026-06-18, setup-node v6.4.0 2026-04-20).