### PR TITLE
ci: persist Clerk public config in wrangler.jsonc vars

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -7,6 +7,18 @@
     "nodejs_compat",
     "global_fetch_strictly_public"
   ],
+  // Public Clerk config (non-secret). Checked in so CI deploys — which have no
+  // .dev.vars — still configure Clerk. The secret key is a wrangler secret
+  // (CLERK_SECRET_KEY), not here. Keep in sync with .dev.vars. Without these,
+  // the Clerk middleware throws on every authed route (the CI-deploy outage:
+  // /admin, /receipts → 500).
+  "vars": {
+    "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY": "pk_live_Y2xlcmsuZGF6YmVlei5jb20k",
+    "NEXT_PUBLIC_CLERK_SIGN_IN_URL": "/receipts/sign-in",
+    "NEXT_PUBLIC_CLERK_SIGN_UP_URL": "/receipts/sign-in",
+    "NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL": "/receipts",
+    "NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL": "/receipts"
+  },
   // Manual secret setup:
   // npx wrangler secret put RESEND_API_KEY
   // npx wrangler secret put RECEIPTS_PROCESSOR_KEY   // ADR 0001: Mac MLX consumer auth


### PR DESCRIPTION
Clerk publishable key + redirect URLs as checked-in vars (public, non-secret) so CI deploys (no .dev.vars) configure Clerk. Fixes the auto-deploy outage (CI deploys left the Worker without Clerk config → middleware threw → /admin,/receipts 500). CLERK_SECRET_KEY stays a wrangler secret.