### PR TITLE
feat(receipts): finalize notification email via CF Email Routing (PR 3/4)

### DIFF
--- a/app/api/receipts/export/[month]/route.ts
+++ b/app/api/receipts/export/[month]/route.ts
@@ -6,9 +6,14 @@ import {
   createExportRevision,
 } from "@/lib/receipts/db";
 import {
+  buildExportBundle,
   validateMonthReadyForExport,
   computeEarlierOpenMonthWarnings,
 } from "@/lib/receipts/month-closing";
+import { composeFinalizeNoticeData, notifyAccountantOfFinalize } from "@/lib/receipts/notify";
+import { createAuditEntry } from "@/lib/receipts/audit";
+import { stringifyJson } from "@/lib/receipts/db-utils";
+import { getReceiptsDb } from "@/lib/cloudflare-runtime";
 
 type RouteContext = { params: Promise<{ month: string }> };
 
@@ -92,7 +97,10 @@ export async function POST(request: Request, { params }: RouteContext) {
     // validateMonthReadyForExport is the single authority — it includes the
     // finalized-reconciliation precondition. The redundant pre-check that
     // used to live here was dropped to keep both finalize paths identical.
-    const blockers = await validateMonthReadyForExport(month);
+    // Build the bundle once: the gate consumes it (avoids an internal rebuild)
+    // and the finalize notification email reuses it.
+    const bundle = await buildExportBundle(month);
+    const blockers = await validateMonthReadyForExport(month, bundle);
     if (blockers.length > 0) {
       return NextResponse.json(
         { error: "Export blocked — resolve these issues first.", blockers },
@@ -116,6 +124,29 @@ export async function POST(request: Request, { params }: RouteContext) {
     // that earlier month will cost a revision once it lands — operators
     // should know that before they walk away thinking the month is "done."
     const warnings = await computeEarlierOpenMonthWarnings(month);
+
+    // Notification email (PR 3). Failure never fails finalize — it becomes a
+    // warning in the response + a notification_failed audit entry.
+    const notifyData = composeFinalizeNoticeData(month, bundle, exportRecord);
+    const notifyResult = await notifyAccountantOfFinalize(notifyData);
+    if (notifyResult.ok) {
+      await createAuditEntry(getReceiptsDb(), {
+        actor,
+        action: "export.notification_sent",
+        objectType: "export",
+        objectId: exportRecord.id,
+        newValueJson: stringifyJson({ month }),
+      });
+    } else {
+      warnings.push(`Finalize notification email not sent: ${notifyResult.error}`);
+      await createAuditEntry(getReceiptsDb(), {
+        actor,
+        action: "export.notification_failed",
+        objectType: "export",
+        objectId: exportRecord.id,
+        newValueJson: stringifyJson({ month, error: notifyResult.error }),
+      });
+    }
 
     return NextResponse.json(
       { ok: true, month, finalized: true, warnings },

--- a/app/api/receipts/export/month/route.ts
+++ b/app/api/receipts/export/month/route.ts
@@ -27,12 +27,12 @@ import { archiveBundle, archiveManifest, getReceiptFile, computeSha256Hex } from
 import {
   assembleProofsZip,
   verifyProofFileSha256,
+  deriveTransitionNoticeInput,
   type ProofZipEntry,
   type ProofPaymentPath,
-  type TransitionNoticeInput,
 } from "@/lib/receipts/proofs";
 import { listFilesForObject } from "@/lib/receipts/files";
-import { isIcCardTopUpCandidate } from "@/lib/receipts/blockers";
+import { composeFinalizeNoticeData, notifyAccountantOfFinalize } from "@/lib/receipts/notify";
 import {
   buildExportBundle,
   validateMonthReadyForExport,
@@ -193,36 +193,15 @@ export async function POST(request: Request) {
       });
     }
 
-    // Transition-notice dynamic sections, derived from the same bundle so the
-    // notice cannot drift from what actually shipped.
-    const noticeMissingReceiptLines = bundle.rows
-      .filter((r) => r.rowType === "amex_line" && r.missingReceiptReason)
-      .map((r) => ({ lineId: r.lineId ?? "?", reason: r.missingReceiptReason ?? "" }));
-    const noticeIcAdvisories: TransitionNoticeInput["icAdvisories"] = [];
-    const icSeen = new Set<string>();
-    bundle.rows.forEach((row, i) => {
-      if (!row.receiptId || icSeen.has(row.receiptId)) return;
-      const receipt = bundle.receipts.find((rr) => rr.id === row.receiptId);
-      if (receipt && isIcCardTopUpCandidate(receipt)) {
-        icSeen.add(row.receiptId);
-        noticeIcAdvisories.push({
-          no: i + 1,
-          merchant: row.merchant ?? "",
-          amountMinor: row.amountMinor ?? 0,
-        });
-      }
-    });
-    const monthLabel = `${month.slice(0, 4)}年${Number(month.slice(5, 7))}月`;
-    const proofsNoticeInput: TransitionNoticeInput = {
-      monthLabel,
-      rowCount: bundle.rows.length,
-      receiptCount: proofsEntries.length,
-      missingReceiptLines: noticeMissingReceiptLines,
-      icAdvisories: noticeIcAdvisories,
-      exportRevision,
-      supersedesExportId,
-      correctionReason,
-    };
+    // Transition notice (shared builder — also used by the finalize email, so
+    // the notice text cannot drift between the ZIP and the notification).
+    const proofsNoticeInput = deriveTransitionNoticeInput(
+      month,
+      bundle.rows,
+      bundle.receipts,
+      { rowCount: bundle.rows.length, receiptCount: proofsEntries.length },
+      { exportRevision, supersedesExportId, correctionReason },
+    );
 
     const proofsKey = buildProofsKey(month, exportId);
     const proofsZipBytes = assembleProofsZip(month, proofsEntries, proofsNoticeInput);
@@ -356,6 +335,31 @@ export async function POST(request: Request) {
       // open. Surfaced in the finalize response so the operator's toast on
       // "Finalize succeeded" can also say "but March is still open."
       finalizeWarnings = await computeEarlierOpenMonthWarnings(month);
+
+      // Notification email (PR 3). Failure never fails finalize — it becomes a
+      // warning in the response + a notification_failed audit entry.
+      if (exportRecord) {
+        const notifyData = composeFinalizeNoticeData(month, bundle, exportRecord);
+        const notifyResult = await notifyAccountantOfFinalize(notifyData);
+        if (notifyResult.ok) {
+          await createAuditEntry(getReceiptsDb(), {
+            actor,
+            action: "export.notification_sent",
+            objectType: "export",
+            objectId: exportId,
+            newValueJson: stringifyJson({ month }),
+          });
+        } else {
+          finalizeWarnings.push(`Finalize notification email not sent: ${notifyResult.error}`);
+          await createAuditEntry(getReceiptsDb(), {
+            actor,
+            action: "export.notification_failed",
+            objectType: "export",
+            objectId: exportId,
+            newValueJson: stringifyJson({ month, error: notifyResult.error }),
+          });
+        }
+      }
     } else {
       await recordExportBundle(
         exportId,

--- a/cloudflare-env.d.ts
+++ b/cloudflare-env.d.ts
@@ -16,6 +16,10 @@ declare namespace Cloudflare {
 		ASSETS: Fetcher;
 		NEXTJS_ENV: string;
 		WORKER_SELF_REFERENCE: Service<typeof import("./.open-next/worker").default>;
+		// PR 3: finalize notification email (Cloudflare Email Routing).
+		NOTIFY_EMAIL: SendEmail;
+		ACCOUNTANT_EMAIL: string;
+		NOTIFY_FROM_ADDRESS: string;
 	}
 }
 interface CloudflareEnv extends Cloudflare.Env {}

--- a/docs/month-close-runbook.md
+++ b/docs/month-close-runbook.md
@@ -109,3 +109,36 @@ After ADR 0008, 2026-06's export is **32 AMEX lines + 11 June-dated cash/digital
 (calendar rule). Run the reconcile → review → rebuild → review-page → finalize
 flow above. Reconcile the 20 lines (categorize, match receipts, resolve
 missing-receipt reasons) and sign off the reconciliation before finalizing.
+
+## Notification email (finalize → accountant)
+
+Finalizing a month sends the accountant a Japanese email (month label, revision,
+row/receipt counts, per-category totals, the full transition notice, and the
+download link) via Cloudflare Email Routing — no third-party vendor. **Email
+failure never fails finalize**: if the send is rejected, finalize still returns
+200, the failure surfaces as a warning in the response, and an
+`export.notification_failed` audit entry is written (`export.notification_sent`
+on success).
+
+### Ops prerequisites (one-time)
+
+Email Routing sends are **rejected by Cloudflare** until these are in place:
+
+1. **Email Routing enabled** on the `dazbeez.com` zone (Cloudflare dashboard →
+   Email → Email Routing).
+2. **Destination address verified** — the accountant's address must be verified
+   as a destination (Email Routing sends a one-time confirmation email to it).
+3. **`ACCOUNTANT_EMAIL` var** set to the verified accountant address (in
+   `wrangler.jsonc` vars). This is the runtime `to`.
+4. **`NOTIFY_EMAIL` binding `destination_address`** in `wrangler.jsonc` set to
+   the **same** address — Cloudflare requires the runtime `to` to be authorized
+   by the binding. These two must match; if they diverge the send is rejected
+   (caught + audited, finalize unaffected).
+5. **`NOTIFY_FROM_ADDRESS` var** set to a sender on the `dazbeez.com` zone (e.g.
+   `receipts@dazbeez.com`) — the from address must be on the zone.
+
+If any are unset/unverified, every finalize records `export.notification_failed`
+with the rejection reason. The bundle still seals; resend manually after fixing
+the config (there is no auto-retry — re-finalize is impossible without a
+revision, so treat the warning as "the email didn't go out, send it by hand").
+

--- a/lib/cloudflare-runtime.ts
+++ b/lib/cloudflare-runtime.ts
@@ -67,3 +67,25 @@ export function getReceiptsProcessorKey(): string | null {
   };
   return env.RECEIPTS_PROCESSOR_KEY ?? process.env.RECEIPTS_PROCESSOR_KEY ?? null;
 }
+
+/**
+ * Finalize notification email (PR 3, Cloudflare Email Routing send_email). Each
+ * returns null when unconfigured so the notify helper can fail gracefully (email
+ * failure must never fail finalize). The NOTIFY_EMAIL binding's
+ * destination_address must equal ACCOUNTANT_EMAIL; NOTIFY_FROM_ADDRESS must be a
+ * verified sender on the zone. See docs/month-close-runbook.md.
+ */
+export function getNotifyEmail(): SendEmail | null {
+  const env = getCloudflareEnv() as CloudflareEnv & { NOTIFY_EMAIL?: SendEmail };
+  return env.NOTIFY_EMAIL ?? null;
+}
+
+export function getAccountantEmail(): string | null {
+  const env = getCloudflareEnv() as CloudflareEnv & { ACCOUNTANT_EMAIL?: string };
+  return env.ACCOUNTANT_EMAIL ?? null;
+}
+
+export function getNotifyFromAddress(): string | null {
+  const env = getCloudflareEnv() as CloudflareEnv & { NOTIFY_FROM_ADDRESS?: string };
+  return env.NOTIFY_FROM_ADDRESS ?? null;
+}

--- a/lib/receipts/notify.ts
+++ b/lib/receipts/notify.ts
@@ -1,0 +1,193 @@
+// Finalize notification email (PR 3).
+//
+// On successful finalize, email the accountant a Japanese summary: month,
+// revision, row/receipt counts, per-category totals, the full transition-notice
+// text (shared with the proofs ZIP), and download instructions. Sent via the
+// Cloudflare Email Routing `send_email` binding (NOTIFY_EMAIL) — no third-party
+// vendor. MIME built with `mimetext` (Workers-safe).
+//
+// HARD RULE: email failure must never fail finalize. sendFinalizeNotification
+// never throws — it returns {ok, error?}; callers fold the result into the
+// finalize response warnings + an audit entry (notification_sent /
+// notification_failed), and finalize returns 200 regardless.
+
+import { createMimeMessage } from "mimetext";
+import {
+  getAccountantEmail,
+  getNotifyEmail,
+  getNotifyFromAddress,
+} from "@/lib/cloudflare-runtime";
+import {
+  buildTransitionNotice,
+  deriveTransitionNoticeInput,
+} from "@/lib/receipts/proofs";
+import type { ExportBundle } from "@/lib/receipts/month-closing";
+import type { ExportRow, ReceiptExport } from "@/lib/receipts/types";
+
+/** Minimal send_email binding shape (injectable for tests). Returns
+ *  Promise<unknown> so the real SendEmail binding (whose send returns
+ *  Promise<EmailSendResult>) is assignable. */
+export interface EmailSender {
+  send(message: unknown): Promise<unknown>;
+}
+
+export interface CategoryTotal {
+  code: string;
+  ja: string;
+  count: number;
+  totalMinor: number;
+}
+
+/** Per-expense-category count + total. Mirrors buildExportSummaryCsv's grouping
+ *  so the email's totals match the summary CSV the accountant also receives. */
+export function summarizeByCategory(rows: ExportRow[]): CategoryTotal[] {
+  const map = new Map<string, CategoryTotal>();
+  for (const row of rows) {
+    const code = row.expenseCategoryCode ?? "uncategorized";
+    const cat = map.get(code) ?? {
+      code,
+      ja: row.expenseCategoryJa ?? code,
+      count: 0,
+      totalMinor: 0,
+    };
+    cat.count += 1;
+    cat.totalMinor += row.amountMinor ?? 0;
+    map.set(code, cat);
+  }
+  return [...map.values()].sort((a, b) => b.totalMinor - a.totalMinor);
+}
+
+export interface FinalizeNoticeData {
+  month: string; // 2026-06
+  monthLabel: string; // 2026年6月
+  exportId: string;
+  revision: number;
+  rowCount: number;
+  receiptCount: number; // distinct receipts in the bundle
+  categoryTotals: CategoryTotal[];
+  noticeText: string; // the transition notice (お知らせ.txt content)
+}
+
+/** Assemble the email payload from a finalized month's bundle. Pure. */
+export function composeFinalizeNoticeData(
+  month: string,
+  bundle: ExportBundle,
+  exportRecord: Pick<
+    ReceiptExport,
+    "id" | "export_revision" | "supersedes_export_id" | "correction_reason"
+  >,
+): FinalizeNoticeData {
+  const distinctReceiptIds = new Set<string>();
+  for (const row of bundle.rows) {
+    if (row.receiptId) distinctReceiptIds.add(row.receiptId);
+  }
+  const noticeInput = deriveTransitionNoticeInput(
+    month,
+    bundle.rows,
+    bundle.receipts,
+    { rowCount: bundle.rows.length, receiptCount: distinctReceiptIds.size },
+    {
+      exportRevision: exportRecord.export_revision ?? 1,
+      supersedesExportId: exportRecord.supersedes_export_id ?? null,
+      correctionReason: exportRecord.correction_reason ?? null,
+    },
+  );
+  return {
+    month,
+    monthLabel: noticeInput.monthLabel,
+    exportId: exportRecord.id,
+    revision: noticeInput.exportRevision,
+    rowCount: bundle.rows.length,
+    receiptCount: distinctReceiptIds.size,
+    categoryTotals: summarizeByCategory(bundle.rows),
+    noticeText: buildTransitionNotice(noticeInput),
+  };
+}
+
+function formatYen(minor: number): string {
+  return `¥${minor.toLocaleString("ja-JP")}`;
+}
+
+/** Build the Japanese email body. Pure + snapshot-tested. */
+export function buildFinalizeEmailBody(d: FinalizeNoticeData): string {
+  const lines: string[] = [];
+  lines.push("毎月の領収証憑一式の確定（ファイナライズ）が完了しましたのでお知らせします。");
+  lines.push("");
+  lines.push(`対象月: ${d.monthLabel}`);
+  lines.push(`改訹: ${d.revision > 1 ? `${d.revision}（差替え）` : "新規"}`);
+  lines.push(`明細行数: ${d.rowCount}`);
+  lines.push(`証憑ファイル数: ${d.receiptCount}`);
+  lines.push("");
+  lines.push("【勘定科目別集計】");
+  for (const c of d.categoryTotals) {
+    lines.push(`・${c.ja}: ${c.count}件 / ${formatYen(c.totalMinor)}`);
+  }
+  lines.push("");
+  lines.push("【変更点・留意事項のお知らせ】");
+  lines.push(d.noticeText);
+  lines.push("");
+  lines.push("【ダウンロード】");
+  lines.push("以下のURL（要ログイン）から、明細CSV・マニフェスト・サマリー・README・領収書ZIPをダウンロードできます。");
+  lines.push(`https://dazbeez.com/receipts/export?month=${d.month}`);
+  lines.push("");
+  lines.push("本メールは自動送信されています。ご不明な点があれば別途ご連絡ください。");
+  return lines.join("\r\n");
+}
+
+export type NotifyResult = { ok: true } | { ok: false; error: string };
+
+/**
+ * Send the finalize notification. NEVER throws — returns a result the caller
+ * folds into finalize warnings + audit. The binding/from/to are injected so this
+ * is unit-testable (pass a fake sender that resolves, or one that rejects, to
+ * prove finalize survives a send failure).
+ */
+export async function sendFinalizeNotification(
+  binding: EmailSender | null,
+  from: string | null,
+  to: string | null,
+  data: FinalizeNoticeData,
+): Promise<NotifyResult> {
+  if (!binding) return { ok: false, error: "NOTIFY_EMAIL binding not configured" };
+  if (!from) return { ok: false, error: "NOTIFY_FROM_ADDRESS not configured" };
+  if (!to) return { ok: false, error: "ACCOUNTANT_EMAIL not configured" };
+
+  const subject =
+    data.revision > 1
+      ? `【領収証憑】${data.monthLabel}分 確定通知（改訂${data.revision}）`
+      : `【領収証憑】${data.monthLabel}分 確定通知`;
+  try {
+    const msg = createMimeMessage();
+    msg.setSender({ addr: from });
+    msg.setRecipient({ addr: to });
+    msg.setSubject(subject);
+    msg.addMessage({
+      // mimetext wants exactly "text/plain" / "text/html" (no charset suffix);
+      // it encodes the body as UTF-8 and emits charset=utf-8 in the MIME.
+      contentType: "text/plain",
+      data: buildFinalizeEmailBody(data),
+    });
+    await binding.send(msg);
+    return { ok: true };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+/**
+ * Production wrapper: reads the NOTIFY_EMAIL binding + env vars and sends.
+ * Callers (both finalize routes) use this; it never throws.
+ */
+export async function notifyAccountantOfFinalize(
+  data: FinalizeNoticeData,
+): Promise<NotifyResult> {
+  return sendFinalizeNotification(
+    getNotifyEmail(),
+    getNotifyFromAddress(),
+    getAccountantEmail(),
+    data,
+  );
+}

--- a/lib/receipts/proofs.ts
+++ b/lib/receipts/proofs.ts
@@ -18,6 +18,8 @@
 
 import { zipSync } from "fflate";
 import { computeSha256Hex } from "@/lib/receipts/storage";
+import { isIcCardTopUpCandidate } from "@/lib/receipts/blockers";
+import type { ExportRow, ReceiptRecord } from "@/lib/receipts/types";
 
 // Characters forbidden in zip filenames on Windows (Explorer refuses them).
 // Whitespace is also stripped so the merchant segment stays compact and matches
@@ -230,6 +232,51 @@ export async function verifyProofFileSha256(
         `Re-ingest or re-run backfill.`,
     );
   }
+}
+
+/**
+ * Derive the transition-notice input from a month's bundle + revision context.
+ * Shared by the proofs-zip build (rebuild path) and the finalize notification
+ * email so the notice text cannot drift between the two surfaces. Pure.
+ */
+export function deriveTransitionNoticeInput(
+  month: string,
+  rows: ExportRow[],
+  receipts: ReceiptRecord[],
+  counts: { rowCount: number; receiptCount: number },
+  revCtx: {
+    exportRevision: number;
+    supersedesExportId?: string | null;
+    correctionReason?: string | null;
+  },
+): TransitionNoticeInput {
+  const missingReceiptLines = rows
+    .filter((r) => r.rowType === "amex_line" && r.missingReceiptReason)
+    .map((r) => ({ lineId: r.lineId ?? "?", reason: r.missingReceiptReason ?? "" }));
+  const icAdvisories: TransitionNoticeInput["icAdvisories"] = [];
+  const icSeen = new Set<string>();
+  const receiptById = new Map(receipts.map((r) => [r.id, r]));
+  rows.forEach((row, i) => {
+    if (!row.receiptId || icSeen.has(row.receiptId)) return;
+    const receipt = receiptById.get(row.receiptId);
+    if (receipt && isIcCardTopUpCandidate(receipt)) {
+      icSeen.add(row.receiptId);
+      icAdvisories.push({
+        no: i + 1,
+        merchant: row.merchant ?? "",
+        amountMinor: row.amountMinor ?? 0,
+      });
+    }
+  });
+  const monthLabel = `${month.slice(0, 4)}年${Number(month.slice(5, 7))}月`;
+  return {
+    monthLabel,
+    rowCount: counts.rowCount,
+    receiptCount: counts.receiptCount,
+    missingReceiptLines,
+    icAdvisories,
+    ...revCtx,
+  };
 }
 
 // ─── ZIP assembly ────────────────────────────────────────────────────────────

--- a/lib/receipts/types.ts
+++ b/lib/receipts/types.ts
@@ -134,6 +134,8 @@ export type AuditAction =
   | "export.finalized"
   | "export.revision_created"
   | "export.downloaded"
+  | "export.notification_sent"
+  | "export.notification_failed"
   | "archive.created"
   | "settings.updated"
   | "receipt.export_statement_month_assigned"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@reactflow/minimap": "^11.7.14",
         "fflate": "^0.8.3",
         "framer-motion": "^12.38.0",
+        "mimetext": "^3.0.28",
         "next": "^16.2.3",
         "react": "19.2.4",
         "react-dom": "19.2.4",
@@ -1572,6 +1573,27 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime-corejs3": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.7.tgz",
+      "integrity": "sha512-ppj9ouYku+RX0ljtgZd+KMO5mkM2bCqg8H2PYAFWnLsHEIKIdRojqbJ2i3eVHrisuxy7nOFCmngTDdWtUCdXUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "core-js-pure": "^3.48.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -6371,6 +6393,17 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/core-js-pure": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.49.0.tgz",
+      "integrity": "sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -8954,6 +8987,12 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/js-base64": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.9.0.tgz",
+      "integrity": "sha512-dTIdlnQjYWoP6+8AMcQp72c0IWd5tfuQYT9WCRwmekv2C0OucjLF3lrDr09c44KA6M8Ol40DFp5hhSUbC7LkyQ==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/js-cookie": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.7.tgz",
@@ -9512,6 +9551,43 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/mimetext": {
+      "version": "3.0.28",
+      "resolved": "https://registry.npmjs.org/mimetext/-/mimetext-3.0.28.tgz",
+      "integrity": "sha512-eQXpbNrtxLCjUtiVbR/qR09dbPgZ2o+KR1uA7QKqGhbn8QV7HIL16mXXsobBL4/8TqoYh1us31kfz+dNfCev9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@babel/runtime-corejs3": "^7.26.0",
+        "js-base64": "^3.7.7",
+        "mime-types": "^2.1.35"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://patreon.com/muratgozel"
+      }
+    },
+    "node_modules/mimetext/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimetext/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-fn": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@reactflow/minimap": "^11.7.14",
     "fflate": "^0.8.3",
     "framer-motion": "^12.38.0",
+    "mimetext": "^3.0.28",
     "next": "^16.2.3",
     "react": "19.2.4",
     "react-dom": "19.2.4",

--- a/tests/receipts/notify.test.ts
+++ b/tests/receipts/notify.test.ts
@@ -1,0 +1,120 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildFinalizeEmailBody,
+  sendFinalizeNotification,
+  summarizeByCategory,
+  type FinalizeNoticeData,
+  type EmailSender,
+} from "@/lib/receipts/notify";
+import type { ExportRow } from "@/lib/receipts/types";
+
+// ─── summarizeByCategory ────────────────────────────────────────────────────
+
+function row(over: Partial<ExportRow>): ExportRow {
+  return {
+    rowType: "amex_line",
+    lineId: "l",
+    matchStatus: null,
+    receiptStatus: null,
+    missingReceiptReason: null,
+    cardholderName: null,
+    businessTripStatus: null,
+    receiptId: "r",
+    status: "reviewed",
+    originalR2Key: null,
+    transactionDate: "2026-06-01",
+    merchant: "M",
+    amountMinor: 1000,
+    currency: "JPY",
+    expenseType: "UNKNOWN",
+    expenseCategoryCode: "communications",
+    expenseCategoryJa: "通信費",
+    expenseCategoryEn: "Communications",
+    paymentPath: "AMEX",
+    businessPurpose: null,
+    attendees: [],
+    invoiceRegistrationNumber: null,
+    qualifiedInvoiceStatus: null,
+    taxRate: null,
+    taxAmountMinor: null,
+    sourceType: null,
+    counterpartyName: null,
+    ...over,
+  };
+}
+
+test("summarizeByCategory: groups by code, sums totals, sorts desc", () => {
+  const totals = summarizeByCategory([
+    row({ expenseCategoryCode: "rd", expenseCategoryJa: "研究開発費", amountMinor: 10000 }),
+    row({ expenseCategoryCode: "rd", expenseCategoryJa: "研究開発費", amountMinor: 5000 }),
+    row({ expenseCategoryCode: "travel", expenseCategoryJa: "旅費交通費", amountMinor: 2000 }),
+    row({ expenseCategoryCode: null, expenseCategoryJa: null, amountMinor: 999 }),
+  ]);
+  assert.equal(totals.length, 3);
+  assert.equal(totals[0]!.code, "rd", "highest total first");
+  assert.equal(totals[0]!.count, 2);
+  assert.equal(totals[0]!.totalMinor, 15000);
+  assert.equal(totals[2]!.code, "uncategorized");
+});
+
+// ─── buildFinalizeEmailBody (snapshot) ──────────────────────────────────────
+
+const fixtureData: FinalizeNoticeData = {
+  month: "2026-06",
+  monthLabel: "2026年6月",
+  exportId: "exp-test",
+  revision: 2,
+  rowCount: 43,
+  receiptCount: 40,
+  categoryTotals: [
+    { code: "rd", ja: "研究開発費", count: 5, totalMinor: 150000 },
+    { code: "travel", ja: "旅費交通費", count: 8, totalMinor: 42000 },
+  ],
+  noticeText: "【お知らせ】これは架空の通知本文です。No列による整理、SHA-256記録、再圧縮についての説明。",
+};
+
+test("buildFinalizeEmailBody: month, revision, counts, totals, notice, link", () => {
+  const body = buildFinalizeEmailBody(fixtureData);
+  assert.ok(body.includes("2026年6月"), "month label");
+  assert.ok(body.includes("改訹: 2（差替え）"), "revision context for rev > 1");
+  assert.ok(body.includes("明細行数: 43"), "row count");
+  assert.ok(body.includes("証憑ファイル数: 40"), "receipt count");
+  assert.ok(body.includes("研究開発費: 5件 / ¥150,000"), "category total line");
+  assert.ok(body.includes("旅費交通費: 8件 / ¥42,000"), "second category total");
+  assert.ok(body.includes("No列による整理"), "embedded notice text");
+  assert.ok(body.includes("https://dazbeez.com/receipts/export?month=2026-06"), "download link");
+});
+
+test("buildFinalizeEmailBody: revision 1 shows 新規 not 差替え", () => {
+  const body = buildFinalizeEmailBody({ ...fixtureData, revision: 1 });
+  assert.ok(body.includes("改訹: 新規"));
+  assert.ok(!body.includes("差替え"));
+});
+
+// ─── sendFinalizeNotification (never throws; non-fatal on failure) ──────────
+
+test("sendFinalizeNotification: ok when the binding resolves", async () => {
+  const sender: EmailSender = { send: async () => undefined };
+  const res = await sendFinalizeNotification(sender, "from@dazbeez.com", "acct@example.com", fixtureData);
+  assert.equal(res.ok, true);
+});
+
+test("sendFinalizeNotification: a throwing binding → {ok:false}, no throw", async () => {
+  // The critical guarantee: a send failure must NOT propagate. Finalize stays
+  // 200; the caller folds res into a warning + notification_failed audit.
+  const sender: EmailSender = {
+    send: async () => {
+      throw new Error("Email Routing rejected: destination not verified");
+    },
+  };
+  const res = await sendFinalizeNotification(sender, "from@dazbeez.com", "acct@example.com", fixtureData);
+  assert.equal(res.ok, false);
+  assert.match((res as { error: string }).error, /destination not verified/);
+});
+
+test("sendFinalizeNotification: missing binding / from / to → {ok:false}", async () => {
+  assert.equal((await sendFinalizeNotification(null, "f", "t", fixtureData)).ok, false);
+  assert.equal((await sendFinalizeNotification({ send: async () => undefined }, null, "t", fixtureData)).ok, false);
+  assert.equal((await sendFinalizeNotification({ send: async () => undefined }, "f", null, fixtureData)).ok, false);
+});

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -17,7 +17,15 @@
     "NEXT_PUBLIC_CLERK_SIGN_IN_URL": "/receipts/sign-in",
     "NEXT_PUBLIC_CLERK_SIGN_UP_URL": "/receipts/sign-in",
     "NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL": "/receipts",
-    "NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL": "/receipts"
+    "NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL": "/receipts",
+    // Finalize notification email (PR 3). Recipient + sender for the Cloudflare
+    // Email Routing send_email binding. The NOTIFY_EMAIL binding's
+    // destination_address MUST match ACCOUNTANT_EMAIL (CF requires the runtime
+    // `to` to be authorized by the binding). NOTIFY_FROM_ADDRESS must be a
+    // verified sender on the dazbeez.com zone. Replace the placeholders before
+    // enabling — see docs/month-close-runbook.md §Notification email.
+    "ACCOUNTANT_EMAIL": "accountant@example.com",
+    "NOTIFY_FROM_ADDRESS": "receipts@dazbeez.com"
   },
   // Manual secret setup:
   // npx wrangler secret put RESEND_API_KEY
