### PR TITLE
feat(receipts): canonicalize merchant before duplicate/IC matching (PR A)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,6 +248,22 @@ reconciliation finalized. Design consequences:
     printed T-number (receipt 92418c1a, T2810074043972 visible on image).
     Improve Mac-side extractor recall; consider a re-extract pass over
     existing receipts whose extraction_json lacks the field.
+15. **Canonical merchant at capture (write-side canonicalization).** PR A
+    (merchant.ts) ships READ-side canonicalization: computeDuplicateReceiptWarnings
+    grouping + isTopUpVenueMerchant canonicalize before matching, so OCR-garbled
+    chain variants (2026-06 "セブンーエレブン" vs "セブン-イレブン 東中野末広橋店")
+    cluster/match without touching stored data. Assessed WRITE-side here, did
+    NOT build it: a canonical_merchant column populated at capture would need a
+    schema migration + backfill + edits to THREE write paths (MLX-extraction
+    apply, amex import, the receipt PATCH merchant field) and re-canonicalize on
+    every operator edit — it touches the MLX consumer contract (the garbles
+    originate in extraction.ts parseMerchant VLM output). Recommendation:
+    DEFER until backlog #14 (extraction recall) lands — canonicalizing a
+    column that a noisy extractor keeps re-garbling is churn. When added, a
+    stored canonical key also lets the manifest/export and the reconcile dedup
+    UI show a clean merchant without re-deriving. Read-side canonicalization
+    delivers the user value now (June-2 pair clusters; IC count 7→8) and is the
+    single match authority until then.
 
 ## Two-Agent Workflow: Sandbox (Architect) vs. CLI (Worker)
 

--- a/lib/receipts/blockers.ts
+++ b/lib/receipts/blockers.ts
@@ -13,6 +13,7 @@
 import { requiresAttendees } from "@/lib/receipts/categories";
 import { isPendingProcessing } from "@/lib/receipts/extraction-state";
 import { resolveLineCategory } from "@/lib/receipts/line-classification";
+import { canonicalizeMerchant, detectMerchantChain } from "@/lib/receipts/merchant";
 import type { AmexStatementLine, ReceiptRecord } from "@/lib/receipts/types";
 
 // ─── Shared predicates (tile ⇄ gate) ─────────────────────────────────────
@@ -65,39 +66,6 @@ export const IC_CARD_TOPUP_AMOUNTS_MINOR: ReadonlySet<number> = new Set([
   1000, 2000, 3000, 5000, 10000,
 ]);
 
