### PR TITLE
feat(receipts): non-blocking IC-card top-up warning + runbook §IC cards

### DIFF
--- a/app/(receipt-system)/receipts/export/[month]/review/page.tsx
+++ b/app/(receipt-system)/receipts/export/[month]/review/page.tsx
@@ -16,6 +16,7 @@ import {
   computeExportBlockers,
   computeDuplicateReceiptWarnings,
   computeExportWarnings,
+  computeIcCardTopUpWarnings,
 } from "@/lib/receipts/blockers";
 import { deriveStatementWindow } from "@/lib/receipts/statement-window";
 import { formatMonth } from "@/lib/receipts/format";
@@ -71,6 +72,7 @@ export default async function ReviewPage({ params }: { params: Params }) {
   const warnings = [
     ...computeExportWarnings(monthLines),
     ...computeDuplicateReceiptWarnings(monthReceipts),
+    ...computeIcCardTopUpWarnings(monthReceipts),
   ];
 
   return (

--- a/app/(receipt-system)/receipts/export/page.tsx
+++ b/app/(receipt-system)/receipts/export/page.tsx
@@ -25,6 +25,7 @@ import {
   computeExportBlockers,
   computeDuplicateReceiptWarnings,
   computeExportWarnings,
+  computeIcCardTopUpWarnings,
 } from "@/lib/receipts/blockers";
 import {
   ACCOUNTANT_DISCLAIMER_EN,
@@ -106,6 +107,7 @@ export default async function ExportPage({
   const warnings = [
     ...computeExportWarnings(monthLines),
     ...computeDuplicateReceiptWarnings(monthReceipts),
+    ...computeIcCardTopUpWarnings(monthReceipts),
   ];
   // Statement window (transaction-date range the statement covers) for the
   // manifest-preview header — the operator conflated 2026-06 and 2026-07 rows

--- a/docs/month-close-runbook.md
+++ b/docs/month-close-runbook.md
@@ -49,6 +49,7 @@ rule definitions. If the tile shows a blocker, the gate will enforce it.
 | Cross-month match | A receipt is matched to AMEX lines in two different statement months. | Disambiguate the match in reconcile so the receipt belongs to one statement. |
 | Business-trip candidate | A line is flagged as a trip candidate, unresolved. | `/receipts/reconcile` — confirm or dismiss the trip cluster. |
 | Possible duplicate cash/digital receipts (warning) | 2+ CASH/DIGITAL receipts share merchant + amount + transaction_date. | `/receipts/review/<id>` — confirm distinct (non-blocking, no auto-dedup). |
+| Possible IC-card top-ups (warning) | A CASH/DIGITAL travel-transportation receipt for a round ¥1k/2k/3k/5k/10k sum at a top-up venue (convenience store / station). | `/receipts/review/<id>` — confirm business usage (non-blocking; see IC cards below). |
 
 ## Rebuild vs finalize
 
@@ -73,9 +74,34 @@ keys the finalize route checks).
 
 **Discretionary override** — on a receipt's edit view (CASH/DIGITAL only), the "Statement month" control reassigns `export_statement_month` to a different **open** month. Blocked for sealed months (the export already shipped — use the revision flow). A confirm dialog states the consequence; audited as `receipt.export_statement_month_overridden`.
 
+## IC cards (Suica / PASMO / ICOCA top-ups)
+
+The export screen and review page raise a non-blocking **"Possible IC-card
+top-ups"** warning when a CASH/DIGITAL receipt categorized as
+`travel_transportation` is a round sum (¥1,000 / ¥2,000 / ¥3,000 / ¥5,000 /
+¥10,000) charged at a top-up venue (セブン-イレブン, ローソン, ファミリーマート,
+NewDays, or a station). All three signals — round sum, venue, and travel
+category — must match on the same receipt; that conjunction is what keeps the
+false-positive rate low (a real ¥1,900 EMot rail fare, or a non-round ¥10,450
+store charge, won't trip it).
+
+An IC-card top-up is a **prepayment, not a travel expense at the moment of
+charge**. Responsible practice — pick whichever fits the card's use:
+
+- **Expense as you go** — keep the card's 利用履歴 (usage history) and claim the
+  actual trip fares as `travel_transportation` as the balance is consumed. The
+  top-up charge itself is then a cash movement, not a deductible travel cost.
+- **Business-dedicated card** — if the card is used only for business travel,
+  note that on the receipt (business_purpose); the top-up can be expensed
+  directly.
+
+The warning is **advisory and does not gate finalize**. Surface the 利用履歴 or
+the business-only note, and let accounting decide — **final treatment is the
+accountant's call**.
+
 ## Sealing 2026-06 (current state)
 
-After ADR 0008, 2026-06's export is **32 AMEX lines + 11 June-dated cash/digital receipts** (the calendar rule puts a June-dated cash receipt in June, alongside the June statement). The June review page's Additional Charges section lists those 11, including a **4× セブン-イレブン 東中野末広橋店 ¥10,000 on 2026-06-11** cluster — confirm the duplicate warning (distinct charges, not double-captured) before finalizing. Reconciliation is sealed; gates pass otherwise. Click path: export screen → Rebuild draft → "Review & finalize" → confirm the 11 additional charges + dismiss the duplicate warning → type "june 2026" → Finalize.
+After ADR 0008, 2026-06's export is **32 AMEX lines + 11 June-dated cash/digital receipts** (the calendar rule puts a June-dated cash receipt in June, alongside the June statement). The June review page's Additional Charges section lists those 11, including a **4× セブン-イレブン 東中野末広橋店 ¥10,000 on 2026-06-11** cluster. That same cluster raises two advisory warnings (both non-blocking): the **duplicate** warning (confirm the four are distinct charges, not double-captured) and, because each is a round ¥10,000 travel_transportation charge at a convenience store, the **IC-card top-up** warning (confirm business usage per §IC cards). Reconciliation is sealed; gates pass otherwise. Click path: export screen → Rebuild draft → "Review & finalize" → confirm the 11 additional charges + acknowledge both warnings → type "june 2026" → Finalize.
 
 ## Starting 2026-07
 

--- a/lib/receipts/blockers.ts
+++ b/lib/receipts/blockers.ts
@@ -48,6 +48,94 @@ export function isUnreviewedReceipt(receipt: ReceiptRecord): boolean {
   return receipt.status === "needs_review" && !isPendingProcessing(receipt);
 }
 
+// ─── IC-card top-up heuristic (non-blocking warning) ──────────────────────
+// A CASH/DIGITAL receipt categorized as travel_transportation, charged for a
+// round top-up sum at a top-up venue (convenience store / station), is likely
+// a prepaid IC-card (Suica/PASMO/ICOCA/etc.) charge — a prepayment, not a
+// travel expense at the moment of charge. Informational warning only: it may
+// be entirely business, and the responsible treatment (expense it as trips
+// deplete the card, or treat the card as business-dedicated) is the
+// accountant's call. NOT wired into the finalize gate — it is advisory.
+// False positives are kept low by requiring ALL THREE signals (round sum AND
+// top-up venue AND travel category) on the same receipt.
+
+/** Round yen sums typical of an IC-card top-up. JPY has no minor units, so
+ * amount_minor IS the yen value. */
+export const IC_CARD_TOPUP_AMOUNTS_MINOR: ReadonlySet<number> = new Set([
+  1000, 2000, 3000, 5000, 10000,
+]);
+
+// Merchant substrings that signal a likely IC-card top-up point: the three
+// major convenience-store chains, the JR NewDays kiosk, and station ticket
+// machines. Matched case-insensitively as substrings of the normalized
+// merchant name (handles chain + branch suffixes like
+// "セブン-イレブン 東中野末広橋店"). Katakana variants are listed explicitly;
+// toLowerCase() only touches the ASCII half.
+const IC_CARD_TOPUP_VENUE_PATTERNS: readonly string[] = [
+  // セブン-イレブン (with / without the hyphen; ASCII spellings)
+  "セブン-イレブン",
+  "セブンイレブン",
+  "seven-eleven",
+  "seven eleven",
+  "7-eleven",
+  "7 eleven",
+  "7eleven",
+  // ローソン
+  "ローソン",
+  "lawson",
+  // ファミリーマート
+  "ファミリーマート",
+  "ファミマ",
+  "familymart",
+  "family mart",
+  "family-mart",
+  // NewDays (JR kiosk)
+  "newdays",
+  "new days",
+  "new-days",
+  // 駅 / station ticket machines
+  "駅",
+  "station",
+];
+
+/** True for a round yen sum typical of an IC-card top-up (¥1k/¥2k/¥3k/¥5k/¥10k). */
+export function isRoundTopUpAmount(
+  amountMinor: number | null | undefined,
+): boolean {
+  return amountMinor != null && IC_CARD_TOPUP_AMOUNTS_MINOR.has(amountMinor);
+}
+
+/** True when the merchant name matches a top-up-venue signal (convenience
+ * store / JR kiosk / station). Null/empty merchants never match. */
+export function isTopUpVenueMerchant(
+  merchant: string | null | undefined,
+): boolean {
+  if (!merchant) return false;
+  const normalized = merchant.toLowerCase();
+  return IC_CARD_TOPUP_VENUE_PATTERNS.some((p) => normalized.includes(p));
+}
+
+/** True when a receipt looks like a prepaid IC-card top-up rather than a
+ * travel expense: CASH/DIGITAL path, travel_transportation category, a round
+ * top-up sum, AND a top-up-venue merchant. All four must hold — a real rail
+ * fare (¥1,900 EMot, not a venue and not round) or a non-round store charge
+ * (¥10,450 PC Depot) won't trip it. Never gates finalize; advisory only. */
+export function isIcCardTopUpCandidate(
+  receipt: Pick<
+    ReceiptRecord,
+    "payment_path" | "expense_category_code" | "amount_minor" | "merchant"
+  >,
+): boolean {
+  if (receipt.payment_path !== "CASH" && receipt.payment_path !== "DIGITAL") {
+    return false;
+  }
+  if (receipt.expense_category_code !== "travel_transportation") return false;
+  return (
+    isRoundTopUpAmount(receipt.amount_minor) &&
+    isTopUpVenueMerchant(receipt.merchant)
+  );
+}
+
 export type BlockerSeverity = "blocker" | "warn";
 
 export type Blocker = {
@@ -246,6 +334,40 @@ export function computeDuplicateReceiptWarnings(
         `${clusters.length} cluster(s) share merchant + amount + date ` +
         `(e.g. ${first.merchant} ×${clusters[0]!.length} on ${first.transaction_date}). ` +
         `Confirm these are distinct charges, not double-captured.`,
+      href: `/receipts/review/${first.id}`,
+      ctaLabel: "Open first",
+    },
+  ];
+}
+
+/**
+ * Non-blocking warning when a CASH/DIGITAL travel_transportation receipt looks
+ * like a prepaid IC-card (Suica/PASMO/ICOCA) top-up — round sum + top-up
+ * venue merchant (convenience store / station). Mirrors
+ * computeDuplicateReceiptWarnings: same surfacing (severity "warn", same
+ * BlockerTriage row), no gate change, deep-links to the first matching
+ * receipt. See isIcCardTopUpCandidate for the predicate + false-positive
+ * controls.
+ *
+ * Top-ups are prepayments, not travel expenses at charge time — the warning
+ * asks the operator to confirm business usage, not to reclassify. Final
+ * treatment is the accountant's call (month-close runbook §IC cards).
+ */
+export function computeIcCardTopUpWarnings(
+  receipts: ReceiptRecord[],
+): Blocker[] {
+  const candidates = receipts.filter(isIcCardTopUpCandidate);
+  if (candidates.length === 0) return [];
+  const first = candidates[0]!;
+  return [
+    {
+      severity: "warn",
+      count: candidates.length,
+      label: "Possible IC-card top-ups (categorized as travel)",
+      detail:
+        `Looks like an IC-card top-up. Top-ups are prepayments, not travel ` +
+        `expenses at charge time — confirm business usage (attach the card's ` +
+        `利用履歴) or note that the card is business-dedicated.`,
       href: `/receipts/review/${first.id}`,
       ctaLabel: "Open first",
     },

--- a/tests/receipts/blockers.test.ts
+++ b/tests/receipts/blockers.test.ts
@@ -1,6 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { computeExportBlockers, type Blocker } from "@/lib/receipts/blockers";
+import {
+  computeExportBlockers,
+  computeIcCardTopUpWarnings,
+  isIcCardTopUpCandidate,
+  type Blocker,
+} from "@/lib/receipts/blockers";
 import type { AmexStatementLine, ReceiptRecord } from "@/lib/receipts/types";
 
 // Fixture builders mirror tests/receipts/reconciliation-signoff.test.ts so the
@@ -228,5 +233,138 @@ test("blockers: needs_review receipt still pending processing is NOT unreviewed"
     unreviewed ?? null,
     null,
     `expected no unreviewed blocker for a pending receipt, got: ${JSON.stringify(blockers)}`,
+  );
+});
+
+// ─── IC-card top-up warning ────────────────────────────────────────────────
+// Non-blocking advisory. All three signals (CASH/DIGITAL path +
+// travel_transportation category + round top-up sum + top-up-venue merchant)
+// must hold. Mirrors computeDuplicateReceiptWarnings surfacing.
+
+test("ic-card warning: fires on the 4× ¥10,000 セブン-イレブン 06-11 prod cluster", () => {
+  // Real prod case (2026-06): four CASH/DIGITAL travel_transportation
+  // receipts, ¥10,000 each at セブン-イレブン (chain + branch suffix). Round
+  // sum + top-up venue + travel category → all signals → one warning, count 4,
+  // deep-linking to the first receipt.
+  const receipts: ReceiptRecord[] = [0, 1, 2, 3].map((i) =>
+    makeReceipt({
+      id: `ic-${i}`,
+      payment_path: i % 2 === 0 ? "CASH" : "DIGITAL",
+      expense_category_code: "travel_transportation",
+      merchant: "セブン-イレブン 東中野末広橋店",
+      amount_minor: 10000,
+      transaction_date: "2026-06-11",
+    }),
+  );
+
+  const warnings = computeIcCardTopUpWarnings(receipts);
+  assert.equal(
+    warnings.length,
+    1,
+    `expected one IC-card warning, got: ${JSON.stringify(warnings)}`,
+  );
+  const w = warnings[0]!;
+  assert.equal(w.severity, "warn");
+  assert.equal(w.count, 4);
+  assert.equal(w.label, "Possible IC-card top-ups (categorized as travel)");
+  assert.equal(w.href, "/receipts/review/ic-0");
+});
+
+test("ic-card warning: does NOT fire on a ¥10,450 PC Depot charge (non-round, non-travel)", () => {
+  // Fails on every signal: non-round amount (10450), non-travel category
+  // (supplies), non-venue merchant. None of the three conditions hold.
+  const receipts: ReceiptRecord[] = [
+    makeReceipt({
+      id: "pcd-1",
+      payment_path: "CASH",
+      expense_category_code: "supplies",
+      merchant: "PC Depot",
+      amount_minor: 10450,
+      transaction_date: "2026-06-12",
+    }),
+  ];
+
+  const warnings = computeIcCardTopUpWarnings(receipts);
+  assert.equal(
+    warnings.length,
+    0,
+    `expected no IC-card warning, got: ${JSON.stringify(warnings)}`,
+  );
+});
+
+test("ic-card warning: does NOT fire on a ¥1,900 EMot rail fare (actual usage, not a top-up venue)", () => {
+  // Genuine travel expense: travel category + DIGITAL path, but neither a
+  // round top-up sum (1900) nor a top-up venue (EMot). Real usage, not a
+  // top-up, so the warning stays silent.
+  const receipts: ReceiptRecord[] = [
+    makeReceipt({
+      id: "emot-1",
+      payment_path: "DIGITAL",
+      expense_category_code: "travel_transportation",
+      merchant: "EMot",
+      amount_minor: 1900,
+      transaction_date: "2026-06-13",
+    }),
+  ];
+
+  const warnings = computeIcCardTopUpWarnings(receipts);
+  assert.equal(
+    warnings.length,
+    0,
+    `expected no IC-card warning, got: ${JSON.stringify(warnings)}`,
+  );
+});
+
+test("ic-card predicate: AMEX path is out of scope even with round sum + venue + travel", () => {
+  // The trigger is CASH/DIGITAL receipts. An AMEX charge would surface as a
+  // statement line, not a receipt — so an AMEX-path receipt is never a
+  // candidate, regardless of the other signals.
+  assert.equal(
+    isIcCardTopUpCandidate({
+      payment_path: "AMEX",
+      expense_category_code: "travel_transportation",
+      amount_minor: 10000,
+      merchant: "セブン-イレブン",
+    }),
+    false,
+  );
+});
+
+test("ic-card predicate: round ¥3,000 at a station + travel + CASH → candidate", () => {
+  // 駅 (station) is a top-up-venue signal; ¥3,000 is a round top-up sum.
+  assert.equal(
+    isIcCardTopUpCandidate({
+      payment_path: "CASH",
+      expense_category_code: "travel_transportation",
+      amount_minor: 3000,
+      merchant: "新宿駅",
+    }),
+    true,
+  );
+});
+
+test("ic-card predicate: round ¥5,000 travel charge at a non-venue merchant (taxi) → not a candidate", () => {
+  assert.equal(
+    isIcCardTopUpCandidate({
+      payment_path: "CASH",
+      expense_category_code: "travel_transportation",
+      amount_minor: 5000,
+      merchant: "日本交通タクシー",
+    }),
+    false,
+  );
+});
+
+test("ic-card predicate: convenience store + round sum but non-travel category → not a candidate", () => {
+  // Same venue + amount, but categorized as entertainment — the IC-card
+  // hypothesis applies narrowly to travel_transportation.
+  assert.equal(
+    isIcCardTopUpCandidate({
+      payment_path: "CASH",
+      expense_category_code: "entertainment",
+      amount_minor: 10000,
+      merchant: "ローソン",
+    }),
+    false,
   );
 });


### PR DESCRIPTION
## What

Adds a **non-blocking "possible IC-card top-up" warning** to the receipts export/review screens, surfaced identically to the existing duplicate-receipt warning (same `BlockerTriage` row, amber pill, deep-link to the first match). **No finalize-gate change** — advisory only.

## Trigger (all three required → low false positives)

A **CASH/DIGITAL** receipt categorized **`travel_transportation`**, with a **round top-up sum** (¥1,000 / ¥2,000 / ¥3,000 / ¥5,000 / ¥10,000) charged at a **top-up venue** (セブン-イレブン · ローソン · ファミリーマート · NewDays · 駅/station).

> An IC-card top-up is a prepayment, not a travel expense at charge time. The warning asks the operator to confirm business usage (attach the card's 利用履歴, or note the card is business-dedicated) — **final treatment is the accountant's call.**

## Changes

| File | Change |
|---|---|
| `lib/receipts/blockers.ts` | Shared predicates `isRoundTopUpAmount`, `isTopUpVenueMerchant`, `isIcCardTopUpCandidate` + `computeIcCardTopUpWarnings` (mirrors `computeDuplicateReceiptWarnings`) |
| `app/(receipt-system)/receipts/export/page.tsx` | Add to the month `warnings` array |
| `app/.../export/[month]/review/page.tsx` | Add to the month `warnings` array |
| `docs/month-close-runbook.md` | New **§IC cards** section + blockers-table row; 2026-06 note (same ¥10k セブン cluster raises both this and the duplicate warning) |
| `tests/receipts/blockers.test.ts` | 7 new tests |

## Tests

- ✅ fires on the **4× ¥10,000 セブン-イレブン 06-11** prod cluster (count 4, correct deep-link)
- ✅ silent on **¥10,450 PC Depot** (non-round, non-travel)
- ✅ silent on **¥1,900 EMot rail fare** (non-round, non-venue — actual usage)
- ✅ AMEX path out of scope; station venue matches; non-venue taxi silent; non-travel category silent

## Verification (all green, matching CI `verify` job)

`npm test` (307 pass) · `npx tsc --noEmit` · `npm run lint` · `npm run build:cf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)