### PR TITLE
feat(receipts): ADR 0006 PR #3 — membership UI, override, duplicate warning, runbook

### DIFF
--- a/app/(receipt-system)/receipts/export/[month]/review/page.tsx
+++ b/app/(receipt-system)/receipts/export/[month]/review/page.tsx
@@ -10,10 +10,11 @@ import {
   listAmexLinesForBusinessTripReports,
   listBusinessTripReports,
 } from "@/lib/receipts/db";
-import { listUnknownInScopeReceipts } from "@/lib/receipts/membership";
+import { listUnknownInScopeReceipts, loadStatementWindows } from "@/lib/receipts/membership";
 import { assertReceiptsPageAccess } from "@/lib/receipts/auth-request";
 import {
   computeExportBlockers,
+  computeDuplicateReceiptWarnings,
   computeExportWarnings,
 } from "@/lib/receipts/blockers";
 import { deriveStatementWindow } from "@/lib/receipts/statement-window";
@@ -48,6 +49,11 @@ export default async function ReviewPage({ params }: { params: Params }) {
   // — the same set the finalize gate (validateMonthReadyForExport) uses for its
   // unreviewed check, so the tile and gate cannot drift.
   const monthReceipts = [...bundle.receipts, ...unknownInScope];
+  // ADR 0006 (PR #3): the membership cycle window for the Additional Charges
+  // header — (close(M-1), close(M)] — so the operator can see which
+  // transaction-date range a cash receipt must fall in to ship in this month.
+  const cycleWindow =
+    (await loadStatementWindows()).find((w) => w.statementMonth === month) ?? null;
   const tripLines = await listAmexLinesForBusinessTripReports(
     tripReports.map((r) => r.id),
   );
@@ -67,13 +73,17 @@ export default async function ReviewPage({ params }: { params: Params }) {
     monthLines,
     bundle.receipts,
   );
-  const warnings = computeExportWarnings(monthLines);
+  const warnings = [
+    ...computeExportWarnings(monthLines),
+    ...computeDuplicateReceiptWarnings(monthReceipts),
+  ];
 
   return (
     <ReviewScreen
       month={month}
       monthLabel={formatMonth(month)}
       window={window}
+      cycleWindow={cycleWindow}
       rows={bundle.rows}
       receipts={bundle.receipts}
       currentExport={currentExport}

--- a/app/(receipt-system)/receipts/export/page.tsx
+++ b/app/(receipt-system)/receipts/export/page.tsx
@@ -5,7 +5,12 @@ import {
   listAmexLineCountsByMonth,
   listReconciliationStatusByMonth,
 } from "@/lib/receipts/db";
-import { listUnknownInScopeReceipts } from "@/lib/receipts/membership";
+import {
+  listAwaitingReceipts,
+  listUnassignableReceipts,
+  listUnknownInScopeReceipts,
+  nextExpectedStatementMonth,
+} from "@/lib/receipts/membership";
 import {
   formatCategoryLabel,
   getCategoryByCode,
@@ -20,6 +25,7 @@ import { MonthSwitcher, type MonthOption } from "@/components/receipts/month-swi
 import { formatMonth } from "@/lib/receipts/format";
 import {
   computeExportBlockers,
+  computeDuplicateReceiptWarnings,
   computeExportWarnings,
 } from "@/lib/receipts/blockers";
 import {
@@ -75,13 +81,16 @@ export default async function ExportPage({
   // We still fetch the unfiltered month receipts + lines separately for the
   // blockers panel (computeExportBlockers runs over the raw receipt set,
   // including UNKNOWN payment_path that the bundle intentionally excludes).
-  const [bundle, exports, unknownInScope, monthLines, currentExport] =
+  const [bundle, exports, unknownInScope, monthLines, currentExport, awaiting, unassignable, nextExpected] =
     await Promise.all([
       buildExportBundle(month),
       listExports(),
       listUnknownInScopeReceipts(month),
       listAmexLines(month),
       getExport(month),
+      listAwaitingReceipts(),
+      listUnassignableReceipts(),
+      nextExpectedStatementMonth(),
     ]);
   // ADR 0006 (PR #2): tile counting set = in-scope receipts for M = the bundle
   // (matched AMEX + CASH/DIGITAL assigned to M) ∪ UNKNOWN in M's natural window
@@ -98,7 +107,10 @@ export default async function ExportPage({
   // were all matched to April/May receipts). monthReceipts (month-scoped) still
   // drives the pending / unreviewed / unknown counts.
   const blockers = computeExportBlockers(monthReceipts, monthLines, bundle.receipts);
-  const warnings = computeExportWarnings(monthLines);
+  const warnings = [
+    ...computeExportWarnings(monthLines),
+    ...computeDuplicateReceiptWarnings(monthReceipts),
+  ];
   // Statement window (transaction-date range the statement covers) for the
   // manifest-preview header — the operator conflated 2026-06 and 2026-07 rows
   // partly because the preview didn't restate which month/dates it belongs to.
@@ -139,6 +151,9 @@ export default async function ExportPage({
         manifestSample={manifestSample}
         manifestSize={manifestSize}
         statementWindow={statementWindow}
+        awaitingReceipts={awaiting}
+        unassignableReceipts={unassignable}
+        nextExpectedMonth={nextExpected}
       />
       <div className="border-t border-amber-100 bg-amber-50 px-8 py-4 text-xs text-amber-900">
         <p className="font-semibold">Accountant review boundary</p>

--- a/app/(receipt-system)/receipts/review/[id]/page.tsx
+++ b/app/(receipt-system)/receipts/review/[id]/page.tsx
@@ -11,6 +11,7 @@ import { QueueRail } from "@/components/receipts/review/queue-rail";
 import { buildQueueItems } from "@/lib/receipts/queue-items";
 import { ImagePane } from "@/components/receipts/review/image-pane";
 import { FormPane } from "@/components/receipts/review/form-pane";
+import { listOpenStatementMonths, naturalMonthForDate } from "@/lib/receipts/membership";
 import {
   InlineServerError,
   isNextInternalError,
@@ -53,6 +54,13 @@ async function renderReceiptPage(params: Promise<{ id: string }>) {
     listReceiptRecords({ limit: 200 }),
   ]);
   if (!receipt) notFound();
+
+  // ADR 0006 §D6: open statement months (override targets) + the receipt's
+  // natural cycle month, for the discretionary membership override control.
+  const [overrideTargetMonths, naturalStatementMonth] = await Promise.all([
+    listOpenStatementMonths(),
+    naturalMonthForDate(receipt.transaction_date),
+  ]);
 
   // Compute compliance checks fresh on render so the panel always reflects
   // the current state (track_tax_breakdown toggle, backfilled manifest rows,
@@ -137,6 +145,8 @@ async function renderReceiptPage(params: Promise<{ id: string }>) {
             prevReceiptId={prevReceiptId}
             hasAmexMatch={activeFlags?.hasMatch ?? false}
             reReviewNeeded={activeFlags?.reReviewNeeded ?? false}
+            overrideTargetMonths={overrideTargetMonths}
+            naturalStatementMonth={naturalStatementMonth}
           />
         </div>
       }

--- a/app/api/receipts/[id]/route.ts
+++ b/app/api/receipts/[id]/route.ts
@@ -9,6 +9,8 @@ import {
 } from "@/lib/receipts/validation";
 import { isCanonicalCode } from "@/lib/receipts/categories";
 import { getReceiptsDb } from "@/lib/cloudflare-runtime";
+import { createAuditEntry } from "@/lib/receipts/audit";
+import { loadSealedExportMonths } from "@/lib/receipts/membership";
 import {
   runComplianceChecksForReceipt,
   listChecksForObject,
@@ -129,6 +131,7 @@ export async function PATCH(request: Request, { params }: RouteContext) {
       taxAmountMinor?: number | null;
       businessPurpose?: string | null;
       expenseCategoryCode?: string | null;
+      exportStatementMonth?: string | null;
       status?: string;
       attendees?: string[];
       // Compliance fields
@@ -251,6 +254,42 @@ export async function PATCH(request: Request, { params }: RouteContext) {
       }
     }
 
+    // ADR 0006 §D6: discretionary export_statement_month override (cash/digital
+    // only). Target must be export-open — the two-lock model's EXPORT seal
+    // (loadSealedExportMonths), not the reconciliation seal. A sealed month's
+    // bundle already shipped; reassigning into it would silently double-ship.
+    let exportStatementMonth: string | null | undefined = undefined;
+    if ("exportStatementMonth" in body) {
+      if (receipt.payment_path !== "CASH" && receipt.payment_path !== "DIGITAL") {
+        return NextResponse.json(
+          { error: "Statement-month override only applies to cash/digital receipts." },
+          { status: 400 },
+        );
+      }
+      const raw = body.exportStatementMonth;
+      if (raw === null || raw === "") {
+        exportStatementMonth = null;
+      } else if (typeof raw === "string" && /^\d{4}-\d{2}$/.test(raw)) {
+        const sealed = await loadSealedExportMonths();
+        if (sealed.has(raw)) {
+          return NextResponse.json(
+            {
+              error:
+                `${raw}'s export is finalized — cannot reassign a receipt into a sealed month. ` +
+                `Pick an open month, or use the export revision flow.`,
+            },
+            { status: 422 },
+          );
+        }
+        exportStatementMonth = raw;
+      } else {
+        return NextResponse.json(
+          { error: "Invalid exportStatementMonth (expected YYYY-MM or null)." },
+          { status: 400 },
+        );
+      }
+    }
+
     await updateReceiptRecord(
       id,
       {
@@ -263,6 +302,7 @@ export async function PATCH(request: Request, { params }: RouteContext) {
         taxAmountMinor: body.taxAmountMinor,
         businessPurpose,
         expenseCategoryCode,
+        exportStatementMonth,
         status: body.status as ReceiptStatus | undefined,
         sourceType,
         invoiceRegistrationNumber,
@@ -272,6 +312,23 @@ export async function PATCH(request: Request, { params }: RouteContext) {
       },
       actor,
     );
+
+    // ADR 0006 §D6: dedicated audit for the override (old → new month + actor),
+    // separate from the generic receipt.updated entry updateReceiptRecord writes.
+    if ("exportStatementMonth" in body) {
+      await createAuditEntry(getReceiptsDb(), {
+        actor,
+        action: "receipt.export_statement_month_overridden",
+        objectType: "receipt",
+        objectId: id,
+        oldValueJson: JSON.stringify({
+          export_statement_month: receipt.export_statement_month ?? null,
+        }),
+        newValueJson: JSON.stringify({
+          export_statement_month: exportStatementMonth,
+        }),
+      });
+    }
 
     if (Array.isArray(body.attendees)) {
       const attendeeInputs: CreateAttendeeInput[] = body.attendees

--- a/components/receipts/export/export-screen.tsx
+++ b/components/receipts/export/export-screen.tsx
@@ -12,7 +12,8 @@ import {
   FileTextIcon,
   LockIcon,
 } from "@/components/ui/icons";
-import type { ReceiptExport } from "@/lib/receipts/types";
+import type { ReceiptExport, ReceiptRecord } from "@/lib/receipts/types";
+import { formatAmountMinor } from "@/lib/receipts/format";
 import type { Blocker } from "@/lib/receipts/blockers";
 import {
   buildManifestPreviewCsv,
@@ -49,6 +50,78 @@ export interface ExportScreenProps {
   manifestSample: ManifestSampleRow[];
   manifestSize: { rowsTotal: number; sizeBytes: number; sha256: string | null };
   statementWindow: StatementWindow | null;
+  /** ADR 0006 (PR #3): dated CASH/DIGITAL receipts past the newest close —
+   *  self-resolve when the covering statement imports. Informational. */
+  awaitingReceipts: ReceiptRecord[];
+  /** ADR 0006 (PR #3): undated CASH/DIGITAL receipts — can never be assigned,
+   *  need operator action. Needs-attention. */
+  unassignableReceipts: ReceiptRecord[];
+  nextExpectedMonth: string | null;
+}
+
+/** ADR 0006 (PR #3): receipts not yet in any statement-month bundle. Two
+ * DISTINCT states — do not lump them:
+ *  - Awaiting (amber): dated, past the newest close; self-resolves on next import.
+ *  - Unassignable (red): undated; can never be assigned, needs operator action. */
+function UnassignedReceiptsSection({
+  awaiting,
+  unassignable,
+  nextExpectedMonth,
+}: {
+  awaiting: ReceiptRecord[];
+  unassignable: ReceiptRecord[];
+  nextExpectedMonth: string | null;
+}) {
+  if (awaiting.length === 0 && unassignable.length === 0) return null;
+  return (
+    <div className="space-y-3">
+      {unassignable.length > 0 && (
+        <Card>
+          <div className="flex items-baseline justify-between">
+            <div className="text-[13px] font-semibold text-red-700">
+              Unassignable — missing transaction date
+            </div>
+            <Pill tone="red" size="sm">{unassignable.length}</Pill>
+          </div>
+          <p className="mt-1 text-[12px] text-gray-500">
+            These cash/digital receipts have no date and can never be assigned to a statement cycle. Set a transaction date to assign them.
+          </p>
+          <ul className="mt-2 space-y-0.5 text-[12.5px]">
+            {unassignable.map((r) => (
+              <li key={r.id}>
+                <Link href={`/receipts/review/${r.id}`} className="text-amber-700 hover:underline">
+                  {r.merchant ?? `R-${r.id.slice(0, 8)}`} · captured {r.captured_at.slice(0, 10)}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </Card>
+      )}
+      {awaiting.length > 0 && (
+        <Card>
+          <div className="flex items-baseline justify-between">
+            <div className="text-[13px] font-semibold text-gray-700">Awaiting statement</div>
+            <Pill tone="amber" size="sm">{awaiting.length}</Pill>
+          </div>
+          <p className="mt-1 text-[12px] text-gray-500">
+            Dated cash/digital receipts past the newest imported statement — they self-assign when the covering statement imports{nextExpectedMonth ? ` (expected ~${nextExpectedMonth})` : ""}.
+          </p>
+          <ul className="mt-2 space-y-0.5 text-[12.5px]">
+            {awaiting.map((r) => (
+              <li key={r.id} className="flex justify-between gap-3">
+                <Link href={`/receipts/review/${r.id}`} className="truncate text-amber-700 hover:underline">
+                  {r.transaction_date} · {r.merchant ?? `R-${r.id.slice(0, 8)}`}
+                </Link>
+                <span className="shrink-0 tabular-nums text-gray-400">
+                  {r.amount_minor != null ? formatAmountMinor(r.amount_minor, r.currency) : ""}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </Card>
+      )}
+    </div>
+  );
 }
 
 export function ExportScreen(props: ExportScreenProps) {
@@ -119,6 +192,11 @@ export function ExportScreen(props: ExportScreenProps) {
           {!finalized && (
             <BlockerTriage blockers={props.blockers} warnings={props.warnings} />
           )}
+          <UnassignedReceiptsSection
+            awaiting={props.awaitingReceipts}
+            unassignable={props.unassignableReceipts}
+            nextExpectedMonth={props.nextExpectedMonth}
+          />
           {draftBuilt ? (
             <DraftPreview
               stats={props.draftStats}

--- a/components/receipts/export/review-screen.tsx
+++ b/components/receipts/export/review-screen.tsx
@@ -15,12 +15,14 @@ import type {
   ReceiptExport,
   ReceiptRecord,
 } from "@/lib/receipts/types";
-import type { StatementWindow } from "@/lib/receipts/statement-window";
+import type { MembershipWindow, StatementWindow } from "@/lib/receipts/statement-window";
 
 export interface ReviewScreenProps {
   month: string;
   monthLabel: string;
   window: StatementWindow | null;
+  /** ADR 0006 membership cycle window (close(M-1), close(M)] — for the Additional Charges header. */
+  cycleWindow: MembershipWindow | null;
   rows: ExportRow[];
   /** bundle.receipts — ID-fetched matched receipts, for side-by-side lookup. */
   receipts: ReceiptRecord[];
@@ -66,7 +68,11 @@ export function ReviewScreen(props: ReviewScreenProps) {
       <div className="space-y-8 px-8 py-8">
         <SummarySection rows={props.rows} receipts={props.receipts} />
         <SideBySideSection amexRows={amexRows} receipts={props.receipts} />
-        <AdditionalChargesSection chargeRows={chargeRows} />
+        <AdditionalChargesSection
+          chargeRows={chargeRows}
+          monthLabel={props.monthLabel}
+          cycleWindow={props.cycleWindow}
+        />
         <BusinessTripsSection
           tripReports={props.tripReports}
           tripLines={props.tripLines}
@@ -439,12 +445,36 @@ function ConsolidatedGroup({
 
 // ─── Section 3: Additional charges (CASH/DIGITAL) ────────────────────────
 
-function AdditionalChargesSection({ chargeRows }: { chargeRows: ExportRow[] }) {
+/** Format a membership window (startExclusive, endInclusive] as the cash-eligible
+ * date range a receipt must fall in to ship in this statement month. The lower
+ * bound is exclusive, so it displays as startExclusive+1 day (a cash receipt
+ * dated exactly on close(M-1) belongs to M-1, not M). Null start ⇒ open. */
+function formatCycleRange(w: MembershipWindow): string {
+  const end = w.endInclusive;
+  if (!w.startExclusive) return `open – ${end}`;
+  const d = new Date(`${w.startExclusive}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + 1);
+  return `${d.toISOString().slice(0, 10)} – ${end}`;
+}
+
+function AdditionalChargesSection({
+  chargeRows,
+  monthLabel,
+  cycleWindow,
+}: {
+  chargeRows: ExportRow[];
+  monthLabel: string;
+  cycleWindow: MembershipWindow | null;
+}) {
+  const range = cycleWindow ? formatCycleRange(cycleWindow) : null;
+  const sub = range
+    ? `${monthLabel} cycle · ${range} · ${chargeRows.length} receipt${chargeRows.length === 1 ? "" : "s"}`
+    : `${monthLabel} cycle · ${chargeRows.length} receipt${chargeRows.length === 1 ? "" : "s"}`;
   return (
     <div>
       <SectionTitle
         title="Additional charges"
-        sub="Non-AMEX receipts (cash/digital) that ship in the export"
+        sub={sub}
       />
       <Card pad={0}>
         <div className="grid grid-cols-[120px_1fr_120px_140px_100px] border-b border-gray-150 bg-gray-50 px-4 py-2 text-[10.5px] font-bold uppercase tracking-[0.05em] text-gray-500">
@@ -456,7 +486,7 @@ function AdditionalChargesSection({ chargeRows }: { chargeRows: ExportRow[] }) {
         </div>
         {chargeRows.length === 0 ? (
           <div className="px-4 py-8 text-center text-[12.5px] text-gray-400">
-            No cash/digital receipts for this month.
+            No cash/digital receipts in this cycle.
           </div>
         ) : (
           chargeRows.map((r, i) => (

--- a/components/receipts/review/form-pane.tsx
+++ b/components/receipts/review/form-pane.tsx
@@ -56,6 +56,10 @@ export interface FormPaneProps {
   prevReceiptId: string | null;
   hasAmexMatch: boolean;
   reReviewNeeded: boolean;
+  /** ADR 0006 §D6: open statement months (valid override targets). */
+  overrideTargetMonths: string[];
+  /** The receipt's natural cycle month (label only). */
+  naturalStatementMonth: string | null;
 }
 
 export function FormPane(props: FormPaneProps) {
@@ -108,6 +112,7 @@ export function FormPane(props: FormPaneProps) {
   // Audit B4: post-save warnings from the API (e.g. compliance recompute
   // failed). Save succeeded, so this is a toast — not an error state.
   const [apiWarnings, setApiWarnings] = useState<string[]>([]);
+  const [overrideBusy, setOverrideBusy] = useState(false);
 
   // ─── OCR extraction (delegated to the useExtraction hook) ───────────
   const {
@@ -231,6 +236,37 @@ export function FormPane(props: FormPaneProps) {
       router,
     ],
   );
+
+  // ADR 0006 §D6: discretionary export_statement_month override. Explicit (not
+  // autosaved) — a confirm states the consequence, then a dedicated PATCH. The
+  // server guards the target month is export-open (two-lock model).
+  async function handleOverride(target: string) {
+    const current = receipt.export_statement_month ?? null;
+    if (!target || target === current) return;
+    const ok = window.confirm(
+      `Reassign this receipt's statement month to ${target}?\n\n` +
+        `It will ship in ${target}'s export${current ? ` instead of ${current}` : ""}. This change is audited.`,
+    );
+    if (!ok) return;
+    setOverrideBusy(true);
+    try {
+      const res = await fetch(`/api/receipts/${receipt.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ exportStatementMonth: target }),
+      });
+      const json = (await res.json().catch(() => ({}))) as { error?: string };
+      if (!res.ok) {
+        setSave({ kind: "error", message: json.error ?? "Override failed" });
+        return;
+      }
+      router.refresh();
+    } catch {
+      setSave({ kind: "error", message: "Network error" });
+    } finally {
+      setOverrideBusy(false);
+    }
+  }
 
   useEffect(() => {
     if (initialRenderRef.current) {
@@ -577,6 +613,41 @@ export function FormPane(props: FormPaneProps) {
             </Field>
           </div>
         </FormGroup>
+
+        {(paymentPath === "CASH" || paymentPath === "DIGITAL") && (
+          <div className="rounded-xl border border-gray-200 bg-white p-4">
+            <div className="text-[11px] font-semibold uppercase tracking-[0.05em] text-gray-500">
+              Statement month
+            </div>
+            <p className="mt-1 text-[12px] text-gray-500">
+              The cycle this receipt ships in (ADR 0006). Natural cycle:{" "}
+              <span className="font-medium text-gray-700">
+                {props.naturalStatementMonth ?? "— awaiting / no date"}
+              </span>
+              . Override moves it to a different open month — audited, sealed months blocked.
+            </p>
+            <div className="mt-2.5 flex items-center gap-2">
+              <select
+                value={receipt.export_statement_month ?? ""}
+                onChange={(e) => handleOverride(e.target.value)}
+                disabled={overrideBusy}
+                className="h-[36px] rounded-lg border border-gray-200 bg-white px-3 text-sm text-gray-900 focus:border-amber-500 focus:outline-none"
+              >
+                <option value="">
+                  {receipt.export_statement_month ?? "— unassigned —"}
+                </option>
+                {props.overrideTargetMonths
+                  .filter((m) => m !== receipt.export_statement_month)
+                  .map((m) => (
+                    <option key={m} value={m}>
+                      {m}
+                    </option>
+                  ))}
+              </select>
+              {overrideBusy && <span className="text-[12px] text-gray-400">Reassigning…</span>}
+            </div>
+          </div>
+        )}
 
         <div className="mt-5 flex items-center gap-2.5 rounded-xl bg-gray-50 p-3.5">
           <Btn

--- a/docs/month-close-runbook.md
+++ b/docs/month-close-runbook.md
@@ -21,16 +21,14 @@ path calls `finalize=true`.
 ## The statement month vs transaction dates
 
 An AMEX statement labeled `YYYY-MM` covers a **~6-week transaction window that
-lags the label** — e.g. the 2026-06 statement contains lines dated Apr 10 –
-May 7. The export bundle is scoped by **`statement_month`** (not
-transaction_date), so a June-statement line dated in April is correct and
-ships in the June export. The manifest-preview header restates the window
-("June 2026 statement · Apr 10 – May 7 · 42 rows") to avoid confusing this
-with the next month's statement.
+lags the label** — e.g. the 2026-06 statement contains lines dated Apr 10 – May 7.
 
-Rows in the bundle = AMEX statement lines + in-month CASH/DIGITAL receipts
-(matched receipts appear once on their line; UNKNOWN-path receipts are
-excluded and block finalize).
+- **AMEX lines** ship in their `statement_month` (a June-statement line dated in April is correct).
+- **CASH/DIGITAL receipts** ship by **statement-cycle membership** (ADR 0006): each receipt has a stored `export_statement_month` — the cycle its `transaction_date` falls in. `window(M) = (close(M-1), close(M)]` where `close(M)` = MAX `transaction_date` over statement M's AMEX lines, zero slack. A cash receipt dated May 3 belongs to the 2026-06 cycle (Apr 11 – May 7) and ships in **June** — the same cycle as the AMEX lines, not the calendar month of its date.
+
+The export bundle is still `buildExportBundle(month)`; PR #2 flipped it to select CASH/DIGITAL by `export_statement_month` instead of `transaction_date LIKE`. The **Additional charges** section header now shows the cycle range and receipt count (e.g. "June 2026 cycle · Apr 11 – May 7 · 0 receipts"). UNKNOWN-path receipts are excluded and block finalize.
+
+Membership is sticky: assigned once (at capture, when a date is first set, or by the AMEX-import sweep) and never re-derived — if a re-import shifts a close, existing assignments stay put and a drift warning is logged. Receipts dated beyond the newest imported statement's close are **awaiting** (NULL); undated cash/digital receipts are **unassignable** — see below.
 
 ## Blockers — what each means and where to fix it
 
@@ -50,6 +48,7 @@ rule definitions. If the tile shows a blocker, the gate will enforce it.
 | Compliance blocker / warning | Open compliance-engine checks on the month's receipts. | Resolve in the compliance UI; warnings only block if `export_block_on_warnings=true`. |
 | Cross-month match | A receipt is matched to AMEX lines in two different statement months. | Disambiguate the match in reconcile so the receipt belongs to one statement. |
 | Business-trip candidate | A line is flagged as a trip candidate, unresolved. | `/receipts/reconcile` — confirm or dismiss the trip cluster. |
+| Possible duplicate cash/digital receipts (warning) | 2+ CASH/DIGITAL receipts share merchant + amount + transaction_date. | `/receipts/review/<id>` — confirm distinct (non-blocking, no auto-dedup). |
 
 ## Rebuild vs finalize
 
@@ -66,12 +65,21 @@ If finalize 400s with "Export bundle has not been generated yet", you haven't
 rebuilt since the last deploy — click Rebuild first (it persists the archive
 keys the finalize route checks).
 
+## Membership states & override (ADR 0006)
+
+**Awaiting statement** — dated CASH/DIGITAL receipts past the newest imported statement's close (`export_statement_month` NULL). Shown on the export page. Self-resolving: the next AMEX import whose window covers the date assigns them via the import sweep.
+
+**Unassignable** — cash/digital receipts with no `transaction_date`. These can never be assigned and are invisible to every membership query. Needs-attention on the export page; deep-link to the receipt and set a date.
+
+**Late-receipt roll-forward** — a receipt captured after its covering month's export shipped is rolled forward to the next **open** statement month (audited `receipt.export_statement_month_rolled_forward`). "Open" = the export is not finalized (two-lock model: the **export** seal, not the reconciliation seal).
+
+**Discretionary override** — on a receipt's edit view (CASH/DIGITAL only), the "Statement month" control reassigns `export_statement_month` to a different **open** month. Blocked for sealed months (the export already shipped — use the revision flow). A confirm dialog states the consequence; audited as `receipt.export_statement_month_overridden`.
+
+**Drift warning** — if a statement re-import shifts a close date, existing assignments are held fixed (sticky); each mismatch is logged (`receipt.export_statement_month_window_drift`) and surfaced as a non-blocking warning. Override to correct if needed.
+
 ## Sealing 2026-06 (current state)
 
-2026-06 is clear to seal: reconciliation sealed, 0 uncategorized, 0
-unreviewed, 0 UNKNOWN-path, 0 cross-month matches. Click path: export screen →
-Rebuild draft → "Review & finalize" → review page → type "june 2026" →
-Finalize.
+After ADR 0006 (PR #1–#3), 2026-06's export is **AMEX-only**: its 10 June-dated cash receipts belong to the 2026-07 cycle (window Apr 11 – May 7 has 0 cash) and now ship in July. The June review page's Additional Charges section is empty with the cycle range in the header. Reconciliation is sealed; gates pass. Click path: export screen → Rebuild draft → "Review & finalize" → confirm 0 additional charges → type "june 2026" → Finalize.
 
 ## Starting 2026-07
 

--- a/lib/receipts/blockers.ts
+++ b/lib/receipts/blockers.ts
@@ -211,3 +211,43 @@ export function computeExportWarnings(lines: AmexStatementLine[]): Blocker[] {
 
   return warnings;
 }
+
+/**
+ * Non-blocking warning when 2+ CASH/DIGITAL receipts share merchant +
+ * amount_minor + transaction_date (e.g. several ¥10,000 Seven-Eleven charges
+ * on the same day). ADR 0006 §D9 / PR #3. Warning only — no auto-dedup, not a
+ * finalize blocker. Deep-links to the first offending receipt's edit view.
+ *
+ * Receipts not in the CASH/DIGITAL paths, or missing merchant/amount/date, are
+ * ignored (they can't form a duplicate cluster on these keys).
+ */
+export function computeDuplicateReceiptWarnings(
+  receipts: ReceiptRecord[],
+): Blocker[] {
+  const groups = new Map<string, ReceiptRecord[]>();
+  for (const r of receipts) {
+    if (r.payment_path !== "CASH" && r.payment_path !== "DIGITAL") continue;
+    if (!r.transaction_date || r.merchant == null || r.amount_minor == null) continue;
+    const key = `${r.merchant} ${r.amount_minor} ${r.transaction_date}`;
+    const g = groups.get(key) ?? [];
+    g.push(r);
+    groups.set(key, g);
+  }
+  const clusters = [...groups.values()].filter((g) => g.length >= 2);
+  if (clusters.length === 0) return [];
+  const totalFlagged = clusters.reduce((s, g) => s + g.length, 0);
+  const first = clusters[0]![0]!;
+  return [
+    {
+      severity: "warn",
+      count: totalFlagged,
+      label: "Possible duplicate cash/digital receipts",
+      detail:
+        `${clusters.length} cluster(s) share merchant + amount + date ` +
+        `(e.g. ${first.merchant} ×${clusters[0]!.length} on ${first.transaction_date}). ` +
+        `Confirm these are distinct charges, not double-captured.`,
+      href: `/receipts/review/${first.id}`,
+      ctaLabel: "Open first",
+    },
+  ];
+}

--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -247,6 +247,14 @@ export async function updateReceiptRecord(
   if ("processedR2Key" in input) { sets.push("processed_r2_key = ?"); binds.push(input.processedR2Key ?? null); }
   if ("extractionJson" in input) { sets.push("extraction_json = ?"); binds.push(input.extractionJson ?? null); }
   if ("exportedMonth" in input) { sets.push("exported_month = ?"); binds.push(input.exportedMonth ?? null); }
+  // ADR 0006 §D6: discretionary override of the sticky export_statement_month.
+  // The route guards the target month is export-open and writes the dedicated
+  // audit entry; this just applies the column. Explicit override wins over the
+  // automatic assignment hook below.
+  if ("exportStatementMonth" in input) {
+    sets.push("export_statement_month = ?");
+    binds.push(input.exportStatementMonth ?? null);
+  }
   if ("expenseCategoryCode" in input) { sets.push("expense_category_code = ?"); binds.push(input.expenseCategoryCode ?? null); }
   if ("sourceType" in input) { sets.push("source_type = ?"); binds.push(input.sourceType ?? null); }
   if ("invoiceRegistrationNumber" in input) { sets.push("invoice_registration_number = ?"); binds.push(input.invoiceRegistrationNumber ?? null); }
@@ -305,7 +313,8 @@ export async function updateReceiptRecord(
     "transactionDate" in input &&
     input.transactionDate &&
     (effectivePaymentPath === "CASH" || effectivePaymentPath === "DIGITAL") &&
-    !before.export_statement_month
+    !before.export_statement_month &&
+    !("exportStatementMonth" in input)
   ) {
     try {
       await assignMembershipForReceipt(id, input.transactionDate, actor);

--- a/lib/receipts/membership.ts
+++ b/lib/receipts/membership.ts
@@ -114,6 +114,98 @@ export async function listReceiptsByExportStatementMonth(
   return res.results ?? [];
 }
 
+// ─── Unassigned-receipt surfaces (awaiting / unassignable) ─────────────────
+
+/** Increment a YYYY-MM by n months (n may be negative). */
+function incrementMonth(ym: string, n: number): string {
+  const [y, m] = ym.split("-").map(Number);
+  const total = y * 12 + (m - 1) + n;
+  const ny = Math.floor(total / 12);
+  const nm = (total % 12) + 1;
+  return `${ny}-${String(nm).padStart(2, "0")}`;
+}
+
+/**
+ * Heuristic next statement month for "awaiting" receipts (dated past the
+ * newest close): the statement immediately after the newest imported one. A
+ * rough hint — awaiting receipts are usually recent captures just past the
+ * newest close, so the next statement is the right landing month. Labeled
+ * "expected" in the UI; the operator sees the actual transaction_date too.
+ */
+export async function nextExpectedStatementMonth(): Promise<string | null> {
+  const windows = await loadStatementWindows();
+  if (windows.length === 0) return null;
+  const newest = windows[windows.length - 1]!.statementMonth;
+  return incrementMonth(newest, 1);
+}
+
+/**
+ * CASH/DIGITAL receipts awaiting a covering statement — dated, unassigned
+ * (export_statement_month NULL). Self-resolving: the next AMEX import whose
+ * window covers the date assigns them via the sweep. Informational, not a
+ * blocker.
+ */
+export async function listAwaitingReceipts(): Promise<ReceiptRecord[]> {
+  const db = getReceiptsDb();
+  const res = await db
+    .prepare(
+      `SELECT * FROM receipt_records
+       WHERE export_statement_month IS NULL
+         AND payment_path IN ('CASH', 'DIGITAL')
+         AND deleted_at IS NULL
+         AND transaction_date IS NOT NULL
+       ORDER BY transaction_date ASC`,
+    )
+    .all<ReceiptRecord>();
+  return res.results ?? [];
+}
+
+/**
+ * CASH/DIGITAL receipts that can NEVER be assigned — no transaction_date.
+ * Distinct from awaiting: these need operator action (set a date), will never
+ * auto-resolve, and are invisible to every membership query. Style as
+ * needs-attention; deep-link to the receipt's edit view.
+ */
+export async function listUnassignableReceipts(): Promise<ReceiptRecord[]> {
+  const db = getReceiptsDb();
+  const res = await db
+    .prepare(
+      `SELECT * FROM receipt_records
+       WHERE export_statement_month IS NULL
+         AND payment_path IN ('CASH', 'DIGITAL')
+         AND deleted_at IS NULL
+         AND transaction_date IS NULL
+       ORDER BY captured_at DESC`,
+    )
+    .all<ReceiptRecord>();
+  return res.results ?? [];
+}
+
+/** Imported statement months that are NOT export-sealed — the valid targets for
+ *  a discretionary membership override (ADR §D6). A receipt may be reassigned to
+ *  any open month; sealed months are blocked (the bundle already shipped). */
+export async function listOpenStatementMonths(): Promise<string[]> {
+  const [windows, sealed] = await Promise.all([
+    loadStatementWindows(),
+    loadSealedExportMonths(),
+  ]);
+  return windows
+    .map((w) => w.statementMonth)
+    .filter((m) => !sealed.has(m))
+    .sort();
+}
+
+/** The natural statement month for a date (the cycle it falls in by window
+ *  math), ignoring sealed-state/roll-forward. Used to label the receipt's
+ *  "natural" month next to an override. Null if the date is awaiting. */
+export async function naturalMonthForDate(
+  date: string | null,
+): Promise<string | null> {
+  if (!date) return null;
+  const windows = await loadStatementWindows();
+  return naturalStatementMonth(date, windows);
+}
+
 // ─── Assignment (capture / update / import sweep) ──────────────────────────
 
 /**


### PR DESCRIPTION
## ADR 0006 PR #3 — Membership UI, override, duplicate warning, runbook

Final UI/warnings/docs PR for statement-cycle membership. (Manual business trips + ADR 0007 split into a follow-up PR — trips are a separable meta-layer.)

### A — Additional Charges cycle header
`review-screen.tsx` `AdditionalChargesSection` now shows the statement cycle range + receipt count in its header (e.g. "June 2026 cycle · 2026-04-11 – 2026-05-07 · 0 receipts"). The route feeds the membership window `(close(M-1), close(M)]`; lower bound is exclusive so it displays as `startExclusive+1`.

### B — Awaiting + Unassignable (distinct states)
Export page gets two cards (NOT lumped):
- **Awaiting statement** (amber): dated CASH/DIGITAL past the newest close; self-resolves on next import. Shows expected next month.
- **Unassignable — missing transaction date** (red): undated CASH/DIGITAL; can never be assigned, needs operator action. Deep-links to the receipt's edit view.

### C — Discretionary override (ADR §D6)
A "Statement month" control on the receipt edit view (CASH/DIGITAL only) reassigns `export_statement_month` to an **open** month. Confirm dialog states the consequence; the PATCH handler guards the target is export-open (`loadSealedExportMonths` — the two-lock **export** seal), else 422. Audited as `receipt.export_statement_month_overridden` (old → new → actor).

### D — Duplicate-receipt warning (non-blocking)
`computeDuplicateReceiptWarnings` in `blockers.ts` flags 2+ CASH/DIGITAL receipts sharing merchant + amount + transaction_date. Surfaced on the review + export pages as a warning; deep-links to the first receipt. No auto-dedup, not a blocker.

### F12 — Runbook
`docs/month-close-runbook.md`: cycle membership rule (what Additional charges now means), awaiting vs unassignable, override procedure + guardrails, late-receipt roll-forward, duplicate warning, updated June-sealing state.

### Gates
tsc ✓ · 312 tests ✓ · lint ✓ · build:cf ✓ · no new migration, no new deps.

### ⚠️ Note
This PR does **not** include manual business-trip registration (section E) — split into a follow-up PR. Trips are a meta-layer (allowed regardless of export state); the existing finalize gate on unresolved `business_trip_status='candidate'` lines is unchanged.

### Operator click-path after this lands
1. Walk `/receipts/export/2026-06/review` — expect **0 additional charges** with the cycle range in the header, gates clear.
2. **Finalize June.**
3. (Follow-up PR) Register the Odawara trip — valid before or after sealing under the meta-layer semantics.
