### PR TITLE
feat(receipts): proof_copy derivatives at ingest (PR 1/4)

### DIFF
--- a/app/api/receipts/[id]/proof/route.ts
+++ b/app/api/receipts/[id]/proof/route.ts
@@ -1,0 +1,143 @@
+import { NextResponse } from "next/server";
+import { requireReceiptsActor } from "@/lib/receipts/auth";
+import { getReceiptRecord } from "@/lib/receipts/db";
+import { createAuditEntry } from "@/lib/receipts/audit";
+import { stringifyJson } from "@/lib/receipts/db-utils";
+import { createReceiptFile, deleteProofCopyForReceipt } from "@/lib/receipts/files";
+import {
+  computeSha256Hex,
+  proofCopyR2Key,
+  putProofCopy,
+} from "@/lib/receipts/storage";
+import { getReceiptsDb, getReceiptsProcessorKey } from "@/lib/cloudflare-runtime";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+const PROCESSOR_ACTOR = "mlx-consumer@mac";
+
+// Constant-time string compare so the processor key can't be probed by timing.
+// (Mirrors app/api/receipts/[id]/extract/route.ts — same processor-key path.)
+function timingSafeEqual(a: string, b: string): boolean {
+  const enc = new TextEncoder();
+  const ab = enc.encode(a);
+  const bb = enc.encode(b);
+  const len = Math.max(ab.length, bb.length);
+  let mismatch = ab.length ^ bb.length;
+  for (let i = 0; i < len; i += 1) mismatch |= (ab[i] ?? 0) ^ (bb[i] ?? 0);
+  return mismatch === 0;
+}
+
+// Accepted proof-derivative content types. The Mac consumer does all image
+// work before posting: JPEGs are recompressed (resize 1600, q75, EXIF stripped)
+// in consumer.py; PDFs pass through unchanged (rasterizing legal docs loses
+// text). The Worker never transforms image bytes (CPU budget, no native codecs).
+const ACCEPTED_PROOF_TYPES = new Map<string, "jpg" | "pdf">([
+  ["image/jpeg", "jpg"],
+  ["application/pdf", "pdf"],
+]);
+
+/**
+ * POST /api/receipts/[id]/proof
+ *
+ * Stores a compact proof derivative (role `proof_copy`) generated on the Mac
+ * consumer at ingest (ADR 0001 processor-key path). Lives in the live
+ * RECEIPTS_BUCKET at a stable per-receipt key; the sealed proofs ZIP prefers it
+ * over the original to keep the bundle small.
+ *
+ * Idempotent upsert: a prior proof_copy row for the receipt is deleted and the
+ * R2 object overwritten, so re-ingest / backfill --force refreshes the
+ * derivative without violating the r2_key UNIQUE constraint.
+ *
+ * Auth mirrors the extract endpoint: a valid `x-receipts-processor-key` header
+ * authenticates the Mac consumer; otherwise a Clerk-authenticated human may post.
+ */
+export async function POST(request: Request, { params }: RouteContext) {
+  try {
+    const processorKey = getReceiptsProcessorKey();
+    const presentedKey = request.headers.get("x-receipts-processor-key");
+    const isProcessor =
+      !!processorKey && !!presentedKey && timingSafeEqual(presentedKey, processorKey);
+    const actor = isProcessor
+      ? PROCESSOR_ACTOR
+      : await requireReceiptsActor(request.headers);
+
+    const { id } = await params;
+
+    const contentType = (request.headers.get("content-type") ?? "")
+      .toLowerCase()
+      .split(";")[0]
+      .trim();
+    const ext = ACCEPTED_PROOF_TYPES.get(contentType);
+    if (!ext) {
+      return NextResponse.json(
+        {
+          error: `Unsupported proof content-type "${contentType}". Expected one of: ${[...ACCEPTED_PROOF_TYPES.keys()].join(", ")}.`,
+        },
+        { status: 400 },
+      );
+    }
+
+    const receipt = await getReceiptRecord(id);
+    if (!receipt) {
+      return NextResponse.json({ error: "Receipt not found." }, { status: 404 });
+    }
+
+    const bytes = await request.arrayBuffer();
+    if (bytes.byteLength === 0) {
+      return NextResponse.json({ error: "Empty proof body." }, { status: 400 });
+    }
+
+    const sha256 = await computeSha256Hex(bytes);
+    const sizeBytes = bytes.byteLength;
+    const r2Key = proofCopyR2Key(id, ext);
+    const db = getReceiptsDb();
+
+    // Upsert: clear any prior proof_copy row (r2_key UNIQUE), overwrite the R2
+    // object, then insert the fresh row. R2 + D1 are not in one transaction —
+    // if the insert fails after the put, the orphaned object is harmless (a
+    // later retry overwrites it at the same stable key).
+    await deleteProofCopyForReceipt(db, id);
+    await putProofCopy(r2Key, bytes, contentType);
+    await createReceiptFile(db, {
+      objectType: "receipt",
+      objectId: id,
+      role: "proof_copy",
+      r2Bucket: "receipts",
+      r2Key,
+      originalFilename: `proof.${ext}`,
+      contentType,
+      fileSizeBytes: sizeBytes,
+      sha256Hash: sha256,
+      uploadedBy: actor,
+      isOriginal: false,
+    });
+
+    await createAuditEntry(db, {
+      actor,
+      action: "receipt.proof_uploaded",
+      objectType: "receipt",
+      objectId: id,
+      newValueJson: stringifyJson({
+        r2Key,
+        sha256,
+        sizeBytes,
+        contentType,
+        via: isProcessor ? "mlx_consumer" : "human",
+      }),
+    });
+
+    return NextResponse.json(
+      { ok: true, r2Key, sha256, sizeBytes },
+      { status: 200 },
+    );
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Unauthorized")) {
+      return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+    }
+    console.error("[api/receipts/[id]/proof] POST failed", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Proof upload failed." },
+      { status: 500 },
+    );
+  }
+}

