### PR TITLE
feat(receipts): per-row duplicate badges on review page (PR B)

### DIFF
--- a/components/receipts/export/review-screen.tsx
+++ b/components/receipts/export/review-screen.tsx
@@ -7,7 +7,11 @@ import {
   formatPaymentPath,
 } from "@/lib/receipts/format";
 import { formatCategoryLabel } from "@/lib/receipts/categories";
-import type { Blocker } from "@/lib/receipts/blockers";
+import {
+  buildDuplicateBadgeMap,
+  type Blocker,
+  type DuplicateBadge,
+} from "@/lib/receipts/blockers";
 import type {
   AmexStatementLine,
   BusinessTripReport,
@@ -38,6 +42,13 @@ export function ReviewScreen(props: ReviewScreenProps) {
   const amexRows = props.rows.filter((r) => r.rowType === "amex_line");
   const chargeRows = props.rows.filter((r) => r.rowType === "receipt");
   const gateClear = props.gateBlockers.length === 0;
+  // Per-row duplicate badges for the Additional Charges list — the SAME
+  // clustering (canonicalized merchant + amount + date) the aggregate
+  // "Possible duplicate" warning card uses, so a receipt can never be flagged
+  // on one surface and not the other. Computed from props.receipts
+  // (bundle.receipts), which is CASH/DIGITAL-identical to the page's
+  // monthReceipts grouping set, so badges match the card exactly.
+  const dupBadgeById = buildDuplicateBadgeMap(props.receipts);
 
   return (
     <div className="bg-gray-50 pb-16">
@@ -69,6 +80,7 @@ export function ReviewScreen(props: ReviewScreenProps) {
         <AdditionalChargesSection
           chargeRows={chargeRows}
           monthLabel={props.monthLabel}
+          dupBadgeById={dupBadgeById}
         />
         <BusinessTripsSection
           tripReports={props.tripReports}
@@ -445,9 +457,11 @@ function ConsolidatedGroup({
 function AdditionalChargesSection({
   chargeRows,
   monthLabel,
+  dupBadgeById,
 }: {
   chargeRows: ExportRow[];
   monthLabel: string;
+  dupBadgeById: Map<string, DuplicateBadge>;
 }) {
   // ADR 0008: a cash/digital receipt ships in the CALENDAR month of its
   // transaction_date — so this section's population is "receipts assigned to
@@ -473,24 +487,38 @@ function AdditionalChargesSection({
             No cash/digital receipts in this month.
           </div>
         ) : (
-          chargeRows.map((r, i) => (
-            <div
-              key={i}
-              className="grid grid-cols-[120px_1fr_120px_140px_100px] items-center border-b border-gray-150 px-4 py-2.5 text-[12px]"
-            >
-              <span className="text-gray-600">{r.transactionDate ?? "—"}</span>
-              <span className="truncate font-medium text-gray-900">{r.merchant ?? "—"}</span>
-              <span className="text-right tabular-nums">
-                {formatAmountMinor(r.amountMinor ?? 0, r.currency)}
-              </span>
-              <span className="text-gray-600">{formatCategoryLabel(r.expenseCategoryCode)}</span>
-              <span>
-                <Pill tone="gray" size="sm">
-                  {formatPaymentPath(r.paymentPath)}
-                </Pill>
-              </span>
-            </div>
-          ))
+          chargeRows.map((r, i) => {
+            const dupBadge = r.receiptId ? dupBadgeById.get(r.receiptId) : undefined;
+            return (
+              <div
+                key={i}
+                className="grid grid-cols-[120px_1fr_120px_140px_100px] items-center border-b border-gray-150 px-4 py-2.5 text-[12px]"
+              >
+                <span className="text-gray-600">{r.transactionDate ?? "—"}</span>
+                <div className="flex min-w-0 items-center gap-1.5">
+                  <span className="truncate font-medium text-gray-900">{r.merchant ?? "—"}</span>
+                  {dupBadge && (
+                    <Link
+                      href={`/receipts/review/${dupBadge.firstId}`}
+                      className="inline-flex shrink-0 items-center rounded-full bg-amber-100 px-1.5 py-0.5 text-[10px] font-bold text-amber-700 hover:bg-amber-200"
+                      title={`Part of a ${dupBadge.count}-receipt duplicate cluster (same canonical merchant + amount + date). Open the first to review.`}
+                    >
+                      dup ×{dupBadge.count}
+                    </Link>
+                  )}
+                </div>
+                <span className="text-right tabular-nums">
+                  {formatAmountMinor(r.amountMinor ?? 0, r.currency)}
+                </span>
+                <span className="text-gray-600">{formatCategoryLabel(r.expenseCategoryCode)}</span>
+                <span>
+                  <Pill tone="gray" size="sm">
+                    {formatPaymentPath(r.paymentPath)}
+                  </Pill>
+                </span>
+              </div>
+            );
+          })
         )}
       </Card>
     </div>

--- a/lib/receipts/blockers.ts
+++ b/lib/receipts/blockers.ts
@@ -55,7 +55,7 @@ export function isUnreviewedReceipt(receipt: ReceiptRecord): boolean {
 // a prepaid IC-card (Suica/PASMO/ICOCA/etc.) charge — a prepayment, not a
 // travel expense at the moment of charge. Informational warning only: it may
 // be entirely business, and the responsible treatment (expense it as trips
-// deplete the card, or treat the card as business-dedicated) is the
+// deplete the card, or treat the card is business-dedicated) is the
 // accountant's call. NOT wired into the finalize gate — it is advisory.
 // False positives are kept low by requiring ALL THREE signals (round sum AND
 // top-up venue AND travel category) on the same receipt.
@@ -271,6 +271,88 @@ export function computeExportWarnings(lines: AmexStatementLine[]): Blocker[] {
   return warnings;
 }
 
+// ─── CASH/DIGITAL duplicate clustering ────────────────────────────────────
+// One canonicalization-aware clustering implementation drives both the
+// aggregate warning card (computeDuplicateReceiptWarnings) and the per-row
+// badge map (buildDuplicateBadgeMap / groupDuplicateReceipts) so a receipt can
+// never be flagged on one surface and not the other.
+
+/**
+ * Build the CASH/DIGITAL duplicate clusters: receipts sharing a canonicalized
+ * merchant (merchant.ts) + amount_minor + transaction_date. Internal — carries
+ * the full receipt objects so the aggregate card can read merchant/date/id.
+ * groupDuplicateReceipts is the public ids-only projection; the key is JSON-
+ * encoded (not NUL-separated) so the file stays grep/git-tooling friendly.
+ * Cluster order is insertion order (first-seen first); within a cluster, input
+ * order — matching the pre-refactor aggregate-card behavior exactly.
+ */
+function clusterDuplicates(
+  receipts: ReceiptRecord[],
+): { key: string; receipts: ReceiptRecord[] }[] {
+  const groups = new Map<string, ReceiptRecord[]>();
+  for (const r of receipts) {
+    if (r.payment_path !== "CASH" && r.payment_path !== "DIGITAL") continue;
+    if (!r.transaction_date || r.merchant == null || r.amount_minor == null) continue;
+    // Canonicalize the merchant in the grouping key so OCR-garbled variants of
+    // the same chain cluster together (2026-06: "セブンーエレブン" + "セブン-イレブン
+    // 東中野末広橋店" — two photos of one PASMO top-up — never clustered because
+    // the raw strings differ). Display still uses r.merchant verbatim.
+    const key = JSON.stringify([
+      canonicalizeMerchant(r.merchant),
+      r.amount_minor,
+      r.transaction_date,
+    ]);
+    const g = groups.get(key) ?? [];
+    g.push(r);
+    groups.set(key, g);
+  }
+  const out: { key: string; receipts: ReceiptRecord[] }[] = [];
+  for (const [key, recs] of groups) {
+    if (recs.length >= 2) out.push({ key, receipts: recs });
+  }
+  return out;
+}
+
+/** A duplicate cluster's membership (ids only) — the display-agnostic view. */
+export type DuplicateCluster = { key: string; ids: string[] };
+
+/**
+ * Group CASH/DIGITAL receipts into duplicate clusters (canonicalized merchant +
+ * amount + date, size ≥ 2). Returns ids only — the pure, display-agnostic view
+ * the review-page badge logic consumes. Callers needing the aggregate warning
+ * card should use computeDuplicateReceiptWarnings (same clustering).
+ */
+export function groupDuplicateReceipts(
+  receipts: ReceiptRecord[],
+): DuplicateCluster[] {
+  return clusterDuplicates(receipts).map((c) => ({
+    key: c.key,
+    ids: c.receipts.map((r) => r.id),
+  }));
+}
+
+/** Badge info for a receipt in a duplicate cluster: deep-link target (the
+ *  cluster's first receipt) + cluster size. */
+export type DuplicateBadge = { firstId: string; count: number };
+
+/**
+ * Map every receipt id that belongs to a duplicate cluster → its badge info
+ * (first receipt id for the deep-link + cluster size). Receipts not in any
+ * cluster are absent. Pure — unit-tested, then consumed by the review-page
+ * Additional Charges list to render per-row "dup ×N" badges.
+ */
+export function buildDuplicateBadgeMap(
+  receipts: ReceiptRecord[],
+): Map<string, DuplicateBadge> {
+  const map = new Map<string, DuplicateBadge>();
+  for (const c of clusterDuplicates(receipts)) {
+    const firstId = c.receipts[0]!.id;
+    const count = c.receipts.length;
+    for (const r of c.receipts) map.set(r.id, { firstId, count });
+  }
+  return map;
+}
+
 /**
  * Non-blocking warning when 2+ CASH/DIGITAL receipts share a CANONICALIZED
  * merchant + amount_minor + transaction_date (e.g. several ¥10,000 Seven-Eleven
@@ -286,23 +368,10 @@ export function computeExportWarnings(lines: AmexStatementLine[]): Blocker[] {
 export function computeDuplicateReceiptWarnings(
   receipts: ReceiptRecord[],
 ): Blocker[] {
-  const groups = new Map<string, ReceiptRecord[]>();
-  for (const r of receipts) {
-    if (r.payment_path !== "CASH" && r.payment_path !== "DIGITAL") continue;
-    if (!r.transaction_date || r.merchant == null || r.amount_minor == null) continue;
-    // Canonicalize the merchant in the grouping key so OCR-garbled variants of
-    // the same chain cluster together (2026-06: "セブンーエレブン" + "セブン-イレブン
-    // 東中野末広橋店" — two photos of one PASMO top-up — never clustered because
-    // the raw strings differ). Display still uses r.merchant verbatim.
-    const key = `${canonicalizeMerchant(r.merchant)}\u0000${r.amount_minor}\u0000${r.transaction_date}`;
-    const g = groups.get(key) ?? [];
-    g.push(r);
-    groups.set(key, g);
-  }
-  const clusters = [...groups.values()].filter((g) => g.length >= 2);
+  const clusters = clusterDuplicates(receipts);
   if (clusters.length === 0) return [];
-  const totalFlagged = clusters.reduce((s, g) => s + g.length, 0);
-  const first = clusters[0]![0]!;
+  const totalFlagged = clusters.reduce((s, c) => s + c.receipts.length, 0);
+  const first = clusters[0]!.receipts[0]!;
   return [
     {
       severity: "warn",
@@ -310,7 +379,7 @@ export function computeDuplicateReceiptWarnings(
       label: "Possible duplicate cash/digital receipts",
       detail:
         `${clusters.length} cluster(s) share merchant + amount + date ` +
-        `(e.g. ${first.merchant} ×${clusters[0]!.length} on ${first.transaction_date}). ` +
+        `(e.g. ${first.merchant} ×${clusters[0]!.receipts.length} on ${first.transaction_date}). ` +
         `Confirm these are distinct charges, not double-captured.`,
       href: `/receipts/review/${first.id}`,
       ctaLabel: "Open first",

--- a/tests/receipts/blockers.test.ts
+++ b/tests/receipts/blockers.test.ts
@@ -1,9 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  buildDuplicateBadgeMap,
   computeExportBlockers,
   computeDuplicateReceiptWarnings,
   computeIcCardTopUpWarnings,
+  groupDuplicateReceipts,
   isIcCardTopUpCandidate,
   isTopUpVenueMerchant,
   type Blocker,
@@ -457,4 +459,88 @@ test("ic-card warning: the full 2026-06 candidate set counts as 8 (not 7)", () =
     8,
     `expected all 8 IC candidates, got: ${warnings[0]!.count}`,
   );
+});
+
+// ─── duplicate cluster membership + badges (PR B) ──────────────────────────
+
+test("groupDuplicateReceipts: exposes cluster membership (ids only)", () => {
+  // 4 receipts at the same canonical merchant + amount + date → one cluster of
+  // 4. A receipt missing a date, and an AMEX-path receipt, are excluded.
+  const cluster = [0, 1, 2, 3].map((i) =>
+    makeReceipt({
+      id: `m-${i}`,
+      payment_path: "CASH",
+      merchant: "セブン-イレブン 東中野末広橋店",
+      amount_minor: 10000,
+      transaction_date: "2026-06-11",
+    }),
+  );
+  const noDate = makeReceipt({
+    id: "m-nodate",
+    payment_path: "CASH",
+    merchant: "セブン-イレブン 東中野末広橋店",
+    amount_minor: 10000,
+    transaction_date: null,
+  });
+  const amex = makeReceipt({
+    id: "m-amex",
+    payment_path: "AMEX",
+    merchant: "セブン-イレブン 東中野末広橋店",
+    amount_minor: 10000,
+    transaction_date: "2026-06-11",
+  });
+
+  const groups = groupDuplicateReceipts([...cluster, noDate, amex]);
+  assert.equal(groups.length, 1, `expected one cluster, got: ${JSON.stringify(groups)}`);
+  assert.equal(groups[0]!.ids.length, 4);
+  assert.deepEqual(
+    [...groups[0]!.ids].sort(),
+    ["m-0", "m-1", "m-2", "m-3"],
+  );
+  // The dateless + AMEX receipts never appear in any cluster.
+  const allIds = new Set(groups.flatMap((g) => g.ids));
+  assert.equal(allIds.has("m-nodate"), false);
+  assert.equal(allIds.has("m-amex"), false);
+});
+
+test("buildDuplicateBadgeMap: every clustered receipt → badge; unclustered absent", () => {
+  // Two clusters: a pair (June-2 garble+canonical) and a triple (same merchant).
+  const pair = [
+    makeReceipt({ id: "p-1", payment_path: "CASH", merchant: "セブンーエレブン", amount_minor: 10000, transaction_date: "2026-06-02" }),
+    makeReceipt({ id: "p-2", payment_path: "CASH", merchant: "セブン-イレブン 東中野末広橋店", amount_minor: 10000, transaction_date: "2026-06-02" }),
+  ];
+  const triple = [0, 1, 2].map((i) =>
+    makeReceipt({ id: `t-${i}`, payment_path: "DIGITAL", merchant: "ローソン", amount_minor: 3000, transaction_date: "2026-06-15" }),
+  );
+  const lone = makeReceipt({ id: "lone-1", payment_path: "CASH", merchant: "PC Depot", amount_minor: 10450, transaction_date: "2026-06-12" });
+
+  const map = buildDuplicateBadgeMap([...pair, ...triple, lone]);
+
+  // Pair: both map to the cluster's first receipt (p-1), count 2.
+  assert.deepEqual(map.get("p-1"), { firstId: "p-1", count: 2 });
+  assert.deepEqual(map.get("p-2"), { firstId: "p-1", count: 2 });
+  // Triple: all map to t-0, count 3.
+  assert.deepEqual(map.get("t-0"), { firstId: "t-0", count: 3 });
+  assert.deepEqual(map.get("t-2"), { firstId: "t-0", count: 3 });
+  // The lone receipt is not in any cluster.
+  assert.equal(map.has("lone-1"), false);
+});
+
+test("computeDuplicateReceiptWarnings: card behavior unchanged after refactor", () => {
+  // The refactor extracted clusterDuplicates + groupDuplicateReceipts; the
+  // aggregate card must still fire with the same count/label/href.
+  const cluster = [0, 1, 2, 3].map((i) =>
+    makeReceipt({
+      id: `c-${i}`,
+      payment_path: "CASH",
+      merchant: "セブン-イレブン 東中野末広橋店",
+      amount_minor: 10000,
+      transaction_date: "2026-06-11",
+    }),
+  );
+  const w = computeDuplicateReceiptWarnings(cluster);
+  assert.equal(w.length, 1);
+  assert.equal(w[0]!.count, 4);
+  assert.equal(w[0]!.label, "Possible duplicate cash/digital receipts");
+  assert.equal(w[0]!.href, "/receipts/review/c-0");
 });


### PR DESCRIPTION
## What

Part 2 of the close-time triage batch. The duplicate warning was one aggregate card deep-linking to the first receipt; the operator still had to hunt to see **which** rows are in a cluster. Now each Additional Charges row in a duplicate cluster shows an amber **`dup ×N`** pill linking to the cluster's first receipt.

## Changes

- **`blockers.ts`** — extracted one private `clusterDuplicates()` driving both the aggregate card and the new badge surfaces:
  - `groupDuplicateReceipts(receipts): { key, ids[] }[]` — public, ids-only membership view.
  - `buildDuplicateBadgeMap(receipts): Map<id, { firstId, count }>` — the pure badge-visibility logic.
  - `computeDuplicateReceiptWarnings` rebuilt on `clusterDuplicates` — **card output unchanged** (label/detail/count/href identical).
  - Internal grouping key moved from a NUL separator to `JSON.stringify` (grep/git-tooling friendly).
- **`review-screen.tsx`** — `ReviewScreen` computes `buildDuplicateBadgeMap(props.receipts)` (the same CASH/DIGITAL set the aggregate card groups over → a receipt can never be flagged on one surface and not the other) and threads it into `AdditionalChargesSection`. The aggregate card is retained.

## Tests

- `groupDuplicateReceipts`: cluster membership; dateless + AMEX-path receipts excluded.
- `buildDuplicateBadgeMap`: every clustered receipt → `{ firstId, count }`; unclustered absent.
- Regression: aggregate card behavior unchanged after the refactor (count/label/href).

## Verification

`tsc --noEmit` · `npm run lint` · `npm test` (319 pass) · `build:cf` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)