### PR TITLE
feat(receipts): ADR 0006 PR #2 — flip export bundle to statement-cycle membership

### DIFF
--- a/app/(receipt-system)/receipts/export/[month]/review/page.tsx
+++ b/app/(receipt-system)/receipts/export/[month]/review/page.tsx
@@ -9,8 +9,8 @@ import {
   listAmexLines,
   listAmexLinesForBusinessTripReports,
   listBusinessTripReports,
-  listReceiptRecords,
 } from "@/lib/receipts/db";
+import { listUnknownInScopeReceipts } from "@/lib/receipts/membership";
 import { assertReceiptsPageAccess } from "@/lib/receipts/auth-request";
 import {
   computeExportBlockers,
@@ -32,17 +32,22 @@ export default async function ReviewPage({ params }: { params: Params }) {
   // Same sources the finalize gate uses: buildExportBundle (single row-assembly
   // authority) + listReceiptRecordsByIds-by-way-of-bundle.receipts for matched
   // receipts (never month-scoped receipts for line-category resolution — see
-  // PR #72). monthReceipts (month-scoped) feeds only the tile's pending /
-  // unreviewed / unknown counts.
-  const [bundle, currentExport, reconciliation, monthLines, monthReceipts, tripReports] =
+  // PR #72). monthReceipts (membership in-scope: bundle ∪ UNKNOWN-in-window)
+  // feeds only the tile's pending / unreviewed / unknown counts.
+  const [bundle, currentExport, reconciliation, monthLines, unknownInScope, tripReports] =
     await Promise.all([
       buildExportBundle(month),
       getExport(month),
       getFinalizedReconciliationForMonth(month),
       listAmexLines(month),
-      listReceiptRecords({ month, limit: 1000 }),
+      listUnknownInScopeReceipts(month),
       listBusinessTripReports(month),
     ]);
+  // ADR 0006 (PR #2): tile counting set = in-scope receipts for M = the bundle
+  // (matched AMEX + CASH/DIGITAL assigned to M) ∪ UNKNOWN in M's natural window
+  // — the same set the finalize gate (validateMonthReadyForExport) uses for its
+  // unreviewed check, so the tile and gate cannot drift.
+  const monthReceipts = [...bundle.receipts, ...unknownInScope];
   const tripLines = await listAmexLinesForBusinessTripReports(
     tripReports.map((r) => r.id),
   );

--- a/app/(receipt-system)/receipts/export/page.tsx
+++ b/app/(receipt-system)/receipts/export/page.tsx
@@ -1,11 +1,11 @@
 import {
   listAmexLines,
   listExports,
-  listReceiptRecords,
   getExport,
   listAmexLineCountsByMonth,
   listReconciliationStatusByMonth,
 } from "@/lib/receipts/db";
+import { listUnknownInScopeReceipts } from "@/lib/receipts/membership";
 import {
   formatCategoryLabel,
   getCategoryByCode,
@@ -75,14 +75,19 @@ export default async function ExportPage({
   // We still fetch the unfiltered month receipts + lines separately for the
   // blockers panel (computeExportBlockers runs over the raw receipt set,
   // including UNKNOWN payment_path that the bundle intentionally excludes).
-  const [bundle, exports, monthReceipts, monthLines, currentExport] =
+  const [bundle, exports, unknownInScope, monthLines, currentExport] =
     await Promise.all([
       buildExportBundle(month),
       listExports(),
-      listReceiptRecords({ month, limit: 1000 }),
+      listUnknownInScopeReceipts(month),
       listAmexLines(month),
       getExport(month),
     ]);
+  // ADR 0006 (PR #2): tile counting set = in-scope receipts for M = the bundle
+  // (matched AMEX + CASH/DIGITAL assigned to M) ∪ UNKNOWN in M's natural window
+  // — the same set the finalize gate (validateMonthReadyForExport) uses for its
+  // unreviewed check, so the tile and gate cannot drift.
+  const monthReceipts = [...bundle.receipts, ...unknownInScope];
 
   // bundle.receipts is the ID-fetched matched-receipt set (unscoped by month)
   // plus in-month CASH/DIGITAL receipts — the same authority the finalize

--- a/app/api/receipts/amex/import/route.ts
+++ b/app/api/receipts/amex/import/route.ts
@@ -24,6 +24,7 @@ import {
 import { getReceiptsDb } from "@/lib/cloudflare-runtime";
 import { createReceiptFile } from "@/lib/receipts/files";
 import { createAuditEntry } from "@/lib/receipts/audit";
+import { sweepUnassignedReceipts, detectMembershipDrift } from "@/lib/receipts/membership";
 
 /*
  * AMEX CSV Import — Dedup Contract
@@ -295,6 +296,31 @@ export async function POST(request: Request) {
       );
       warnings.push(
         "Statement lines imported, but business-trip candidate detection failed — re-check the month manually.",
+      );
+    }
+
+    // ── ADR 0006: statement-cycle membership sweep + drift detection ──────
+    // The just-imported statement's window now covers previously-awaiting
+    // CASH/DIGITAL receipts — assign them. Then detect drift: if this was a
+    // re-import/amendment that shifted a close, existing assignments may no
+    // longer match the recomputed windows; the freeze rule holds them fixed
+    // and logs each mismatch for the operator. Non-fatal (lines are committed).
+    try {
+      await sweepUnassignedReceipts(actor);
+      const driftCount = await detectMembershipDrift(actor);
+      if (driftCount > 0) {
+        warnings.push(
+          `${driftCount} assigned receipt(s) drifted after this import (a statement close shifted). ` +
+            `Existing assignments are held fixed (freeze rule) — review and override in Review if needed.`,
+        );
+      }
+    } catch (membershipErr) {
+      console.error(
+        "[amex/import] membership sweep/drift failed (statement lines already committed)",
+        membershipErr,
+      );
+      warnings.push(
+        "Statement lines imported, but statement-cycle membership sweep failed — re-check receipts manually.",
       );
     }
 

--- a/docs/adr/0006-statement-window-membership-for-non-amex-receipts.md
+++ b/docs/adr/0006-statement-window-membership-for-non-amex-receipts.md
@@ -116,8 +116,23 @@ export interface AssignmentResult {
   rolledFrom?: string;                  // natural month when rolled / rolled-awaiting
 }
 
-/** @param sealedMonths finalized statement_months (amex_reconciliations.status='finalized').
- *  CASH/DIGITAL only (policy). UNKNOWN does not roll — it must be classified first. */
+/** @param sealedMonths statement months whose export has SHIPPED and cannot be
+ *  reopened — `receipt_exports.status='finalized'` with no draft revision (the
+ *  isMonthLockedForEdits condition, month-lock.ts). This is the "can this
+ *  receipt still ship in M?" lock for CASH/DIGITAL, per the two-lock model.
+ *  CASH/DIGITAL only (policy). UNKNOWN does not roll — it must be classified first.
+ *
+ *  CORRECTION (this PR): an earlier draft of this section named
+ *  `amex_reconciliations.status='finalized'` (the reconciliation seal) here.
+ *  That was wrong for CASH/DIGITAL: a month whose reconciliation is sealed but
+ *  whose export is still a draft can still accept a late cash receipt into its
+ *  rebuildable bundle, so the reconciliation seal must NOT trigger roll-forward.
+ *  Roll-forward answers "can this receipt still ship in M?", and shipping is
+ *  locked by the export seal, not the reconciliation seal. Corrected here so
+ *  the design of record matches the implementation (lib/receipts/membership.ts
+ *  `loadSealedExportMonths`). The PR #1 backfill ran under the original
+ *  reconciliation-sealed wording and produced 0 roll-forward — identical to the
+ *  export-sealed result, since no export is finalized either way. */
 export function assignReceiptMembership(
   date: string | null,
   windows: MembershipWindow[],
@@ -188,8 +203,8 @@ CREATE INDEX IF NOT EXISTS idx_receipts_export_statement_month
 
 ### D6. Override (discretionary, audited, open-months-only)
 
-- **UI:** a `SelectInput` of **open** statement months (imported months whose reconciliation is not finalized) added to `components/receipts/review/form-pane.tsx` `FormPane`, plus a read-only "natural month" label. Included in the existing debounced PATCH body (`form-pane.tsx:180-194`) as `exportStatementMonth`.
-- **Server:** `app/api/receipts/[id]/route.ts` PATCH handler accepts `exportStatementMonth`; before writing, assert the **target** month is open (`getFinalizedReconciliationForMonth(target) === null`), else 422. The receipt's **current** month being sealed is already blocked by the existing guards (`rejectIfReceiptInFinalizedReconciliation` `db.ts:281-300`; `assertTransactionMonthEditable` `month-lock.ts:178`), so override only applies to receipts in open months targeting open months.
+- **UI:** a `SelectInput` of **open** statement months (imported months whose export is not sealed — `loadSealedExportMonths`) added to `components/receipts/review/form-pane.tsx` `FormPane`, plus a read-only "natural month" label. Included in the existing debounced PATCH body (`form-pane.tsx:180-194`) as `exportStatementMonth`.
+- **Server:** `app/api/receipts/[id]/route.ts` PATCH handler accepts `exportStatementMonth`; before writing, assert the **target** month is open (not in `loadSealedExportMonths()`), else 422. "Open" = export not shipped / reopenable, matching the roll-forward definition above — NOT the reconciliation seal. The receipt's **current** month being sealed is already blocked by the existing guards (`rejectIfReceiptInFinalizedReconciliation` `db.ts:281-300`; `assertTransactionMonthEditable` `month-lock.ts:178`), so override only applies to receipts in open months targeting open months.
 - **Audit:** `createAuditEntry` with `action: "receipt.export_statement_month_overridden"`, `oldValueJson: {export_statement_month}`, `newValueJson: {export_statement_month: target}`, `actor` = the Clerk user.
 
 ### D7. Backfill — migration-adjacent TS script `scripts/backfill-export-statement-month.ts`
@@ -197,7 +212,7 @@ CREATE INDEX IF NOT EXISTS idx_receipts_export_statement_month
 Precedent: `scripts/reprocess-extraction.ts` (TS one-off that writes D1 + audit). The script:
 
 1. Loads all `StatementClose` from `amex_statement_lines` (`GROUP BY statement_month → MAX(transaction_date)`).
-2. Loads `sealedMonths` from `amex_reconciliations WHERE status='finalized'`.
+2. Loads `sealedMonths` per §D3 (export-sealed: `receipt_exports` finalized with no draft). *(Historical note: the PR #1 backfill script shipped with the original `amex_reconciliations`-sealed wording; it produced 0 roll-forward, identical to export-sealed since no export is finalized. The forward hooks in PR #2 use `loadSealedExportMonths`.)*
 3. Computes `windows = computeStatementWindows(closes)` once.
 4. Selects `WHERE export_statement_month IS NULL AND payment_path IN ('CASH','DIGITAL') AND deleted_at IS NULL AND transaction_date IS NOT NULL`.
 5. For each: `assignReceiptMembership(date, windows, sealedMonths, { rollForward: true })`, `UPDATE receipt_records SET export_statement_month=?`, and `createAuditEntry(action: assigned | rolled_forward, oldValueJson: null, newValueJson: {month, reason, rolledFrom?})`.

--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/receipts/month-lock";
 import { shouldOverwriteMerchant } from "@/lib/receipts/reconciliation";
 import { retentionUntilIso } from "@/lib/receipts/retention";
+import { assignMembershipForReceipt } from "@/lib/receipts/membership";
 import { deleteAmexArtifact } from "@/lib/receipts/storage";
 import { PENDING_EXTRACTION_STATES } from "@/lib/receipts/types";
 import type {
@@ -121,6 +122,23 @@ export async function createReceiptRecord(
     objectId: id,
     newValueJson: stringifyJson({ paymentPath, expenseType, source: input.source ?? "upload" }),
   });
+
+  // ADR 0006 (PR #2): assign statement-cycle membership at capture for
+  // CASH/DIGITAL receipts that arrive with a date. The async capture path
+  // inserts with no date (status='captured') and is assigned when the extractor
+  // backfills the date via updateReceiptRecord; the import sweep is the safety
+  // net for anything still NULL. Non-fatal: a failed assignment leaves the
+  // receipt created (NULL month), recoverable by the sweep.
+  if (
+    (paymentPath === "CASH" || paymentPath === "DIGITAL") &&
+    input.transactionDate
+  ) {
+    try {
+      await assignMembershipForReceipt(id, input.transactionDate, actor);
+    } catch (assignErr) {
+      console.error("[createReceiptRecord] membership assignment failed", assignErr);
+    }
+  }
 
   return id;
 }
@@ -276,6 +294,25 @@ export async function updateReceiptRecord(
     oldValueJson: stringifyJson(before),
     newValueJson: stringifyJson(input),
   });
+
+  // ADR 0006 (PR #2): if a date is being set on a CASH/DIGITAL receipt that has
+  // no membership yet, assign it now (sticky — only when currently NULL; an
+  // already-assigned receipt is never re-derived here, matching the freeze
+  // rule). If the date CHANGED on an assigned receipt, drift detection (the
+  // import sweep) flags the mismatch for the operator rather than silently
+  // reassigning.
+  if (
+    "transactionDate" in input &&
+    input.transactionDate &&
+    (effectivePaymentPath === "CASH" || effectivePaymentPath === "DIGITAL") &&
+    !before.export_statement_month
+  ) {
+    try {
+      await assignMembershipForReceipt(id, input.transactionDate, actor);
+    } catch (assignErr) {
+      console.error("[updateReceiptRecord] membership assignment failed", assignErr);
+    }
+  }
 }
 
 async function rejectIfReceiptInFinalizedReconciliation(

--- a/lib/receipts/membership.ts
+++ b/lib/receipts/membership.ts
@@ -1,0 +1,301 @@
+// ADR 0006 — D1-backed statement-cycle membership helpers.
+//
+// The PURE window/assignment math lives in statement-window.ts; this module
+// loads its inputs from D1 and is where persistence decisions are made. Used by
+// buildExportBundle (PR #2 bundle flip), the capture/import assignment hooks,
+// drift detection, and the finalize-gate / tile re-scoping.
+//
+// "Sealed" here = an export month that has SHIPPED and cannot be reopened
+// (finalized AND no draft revision) — i.e. the isMonthLockedForEdits condition
+// from month-lock.ts. Per ADR §D3 (corrected in this PR from the original
+// reconciliation-sealed wording): for CASH/DIGITAL the relevant lock is the
+// EXPORT, not the reconciliation. A month whose reconciliation is sealed but
+// whose export is still a draft can still accept a late cash receipt into its
+// rebuildable bundle, so the reconciliation seal must NOT trigger roll-forward.
+// See the ADR §D3 correction note for the full rationale.
+
+import { getReceiptsDb } from "@/lib/cloudflare-runtime";
+import { createAuditEntry } from "@/lib/receipts/audit";
+import { nowIso } from "@/lib/receipts/db-utils";
+import {
+  assignReceiptMembership,
+  computeStatementWindows,
+  naturalStatementMonth,
+  type AssignmentResult,
+  type MembershipWindow,
+  type StatementClose,
+} from "@/lib/receipts/statement-window";
+import type { PaymentPath, ReceiptRecord } from "@/lib/receipts/types";
+
+/**
+ * Membership windows computed from live AMEX line closes:
+ * window(M) = (close(M-1), close(M)], close(M) = MAX(transaction_date) over
+ * statement M's lines. Statements with no dated lines are dropped (cannot anchor
+ * a window). See statement-window.ts / ADR §D2.
+ */
+export async function loadStatementWindows(): Promise<MembershipWindow[]> {
+  const db = getReceiptsDb();
+  const res = await db
+    .prepare(
+      `SELECT statement_month, MAX(transaction_date) AS close
+       FROM amex_statement_lines
+       WHERE transaction_date IS NOT NULL
+       GROUP BY statement_month`,
+    )
+    .all<{ statement_month: string; close: string | null }>();
+  const closes: StatementClose[] = (res.results ?? [])
+    .filter((r) => Boolean(r.statement_month) && Boolean(r.close))
+    .map((r) => ({ statementMonth: r.statement_month, close: r.close as string }));
+  return computeStatementWindows(closes);
+}
+
+/**
+ * Statement months sealed against new CASH/DIGITAL membership = exports that
+ * shipped AND have no open draft revision (the isMonthLockedForEdits
+ * condition). Roll-forward and the override both treat these as closed targets.
+ */
+export async function loadSealedExportMonths(): Promise<Set<string>> {
+  const db = getReceiptsDb();
+  const res = await db
+    .prepare(
+      `SELECT export_month FROM receipt_exports
+       WHERE status = 'finalized'
+         AND export_month NOT IN (
+           SELECT export_month FROM receipt_exports WHERE status = 'draft'
+         )`,
+    )
+    .all<{ export_month: string }>();
+  return new Set((res.results ?? []).map((r) => r.export_month));
+}
+
+/**
+ * UNKNOWN-path receipts "in scope" for statement month M = those whose
+ * transaction_date's natural window is M. UNKNOWN has no stored membership
+ * month, so its finalize-gate / tile scope is computed. An UNKNOWN receipt
+ * dated beyond the newest close is "awaiting" and is in no month's scope
+ * (blocks nothing). Shared by the finalize gate (gate 2) and the export tile
+ * so the two cannot drift.
+ */
+export async function listUnknownInScopeReceipts(
+  month: string,
+): Promise<ReceiptRecord[]> {
+  const windows = await loadStatementWindows();
+  const db = getReceiptsDb();
+  const res = await db
+    .prepare(
+      `SELECT * FROM receipt_records
+       WHERE deleted_at IS NULL
+         AND payment_path = 'UNKNOWN'
+         AND transaction_date IS NOT NULL`,
+    )
+    .all<ReceiptRecord>();
+  return (res.results ?? []).filter(
+    (r) =>
+      r.transaction_date !== null &&
+      naturalStatementMonth(r.transaction_date, windows) === month,
+  );
+}
+export async function listReceiptsByExportStatementMonth(
+  month: string,
+  paymentPaths: PaymentPath[] = ["CASH", "DIGITAL"],
+): Promise<ReceiptRecord[]> {
+  const db = getReceiptsDb();
+  const placeholders = paymentPaths.map(() => "?").join(",");
+  const res = await db
+    .prepare(
+      `SELECT * FROM receipt_records
+       WHERE deleted_at IS NULL
+         AND export_statement_month = ?
+         AND payment_path IN (${placeholders})
+       ORDER BY transaction_date ASC`,
+    )
+    .bind(month, ...paymentPaths)
+    .all<ReceiptRecord>();
+  return res.results ?? [];
+}
+
+// ─── Assignment (capture / update / import sweep) ──────────────────────────
+
+/**
+ * Assign `export_statement_month` for one CASH/DIGITAL receipt, persisting it
+ * + an audit row. Used at capture (when a date is supplied) and when a date is
+ * first set on a previously-dateless receipt. Sticky-safe: the UPDATE is gated
+ * on `export_statement_month IS NULL`, so a receipt that already has an
+ * assignment (or got assigned by a concurrent sweep) is not overwritten. A null
+ * result (awaiting) writes nothing — the column stays NULL until a covering
+ * statement imports and the sweep picks it up.
+ */
+export async function assignMembershipForReceipt(
+  receiptId: string,
+  transactionDate: string | null,
+  actor: string,
+): Promise<AssignmentResult> {
+  if (!transactionDate) return { month: null, reason: "awaiting" };
+  const [windows, sealedMonths] = await Promise.all([
+    loadStatementWindows(),
+    loadSealedExportMonths(),
+  ]);
+  const result = assignReceiptMembership(transactionDate, windows, sealedMonths, {
+    rollForward: true,
+  });
+  if (result.month === null) return result;
+  const db = getReceiptsDb();
+  await db
+    .prepare(
+      `UPDATE receipt_records SET export_statement_month = ?, updated_at = ?
+       WHERE id = ? AND export_statement_month IS NULL`,
+    )
+    .bind(result.month, nowIso(), receiptId)
+    .run();
+  await createAuditEntry(db, {
+    actor,
+    action:
+      result.reason === "roll-forward"
+        ? "receipt.export_statement_month_rolled_forward"
+        : "receipt.export_statement_month_assigned",
+    objectType: "receipt",
+    objectId: receiptId,
+    oldValueJson: null,
+    newValueJson: JSON.stringify({
+      export_statement_month: result.month,
+      reason: result.reason,
+      rolledFrom: result.rolledFrom ?? null,
+    }),
+  });
+  return result;
+}
+
+export interface MembershipSweepSummary {
+  processed: number;
+  assigned: number;
+  awaiting: number;
+  rolledForward: number;
+  byMonth: Record<string, number>;
+}
+
+/**
+ * Assign every unassigned CASH/DIGITAL receipt (the freeze rule: only NULL
+ * rows are touched). Loads windows + sealed months ONCE, then loops. Called by
+ * the AMEX import route after lines land (a newly-imported statement's window
+ * now covers previously-awaiting receipts) and reusable as a maintenance sweep.
+ */
+export async function sweepUnassignedReceipts(
+  actor: string,
+): Promise<MembershipSweepSummary> {
+  const [windows, sealedMonths] = await Promise.all([
+    loadStatementWindows(),
+    loadSealedExportMonths(),
+  ]);
+  const db = getReceiptsDb();
+  const res = await db
+    .prepare(
+      `SELECT id, transaction_date FROM receipt_records
+       WHERE export_statement_month IS NULL
+         AND payment_path IN ('CASH', 'DIGITAL')
+         AND deleted_at IS NULL
+         AND transaction_date IS NOT NULL`,
+    )
+    .all<{ id: string; transaction_date: string }>();
+  const summary: MembershipSweepSummary = {
+    processed: 0,
+    assigned: 0,
+    awaiting: 0,
+    rolledForward: 0,
+    byMonth: {},
+  };
+  for (const r of res.results ?? []) {
+    summary.processed++;
+    const result = assignReceiptMembership(r.transaction_date, windows, sealedMonths, {
+      rollForward: true,
+    });
+    if (result.month === null) {
+      summary.awaiting++;
+      continue;
+    }
+    await db
+      .prepare(
+        `UPDATE receipt_records SET export_statement_month = ?, updated_at = ?
+         WHERE id = ? AND export_statement_month IS NULL`,
+      )
+      .bind(result.month, nowIso(), r.id)
+      .run();
+    await createAuditEntry(db, {
+      actor,
+      action:
+        result.reason === "roll-forward"
+          ? "receipt.export_statement_month_rolled_forward"
+          : "receipt.export_statement_month_assigned",
+      objectType: "receipt",
+      objectId: r.id,
+      oldValueJson: null,
+      newValueJson: JSON.stringify({
+        export_statement_month: result.month,
+        reason: result.reason,
+        rolledFrom: result.rolledFrom ?? null,
+      }),
+    });
+    summary.assigned++;
+    if (result.reason === "roll-forward") summary.rolledForward++;
+    summary.byMonth[result.month] = (summary.byMonth[result.month] ?? 0) + 1;
+  }
+  return summary;
+}
+
+/**
+ * Freeze-rule drift detection (ADR §D3). Recomputes each assigned CASH/DIGITAL
+ * receipt's membership from scratch (windows + sealed, with roll-forward) and
+ * compares to the stored value. A mismatch means a close shifted, a month
+ * sealed/unsealed, or the receipt was overridden — NEVER reassign (freeze); log
+ * a `receipt.export_statement_month_window_drift` audit row per drifted receipt
+ * and return the count so the import route can surface a non-blocking warning.
+ *
+ * Uses recompute (not a raw natural-month compare) so legitimate roll-forwards
+ * don't false-positive: a rolled receipt recomputes to its rolled month while
+ * the roll target is still the first open month past the sealed natural month.
+ */
+export async function detectMembershipDrift(actor: string): Promise<number> {
+  const [windows, sealedMonths] = await Promise.all([
+    loadStatementWindows(),
+    loadSealedExportMonths(),
+  ]);
+  const db = getReceiptsDb();
+  const res = await db
+    .prepare(
+      `SELECT id, transaction_date, export_statement_month FROM receipt_records
+       WHERE export_statement_month IS NOT NULL
+         AND payment_path IN ('CASH', 'DIGITAL')
+         AND deleted_at IS NULL
+         AND transaction_date IS NOT NULL`,
+    )
+    .all<{
+      id: string;
+      transaction_date: string;
+      export_statement_month: string;
+    }>();
+  let drifted = 0;
+  for (const r of res.results ?? []) {
+    const recomputed = assignReceiptMembership(
+      r.transaction_date,
+      windows,
+      sealedMonths,
+      { rollForward: true },
+    );
+    if (recomputed.month !== r.export_statement_month) {
+      drifted++;
+      await createAuditEntry(db, {
+        actor,
+        action: "receipt.export_statement_month_window_drift",
+        objectType: "receipt",
+        objectId: r.id,
+        oldValueJson: JSON.stringify({ export_statement_month: r.export_statement_month }),
+        newValueJson: JSON.stringify({
+          recomputed_month: recomputed.month,
+          reason: recomputed.reason,
+          rolledFrom: recomputed.rolledFrom ?? null,
+          transaction_date: r.transaction_date,
+        }),
+      });
+    }
+  }
+  return drifted;
+}

--- a/lib/receipts/month-closing.ts
+++ b/lib/receipts/month-closing.ts
@@ -3,10 +3,13 @@ import {
   getFinalizedReconciliationForMonth,
   listAmexLineAttendeeNamesByMonth,
   listAmexLines,
-  listAllReceiptsInMonth,
   listAttendeeNamesByReceiptIds,
   listReceiptRecordsByIds,
 } from "@/lib/receipts/db";
+import {
+  listReceiptsByExportStatementMonth,
+  listUnknownInScopeReceipts,
+} from "@/lib/receipts/membership";
 import { getComplianceSettings } from "@/lib/receipts/settings";
 import { summarizeOpenChecksForExport } from "@/lib/receipts/compliance";
 import { getReceiptsDb } from "@/lib/cloudflare-runtime";
@@ -35,15 +38,16 @@ import { isUnreviewedReceipt } from "@/lib/receipts/blockers";
  *   - One row per AMEX statement line of month M (RowType=amex_line),
  *     with the matched receipt's fields joined when present.
  *     Missing-receipt and no-receipt lines appear with their reasons.
- *   - One row per CASH/DIGITAL receipt with transaction_date in month M
- *     (RowType=receipt). Transaction date is the accounting anchor for
- *     these — they have no statement.
+ *   - One row per CASH/DIGITAL receipt ASSIGNED to statement month M
+ *     (RowType=receipt) — selected by export_statement_month, not the
+ *     calendar month of transaction_date (ADR 0006). The cycle a receipt
+ *     belongs to can lag its date by ~6 weeks.
  *   - A receipt matched to a line appears once (on the line row), never
- *     twice — even if its payment_path is CASH/DIGITAL and its
- *     transaction_date happens to fall in M.
+ *     twice — even if its payment_path is CASH/DIGITAL and it is also
+ *     assigned to M.
  *   - payment_path='UNKNOWN' receipts are intentionally excluded: their
  *     export month is ambiguous. validateMonthReadyForExport blocks
- *     finalize when any are present.
+ *     finalize when any in-scope UNKNOWN receipt is present.
  */
 export interface ExportBundle {
   /** Bundle rows in CSV order: AMEX lines first (by transaction_date), then receipts. */
@@ -81,18 +85,16 @@ export async function buildExportBundle(month: string): Promise<ExportBundle> {
   const matchedReceiptMap = new Map<string, ReceiptRecord>();
   for (const r of matchedReceipts) matchedReceiptMap.set(r.id, r);
 
-  // (3) Non-AMEX receipts anchored by transaction_date in month M. UNKNOWN
-  // is intentionally excluded here (ambiguous export month) — the
-  // validator blocks finalize when any UNKNOWN receipts exist. Pages
-  // internally via listAllReceiptsInMonth and refuses to silently
-  // truncate at the cap (audit A6 — a partial bundle is an audit failure).
-  const [cashReceipts, digitalReceipts] = await Promise.all([
-    listAllReceiptsInMonth(month, { paymentPath: "CASH" }),
-    listAllReceiptsInMonth(month, { paymentPath: "DIGITAL" }),
-  ]);
-  // A receipt matched to a line appears once on the line row — drop it
-  // from the CASH/DIGITAL receipt-rows section so it cannot double-count.
-  const nonAmexReceipts = [...cashReceipts, ...digitalReceipts].filter(
+  // (3) Non-AMEX receipts selected by STORED statement-cycle membership
+  // (ADR 0006 / PR #2): export_statement_month = M, not the calendar month
+  // of transaction_date. A receipt whose transaction_date sits in a different
+  // calendar month than its cycle (the ~6-week AMEX lag) ships in the cycle's
+  // statement month. UNKNOWN is intentionally excluded — it has no assigned
+  // month and blocks finalize at gate 2 until classified. Membership is
+  // assigned/stickied at capture, on first date-set, and by the import sweep
+  // (lib/receipts/membership.ts); receipts the sweep hasn't reached stay NULL
+  // and are excluded here.
+  const nonAmexReceipts = (await listReceiptsByExportStatementMonth(month)).filter(
     (r) => !matchedReceiptMap.has(r.id),
   );
 
@@ -370,27 +372,27 @@ export async function validateMonthReadyForExport(
   const bundle = prebuiltBundle ?? (await buildExportBundle(month));
   const db = getReceiptsDb();
 
-  // (2) UNKNOWN payment_path — queried directly; the bundle excludes UNKNOWN.
-  const unknownResult = await db
-    .prepare(
-      `SELECT id, merchant FROM receipt_records
-       WHERE deleted_at IS NULL
-         AND payment_path = 'UNKNOWN'
-         AND transaction_date LIKE ?`,
-    )
-    .bind(`${month}%`)
-    .all<{ id: string; merchant: string | null }>();
+  // ADR 0006 (PR #2): gate scope is statement-cycle membership, not the
+  // calendar month of transaction_date. CASH/DIGITAL in scope = assigned to M
+  // (already in bundle.receipts, alongside matched AMEX). UNKNOWN has no stored
+  // month, so its scope is computed via listUnknownInScopeReceipts: an UNKNOWN
+  // receipt blocks M only if its transaction_date's natural window is M. An
+  // UNKNOWN receipt dated beyond the newest close is "awaiting" and blocks nothing.
+  const unknownInScope = await listUnknownInScopeReceipts(month);
 
-  // (2.5) Unreviewed receipts in-month (core applies the pending exclusion).
-  const unreviewedResult = await db
-    .prepare(
-      `SELECT * FROM receipt_records
-       WHERE deleted_at IS NULL
-         AND status = 'needs_review'
-         AND transaction_date LIKE ?`,
-    )
-    .bind(`${month}%`)
-    .all<ReceiptRecord>();
+  // (2) UNKNOWN payment_path — only those in M's natural window.
+  const unknownReceipts = unknownInScope.map((r) => ({
+    id: r.id,
+    merchant: r.merchant,
+  }));
+
+  // (2.5) Unreviewed receipts in scope for M = the bundle (matched AMEX +
+  // CASH/DIGITAL assigned to M) ∪ UNKNOWN in M's natural window. This supersedes
+  // PR #73's calendar-scoped (`transaction_date LIKE month%`) query: now that
+  // ADR 0006 defines shipping membership, scoping the unreviewed gate by the
+  // bundle keeps gate ⇄ bundle consistent. Core applies isUnreviewedReceipt
+  // (pending-exclusion) to each.
+  const unreviewedReceipts = [...bundle.receipts, ...unknownInScope];
 
   // (4) AMEX-line attendees.
   const amexAttendees = await listAmexLineAttendeeNamesByMonth(month);
@@ -422,8 +424,8 @@ export async function validateMonthReadyForExport(
     month,
     reconciliation,
     bundle,
-    unknownReceipts: unknownResult.results ?? [],
-    unreviewedReceipts: unreviewedResult.results ?? [],
+    unknownReceipts,
+    unreviewedReceipts,
     amexAttendees,
     complianceSummary: summary,
     complianceSettings: settings,

--- a/tests/receipts/month-closing.test.ts
+++ b/tests/receipts/month-closing.test.ts
@@ -183,6 +183,30 @@ test("gate 2.5: needs_review receipt (not pending) blocks; pending is excluded",
   );
 });
 
+// ADR 0006 (PR #2): gate 2.5 now derives its in-scope set from the bundle,
+// which includes matched AMEX receipts. An unreviewed AMEX receipt that ships
+// in M must block M's finalize — it is no longer hidden by calendar-date
+// scoping (the PR #73 behavior this supersedes). The core does not special-case
+// payment_path at gate 2.5; AMEX is skipped only at gate 3 (field checks).
+test("gate 2.5: unreviewed AMEX receipt (in scope via bundle) blocks", () => {
+  const blockers = validateMonthReadyForExportCore(
+    makeInput({
+      unreviewedReceipts: [
+        makeReceipt({
+          id: "r-amex-needs",
+          payment_path: "AMEX",
+          status: "needs_review",
+          merchant: "AMEX MATCH",
+        }),
+      ],
+    }),
+  );
+  assert.ok(
+    blockers.some((b) => b.includes("AMEX MATCH") && b.includes("unreviewed")),
+    `unreviewed AMEX in scope must block: ${JSON.stringify(blockers)}`,
+  );
+});
+
 // (3) Receipt-level (CASH/DIGITAL) field completeness
 test("gate 3: CASH receipt missing expense category blocks; AMEX is skipped here", () => {
   const blockers = validateMonthReadyForExportCore(


### PR DESCRIPTION
## ADR 0006 PR #2 — Flip the export bundle to statement-cycle membership (behavior change)

Flips `buildExportBundle`, the finalize gates, and the export tile to select CASH/DIGITAL receipts by stored `export_statement_month` (statement-cycle membership) instead of the calendar month of `transaction_date`. The column was added + backfilled in PR #1 (#91); this PR makes the code read it.

### Behavior change
- **2026-06's export bundle becomes AMEX-only** — its 10 June-dated cash receipts belong to the 2026-07 cycle (window Apr 11–May 7 has 0 cash), so they move to 2026-07. 2026-06 export was a draft (not finalized); none of these receipts had `exported_month` set. Recomposition is safe and expected.
- New CASH/DIGITAL captures get `export_statement_month` assigned at capture (or when the extractor backfills the date); the AMEX-import route sweeps any unassigned receipts and runs drift detection.

### Supersedes PR #73 (gate 2.5 scoping)
PR #73 deliberately chose calendar-scoping (`transaction_date LIKE month%`) for gate 2.5. **Membership-based scoping replaces it now that ADR 0006 defines shipping membership** — gate 2.5 derives its in-scope set from the bundle (matched AMEX + CASH/DIGITAL assigned to M) ∪ UNKNOWN-in-M's-natural-window. Side effect (the point): an unreviewed AMEX receipt matched into M but dated in a different calendar month now blocks M's finalize (previously slipped through). Near-zero practical impact (confirmed matches promote to reconciled), but correct where it occurs.

### ADR §D3 corrected (export-sealed, not reconciliation-sealed)
Roll-forward / override "sealed" = `receipt_exports` finalized with no draft (the `isMonthLockedForEdits` condition), per the two-lock model — **not** `amex_reconciliations` finalized. A month whose reconciliation is sealed but whose export is still a draft can still accept a late cash receipt, so the reconciliation seal must not trigger roll-forward. Amended in the ADR (design of record) with a note that reconciliation-sealed was the original wording. Zero prod impact (no export finalized → 0 roll-forward either way; the PR #1 backfill already produced 0).

### What changed
- `lib/receipts/membership.ts` (new): `loadStatementWindows`, `loadSealedExportMonths`, `listReceiptsByExportStatementMonth`, `listUnknownInScopeReceipts`, `assignMembershipForReceipt`, `sweepUnassignedReceipts`, `detectMembershipDrift`.
- `lib/receipts/month-closing.ts`: `buildExportBundle` selects by the column; gates 2/2.5 re-scoped to membership (UNKNOWN via natural-window in-memory; gate 2.5 from the bundle).
- `lib/receipts/db.ts`: capture + update assignment hooks (sticky — only when currently NULL).
- `app/api/receipts/amex/import/route.ts`: post-import sweep + drift detection (non-fatal).
- export + review pages: tile counting set = bundle ∪ UNKNOWN-in-window.
- tests: +1 regression (unreviewed AMEX in scope blocks gate 2.5). Pure window/assignment math covered by PR #1's 23 tests; D1-backed wrappers verified live below.

### Gates
tsc ✓ · 312 tests ✓ · lint ✓ · build:cf ✓

### ✅ Live verify (hard gate, pre-deploy)
- `buildExportBundle(2026-06)` = **AMEX-only**: 32 AMEX lines + **0** CASH/DIGITAL (column has 0 receipts assigned to 2026-06).
- `buildExportBundle(2026-07)` = 20 AMEX lines + **11** CASH/DIGITAL.
- Column distribution unchanged since PR #1 backfill (no drift).

### ⚠️ Sequencing lock
Between PR #1 and this deploy, finalizing 2026-06 would have double-shipped the 10 cash (old calendar filter vs new column). This PR closes the gap. **Do not finalize 2026-06 until this deploy verifies** — after deploy, 2026-06 is AMEX-only and sealable; the operator re-walks the June review page (expect an empty Additional Charges section).