--- a/lib/receipts/files.ts
+++ b/lib/receipts/files.ts
@@ -76,3 +76,25 @@ export async function findFileBySha256(
     .bind(sha256)
     .first<ReceiptFile>();
 }
+
+/**
+ * Delete any existing proof_copy row for a receipt (upsert preamble).
+ *
+ * Proof copies live at a STABLE r2_key (`receipts/<id>/proof.<ext>`) and
+ * `receipt_files.r2_key` is UNIQUE, so regenerating a derivative (re-ingest,
+ * backfill --force) must clear the prior row before the fresh INSERT —
+ * otherwise the insert trips the unique constraint. The R2 object itself is
+ * overwritten separately by putProofCopy.
+ */
+export async function deleteProofCopyForReceipt(
+  db: D1Database,
+  receiptId: string,
+): Promise<void> {
+  await db
+    .prepare(
+      `DELETE FROM receipt_files
+       WHERE object_type = 'receipt' AND object_id = ? AND role = 'proof_copy'`,
+    )
+    .bind(receiptId)
+    .run();
+}

--- a/lib/receipts/storage.ts
+++ b/lib/receipts/storage.ts
@@ -50,6 +50,35 @@ export async function getReceiptFile(
   };
 }
 
+// ─── Proof-copy derivatives (PR 1) ─────────────────────────────────────────
+// Compact proof image generated on the Mac consumer at ingest (resize 1600,
+// JPEG q75; PDFs pass through). Stored in the LIVE receipts bucket under a
+// STABLE per-receipt key so the proofs ZIP (sealed-bundle artifact) can prefer
+// it over the original to keep the bundle small.
+
+export function proofCopyR2Key(receiptId: string, ext: "jpg" | "pdf"): string {
+  return `receipts/${receiptId}/proof.${ext}`;
+}
+
+/**
+ * Overwrite-capable put for a proof-copy derivative. Unlike uploadOriginal
+ * (which guards against collisions to protect originals), proof copies are
+ * regenerable — re-ingest and `backfill_proof_copies.py --force` refresh them
+ * in place. The caller deletes any prior proof_copy receipt_files row first so
+ * the r2_key UNIQUE constraint still holds after the fresh insert.
+ */
+export async function putProofCopy(
+  key: string,
+  data: ArrayBuffer,
+  contentType: string,
+): Promise<void> {
+  const bucket = getReceiptsBucket();
+  await bucket.put(key, data, {
+    httpMetadata: { contentType },
+    customMetadata: retentionMetadata(),
+  });
+}
+
 export async function archiveBundle(
   key: string,
   data: ArrayBuffer,

--- a/lib/receipts/types.ts
+++ b/lib/receipts/types.ts
@@ -139,6 +139,7 @@ export type AuditAction =
   | "receipt.export_statement_month_assigned"
   | "receipt.export_statement_month_overridden"
   | "receipt.export_statement_month_rolled_forward"
+  | "receipt.proof_uploaded"
   // ADR 0008 one-time policy migration (window → calendar month). Replaces the
   // ADR 0006 _window_drift action — calendar membership has no AMEX-line
   // dependency, so drift detection is retired.
@@ -203,6 +204,7 @@ export type ComplianceCheckSeverity = "info" | "warning" | "blocker";
 export type ReceiptFileRole =
   | "original"
   | "processed"
+  | "proof_copy"
   | "back_side"
   | "continuation"
   | "related_invoice"

--- a/middleware.ts
+++ b/middleware.ts
@@ -36,6 +36,7 @@ const isPublicRoute = createRouteMatcher([
   "/api/receipts/:id/file",
   "/api/receipts/:id/extract",
   "/api/receipts/:id/extraction-failed",
+  "/api/receipts/:id/proof",
 ]);
 
 export default clerkMiddleware(async (auth, request) => {

--- a/scripts/receipts-consumer/backfill_proof_copies.py
+++ b/scripts/receipts-consumer/backfill_proof_copies.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Backfill proof-copy derivatives for receipts that lack one.
+
+Proof copies are normally generated at ingest by consumer.py (PR 1). This
+script recovers receipts captured BEFORE that path shipped, or whose proof post
+failed (advisory — extraction succeeded but no proof_copy row landed).
+
+Runs on the Mac against D1 + the Worker /proof endpoint:
+  --dry-run (default): print a plan table, write nothing.
+  --write:             fetch each original, build the derivative, POST /proof.
+  --local:             target LOCAL D1 (cf:dev) — for the seeded dry-run demo.
+                       Default is --remote (live; operator-only).
+  --force:             regenerate even where a proof_copy already exists.
+  --id <uuid>:         narrow to one receipt.
+
+Idempotent + resumable: by default it selects only receipts WITHOUT a
+proof_copy, so re-running after a partial --write picks up exactly the rest.
+
+Run (Mac, venv):
+  .venv/bin/python3 backfill_proof_copies.py --local --dry-run    # seeded cf:dev
+  .venv/bin/python3 backfill_proof_copies.py --remote --dry-run   # live plan (read-only)
+  .venv/bin/python3 backfill_proof_copies.py --remote --write     # apply
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+
+# consumer.py reads these at import time. Default them so --help / --dry-run
+# work without the full runtime env; --write (posting) needs real values.
+os.environ.setdefault("CF_ACCOUNT_ID", "d")
+os.environ.setdefault("CF_QUEUE_ID", "d")
+os.environ.setdefault("CF_API_TOKEN", "d")
+os.environ.setdefault("RECEIPTS_EXTRACT_URL", "http://d")
+os.environ.setdefault("RECEIPTS_PROCESSOR_KEY", "d")
+os.environ.setdefault("MLX_MODEL", "d")
+
+import consumer  # type: ignore  # noqa: E402
+
+
+def list_receipts_needing_proof(
+    *, local: bool, force: bool, only_id: str | None
+) -> list[dict]:
+    """Receipts to (re)generate a proof_copy for.
+
+    Default: non-deleted receipts with an original file and NO proof_copy row.
+    --force: all non-deleted receipts with an original file (regenerate existing).
+    """
+    where_id = f" AND r.id = {consumer._sql_escape(only_id)}" if only_id else ""
+    if force:
+        clause = ""
+    else:
+        # NOT EXISTS a proof_copy row — the idempotency guard. Re-running after
+        # a partial --write selects exactly the remaining misses.
+        clause = (
+            "AND NOT EXISTS ("
+            " SELECT 1 FROM receipt_files rf"
+            " WHERE rf.object_type = 'receipt' AND rf.object_id = r.id"
+            " AND rf.role = 'proof_copy')"
+        )
+    return consumer._d1_query(
+        "SELECT r.id, r.merchant, r.original_r2_key, r.captured_at "
+        "FROM receipt_records r "
+        "WHERE r.deleted_at IS NULL "
+        "AND r.original_r2_key IS NOT NULL "
+        + clause
+        + where_id
+        + " ORDER BY r.captured_at;",
+        local=local,
+    )
+
+
+def build_proof_from_original(
+    receipt_id: str, r2_key: str
+) -> tuple[bytes, str] | None:
+    """Fetch the original file and build its proof derivative.
+
+    Writes the fetched bytes to a temp file with the right suffix so
+    make_proof_derivative can branch (PDF pass-through vs JPEG recompress).
+    """
+    raw = consumer.fetch_original_bytes(receipt_id)
+    if raw is None:
+        return None
+    suffix = ".pdf" if r2_key.lower().endswith(".pdf") else ".jpg"
+    fd, path = tempfile.mkstemp(suffix=suffix)
+    os.close(fd)
+    try:
+        with open(path, "wb") as fh:
+            fh.write(raw)
+        return consumer.make_proof_derivative(path)
+    finally:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+
+def main() -> None:
+    args = sys.argv[1:]
+    dry_run = "--write" not in args
+    local = "--local" in args
+    force = "--force" in args
+    only_id = None
+    if "--id" in args:
+        i = args.index("--id")
+        if i + 1 >= len(args):
+            print("--id requires a UUID argument", file=sys.stderr)
+            sys.exit(2)
+        only_id = args[i + 1]
+
+    target = "LOCAL D1 (cf:dev)" if local else "REMOTE D1 (live)"
+    mode = "[dry-run]" if dry_run else "[WRITE]"
+    rows = list_receipts_needing_proof(local=local, force=force, only_id=only_id)
+
+    print(f"Proof-copy backfill — {target} {mode} — force={force}")
+    if not rows:
+        print("No receipts need a proof_copy. Clean.")
+        return
+    print(f"{'id':36}  {'merchant':24}  original_r2_key")
+    print("-" * 92)
+    stats = {"ok": 0, "fail": 0, "skip": 0}
+    for r in rows:
+        rid = str(r["id"])
+        merchant = str(r.get("merchant") or "")[:24]
+        r2_key = str(r["original_r2_key"])
+        print(f"{rid:36}  {merchant:24}  {r2_key}")
+        if dry_run:
+            continue
+        proof = build_proof_from_original(rid, r2_key)
+        if proof is None:
+            print(f"  [skip] {rid}: could not build proof", file=sys.stderr)
+            stats["skip"] += 1
+            continue
+        try:
+            consumer.post_proof(rid, *proof)
+            stats["ok"] += 1
+            print(f"  [ok]   {rid}")
+        except Exception as exc:  # noqa: BLE001
+            print(f"  [fail] {rid}: {exc}", file=sys.stderr)
+            stats["fail"] += 1
+
+    print(
+        f"\nDone. ok={stats['ok']}, fail={stats['fail']}, skip={stats['skip']} "
+        f"(of {len(rows)} candidate)."
+    )
+    if dry_run:
+        print("Dry-run only. Re-run with --write to apply.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/receipts-consumer/consumer.py
+++ b/scripts/receipts-consumer/consumer.py
@@ -31,6 +31,7 @@ Config via env (see .env.example):
 """
 from __future__ import annotations
 
+import io
 import json
 import os
 import subprocess
@@ -289,6 +290,139 @@ def post_extraction_failed(receipt_id: str, reason: str) -> None:
         )
 
 
+# ─── Proof-copy derivatives (PR 1) ────────────────────────────────────────────
+# A compact proof image generated at ingest and stored alongside the original
+# (receipt_files role='proof_copy'; R2 key receipts/<id>/proof.<ext>). The
+# sealed proofs ZIP prefers it over the original to keep the accountant bundle
+# small (<5 MB vs ~19 MB raw). ALL image work happens HERE on the Mac (PIL) —
+# the Worker only stores the bytes (CPU budget, no native image codecs).
+#
+# Proof generation is ADVISORY: a failure must never fail extraction. The
+# consumer builds + posts the derivative after a successful /extract, wrapped so
+# any error is logged and swallowed (backfill_proof_copies.py recovers misses).
+
+PROOF_MAX_LONGEST_SIDE = 1600
+PROOF_JPEG_QUALITY = 75
+
+
+def make_proof_derivative(image_path: str) -> tuple[bytes, str] | None:
+    """Build a compact proof derivative from a local image file.
+
+    Raster images: resize the longest side to <=1600px (never upscale), JPEG
+    quality 75, EXIF stripped AFTER baking orientation into the pixels. Returns
+    (jpeg_bytes, "image/jpeg").
+
+    PDFs: pass through unchanged (already compact; rasterizing legal documents
+    loses the selectable text the accountant relies on). Returns (pdf_bytes,
+    "application/pdf").
+
+    Returns None only when a raster image can't be opened (the caller treats
+    that as a skipped proof, not a failure). Any other error propagates so the
+    caller's advisory wrapper can log it.
+    """
+    suffix = os.path.splitext(image_path)[1].lower()
+    if suffix == ".pdf":
+        with open(image_path, "rb") as fh:
+            return fh.read(), "application/pdf"
+
+    from PIL import Image, ImageOps  # lazy: keeps --help + unit tests cheap
+
+    try:
+        img = Image.open(image_path)
+    except Exception:  # noqa: BLE001 — caller treats None as "skip proof"
+        return None
+    try:
+        # Bake EXIF orientation into the pixels, then drop all metadata so no
+        # location/camera data ships to the accountant.
+        transposed = ImageOps.exif_transpose(img)
+        if transposed is not None:
+            img = transposed
+        if img.mode not in ("RGB", "L"):
+            img = img.convert("RGB")
+        # thumbnail() preserves aspect ratio, fits within the box (longest side
+        # <=1600), and never upsizes — exactly the proof sizing we want.
+        img.thumbnail(
+            (PROOF_MAX_LONGEST_SIDE, PROOF_MAX_LONGEST_SIDE),
+            Image.Resampling.LANCZOS,
+        )
+        buf = io.BytesIO()
+        img.save(buf, format="JPEG", quality=PROOF_JPEG_QUALITY)
+        return buf.getvalue(), "image/jpeg"
+    finally:
+        img.close()
+
+
+def fetch_original_bytes(receipt_id: str) -> bytes | None:
+    """Fetch the receipt's ORIGINAL file bytes via the Worker /file endpoint.
+
+    Same processor-key proxy as fetch_image, but WITHOUT PDF rasterization.
+    Used for proof generation where PDFs must pass through uncompressed:
+    fetch_image rasterizes PDFs to PNG for MLX and discards the original, so the
+    PDF proof path re-fetches the raw bytes here. Returns None on failure
+    (caller skips the proof for this receipt).
+    """
+    headers = {"x-receipts-processor-key": PROCESSOR_KEY}
+    if CF_ACCESS_CLIENT_ID and CF_ACCESS_CLIENT_SECRET:
+        headers["CF-Access-Client-Id"] = CF_ACCESS_CLIENT_ID
+        headers["CF-Access-Client-Secret"] = CF_ACCESS_CLIENT_SECRET
+    try:
+        resp = requests.get(
+            f"{EXTRACT_BASE}/{receipt_id}/file",
+            headers=headers,
+            timeout=60,
+        )
+        resp.raise_for_status()
+        return resp.content
+    except requests.RequestException as exc:
+        print(
+            f"[warn] {receipt_id}: proof original fetch failed ({exc})",
+            file=sys.stderr,
+        )
+        return None
+
+
+def post_proof(receipt_id: str, derivative: bytes, content_type: str) -> None:
+    """POST a proof derivative to the Worker's /proof endpoint.
+
+    Same processor-key + Access-token header pattern as apply_to_worker, but the
+    body is raw bytes (image/jpeg or application/pdf), not JSON. Raises on
+    non-2xx so the caller can log; proof generation is advisory, so callers
+    wrap this in try/except and never let it fail extraction.
+    """
+    headers = {
+        "x-receipts-processor-key": PROCESSOR_KEY,
+        "Content-Type": content_type,
+    }
+    if CF_ACCESS_CLIENT_ID and CF_ACCESS_CLIENT_SECRET:
+        headers["CF-Access-Client-Id"] = CF_ACCESS_CLIENT_ID
+        headers["CF-Access-Client-Secret"] = CF_ACCESS_CLIENT_SECRET
+    resp = requests.post(
+        f"{EXTRACT_BASE}/{receipt_id}/proof",
+        headers=headers,
+        data=derivative,
+        timeout=60,
+    )
+    resp.raise_for_status()
+
+
+def generate_proof(
+    receipt_id: str, r2_key: str | None, mlx_image_path: str
+) -> tuple[bytes, str] | None:
+    """Build the proof derivative for a just-extracted receipt.
+
+    For raster images, reuse the file already fetched for MLX (it IS the
+    original). For PDFs, fetch_image rasterized to PNG and discarded the
+    original — re-fetch the raw PDF here so it passes through uncompressed.
+    Returns (bytes, content_type) or None (skip).
+    """
+    if r2_key and r2_key.lower().endswith(".pdf"):
+        raw = fetch_original_bytes(receipt_id)
+        if raw is None:
+            return None
+        return raw, "application/pdf"
+    return make_proof_derivative(mlx_image_path)
+
+
 class PermanentExtractionFailure(Exception):
     """Raised by the consumer for deterministic-permanent local failures we
     detect ourselves (zero-byte download, manifest size mismatch). Distinct
@@ -402,11 +536,17 @@ def _wrangler_env() -> dict[str, str]:
     return env
 
 
-def _d1_query(sql: str) -> list[dict[str, Any]]:
-    """Run a read-only SQL query against remote D1 and return rows as dicts."""
+def _d1_query(sql: str, *, local: bool = False) -> list[dict[str, Any]]:
+    """Run a read-only SQL query against D1 and return rows as dicts.
+
+    local=True targets local D1 (cf:dev) — used by backfill_proof_copies.py
+    --local for the seeded dry-run. Default --remote hits the live DB
+    (operator-only; never in CI/tests).
+    """
     raw = subprocess.check_output(
         ["npx", "wrangler", "d1", "execute", RECEIPTS_DB_NAME,
-         "--remote", "--env-file=/dev/null", "--json", "--command", sql],
+         "--local" if local else "--remote",
+         "--env-file=/dev/null", "--json", "--command", sql],
         text=True,
         env=_wrangler_env(),
     )
@@ -414,11 +554,12 @@ def _d1_query(sql: str) -> list[dict[str, Any]]:
     return (parsed[0] if isinstance(parsed, list) else parsed).get("results", [])
 
 
-def _d1_execute(sql: str) -> None:
-    """Run a write SQL statement against remote D1."""
+def _d1_execute(sql: str, *, local: bool = False) -> None:
+    """Run a write SQL statement against D1 (remote by default; local for cf:dev)."""
     subprocess.check_output(
         ["npx", "wrangler", "d1", "execute", RECEIPTS_DB_NAME,
-         "--remote", "--env-file=/dev/null", "--json", "--command", sql],
+         "--local" if local else "--remote",
+         "--env-file=/dev/null", "--json", "--command", sql],
         text=True,
         env=_wrangler_env(),
     )
@@ -584,16 +725,38 @@ def process_once() -> int:
             # an empty body means R2 has nothing for this key. MLX would
             # either crash or produce gibberish; either way retrying won't
             # help. Post failure + ack.
+            proof: tuple[bytes, str] | None = None  # built while image_path exists
             try:
                 if os.path.getsize(image_path) == 0:
                     raise PermanentExtractionFailure("downloaded file is zero bytes")
                 result = run_mlx(image_path)
+                # Proof derivative (advisory). Built inside the try so the
+                # raster image is still on disk; a build failure is swallowed
+                # — it must never block extraction.
+                try:
+                    proof = generate_proof(receipt_id, r2_key, image_path)
+                except Exception as exc:  # noqa: BLE001
+                    print(
+                        f"[warn] {receipt_id}: proof build failed ({exc})",
+                        file=sys.stderr,
+                    )
             finally:
                 try:
                     os.unlink(image_path)
                 except OSError:
                     pass
             apply_to_worker(receipt_id, result)
+            # Post the proof only after extraction is confirmed. Advisory: a
+            # failure is logged and swallowed (backfill_proof_copies.py recovers
+            # misses; the receipt is already extracted and acked regardless).
+            if proof is not None:
+                try:
+                    post_proof(receipt_id, *proof)
+                except Exception as exc:  # noqa: BLE001
+                    print(
+                        f"[warn] {receipt_id}: proof post failed ({exc})",
+                        file=sys.stderr,
+                    )
             acked.append(lease_id)
             print(f"[ok] {receipt_id}")
         except requests.HTTPError as exc:

--- a/scripts/receipts-consumer/fixtures/seed-local.sql
+++ b/scripts/receipts-consumer/fixtures/seed-local.sql
@@ -1,0 +1,42 @@
+-- Seed for the backfill_proof_copies.py --local dry-run demo (PR 1).
+-- Inserts sample receipt_records + one receipt_files proof_copy row into LOCAL
+-- D1 only. NEVER run against remote — this is a demo fixture, not real data.
+--
+-- Apply (Mac):
+--   npx wrangler d1 migrations apply RECEIPTS_DB --local
+--   npx wrangler d1 execute RECEIPTS_DB --local --file=scripts/receipts-consumer/fixtures/seed-local.sql
+--   cd scripts/receipts-consumer && .venv/bin/python3 backfill_proof_copies.py --local --dry-run
+--
+-- Three receipts:
+--   rec-1  JPEG, NO proof_copy   → should appear in the dry-run plan
+--   rec-2  JPEG, HAS proof_copy  → idempotency skip (NOT in plan)
+--   rec-3  PDF,  NO proof_copy   → should appear in the dry-run plan
+
+INSERT INTO receipt_records
+  (id, captured_at, captured_by, original_r2_key, original_sha256,
+   original_content_type, original_size_bytes, status, merchant, currency,
+   created_at, updated_at)
+VALUES
+  ('11111111-1111-4111-8111-111111111111', '2026-06-01T00:00:00Z', 'seed',
+   'receipts/2026/06/rec-1/seed-img1.jpg',
+   'aaaa0000', 'image/jpeg', 700000, 'reviewed', 'Seed JPEG Merchant', 'JPY',
+   '2026-06-01T00:00:00Z', '2026-06-01T00:00:00Z'),
+  ('22222222-2222-4222-8222-222222222222', '2026-06-02T00:00:00Z', 'seed',
+   'receipts/2026/06/rec-2/seed-img2.jpg',
+   'bbbb0000', 'image/jpeg', 650000, 'reviewed', 'Seed JPEG Already-Proof', 'JPY',
+   '2026-06-02T00:00:00Z', '2026-06-02T00:00:00Z'),
+  ('33333333-3333-4333-8333-333333333333', '2026-06-03T00:00:00Z', 'seed',
+   'receipts/2026/06/rec-3/seed-pdf.pdf',
+   'cccc0000', 'application/pdf', 120000, 'reviewed', 'Seed PDF Merchant', 'JPY',
+   '2026-06-03T00:00:00Z', '2026-06-03T00:00:00Z');
+
+-- rec-2 already has a proof_copy → the idempotent dry-run must skip it.
+INSERT INTO receipt_files
+  (id, object_type, object_id, role, r2_bucket, r2_key, original_filename,
+   content_type, file_size_bytes, sha256_hash, uploaded_by, uploaded_at,
+   created_at, updated_at)
+VALUES
+  ('rf-seed-2', 'receipt', '22222222-2222-4222-8222-222222222222', 'proof_copy',
+   'receipts', 'receipts/22222222-2222-4222-8222-222222222222/proof.jpg',
+   'proof.jpg', 'image/jpeg', 80000, 'bbbb0000-proof', 'seed',
+   '2026-06-02T00:00:00Z', '2026-06-02T00:00:00Z', '2026-06-02T00:00:00Z');

--- a/scripts/receipts-consumer/requirements.txt
+++ b/scripts/receipts-consumer/requirements.txt
@@ -7,3 +7,7 @@ mlx-vlm>=0.1.0
 # Apple Silicon — no poppler or other system deps. Lazy-imported inside
 # fetch_image() so --help works without it installed.
 pymupdf>=1.24
+# Image handling: failure classifier (PIL.UnidentifiedImageError) + proof-copy
+# derivative generation at ingest (resize/q75/EXIF strip). Was transitive via
+# mlx-vlm; made explicit since the consumer now depends on it directly.
+pillow>=10.0

--- a/scripts/receipts-consumer/test_proof_derivative.py
+++ b/scripts/receipts-consumer/test_proof_derivative.py
@@ -1,0 +1,137 @@
+"""Tests for make_proof_derivative in consumer.py (PR 1).
+
+Run:
+  cd scripts/receipts-consumer && \\
+  CF_ACCOUNT_ID=d CF_QUEUE_ID=d CF_API_TOKEN=d \\
+  RECEIPTS_EXTRACT_URL=http://d RECEIPTS_PROCESSOR_KEY=d MLX_MODEL=d \\
+  .venv/bin/python3 -m unittest test_proof_derivative -v
+"""
+from __future__ import annotations
+
+import io
+import os
+import tempfile
+import unittest
+
+# consumer.py reads these at import time; default them so the test runs without
+# the runtime env (mirrors test_permanent_failure.py).
+os.environ.setdefault("CF_ACCOUNT_ID", "d")
+os.environ.setdefault("CF_QUEUE_ID", "d")
+os.environ.setdefault("CF_API_TOKEN", "d")
+os.environ.setdefault("RECEIPTS_EXTRACT_URL", "http://d")
+os.environ.setdefault("RECEIPTS_PROCESSOR_KEY", "d")
+os.environ.setdefault("MLX_MODEL", "d")
+
+import consumer  # type: ignore  # noqa: E402
+from PIL import Image  # noqa: E402
+
+
+def _write_jpeg(path: str, size: tuple[int, int], exif=None) -> None:
+    img = Image.new("RGB", size, color=(120, 160, 200))
+    if exif is not None:
+        img.save(path, format="JPEG", exif=exif)
+    else:
+        img.save(path, format="JPEG")
+
+
+class TestMakeProofDerivative(unittest.TestCase):
+    def test_large_image_resized_to_1600_longest(self):
+        fd, path = tempfile.mkstemp(suffix=".jpg")
+        os.close(fd)
+        try:
+            _write_jpeg(path, (3000, 2000))
+            data, ct = consumer.make_proof_derivative(path)
+            self.assertEqual(ct, "image/jpeg")
+            self.assertEqual(data[:2], b"\xff\xd8")  # JPEG SOI magic
+            out = Image.open(io.BytesIO(data))
+            self.assertLessEqual(max(out.size), consumer.PROOF_MAX_LONGEST_SIDE)
+            # Aspect ratio preserved (3:2), not distorted.
+            self.assertAlmostEqual(out.width / out.height, 3000 / 2000, places=2)
+        finally:
+            os.unlink(path)
+
+    def test_small_image_not_upscaled(self):
+        fd, path = tempfile.mkstemp(suffix=".jpg")
+        os.close(fd)
+        try:
+            _write_jpeg(path, (800, 600))
+            data, _ = consumer.make_proof_derivative(path)
+            out = Image.open(io.BytesIO(data))
+            self.assertEqual(out.size, (800, 600))  # thumbnail never upsizes
+        finally:
+            os.unlink(path)
+
+    def test_portrait_orientation_capped_on_shorter_axis(self):
+        # Portrait 2000x3000 → longest side (height) capped at 1600.
+        fd, path = tempfile.mkstemp(suffix=".jpg")
+        os.close(fd)
+        try:
+            _write_jpeg(path, (2000, 3000))
+            data, _ = consumer.make_proof_derivative(path)
+            out = Image.open(io.BytesIO(data))
+            self.assertLessEqual(max(out.size), consumer.PROOF_MAX_LONGEST_SIDE)
+            self.assertAlmostEqual(out.width / out.height, 2000 / 3000, places=2)
+        finally:
+            os.unlink(path)
+
+    def test_exif_metadata_stripped(self):
+        fd, path = tempfile.mkstemp(suffix=".jpg")
+        os.close(fd)
+        try:
+            exif = Image.Exif()
+            exif[0x010F] = "TestMake"  # Make tag — must not survive
+            _write_jpeg(path, (2000, 1500), exif=exif)
+            # The derivative is saved without an exif= arg → no APP1 segment.
+            data, _ = consumer.make_proof_derivative(path)
+            out = Image.open(io.BytesIO(data))
+            self.assertFalse(dict(out.getexif()), "derivative must strip EXIF")
+        finally:
+            os.unlink(path)
+
+    def test_pdf_passthrough_byte_identical(self):
+        fd, path = tempfile.mkstemp(suffix=".pdf")
+        payload = b"%PDF-1.4\n1 0 obj<<>>endobj\n%%EOF\n"
+        os.write(fd, payload)
+        os.close(fd)
+        try:
+            data, ct = consumer.make_proof_derivative(path)
+            self.assertEqual(ct, "application/pdf")
+            self.assertEqual(data, payload)  # unchanged, no re-encode
+        finally:
+            os.unlink(path)
+
+    def test_unopenable_image_returns_none(self):
+        fd, path = tempfile.mkstemp(suffix=".jpg")
+        os.write(fd, b"this is not actually a JPEG")
+        os.close(fd)
+        try:
+            # None = skip the proof for this receipt, not a failure.
+            self.assertIsNone(consumer.make_proof_derivative(path))
+        finally:
+            os.unlink(path)
+
+    def test_derivative_is_smaller_than_a_high_quality_save(self):
+        # q75 recompression of a noisy-ish image must beat q95 — sanity check
+        # that the quality knob is actually applied (keeps the bundle small).
+        fd, path = tempfile.mkstemp(suffix=".jpg")
+        os.close(fd)
+        try:
+            img = Image.new("RGB", (2000, 2000))
+            # px = (x*7 % 256, y*13 % 256, (x+y) % 256) — high-frequency noise.
+            img.putdata(
+                [
+                    ((x * 7) % 256, (y * 13) % 256, (x + y) % 256)
+                    for y in range(2000)
+                    for x in range(2000)
+                ]
+            )
+            img.save(path, format="JPEG", quality=95)
+            hi = os.path.getsize(path)
+            data, _ = consumer.make_proof_derivative(path)
+            self.assertLess(len(data), hi)
+        finally:
+            os.unlink(path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
First of 4 stacked PRs for the accountant-ready proofs bundle (PR 2/3/4 stack on this branch).

## What
Generate a compact proof derivative on the Mac consumer at ingest and store it alongside the original, so the sealed proofs ZIP (PR 2) can prefer it and keep the accountant bundle small (<5 MB vs ~19 MB raw). All image work on the Mac (PIL); the Worker only stores bytes (CPU budget, no native codecs).

## Changes
- **consumer.py** — `make_proof_derivative` (resize longest side →1600, JPEG q75, EXIF stripped after baking orientation; PDFs pass through), `fetch_original_bytes`, `post_proof`, `generate_proof`; wired into `process_once` as **advisory** (never fails extraction). `_d1_query`/`_d1_execute` gain a `--local` flag for cf:dev.
- **POST /api/receipts/[id]/proof** (NEW) — processor-key + Clerk auth (mirrors `/extract`); idempotent upsert (delete prior `proof_copy` row → overwrite R2 at stable `receipts/<id>/proof.<ext>` → insert fresh `receipt_files` row, `role=proof_copy`). Audits `receipt.proof_uploaded`.
- **middleware.ts** — exempt `/api/receipts/:id/proof` from `auth.protect()`.
- **types.ts** — `ReceiptFileRole += "proof_copy"`; `AuditAction += receipt.proof_uploaded`. (`role` has no DB CHECK — confirmed, **no migration**.)
- **storage.ts** — `proofCopyR2Key` + `putProofCopy` (overwrite-capable).
- **files.ts** — `deleteProofCopyForReceipt` (upsert preamble; `r2_key` UNIQUE).
- **backfill_proof_copies.py** (NEW) — `--dry-run/--write/--local/--force/--id`; idempotent + resumable.
- **fixtures/seed-local.sql** (NEW) — seeded cf:dev dry-run fixture.
- **test_proof_derivative.py** (NEW) — 7 tests. **requirements.txt** — `pillow` explicit.

## Verification
- `tsc --noEmit` ✅ · `npm run lint` ✅ · `npm test` ✅ **333 pass / 0 fail**
- Python `unittest`: **22 pass** (7 new + 15 existing)
- Seeded `--local --dry-run` confirms the idempotency guard (a receipt already carrying `proof_copy` is skipped; JPEG + PDF candidates surface in the plan). Read-only, zero writes.

## Constraints honored
No migration; no writes to production D1/R2; no deploy; the dry-run ran against **local** D1 only. The production dry-run → execute sequence is documented for the operator in PR 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)