### PR TITLE
fix(receipts): hide 領収書ZIP link for proofless finalized exports

### DIFF
--- a/app/(receipt-system)/receipts/export/page.tsx
+++ b/app/(receipt-system)/receipts/export/page.tsx
@@ -170,7 +170,13 @@ export default async function ExportPage({
             sealed in R2 — SHA-256 hashes match the manifest.
           </p>
           <div className="mt-3 flex flex-wrap gap-3">
-            {BUNDLE_DOWNLOAD_LINKS.map(({ file, label }) => (
+            {BUNDLE_DOWNLOAD_LINKS.filter(
+              // 証憑ZIP (proofs) only exists for exports rebuilt after the
+              // proofs code shipped — hide it for proofless finalized exports
+              // (e.g. a month sealed before proofs were added) so the link is
+              // never a dead 404.
+              ({ file }) => file !== "proofs" || !!currentExport?.proofs_r2_key,
+            ).map(({ file, label }) => (
               <a
                 key={file}
                 href={`/api/receipts/export/${month}/download?file=${file}`}
@@ -180,6 +186,12 @@ export default async function ExportPage({
               </a>
             ))}
           </div>
+          {!currentExport?.proofs_r2_key && (
+            <p className="mt-2 text-[11px] text-gray-500">
+              証憑ZIP (proofs) is absent — this export was sealed before proofs were
+              added. Create a revision and rebuild to generate it (see the runbook).
+            </p>
+          )}
         </div>
       )}
       <div className="border-t border-amber-100 bg-amber-50 px-8 py-4 text-xs text-amber-900">

--- a/app/api/receipts/export/[month]/download/route.ts
+++ b/app/api/receipts/export/[month]/download/route.ts
@@ -64,10 +64,15 @@ export async function GET(request: Request, { params }: RouteContext) {
 
     const target = resolveExportDownload(month, exportRecord, file);
     if (!target.r2Key) {
-      return NextResponse.json(
-        { error: `No archived ${file} key recorded for this export.` },
-        { status: 404 },
-      );
+      // The proofs ZIP only exists for exports rebuilt after the proofs code
+      // shipped. A finalized export sealed before that (e.g. revision 1) has no
+      // proofs key — point the operator at the revision flow rather than a bare
+      // "key recorded" message.
+      const message =
+        file === "proofs"
+          ? "This export was sealed before the proofs ZIP existed (no proofs_r2_key). Create a revision and rebuild to generate it."
+          : `No archived ${file} key recorded for this export.`;
+      return NextResponse.json({ error: message }, { status: 404 });
     }
 
     const bucket = getReceiptsArchiveBucket();

--- a/components/receipts/export/finalize-card.tsx
+++ b/components/receipts/export/finalize-card.tsx
@@ -31,6 +31,7 @@ export function FinalizeCard({
   blockerCount,
   warningCount,
   rowsInDraft,
+  hasProofsZip = true,
 }: {
   month: string;
   monthLabel: string;
@@ -39,6 +40,11 @@ export function FinalizeCard({
   blockerCount: number;
   warningCount: number;
   rowsInDraft: number;
+  /** Whether the export has a proofs ZIP (proofs_r2_key). False for exports
+   *  sealed before proofs were added — the 領収書ZIP link is hidden then so it's
+   *  never a dead 404. Defaults true (the common case for a freshly finalized
+   *  export). */
+  hasProofsZip?: boolean;
 }) {
   const router = useRouter();
   const [busy, setBusy] = useState(false);
@@ -109,7 +115,9 @@ export function FinalizeCard({
               bundle:
             </p>
             <div className="mt-3 flex flex-wrap gap-2">
-              {BUNDLE_DOWNLOAD_LINKS.map(({ file, label }) => (
+              {BUNDLE_DOWNLOAD_LINKS.filter(
+                ({ file }) => file !== "proofs" || hasProofsZip,
+              ).map(({ file, label }) => (
                 <a
                   key={file}
                   href={`/api/receipts/export/${month}/download?file=${file}`}

--- a/components/receipts/export/review-screen.tsx
+++ b/components/receipts/export/review-screen.tsx
@@ -108,6 +108,7 @@ export function ReviewScreen(props: ReviewScreenProps) {
         blockerCount={props.gateBlockers.length}
         warningCount={props.warnings.reduce((s, w) => s + w.count, 0)}
         rowsInDraft={props.rows.length}
+        hasProofsZip={Boolean(props.currentExport?.proofs_r2_key)}
       />
     </div>
   );


### PR DESCRIPTION
Addresses the operator-reported dead link: clicking 領収書ZIP on 2026-06 (sealed as rev 1 before the proofs code shipped) returns `{"error":"No archived proofs key recorded for this export."}` — rev 1 has no `proofs_r2_key`.

Rev 1 is sealed + immutable (compliance — PR 4 asserts it stays byte-identical), so the proofs package requires revision 2 (rebuild). This PR stops offering a link that can't resolve:

- **Export page**: filter 領収書ZIP out when no `proofs_r2_key`; show a note pointing to the revision/rebuild flow.
- **finalize-card**: `hasProofsZip` prop (default true) gates the link; `review-screen` threads `currentExport.proofs_r2_key`.
- **Download route**: file-aware 404 — for proofs, "sealed before the proofs ZIP existed; create a revision and rebuild".

`tsc` ✅ `lint` ✅ `npm test` 359 (358 pass, 1 D1-skip). No prod writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)