-// Merchant substrings that signal a likely IC-card top-up point: the three
-// major convenience-store chains, the JR NewDays kiosk, and station ticket
-// machines. Matched case-insensitively as substrings of the normalized
-// merchant name (handles chain + branch suffixes like
-// "セブン-イレブン 東中野末広橋店"). Katakana variants are listed explicitly;
-// toLowerCase() only touches the ASCII half.
-const IC_CARD_TOPUP_VENUE_PATTERNS: readonly string[] = [
-  // セブン-イレブン (with / without the hyphen; ASCII spellings)
-  "セブン-イレブン",
-  "セブンイレブン",
-  "seven-eleven",
-  "seven eleven",
-  "7-eleven",
-  "7 eleven",
-  "7eleven",
-  // ローソン
-  "ローソン",
-  "lawson",
-  // ファミリーマート
-  "ファミリーマート",
-  "ファミマ",
-  "familymart",
-  "family mart",
-  "family-mart",
-  // NewDays (JR kiosk)
-  "newdays",
-  "new days",
-  "new-days",
-  // 駅 / station ticket machines
-  "駅",
-  "station",
-];
-
 /** True for a round yen sum typical of an IC-card top-up (¥1k/¥2k/¥3k/¥5k/¥10k). */
 export function isRoundTopUpAmount(
   amountMinor: number | null | undefined,
@@ -105,14 +73,17 @@ export function isRoundTopUpAmount(
   return amountMinor != null && IC_CARD_TOPUP_AMOUNTS_MINOR.has(amountMinor);
 }
 
-/** True when the merchant name matches a top-up-venue signal (convenience
- * store / JR kiosk / station). Null/empty merchants never match. */
+/** True when the merchant is a likely IC-card top-up point: a canonical
+ * convenience-store chain (detected via merchant.ts, so OCR-garbled spellings
+ * like "セブンーエレブン" still match — fixes the 2026-06 IC-warning undercount)
+ * OR a station (駅 / "station"). Null/empty merchants never match. Advisory. */
 export function isTopUpVenueMerchant(
   merchant: string | null | undefined,
 ): boolean {
   if (!merchant) return false;
-  const normalized = merchant.toLowerCase();
-  return IC_CARD_TOPUP_VENUE_PATTERNS.some((p) => normalized.includes(p));
+  if (detectMerchantChain(merchant) !== null) return true;
+  const lower = merchant.toLowerCase();
+  return lower.includes("駅") || lower.includes("station");
 }
 
 /** True when a receipt looks like a prepaid IC-card top-up rather than a
@@ -301,10 +272,13 @@ export function computeExportWarnings(lines: AmexStatementLine[]): Blocker[] {
 }
 
 /**
- * Non-blocking warning when 2+ CASH/DIGITAL receipts share merchant +
- * amount_minor + transaction_date (e.g. several ¥10,000 Seven-Eleven charges
- * on the same day). ADR 0006 §D9 / PR #3. Warning only — no auto-dedup, not a
- * finalize blocker. Deep-links to the first offending receipt's edit view.
+ * Non-blocking warning when 2+ CASH/DIGITAL receipts share a CANONICALIZED
+ * merchant + amount_minor + transaction_date (e.g. several ¥10,000 Seven-Eleven
+ * charges on the same day). Merchant is canonicalized via merchant.ts so
+ * OCR-garbled variants of the same chain cluster together (2026-06 fix:
+ * "セブンーエレブン" + "セブン-イレブン 東中野末広橋店" — two photos of one charge).
+ * ADR 0006 §D9 / PR #3. Warning only — no auto-dedup, not a finalize blocker.
+ * Deep-links to the first offending receipt's edit view.
  *
  * Receipts not in the CASH/DIGITAL paths, or missing merchant/amount/date, are
  * ignored (they can't form a duplicate cluster on these keys).
@@ -316,7 +290,11 @@ export function computeDuplicateReceiptWarnings(
   for (const r of receipts) {
     if (r.payment_path !== "CASH" && r.payment_path !== "DIGITAL") continue;
     if (!r.transaction_date || r.merchant == null || r.amount_minor == null) continue;
-    const key = `${r.merchant}\u0000${r.amount_minor}\u0000${r.transaction_date}`;
+    // Canonicalize the merchant in the grouping key so OCR-garbled variants of
+    // the same chain cluster together (2026-06: "セブンーエレブン" + "セブン-イレブン
+    // 東中野末広橋店" — two photos of one PASMO top-up — never clustered because
+    // the raw strings differ). Display still uses r.merchant verbatim.
+    const key = `${canonicalizeMerchant(r.merchant)}\u0000${r.amount_minor}\u0000${r.transaction_date}`;
     const g = groups.get(key) ?? [];
     g.push(r);
     groups.set(key, g);

--- a/lib/receipts/merchant.ts
+++ b/lib/receipts/merchant.ts
@@ -1,0 +1,132 @@
+// Merchant canonicalization — survive OCR-garbled convenience-store chain
+// names in matching (duplicate grouping + IC-card top-up venue detection).
+//
+// WHY: the MLX extractor (lib/receipts/extraction.ts parseMerchant, VLM +
+// regex fallback) occasionally emits garbled chain spellings. In 2026-06 a
+// PASMO top-up receipt was stored as "セブンーエレブン" (long-vowel ー, エ for
+// イ, no branch) while its re-photograph was "セブン-イレブン 東中野末広橋店".
+// Two photos of one charge, never clustered by computeDuplicateReceiptWarnings
+// (different merchant string → different group key), and the garbled form
+// missed the IC-card venue list entirely (IC warning undercounted, 7 not 8).
+//
+// This module normalizes those variants to a canonical chain token for
+// MATCHING ONLY. It never rewrites the stored/displayed merchant — display
+// keeps the raw string the operator sees. Read-side only; see PR A backlog
+// note for the write-side (canonical_merchant column) trade-off.
+//
+// Data-driven: extend the CHAINS table, not the code, as new garbles appear.
+
+/** The convenience-store chains we canonicalize. */
+export type MerchantChain =
+  | "seven_eleven"
+  | "lawson"
+  | "familymart"
+  | "newdays";
+
+/** Canonical display token per chain (the form we match/group on). */
+export const CHAIN_CANONICAL: Record<MerchantChain, string> = {
+  seven_eleven: "セブン-イレブン",
+  lawson: "ローソン",
+  familymart: "ファミリーマート",
+  newdays: "NewDays",
+};
+
+// Raw variant needles per chain. These are the READABLE forms; they are
+// normalized (below) once at load time, so list a variant however it appears
+// in the wild — normalize() unifies separators, case, and width before the
+// substring test. Add garbles here as extraction produces them.
+const CHAINS: { chain: MerchantChain; needles: string[] }[] = [
+  {
+    chain: "seven_eleven",
+    // The prod garble "セブンーエレブン" (ー + エ) is listed explicitly because
+    // separator-stripping alone can't map エ → イ.
+    needles: [
+      "セブン-イレブン",
+      "セブンーエレブン",
+      "セブンイレブン",
+      "Seven-Eleven",
+      "7-Eleven",
+      "7 Eleven",
+    ],
+  },
+  { chain: "lawson", needles: ["ローソン", "LAWSON", "Lawson"] },
+  {
+    chain: "familymart",
+    needles: ["ファミリーマート", "ファミマ", "FamilyMart", "Family Mart"],
+  },
+  { chain: "newdays", needles: ["NewDays", "New Days", "ニューデイズ"] },
+];
+
+// Width/case/separator unification applied to BOTH the input merchant and the
+// needles so a substring test is robust to extraction noise.
+//
+// NFKC folds full-width ASCII (Ａ→A, ７→7, －→-) and half-width katakana to
+// full-width. We then lower-case and strip every separator-like rune the
+// extractor has emitted between/within chain names: whitespace, the hyphen-
+// minus (U+002D), the hyphen/dash family (U+2010–U+2015), the katakana
+// prolonged-sound mark ー (U+30FC), and the katakana middle dot ・ (U+30FB).
+// We deliberately do NOT strip other kana, so branch suffixes (東中野末広橋店)
+// survive — canonicalizeMerchant returns only the chain token, but the raw
+// merchant is preserved verbatim for display.
+//
+// The class is built from explicit code points (not a literal "/[...]/") so a
+// literal "-" can't be misparsed as a range operator next to the \s shorthand.
+const SEPARATOR_CODE_POINTS = [
+  0x002d, // hyphen-minus "-"
+  0x2010, 0x2011, 0x2012, 0x2013, 0x2014, 0x2015, // hyphen / dash family
+  0x30fc, // katakana prolonged-sound mark "ー"
+  0x30fb, // katakana middle dot "・"
+];
+const SEPARATOR_RE = new RegExp(
+  "[\\s" +
+    SEPARATOR_CODE_POINTS.map((cp) => "\\u" + cp.toString(16).padStart(4, "0")).join("") +
+    "]",
+  "gu",
+);
+
+export function normalizeMerchantKey(merchant: string): string {
+  return merchant.normalize("NFKC").toLowerCase().replace(SEPARATOR_RE, "");
+}
+
+// Pre-normalized needles, looked up once.
+const NORMALIZED_CHAINS: { chain: MerchantChain; needles: string[] }[] =
+  CHAINS.map((c) => ({
+    chain: c.chain,
+    needles: c.needles.map(normalizeMerchantKey).filter(Boolean),
+  }));
+
+/**
+ * Identify the convenience-store chain a merchant string refers to, or null if
+ * it isn't one of the known chains. Substring match against normalized needles
+ * (so a branch suffix or surrounding text doesn't defeat it). First chain in
+ * declaration order wins on overlap (the chains are orthographic and don't
+ * share normalized needles).
+ */
+export function detectMerchantChain(
+  merchant: string | null | undefined,
+): MerchantChain | null {
+  if (!merchant) return null;
+  const n = normalizeMerchantKey(merchant);
+  if (!n) return null;
+  for (const c of NORMALIZED_CHAINS) {
+    if (c.needles.some((needle) => n.includes(needle))) return c.chain;
+  }
+  return null;
+}
+
+/**
+ * Return the canonical chain token if the merchant is a known chain, else the
+ * merchant unchanged. Use this to build MATCHING KEYS (duplicate grouping) —
+ * it collapses garbled/variant spellings of the same chain to one token so
+ * re-photographs and extraction variants cluster together. Branch info is
+ * intentionally dropped from the key (two photos of one slip often disagree on
+ * whether the branch was captured); the duplicate warning is non-blocking and
+ * advisory, so the rare same-chain-different-branch same-amount-same-day false
+ * positive is acceptable (operator confirms distinct). Never use this for
+ * display — display the raw stored merchant.
+ */
+export function canonicalizeMerchant(merchant: string | null | undefined): string {
+  if (!merchant) return merchant ?? "";
+  const chain = detectMerchantChain(merchant);
+  return chain ? CHAIN_CANONICAL[chain] : merchant;
+}

--- a/tests/receipts/blockers.test.ts
+++ b/tests/receipts/blockers.test.ts
@@ -2,8 +2,10 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import {
   computeExportBlockers,
+  computeDuplicateReceiptWarnings,
   computeIcCardTopUpWarnings,
   isIcCardTopUpCandidate,
+  isTopUpVenueMerchant,
   type Blocker,
 } from "@/lib/receipts/blockers";
 import type { AmexStatementLine, ReceiptRecord } from "@/lib/receipts/types";
@@ -366,5 +368,93 @@ test("ic-card predicate: convenience store + round sum but non-travel category �
       merchant: "ローソン",
     }),
     false,