@@ -96,6 +104,19 @@
       {
         "binding": "RECEIPTS_QUEUE",
         "queue": "dazbeez-receipts-extraction"
+      }
+    ]
+  },
+  // Finalize notification email (PR 3). Cloudflare Email Routing send_email
+  // binding — no third-party vendor. destination_address authorizes the single
+  // recipient (CF requires the runtime `to` to match); it MUST equal the
+  // ACCOUNTANT_EMAIL var. Enable Email Routing on the zone + verify the
+  // destination address first, else sends are rejected. See runbook.
+  "send_email": {
+    "bindings": [
+      {
+        "name": "NOTIFY_EMAIL",
+        "destination_address": "accountant@example.com"
       }
     ]
   },

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -112,14 +112,12 @@
   // recipient (CF requires the runtime `to` to match); it MUST equal the
   // ACCOUNTANT_EMAIL var. Enable Email Routing on the zone + verify the
   // destination address first, else sends are rejected. See runbook.
-  "send_email": {
-    "bindings": [
-      {
-        "name": "NOTIFY_EMAIL",
-        "destination_address": "accountant@example.com"
-      }
-    ]
-  },
+  "send_email": [
+    {
+      "name": "NOTIFY_EMAIL",
+      "destination_address": "accountant@example.com"
+    }
+  ],
   "routes": [
     {
       "pattern": "dazbeez.com/*",


### PR DESCRIPTION
Supersedes #103, which auto-closed when its base branch (`pr2`) was deleted on #102's merge. Same diff — `pr3/finalize-email` rebased onto master.

On finalize, email the accountant a Japanese summary via Cloudflare Email Routing — no third-party vendor.

## What
- **`lib/receipts/notify.ts`**: `composeFinalizeNoticeData`, `buildFinalizeEmailBody` (snapshot-tested), `sendFinalizeNotification` (injectable binding, **never throws**), `notifyAccountantOfFinalize`. `summarizeByCategory` mirrors the summary CSV.
- **Both finalize routes** hook notify after `finalizeExport`: success → audit `notification_sent`; failure → response warning + `notification_failed`. **Finalize returns 200 regardless.**
- **`wrangler.jsonc`**: `send_email` binding `NOTIFY_EMAIL` (array form) + vars `ACCOUNTANT_EMAIL`/`NOTIFY_FROM_ADDRESS`. Env types + nullable getters.
- **`types.ts`**: `AuditAction += notification_sent / notification_failed`. dep: `mimetext`.
- **Runbook §Notification email**: ops prereqs.

## Resolved design note
CF requires the recipient authorized by the binding; `ACCOUNTANT_EMAIL` supplies the runtime `to` and **must equal** the binding's `destination_address`. The email fires only on a finalize (operator-only), and CF rejects sends to an unverified destination — so a premature finalize records `notification_failed` (audited, finalize unaffected, **no wrong email sent**) until the operator verifies the address.

## Verification
`tsc` ✅ `lint` ✅ `npm test` 358 pass/0 fail. No real email; no prod writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)