### PR TITLE
feat(receipts): sealed-bundle download route (GET /api/receipts/export/[month]/download)

### DIFF
--- a/app/(receipt-system)/receipts/export/page.tsx
+++ b/app/(receipt-system)/receipts/export/page.tsx
@@ -37,6 +37,16 @@ import { deriveStatementWindow } from "@/lib/receipts/statement-window";
 
 export const dynamic = "force-dynamic";
 
+// The four artifacts finalize seals in RECEIPTS_ARCHIVE_BUCKET, served by
+// GET /api/receipts/export/[month]/download (Content-Disposition: attachment,
+// so plain anchors download without any client-side code).
+const BUNDLE_DOWNLOAD_LINKS = [
+  { file: "receipts", label: "Receipts CSV" },
+  { file: "manifest", label: "Manifest" },
+  { file: "summary", label: "Summary" },
+  { file: "readme", label: "README" },
+] as const;
+
 export default async function ExportPage({
   searchParams,
 }: {
@@ -151,6 +161,26 @@ export default async function ExportPage({
         statementWindow={statementWindow}
         unassignableReceipts={unassignable}
       />
+      {currentExport?.status === "finalized" && (
+        <div className="border-t border-gray-200 bg-white px-8 py-6">
+          <h2 className="text-sm font-bold text-gray-900">Download bundle</h2>
+          <p className="mt-1 text-xs text-gray-500">
+            Finalized {monthLabel} archive files, served byte-for-byte as
+            sealed in R2 — SHA-256 hashes match the manifest.
+          </p>
+          <div className="mt-3 flex flex-wrap gap-3">
+            {BUNDLE_DOWNLOAD_LINKS.map(({ file, label }) => (
+              <a
+                key={file}
+                href={`/api/receipts/export/${month}/download?file=${file}`}
+                className="rounded-xl border border-amber-300 bg-amber-50 px-4 py-2 text-xs font-semibold text-amber-900 hover:bg-amber-100"
+              >
+                {label}
+              </a>
+            ))}
+          </div>
+        </div>
+      )}
       <div className="border-t border-amber-100 bg-amber-50 px-8 py-4 text-xs text-amber-900">
         <p className="font-semibold">Accountant review boundary</p>
         <p className="mt-1">{ACCOUNTANT_DISCLAIMER_EN}</p>

--- a/app/api/receipts/export/[month]/download/route.ts
+++ b/app/api/receipts/export/[month]/download/route.ts
@@ -1,0 +1,107 @@
+import { NextResponse } from "next/server";
+import { requireReceiptsActor } from "@/lib/receipts/auth";
+import { createAuditEntry } from "@/lib/receipts/audit";
+import { stringifyJson } from "@/lib/receipts/db-utils";
+import { getExport } from "@/lib/receipts/db";
+import {
+  EXPORT_DOWNLOAD_FILES,
+  isExportDownloadFile,
+  resolveExportDownload,
+} from "@/lib/receipts/export";
+import {
+  getReceiptsArchiveBucket,
+  getReceiptsDb,
+} from "@/lib/cloudflare-runtime";
+
+type RouteContext = { params: Promise<{ month: string }> };
+
+/**
+ * GET /api/receipts/export/[month]/download?file=receipts|manifest|summary|readme
+ *
+ * Streams one of the four finalized-bundle artifacts from the archive bucket.
+ * The body is served byte-for-byte as sealed at finalize (BOM+CRLF CSVs whose
+ * SHA-256 is recorded in the manifest) — no re-encoding, or integrity
+ * verification against the manifest breaks.
+ */
+export async function GET(request: Request, { params }: RouteContext) {
+  try {
+    const actor = await requireReceiptsActor(request.headers);
+    const { month } = await params;
+
+    if (!/^\d{4}-\d{2}$/.test(month)) {
+      return NextResponse.json({ error: "Invalid month format." }, { status: 400 });
+    }
+
+    const file = new URL(request.url).searchParams.get("file");
+    if (!file || !isExportDownloadFile(file)) {
+      return NextResponse.json(
+        {
+          error: `Missing or invalid "file" parameter. Expected one of: ${EXPORT_DOWNLOAD_FILES.join(", ")}.`,
+        },
+        { status: 400 },
+      );
+    }
+
+    const exportRecord = await getExport(month);
+    if (!exportRecord) {
+      return NextResponse.json(
+        { error: "No export found for this month." },
+        { status: 404 },
+      );
+    }
+    // Only finalized bundles are downloadable — a draft is not sealed, its
+    // artifacts can still be rebuilt, and handing it to the accountant would
+    // circulate an unverified bundle.
+    if (exportRecord.status !== "finalized") {
+      return NextResponse.json(
+        {
+          error:
+            "Export for this month is still a draft. Finalize the month before downloading the bundle.",
+        },
+        { status: 409 },
+      );
+    }
+
+    const target = resolveExportDownload(month, exportRecord, file);
+    if (!target.r2Key) {
+      return NextResponse.json(
+        { error: `No archived ${file} key recorded for this export.` },
+        { status: 404 },
+      );
+    }
+
+    const bucket = getReceiptsArchiveBucket();
+    const object = await bucket.get(target.r2Key);
+    if (!object) {
+      return NextResponse.json(
+        { error: `Archived ${file} file not found in storage.` },
+        { status: 404 },
+      );
+    }
+
+    await createAuditEntry(getReceiptsDb(), {
+      actor,
+      action: "export.downloaded",
+      objectType: "export",
+      objectId: exportRecord.id,
+      newValueJson: stringifyJson({ month, file }),
+    });
+
+    // Stream the archived bytes as-is — do NOT transform the body.
+    return new Response(object.body, {
+      headers: {
+        "Content-Type": target.contentType,
+        "Content-Disposition": `attachment; filename="${target.filename}"`,
+      },
+    });
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Unauthorized")) {
+      return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+    }
+    console.error("[api/receipts/export/[month]/download] GET failed", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to download export file." },
+      { status: 500 },
+    );
+  }
+}

--- a/components/receipts/export/finalize-card.tsx
+++ b/components/receipts/export/finalize-card.tsx
@@ -6,6 +6,15 @@ import { Btn } from "@/components/ui/btn";
 import { Card } from "@/components/ui/card";
 import { LockIcon } from "@/components/ui/icons";
 
+// The four artifacts sealed in RECEIPTS_ARCHIVE_BUCKET, served by
+// GET /api/receipts/export/[month]/download (Content-Disposition: attachment).
+const BUNDLE_DOWNLOAD_LINKS = [
+  { file: "receipts", label: "Receipts CSV" },
+  { file: "manifest", label: "Manifest" },
+  { file: "summary", label: "Summary" },
+  { file: "readme", label: "README" },
+] as const;
+
 /**
  * Finalize action + panel. Extracted from export-screen.tsx so it can render at
  * the bottom of the pre-finalize review page (the new finalize surface). The
@@ -94,8 +103,21 @@ export function FinalizeCard({
 
         {finalized ? (
           <div className="px-5 py-5 text-[12.5px] text-gray-600">
-            All {rowsInDraft} rows are locked. Reconciliation is signed off. Download the archive
-            bundle from the export screen history.
+            <p>
+              All {rowsInDraft} rows are locked. Reconciliation is signed off. Download the sealed
+              bundle:
+            </p>
+            <div className="mt-3 flex flex-wrap gap-2">
+              {BUNDLE_DOWNLOAD_LINKS.map(({ file, label }) => (
+                <a
+                  key={file}
+                  href={`/api/receipts/export/${month}/download?file=${file}`}
+                  className="rounded-xl border border-amber-300 bg-amber-50 px-3 py-1.5 text-[11.5px] font-semibold text-amber-900 hover:bg-amber-100"
+                >
+                  {label}
+                </a>
+              ))}
+            </div>
           </div>
         ) : (
           <div className="px-5 py-5">

--- a/lib/receipts/export.ts
+++ b/lib/receipts/export.ts
@@ -305,6 +305,67 @@ export function buildReadmeKey(month: string, exportId: string): string {
   return `exports/${month}/${exportId}-README.txt`;
 }
 
+// ─── Bundle download resolution ───────────────────────────────────────────────
+// Pure mapping from a download request to the R2 key + response headers for
+// the GET /api/receipts/export/[month]/download route. Kept here (next to the
+// key builders) so the download route cannot drift from the keys finalize
+// writes, and so the mapping is unit-testable without R2/D1 mocks.
+
+export const EXPORT_DOWNLOAD_FILES = [
+  "receipts",
+  "manifest",
+  "summary",
+  "readme",
+] as const;
+
+export type ExportDownloadFile = (typeof EXPORT_DOWNLOAD_FILES)[number];
+
+export function isExportDownloadFile(
+  value: string,
+): value is ExportDownloadFile {
+  return (EXPORT_DOWNLOAD_FILES as readonly string[]).includes(value);
+}
+
+export function resolveExportDownload(
+  month: string,
+  exportRecord: {
+    id: string;
+    archive_r2_key: string | null;
+    manifest_r2_key: string | null;
+  },
+  file: ExportDownloadFile,
+): { r2Key: string | null; contentType: string; filename: string } {
+  const csv = "text/csv; charset=utf-8";
+  switch (file) {
+    case "receipts":
+      // Stored key — the exact object finalize sealed (BOM+CRLF bytes whose
+      // SHA-256 is recorded in the manifest). Never re-derive or re-encode.
+      return {
+        r2Key: exportRecord.archive_r2_key,
+        contentType: csv,
+        filename: `export-${month}-receipts.csv`,
+      };
+    case "manifest":
+      return {
+        r2Key: exportRecord.manifest_r2_key,
+        contentType: csv,
+        filename: `export-${month}-manifest.csv`,
+      };
+    case "summary":
+      return {
+        r2Key: buildSummaryKey(month, exportRecord.id),
+        contentType: csv,
+        filename: `export-${month}-summary.csv`,
+      };
+    case "readme":
+      return {
+        r2Key: buildReadmeKey(month, exportRecord.id),
+        contentType: "text/plain; charset=utf-8",
+        filename: `export-${month}-readme.txt`,
+      };
+  }
+}
+
 export function buildExportReadme(opts: {
   exportId: string;
   month: string;

--- a/lib/receipts/types.ts
+++ b/lib/receipts/types.ts
@@ -133,6 +133,7 @@ export type AuditAction =
   | "export.generated"
   | "export.finalized"
   | "export.revision_created"
+  | "export.downloaded"
   | "archive.created"
   | "settings.updated"
   | "receipt.export_statement_month_assigned"

--- a/tests/receipts/export-download.test.ts
+++ b/tests/receipts/export-download.test.ts
@@ -1,0 +1,70 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  EXPORT_DOWNLOAD_FILES,
+  isExportDownloadFile,
+  resolveExportDownload,
+  buildSummaryKey,
+  buildReadmeKey,
+} from "@/lib/receipts/export";
+
+// Pure decision logic behind GET /api/receipts/export/[month]/download:
+// which R2 key, Content-Type, and attachment filename each `file` value
+// resolves to. The route itself (auth, 409-on-draft, R2 fetch) runs against
+// live bindings and is exercised via cf:dev, not mocked here.
+
+const month = "2026-06";
+const exportRecord = {
+  id: "exp-123",
+  archive_r2_key: "exports/2026-06/exp-123-receipts.csv",
+  manifest_r2_key: "exports/2026-06/exp-123-manifest.csv",
+};
+
+test("isExportDownloadFile accepts exactly the four bundle files", () => {
+  for (const file of EXPORT_DOWNLOAD_FILES) {
+    assert.equal(isExportDownloadFile(file), true);
+  }
+  assert.equal(isExportDownloadFile(""), false);
+  assert.equal(isExportDownloadFile("zip"), false);
+  assert.equal(isExportDownloadFile("Receipts"), false);
+  assert.equal(isExportDownloadFile("readme.txt"), false);
+});
+
+test("receipts resolves to the STORED archive key, untransformed", () => {
+  const target = resolveExportDownload(month, exportRecord, "receipts");
+  assert.equal(target.r2Key, exportRecord.archive_r2_key);
+  assert.equal(target.contentType, "text/csv; charset=utf-8");
+  assert.equal(target.filename, "export-2026-06-receipts.csv");
+});
+
+test("manifest resolves to the STORED manifest key", () => {
+  const target = resolveExportDownload(month, exportRecord, "manifest");
+  assert.equal(target.r2Key, exportRecord.manifest_r2_key);
+  assert.equal(target.contentType, "text/csv; charset=utf-8");
+  assert.equal(target.filename, "export-2026-06-manifest.csv");
+});
+
+test("summary derives its key via buildSummaryKey", () => {
+  const target = resolveExportDownload(month, exportRecord, "summary");
+  assert.equal(target.r2Key, buildSummaryKey(month, exportRecord.id));
+  assert.equal(target.r2Key, "exports/2026-06/exp-123-summary.csv");
+  assert.equal(target.contentType, "text/csv; charset=utf-8");
+  assert.equal(target.filename, "export-2026-06-summary.csv");
+});
+
+test("readme derives its key via buildReadmeKey and ships as text/plain .txt", () => {
+  const target = resolveExportDownload(month, exportRecord, "readme");
+  assert.equal(target.r2Key, buildReadmeKey(month, exportRecord.id));
+  assert.equal(target.r2Key, "exports/2026-06/exp-123-README.txt");
+  assert.equal(target.contentType, "text/plain; charset=utf-8");
+  assert.equal(target.filename, "export-2026-06-readme.txt");
+});
+
+test("stored-key files surface a null key (route 404s) when the record lacks them", () => {
+  const bare = { id: "exp-123", archive_r2_key: null, manifest_r2_key: null };
+  assert.equal(resolveExportDownload(month, bare, "receipts").r2Key, null);
+  assert.equal(resolveExportDownload(month, bare, "manifest").r2Key, null);
+  // Derived keys never depend on the stored columns.
+  assert.ok(resolveExportDownload(month, bare, "summary").r2Key);
+  assert.ok(resolveExportDownload(month, bare, "readme").r2Key);
+});


### PR DESCRIPTION
## What

Finalizing a monthly export seals 4 files into `RECEIPTS_ARCHIVE_BUCKET` (receipts CSV, manifest CSV, summary CSV, README). Until now, retrieving them required wrangler. This adds a download route + UI links.

## Route — `GET /api/receipts/export/[month]/download?file=receipts|manifest|summary|readme`

Mirrors `reconcile/[month]/manifest/route.ts` exactly (auth → awaited params → month-regex 400 → load → `bucket.get` → stream `object.body` → Unauthorized-401/500 catch), with:

- **file param** validated against an allowlist (no arbitrary-key / path-traversal surface) → 400 otherwise
- **finalized-only** — draft export → **409** (an unsealed bundle can never reach the accountant)
- unknown month → 404; null stored key → 404; R2 object missing → 404
- **byte-for-byte streaming** — `new Response(object.body, { headers })`, no re-encode/BOM. Archived CSVs are BOM+CRLF with SHA-256 in the manifest; any byte change breaks integrity verification.
- **audit** — `export.downloaded` (objectType `export`, objectId = export id, `{ month, file }`)

Pure key/content-type/filename resolution extracted into `resolveExportDownload` (`lib/receipts/export.ts`), beside the other key builders, unit-tested in `tests/receipts/export-download.test.ts`.

## UI

- `export/page.tsx` — "Download bundle" section with 4 links, rendered **only when finalized** (hidden for draft/absent).
- `finalize-card.tsx` — same links in the post-finalize panel (renders on the review page via `ReviewScreen → FinalizeCard`, the spec's optional target, at the component that owns finalized-state).

## Verification

- `tsc --noEmit` ✅ · `npm run lint` ✅ · `npm test` ✅ **355 pass / 0 fail** (incl. 6 new tests)
- `getExport` return shape confirmed: `ReceiptExport` has `id`, `status`, `archive_r2_key`, `manifest_r2_key` — every field the route reads is present.
- No DB migration in this PR (`export.downloaded` is a TS-side `AuditAction` union member; `action` is stored as text).

## Accepted edge cases (operator-reviewed)

1. **Mid-revision download 409s.** `getExport` returns the highest-revision row; a newer draft (revision in progress) → `status !== "finalized"` → 409. Conservative failure mode — correct for compliance. A "download latest finalized revision" affordance deferred unless a real need surfaces.
2. **Audit writes after R2 fetch, before stream.** A download that fails mid-stream is still audited as downloaded. Acceptable for an advisory audit trail; not blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)