+  );
+});
+
+// ─── merchant canonicalization (PR A) ──────────────────────────────────────
+// The 2026-06 gaps: a PASMO top-up stored as the garble "セブンーエレブン"
+// (540a5714) missed the IC venue list (IC warning counted 7, not 8) AND never
+// clustered with its canonical-form re-photograph (0802caae) in the duplicate
+// warning. Canonicalization at the read side fixes both.
+
+test("ic-card venue: OCR-garbled セブンーエレブン now matches (undercount fix)", () => {
+  // Before PR A this returned false (the garble contained neither "セブン-イレブン"
+  // nor "セブンイレブン"), so receipt 540a5714 dropped out of the IC candidate
+  // set and the warning undercounted. detectMerchantChain now recognizes it.
+  assert.equal(isTopUpVenueMerchant("セブンーエレブン"), true);
+  assert.equal(
+    isIcCardTopUpCandidate({
+      payment_path: "CASH",
+      expense_category_code: "travel_transportation",
+      amount_minor: 10000,
+      merchant: "セブンーエレブン",
+    }),
+    true,
+  );
+});
+
+test("duplicate warning: garble + canonical-form pair now clusters (June-2 fix)", () => {
+  // Two photos of one ¥10,000 PASMO top-up on 2026-06-02. The merchant strings
+  // differ in TWO ways (the ー/エ garble AND one carries the branch suffix), so
+  // pre-canonicalization they had different grouping keys and never clustered.
+  // Canonicalizing both to the セブン-イレブン token unifies the key.
+  const receipts: ReceiptRecord[] = [
+    makeReceipt({
+      id: "g-1",
+      payment_path: "CASH",
+      expense_category_code: "travel_transportation",
+      merchant: "セブンーエレブン",
+      amount_minor: 10000,
+      transaction_date: "2026-06-02",
+    }),
+    makeReceipt({
+      id: "g-2",
+      payment_path: "CASH",
+      expense_category_code: "travel_transportation",
+      merchant: "セブン-イレブン 東中野末広橋店",
+      amount_minor: 10000,
+      transaction_date: "2026-06-02",
+    }),
+  ];
+
+  const warnings = computeDuplicateReceiptWarnings(receipts);
+  assert.equal(
+    warnings.length,
+    1,
+    `expected the June-2 pair to cluster, got: ${JSON.stringify(warnings)}`,
+  );
+  assert.equal(warnings[0]!.count, 2);
+});
+
+test("ic-card warning: the full 2026-06 candidate set counts as 8 (not 7)", () => {
+  // Representative of the 8 prod receipts: garble, canonical, different branch,
+  // different dates. All are CASH travel_transportation ¥10k at a セブン — all 8
+  // must now register as IC candidates (the garble was the previous miss).
+  const receipts: ReceiptRecord[] = [
+    ["2026-06-02", "セブンーエレブン"],
+    ["2026-06-02", "セブン-イレブン 東中野末広橋店"],
+    ["2026-06-11", "セブン-イレブン 東中野末広橋店"],
+    ["2026-06-11", "セブン-イレブン 東中野末広橋店"],
+    ["2026-06-11", "セブン-イレブン 東中野末広橋店"],
+    ["2026-06-11", "セブン-イレブン 東中野末広橋店"],
+    ["2026-06-22", "セブン-イレブン 渋谷本町3丁目店"],
+    ["2026-06-27", "セブン-イレブン 東中野末広橋店"],
+  ].map(([date, merchant], i) =>
+    makeReceipt({
+      id: `ic8-${i}`,
+      payment_path: "CASH",
+      expense_category_code: "travel_transportation",
+      merchant,
+      amount_minor: 10000,
+      transaction_date: date,
+    }),
+  );
+
+  const warnings = computeIcCardTopUpWarnings(receipts);
+  assert.equal(warnings.length, 1);
+  assert.equal(
+    warnings[0]!.count,
+    8,
+    `expected all 8 IC candidates, got: ${warnings[0]!.count}`,
   );
 });

