### PR TITLE
feat(receipts): inline category display + editing on review page (PR C)

### DIFF
--- a/components/receipts/export/inline-category-cell.tsx
+++ b/components/receipts/export/inline-category-cell.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+// Inline category display + edit cell for the pre-finalize review page.
+//
+// One cell per row (side-by-side AMEX lines AND additional-charge cash/digital
+// receipts). Shows the RESOLVED category (resolveLineCategory, computed server-
+// side in the bundle) as JP name + EN gloss with a source-of-truth badge, and
+// offers a dropdown when editable. Edits route by source of truth:
+//   - matched AMEX line / cash-digital receipt → PATCH /api/receipts/[id]
+//   - no-receipt / unmatched AMEX line        → PATCH /api/receipts/amex/lines/[id]
+// A line-level category is NEVER written onto a matched line (the receipt
+// shadows it and the manifest would desync) — the server passes the route, the
+// cell just PATCHes it. Locks are also decided server-side (export sealed /
+// reconciliation sealed) and passed as `editable` + `disabledReason`; the cell
+// never offers an edit the API would reject.
+
+import { useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Pill } from "@/components/ui/pill";
+import {
+  EXPENSE_CATEGORIES,
+  formatCategoryLabel,
+  requiresAttendees,
+} from "@/lib/receipts/categories";
+import type { InlineCategoryCellProps } from "@/lib/receipts/category-cell";
+import { buildCategoryPatchBody } from "@/lib/receipts/category-cell";
+
+export type { InlineCategoryCellProps };
+
+export function InlineCategoryCell(props: InlineCategoryCellProps) {
+  const router = useRouter();
+  const [value, setValue] = useState(props.code ?? "");
+  const [trackedCode, setTrackedCode] = useState(props.code ?? "");
+  const [status, setStatus] = useState<"idle" | "saving" | "error">("idle");
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const inFlight = useRef<AbortController | null>(null);
+
+  // Follow server-resolved code changes after a router.refresh() (our own save,
+  // or another tab's edit) — but never clobber an in-flight optimistic value.
+  // Adjusting state during render with a prop-change guard is the React-
+  // recommended way to sync to a prop without a setState-in-effect.
+  if (props.code !== trackedCode) {
+    setTrackedCode(props.code ?? "");
+    if (status !== "saving") setValue(props.code ?? "");
+  }
+
+  const needsAttendees = requiresAttendees(value);
+
+  async function handleChange(next: string) {
+    if (!props.editable || !props.route) return;
+    if (next === value) return;
+    const prev = value;
+    setValue(next); // optimistic
+    setStatus("saving");
+    setErrorMsg(null);
+    inFlight.current?.abort();
+    const ctrl = new AbortController();
+    inFlight.current = ctrl;
+    const url =
+      props.route.kind === "receipt"
+        ? `/api/receipts/${props.route.id}`
+        : `/api/receipts/amex/lines/${props.route.id}`;
+    try {
+      const res = await fetch(url, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(buildCategoryPatchBody(next)),
+        signal: ctrl.signal,
+      });
+      const json = (await res.json().catch(() => ({}))) as { error?: string };
+      if (!res.ok) {
+        setValue(prev); // roll back the optimistic change, visibly
+        setStatus("error");
+        setErrorMsg(json.error ?? "Category save failed.");
+        return;
+      }
+      setStatus("idle");
+      // Refresh so gates / tiles / blocker counts / the resolved category all
+      // re-render from the new DB state.
+      router.refresh();
+    } catch (err) {
+      if ((err as DOMException | undefined)?.name === "AbortError") return;
+      setValue(prev);
+      setStatus("error");
+      setErrorMsg("Network error — category not saved.");
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-center gap-1.5">
+        <span
+          className={
+            "shrink-0 rounded px-1 py-0.5 text-[9px] font-bold uppercase tracking-wide " +
+            (props.sourceLabel === "from receipt"
+              ? "bg-green-50 text-green-700"
+              : "bg-gray-100 text-gray-600")
+          }
+          title={
+            props.sourceLabel === "from receipt"
+              ? "Category resolves from the matched receipt (authoritative)."
+              : "Category is set on the AMEX line (no matched receipt)."
+          }
+        >
+          {props.sourceLabel === "from receipt" ? "receipt" : "line"}
+        </span>
+        {props.editable ? (
+          <select
+            value={value}
+            onChange={(e) => handleChange(e.target.value)}
+            disabled={status === "saving"}
+            className="h-[26px] min-w-0 flex-1 rounded-md border border-gray-200 bg-white px-1.5 text-[11.5px] text-gray-900 focus:border-amber-500 focus:outline-none disabled:bg-gray-50"
+          >
+            <option value="">— Select —</option>
+            {EXPENSE_CATEGORIES.map((c) => (
+              <option key={c.code} value={c.code}>
+                {formatCategoryLabel(c.code)}
+              </option>
+            ))}
+          </select>
+        ) : (
+          <span
+            className="min-w-0 flex-1 truncate text-[11.5px] text-gray-700"
+            title={props.disabledReason ?? undefined}
+          >
+            {props.code ? (
+              `${props.categoryJa ?? ""} — ${props.categoryEn ?? props.code}`.trim()
+            ) : (
+              <span className="italic text-gray-400">uncategorized</span>
+            )}
+          </span>
+        )}
+        {status === "saving" && (
+          <span className="shrink-0 text-[9.5px] text-gray-400">saving…</span>
+        )}
+      </div>
+
+      {/* Uncategorized nudge — only when the operator can actually act. */}
+      {props.editable && !value && (
+        <Pill tone="amber" size="sm">
+          category needed
+        </Pill>
+      )}
+
+      {/* Attendees-required inline warning. Non-blocking: the finalize gate is
+       *  the enforcement point. Shown for any row whose current category
+       *  requires attendees but has none recorded. */}
+      {needsAttendees && !props.hasAttendees && (
+        <span className="text-[10px] text-amber-700">
+          {props.categoryEn ?? "This category"} requires attendees — record them on the receipt before finalizing.
+        </span>
+      )}
+
+      {/* Standard error surfacing (PR #83/#93 convention), per row. */}
+      {status === "error" && errorMsg && (
+        <div className="rounded-md border border-red-200 bg-red-50 px-2 py-1 text-[10px] text-red-700">
+          {errorMsg}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/receipts/export/review-screen.tsx
+++ b/components/receipts/export/review-screen.tsx
@@ -2,6 +2,8 @@ import Link from "next/link";
 import { Card } from "@/components/ui/card";
 import { Pill } from "@/components/ui/pill";
 import { FinalizeCard } from "@/components/receipts/export/finalize-card";
+import { InlineCategoryCell } from "@/components/receipts/export/inline-category-cell";
+import { buildCategoryCellProps } from "@/lib/receipts/category-cell";
 import {
   formatAmountMinor,
   formatPaymentPath,
@@ -76,11 +78,18 @@ export function ReviewScreen(props: ReviewScreenProps) {
 
       <div className="space-y-8 px-8 py-8">
         <SummarySection rows={props.rows} receipts={props.receipts} />
-        <SideBySideSection amexRows={amexRows} receipts={props.receipts} />
+        <SideBySideSection
+          amexRows={amexRows}
+          receipts={props.receipts}
+          finalized={finalized}
+          reconciliationSealed={props.reconciliationSealed}
+        />
         <AdditionalChargesSection
           chargeRows={chargeRows}
           monthLabel={props.monthLabel}
           dupBadgeById={dupBadgeById}
+          finalized={finalized}
+          reconciliationSealed={props.reconciliationSealed}
         />
         <BusinessTripsSection
           tripReports={props.tripReports}
@@ -303,9 +312,13 @@ function SummarySection({
 function SideBySideSection({
   amexRows,
   receipts,
+  finalized,
+  reconciliationSealed,
 }: {
   amexRows: ExportRow[];
   receipts: ReceiptRecord[];
+  finalized: boolean;
+  reconciliationSealed: boolean;
 }) {
   const receiptMap = new Map(receipts.map((r) => [r.id, r]));
   // Group by receiptId to render consolidated-receipt groups together.
@@ -343,13 +356,32 @@ function SideBySideSection({
         ) : (
           <>
             {consolidated.map(([rid, g]) => (
-              <ConsolidatedGroup key={rid} receiptId={rid} rows={g} receipt={receiptMap.get(rid)} />
+              <ConsolidatedGroup
+                key={rid}
+                receiptId={rid}
+                rows={g}
+                receipt={receiptMap.get(rid)}
+                finalized={finalized}
+                reconciliationSealed={reconciliationSealed}
+              />
             ))}
             {singleMatched.map(([rid, g]) => (
-              <SideBySideRow key={rid} row={g[0]!} receipt={receiptMap.get(rid)} />
+              <SideBySideRow
+                key={rid}
+                row={g[0]!}
+                receipt={receiptMap.get(rid)}
+                finalized={finalized}
+                reconciliationSealed={reconciliationSealed}
+              />
             ))}
             {standalone.map((row, i) => (
-              <SideBySideRow key={`none-${i}`} row={row} receipt={undefined} />
+              <SideBySideRow
+                key={`none-${i}`}
+                row={row}
+                receipt={undefined}
+                finalized={finalized}
+                reconciliationSealed={reconciliationSealed}
+              />
             ))}
           </>
         )}
@@ -365,9 +397,13 @@ function SideBySideSection({
 function SideBySideRow({
   row,
   receipt,
+  finalized,
+  reconciliationSealed,
 }: {
   row: ExportRow;
   receipt: ReceiptRecord | undefined;
+  finalized: boolean;
+  reconciliationSealed: boolean;
 }) {
   const amountDelta =
     receipt && receipt.amount_minor !== null && receipt.amount_minor !== row.amountMinor;
@@ -383,6 +419,11 @@ function SideBySideRow({
         <div className="font-medium text-gray-900">{row.merchant ?? "—"}</div>
         <div className="text-[11px] text-gray-500">
           {row.transactionDate} · {formatAmountMinor(row.amountMinor ?? 0, row.currency)}
+        </div>
+        <div className="mt-1.5 max-w-[260px]">
+          <InlineCategoryCell
+            {...buildCategoryCellProps(row, finalized, reconciliationSealed)}
+          />
         </div>
       </div>
       <div className="pr-3">
@@ -426,10 +467,14 @@ function ConsolidatedGroup({
   receiptId,
   rows,
   receipt,
+  finalized,
+  reconciliationSealed,
 }: {
   receiptId: string;
   rows: ExportRow[];
   receipt: ReceiptRecord | undefined;
+  finalized: boolean;
+  reconciliationSealed: boolean;
 }) {
   const lineSum = rows.reduce((s, r) => s + (r.amountMinor ?? 0), 0);
   const balanced = receipt && receipt.amount_minor !== null && receipt.amount_minor === lineSum;
@@ -446,7 +491,13 @@ function ConsolidatedGroup({
         </span>
       </div>
       {rows.map((row, i) => (
-        <SideBySideRow key={i} row={row} receipt={i === 0 ? receipt : undefined} />
+        <SideBySideRow
+          key={i}
+          row={row}
+          receipt={i === 0 ? receipt : undefined}
+          finalized={finalized}
+          reconciliationSealed={reconciliationSealed}
+        />
       ))}
     </div>
   );
@@ -458,10 +509,14 @@ function AdditionalChargesSection({
   chargeRows,
   monthLabel,
   dupBadgeById,
+  finalized,
+  reconciliationSealed,
 }: {
   chargeRows: ExportRow[];
   monthLabel: string;
   dupBadgeById: Map<string, DuplicateBadge>;
+  finalized: boolean;
+  reconciliationSealed: boolean;
 }) {
   // ADR 0008: a cash/digital receipt ships in the CALENDAR month of its
   // transaction_date — so this section's population is "receipts assigned to
@@ -510,7 +565,9 @@ function AdditionalChargesSection({
                 <span className="text-right tabular-nums">
                   {formatAmountMinor(r.amountMinor ?? 0, r.currency)}
                 </span>
-                <span className="text-gray-600">{formatCategoryLabel(r.expenseCategoryCode)}</span>
+                <InlineCategoryCell
+                  {...buildCategoryCellProps(r, finalized, reconciliationSealed)}
+                />
                 <span>
                   <Pill tone="gray" size="sm">
                     {formatPaymentPath(r.paymentPath)}

--- a/lib/receipts/category-cell.ts
+++ b/lib/receipts/category-cell.ts
@@ -1,0 +1,103 @@
+// Pure, testable computation of the inline category cell's props for a
+// review-page row: the WRITE ROUTE (which endpoint a category edit hits) and
+// the LOCK STATE (whether editing is offered). Kept out of the React component
+// so the routing/lock rules are unit-testable without rendering.
+//
+// See components/receipts/export/inline-category-cell.tsx for the UI and
+// review-screen.tsx for the per-row call sites.
+
+import type { ExportRow } from "@/lib/receipts/types";
+
+export type CategoryRoute =
+  | { kind: "receipt"; id: string }
+  | { kind: "line"; id: string };
+
+export interface InlineCategoryCellProps {
+  /** Resolved category code (resolveLineCategory for lines; the receipt's own
+   *  code for cash/digital). Null = uncategorized. */
+  code: string | null;
+  /** JP/EN gloss of the resolved code, precomputed by the bundle. */
+  categoryJa: string | null;
+  categoryEn: string | null;
+  /** Source-of-truth badge: "from receipt" (matched) vs "on line"
+   *  (no-receipt / unmatched). Display only — the write route is separate. */
+  sourceLabel: "from receipt" | "on line";
+  /** Where a category edit is written. Null only when there is no writable
+   *  target (rows reaching this cell always have one). */
+  route: CategoryRoute | null;
+  /** Whether the dropdown is offered. False under any lock. */
+  editable: boolean;
+  /** Why editing is disabled (rendered as a title tooltip), or null. */
+  disabledReason: string | null;
+  /** Whether the row's receipt has attendees recorded — drives the
+   *  attendees-required inline warning (non-blocking; gate enforces). */
+  hasAttendees: boolean;
+}
+
+/**
+ * Routing (source of truth):
+ *   - matched AMEX line (receiptId set) → receipt PATCH — the receipt shadows
+ *     the line, so writing a line category here would desync the manifest.
+ *   - no-receipt / unmatched AMEX line (lineId, no receiptId) → line PATCH.
+ *   - cash/digital receipt row → receipt PATCH.
+ *
+ * Locks (mirror the actual API guards exactly):
+ *   - export finalized → all editing disabled (sealed; revision flow).
+ *   - reconciliation finalized + export draft → AMEX-line rows disabled. The
+ *     line PATCH 409s (rejectIfFinalized) AND a matched line's receipt PATCH
+ *     409s (rejectIfReceiptInFinalizedReconciliation). Standalone CASH/DIGITAL
+ *     receipts are matched to no AMEX line, so their receipt PATCH stays open —
+ *     those rows remain editable. The asymmetry is intentional, mirrored here.
+ */
+export function buildCategoryCellProps(
+  row: ExportRow,
+  finalized: boolean,
+  reconciliationSealed: boolean,
+): InlineCategoryCellProps {
+  const hasReceipt = Boolean(row.receiptId);
+  const sourceLabel: "from receipt" | "on line" = hasReceipt
+    ? "from receipt"
+    : "on line";
+  const route: CategoryRoute | null = hasReceipt
+    ? { kind: "receipt", id: row.receiptId! }
+    : row.lineId
+      ? { kind: "line", id: row.lineId }
+      : null;
+
+  let editable = !finalized;
+  let disabledReason: string | null = null;
+  if (finalized) {
+    editable = false;
+    disabledReason = "Export sealed — use the revision flow to amend (ADR 0009).";
+  } else if (reconciliationSealed && row.rowType === "amex_line") {
+    // Line PATCH 409s and a matched receipt PATCH 409s once the month's
+    // reconciliation is sealed. Cash/digital receipts (no AMEX match) are
+    // untouched by the reconciliation seal and stay editable.
+    editable = false;
+    disabledReason = "Reconciliation is sealed for this month — unseal to edit.";
+  }
+
+  return {
+    code: row.expenseCategoryCode,
+    categoryJa: row.expenseCategoryJa,
+    categoryEn: row.expenseCategoryEn,
+    sourceLabel,
+    route,
+    editable,
+    disabledReason,
+    hasAttendees: row.attendees.length > 0,
+  };
+}
+
+/**
+ * The PATCH body this surface sends for a category edit. Intentionally a SINGLE
+ * field — both /api/receipts/[id] and /api/receipts/amex/lines/[id] are sparse
+ * (#67 contract: only keys present in the body are written), so sending just
+ * expenseCategoryCode guarantees no sibling field (merchant, amount, attendees,
+ * tax, …) is ever touched from this surface. Unit-tested to lock that.
+ */
+export function buildCategoryPatchBody(
+  code: string,
+): { expenseCategoryCode: string | null } {
+  return { expenseCategoryCode: code || null };
+}

--- a/tests/receipts/category-cell.test.ts
+++ b/tests/receipts/category-cell.test.ts
@@ -1,0 +1,156 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildCategoryCellProps,
+  buildCategoryPatchBody,
+} from "@/lib/receipts/category-cell";
+import type { ExportRow } from "@/lib/receipts/types";
+
+// Minimal ExportRow builder — only the fields buildCategoryCellProps reads
+// (rowType / receiptId / lineId / category* / attendees) vary per test; the
+// rest are inert defaults so the shape stays valid against the interface.
+function makeRow(overrides: Partial<ExportRow> = {}): ExportRow {
+  return {
+    rowType: "amex_line",
+    lineId: "line-default",
+    matchStatus: "matched",
+    receiptStatus: "matched",
+    missingReceiptReason: null,
+    cardholderName: null,
+    businessTripStatus: "not_applicable",
+    receiptId: "rec-default",
+    status: "reviewed",
+    originalR2Key: null,
+    transactionDate: "2026-06-11",
+    merchant: "Test Merchant",
+    amountMinor: 1000,
+    currency: "JPY",
+    expenseType: "UNKNOWN",
+    expenseCategoryCode: "communications",
+    expenseCategoryJa: "通信費",
+    expenseCategoryEn: "Communications expenses",
+    paymentPath: "AMEX",
+    businessPurpose: null,
+    attendees: [],
+    invoiceRegistrationNumber: null,
+    qualifiedInvoiceStatus: "not_checked",
+    taxRate: null,
+    taxAmountMinor: null,
+    sourceType: null,
+    counterpartyName: null,
+    ...overrides,
+  };
+}
+
+const matchedLine = () =>
+  makeRow({ rowType: "amex_line", receiptId: "rec-1", lineId: "line-1" });
+const noReceiptLine = () =>
+  makeRow({
+    rowType: "amex_line",
+    receiptId: null,
+    lineId: "line-2",
+    receiptStatus: "missing_receipt",
+    matchStatus: "no_receipt",
+  });
+const cashReceipt = () =>
+  makeRow({
+    rowType: "receipt",
+    receiptId: "rec-2",
+    lineId: null,
+    paymentPath: "CASH",
+  });
+
+// ─── write-path routing (source of truth) ──────────────────────────────────
+
+test("category-cell routing: matched AMEX line → receipt PATCH (receipt shadows line)", () => {
+  // A matched line's category lives on the RECEIPT. Writing it on the line would
+  // desync the manifest (resolveLineCategory prefers the receipt).
+  const p = buildCategoryCellProps(matchedLine(), false, false);
+  assert.deepEqual(p.route, { kind: "receipt", id: "rec-1" });
+  assert.equal(p.sourceLabel, "from receipt");
+  assert.equal(p.editable, true);
+});
+
+test("category-cell routing: no-receipt / unmatched AMEX line → line PATCH", () => {
+  const p = buildCategoryCellProps(noReceiptLine(), false, false);
+  assert.deepEqual(p.route, { kind: "line", id: "line-2" });
+  assert.equal(p.sourceLabel, "on line");
+  assert.equal(p.editable, true);
+});
+
+test("category-cell routing: cash/digital receipt row → receipt PATCH", () => {
+  const p = buildCategoryCellProps(cashReceipt(), false, false);
+  assert.deepEqual(p.route, { kind: "receipt", id: "rec-2" });
+  assert.equal(p.sourceLabel, "from receipt");
+  assert.equal(p.editable, true);
+});
+
+// ─── lock-state rendering ──────────────────────────────────────────────────
+
+test("category-cell locks: open month → everything editable", () => {
+  for (const row of [matchedLine(), noReceiptLine(), cashReceipt()]) {
+    const p = buildCategoryCellProps(row, false, false);
+    assert.equal(p.editable, true);
+    assert.equal(p.disabledReason, null);
+  }
+});
+
+test("category-cell locks: export finalized → all editing disabled", () => {
+  for (const row of [matchedLine(), noReceiptLine(), cashReceipt()]) {
+    const p = buildCategoryCellProps(row, true, false);
+    assert.equal(p.editable, false, `expected disabled for ${row.rowType}`);
+    assert.ok(
+      p.disabledReason && /sealed/i.test(p.disabledReason),
+      `expected sealed reason for ${row.rowType}`,
+    );
+  }
+});
+
+test("category-cell locks: reconciliation sealed + export draft → AMEX lines disabled, cash/digital editable", () => {
+  // The honest asymmetry: the line PATCH 409s and a matched receipt PATCH 409s
+  // once the month's reconciliation is finalized, but a standalone cash/digital
+  // receipt is matched to no AMEX line so its PATCH stays open (June's state).
+  const ml = buildCategoryCellProps(matchedLine(), false, true);
+  assert.equal(ml.editable, false);
+  assert.match(ml.disabledReason!, /reconciliation is sealed/i);
+
+  const nr = buildCategoryCellProps(noReceiptLine(), false, true);
+  assert.equal(nr.editable, false);
+  assert.match(nr.disabledReason!, /reconciliation is sealed/i);
+
+  const cash = buildCategoryCellProps(cashReceipt(), false, true);
+  assert.equal(cash.editable, true, "cash/digital receipt stays editable when only reconciliation is sealed");
+  assert.equal(cash.disabledReason, null);
+});
+
+test("category-cell: resolved category + gloss + attendees pass through", () => {
+  const p = buildCategoryCellProps(
+    makeRow({
+      expenseCategoryCode: "entertainment",
+      expenseCategoryJa: "交際費",
+      expenseCategoryEn: "Entertainment expenses",
+      attendees: ["T Sato"],
+    }),
+    false,
+    false,
+  );
+  assert.equal(p.code, "entertainment");
+  assert.equal(p.categoryJa, "交際費");
+  assert.equal(p.categoryEn, "Entertainment expenses");
+  assert.equal(p.hasAttendees, true);
+});
+
+// ─── #67 regression: sparse PATCH body (both endpoints) ────────────────────
+
+test("category-cell PATCH body: single field — no sibling fields touched (#67)", () => {
+  // Both endpoints are sparse: only keys present are written. Sending just
+  // expenseCategoryCode guarantees merchant/amount/attendees/tax/etc. are never
+  // clobbered from this surface.
+  const body = buildCategoryPatchBody("travel_transportation");
+  assert.deepEqual(body, { expenseCategoryCode: "travel_transportation" });
+  assert.deepEqual(Object.keys(body).sort(), ["expenseCategoryCode"]);
+
+  const cleared = buildCategoryPatchBody("");
+  assert.deepEqual(cleared, { expenseCategoryCode: null });
+  assert.deepEqual(Object.keys(cleared).sort(), ["expenseCategoryCode"]);
+});


### PR DESCRIPTION
## What

Part 3 of the close-time triage batch. At close time the operator saw line items without categories and fixing one meant hunting through Reconcile/Review. Now every row on the pre-finalize review page shows its **resolved category** (JP name + EN gloss + source badge) and **edits in place**, routing the write to the correct source of truth. Independent of PR A/B.

## Changes

- **`lib/receipts/category-cell.ts`** (new, pure, tested) — `buildCategoryCellProps` decides the **write route + lock state** server-side; `buildCategoryPatchBody` locks the sparse **#67** contract (single field → no sibling fields touched).
- **`components/receipts/export/inline-category-cell.tsx`** (new, client) — source badge (`receipt`/`line`), dropdown of `EXPENSE_CATEGORIES` when editable (else read-only JP—EN + tooltip), per-row `saving…` indicator, **optimistic update with visible rollback** on failure, standard red error banner, attendees-required **non-blocking** warning, `category needed` pill. Auto-save on change; `router.refresh()` after save keeps gates/tiles/blocker counts live.
- **`review-screen.tsx`** — cell on every side-by-side AMEX-line row and in the Additional Charges category column.

## Routing (source of truth)

| Row | PATCH target |
|---|---|
| matched AMEX line | `/api/receipts/[id]` (receipt shadows the line) |
| no-receipt / unmatched line | `/api/receipts/amex/lines/[id]` |
| cash/digital receipt | `/api/receipts/[id]` |

A line category is **never** written onto a matched line.

## Locks (mirror the actual API guards)

- **Export finalized** → all editing disabled.
- **Reconciliation sealed + export draft** → AMEX-line rows disabled (line PATCH 409s; matched receipt PATCH 409s via `rejectIfReceiptInFinalizedReconciliation`). But standalone **CASH/DIGITAL receipts are matched to no AMEX line and stay editable** — that asymmetry is intentional and mirrored exactly.
- Attendees-required category with none present → edit **allowed** + inline non-blocking warning (the finalize gate is the enforcement point).

## Tests

Write-path routing (matched→receipt, unmatched→line, cash→receipt); lock states (open / export-sealed / reconciliation-sealed incl. the cash-receipt asymmetry); #67 sparse-body regression (single key, both endpoints).

## Verification

`tsc --noEmit` · `npm run lint` · `npm test` (327 pass) · `build:cf` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)