### PR TITLE
chore(receipts): replace literal NUL bytes in duplicate-key with the NUL escape sequence

### DIFF
--- a/lib/receipts/blockers.ts
+++ b/lib/receipts/blockers.ts
@@ -228,7 +228,7 @@ export function computeDuplicateReceiptWarnings(
   for (const r of receipts) {
     if (r.payment_path !== "CASH" && r.payment_path !== "DIGITAL") continue;
     if (!r.transaction_date || r.merchant == null || r.amount_minor == null) continue;
-    const key = `${r.merchant} ${r.amount_minor} ${r.transaction_date}`;
+    const key = `${r.merchant}\u0000${r.amount_minor}\u0000${r.transaction_date}`;
     const g = groups.get(key) ?? [];
     g.push(r);
     groups.set(key, g);


### PR DESCRIPTION
## What

`computeDuplicateReceiptWarnings` (`lib/receipts/blockers.ts:231`) grouped duplicate cash/digital receipts using **literal NUL bytes** as the field separator in its key (shipped in PR #93). The technique is sound (a NUL can't appear in merchant/amount/date, so it prevents collisions), but raw control bytes in source:

- made `blockers.ts` register as **binary** to `grep` (a NUL terminates C strings, so grep can't see past it),
- **truncated** `awk`/line-oriented tooling at the first NUL,
- hid the bytes from editors,

…which is exactly how it went unnoticed — surfaced by an independent verification pass of ADR 0008 (PR #94).

## Fix

Replace each literal NUL byte with the Unicode NUL escape sequence (backslash-u-0000). **Runtime-identical** — the same NUL character, the same key, the same collision-prevention — but clean UTF-8 source that `grep`/`awk`/`git`/editors read normally.

## Verification

- A codebase-wide scan confirms these were the **only** NUL bytes in `lib`/`app`/`components`/`tests`/`scripts`; **none remain**.
- `npx tsc --noEmit` ✅ · `eslint` ✅ · `npm test` 300/300 ✅
- `grep` now reads `blockers.ts` as a normal text file.

No behavior change. 🤖 Generated with [Claude Code](https://claude.com/claude-code)