--- a/tests/receipts/merchant.test.ts
+++ b/tests/receipts/merchant.test.ts
@@ -1,0 +1,95 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  canonicalizeMerchant,
+  detectMerchantChain,
+  normalizeMerchantKey,
+  CHAIN_CANONICAL,
+} from "@/lib/receipts/merchant";
+
+// ─── detectMerchantChain ───────────────────────────────────────────────────
+
+test("merchant: セブン-イレブン variants all detect as seven_eleven", () => {
+  // The prod garble "セブンーエレブン" (long-vowel ー + エ) is the case that
+  // matters — it defeated both the duplicate grouping and the IC venue list.
+  for (const m of [
+    "セブン-イレブン",
+    "セブンーエレブン", // prod garble (540a5714)
+    "セブンイレブン",
+    "セブン-イレブン 東中野末広橋店", // chain + branch (0802caae)
+    "7-Eleven",
+    "7-Eleven 渋谷本町3丁目店",
+    "SEVEN ELEVEN",
+  ]) {
+    assert.equal(
+      detectMerchantChain(m),
+      "seven_eleven",
+      `expected seven_eleven for «${m}»`,
+    );
+  }
+});
+
+test("merchant: other chains detect", () => {
+  assert.equal(detectMerchantChain("ローソン"), "lawson");
+  assert.equal(detectMerchantChain("LAWSON 新宿三丁目店"), "lawson");
+  assert.equal(detectMerchantChain("ファミリーマート"), "familymart");
+  assert.equal(detectMerchantChain("ファミマ"), "familymart");
+  assert.equal(detectMerchantChain("FamilyMart"), "familymart");
+  assert.equal(detectMerchantChain("NewDays"), "newdays");
+  assert.equal(detectMerchantChain("New Days"), "newdays");
+});
+
+test("merchant: non-chain merchants detect as null", () => {
+  assert.equal(detectMerchantChain("PC Depot"), null);
+  assert.equal(detectMerchantChain("EMot"), null);
+  assert.equal(detectMerchantChain("日本交通タクシー"), null);
+  assert.equal(detectMerchantChain("HOLIDAY SKY LOUNGE 新宿"), null);
+  // A station is NOT a chain (stations vary by name) — handled separately in
+  // isTopUpVenueMerchant, not here.
+  assert.equal(detectMerchantChain("新宿駅"), null);
+  assert.equal(detectMerchantChain(null), null);
+  assert.equal(detectMerchantChain(""), null);
+});
+
+// ─── canonicalizeMerchant ──────────────────────────────────────────────────
+
+test("merchant: canonicalize collapses chain variants to the canonical token", () => {
+  // The two prod strings that never clustered — both canonicalize to the same
+  // token, so a duplicate-grouping key built on canonicalizeMerchant unifies
+  // them.
+  assert.equal(
+    canonicalizeMerchant("セブンーエレブン"),
+    CHAIN_CANONICAL.seven_eleven,
+  );
+  assert.equal(
+    canonicalizeMerchant("セブン-イレブン 東中野末広橋店"),
+    CHAIN_CANONICAL.seven_eleven,
+  );
+  assert.equal(canonicalizeMerchant("7-Eleven"), CHAIN_CANONICAL.seven_eleven);
+  assert.equal(canonicalizeMerchant("ローソン"), CHAIN_CANONICAL.lawson);
+  assert.equal(
+    canonicalizeMerchant("ファミマ"),
+    CHAIN_CANONICAL.familymart,
+  );
+  assert.equal(canonicalizeMerchant("NewDays"), CHAIN_CANONICAL.newdays);
+});
+
+test("merchant: canonicalize returns the merchant unchanged when not a chain", () => {
+  // Non-chain merchants pass through verbatim so existing exact-key clusters
+  // (HOLIDAY SKY LOUNGE, 岡芳商店, …) keep their grouping semantics.
+  assert.equal(canonicalizeMerchant("PC Depot"), "PC Depot");
+  assert.equal(canonicalizeMerchant("HOLIDAY SKY LOUNGE 新宿"), "HOLIDAY SKY LOUNGE 新宿");
+  assert.equal(canonicalizeMerchant(""), "");
+  assert.equal(canonicalizeMerchant(null), "");
+});
+
+// ─── normalizeMerchantKey ──────────────────────────────────────────────────
+
+test("merchant: normalize strips separators, folds width/case", () => {
+  assert.equal(normalizeMerchantKey("セブン-イレブン 東中野末広橋店"), "セブンイレブン東中野末広橋店");
+  assert.equal(normalizeMerchantKey("7-Eleven"), "7eleven");
+  assert.equal(normalizeMerchantKey("Family Mart"), "familymart");
+  // long-vowel ー stripped (so ローソン → ロソン); needles are normalized the
+  // same way so the match still holds.
+  assert.equal(normalizeMerchantKey("ローソン"), "ロソン");
+});


### PR DESCRIPTION
## What

Foundation PR of the close-time triage batch. OCR-garbled convenience-store chain names defeated both shipped matchers in 2026-06. New read-side canonicalization fixes both gaps without touching stored data.

**Prod trigger:** a PASMO top-up stored as `セブンーエレブン` (long-vowel ー, エ for イ) never clustered with its re-photograph `セブン-イレブン 東中野末広橋店` (two photos of one charge), and missed the IC-card venue list so the warning undercounted (7 not 8).

## Changes

- **New `lib/receipts/merchant.ts`** — data-driven variant table + NFKC/separator/case normalization → canonical chain tokens (セブン-イレブン · ローソン · ファミリーマート · NewDays). Extend the table, not the code, as new garbles appear.
- **`computeDuplicateReceiptWarnings`** — grouping key canonicalizes the merchant → June-2 pair clusters.
- **`isTopUpVenueMerchant`** — replaced the brittle substring pattern list with `detectMerchantChain` + 駅/station → garble now matches → IC count 7→8.
- Read-side only. Display keeps the raw stored merchant verbatim.

## Assessed, not built

- **Write-side canonicalization** (`canonical_merchant` column) logged as backlog **#15** — needs a schema migration + backfill + edits to three write paths (MLX extraction apply, AMEX import, receipt PATCH) and re-canonicalization on every operator edit; touches the MLX consumer contract. **Deferred** until extraction-recall work (#14) lands. Read-side delivers the user value now.
- **Item #4** (literal NUL bytes in the duplicate-key separator) was already resolved by #95 — verified clean, no change.

## Tests

- `merchant.test.ts`: canonicalization primitives incl. the exact prod garble `セブンーエレブン` → seven_eleven; non-chains pass through.
- `blockers.test.ts`: garble now a venue match; June-2 pair (`セブンーエレブン` + `セブン-イレブン 東中野末広橋店`) clusters; full 8-candidate IC count.

## Verification

`tsc --noEmit` · `npm run lint` · `npm test` (316 pass) · `build:cf` — all clean.

Part 1 of 3. PR B (per-row duplicate badges) sits on this; PR C (inline category editing) is independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)