### PR TITLE
feat(receipts): draft-bundle downloads with explicit DRAFT labeling

### DIFF
--- a/app/(receipt-system)/receipts/export/page.tsx
+++ b/app/(receipt-system)/receipts/export/page.tsx
@@ -2,6 +2,7 @@ import {
   listAmexLines,
   listExports,
   getExport,
+  getLatestFinalizedExport,
   listAmexLineCountsByMonth,
   listReconciliationStatusByMonth,
 } from "@/lib/receipts/db";
@@ -92,15 +93,23 @@ export default async function ExportPage({
   // We still fetch the unfiltered month receipts + lines separately for the
   // blockers panel (computeExportBlockers runs over the raw receipt set,
   // including UNKNOWN payment_path that the bundle intentionally excludes).
-  const [bundle, exports, unknownInScope, monthLines, currentExport, unassignable] =
-    await Promise.all([
-      buildExportBundle(month),
-      listExports(),
-      listUnknownInScopeReceipts(month),
-      listAmexLines(month),
-      getExport(month),
-      listUnassignableReceipts(),
-    ]);
+  const [
+    bundle,
+    exports,
+    unknownInScope,
+    monthLines,
+    currentExport,
+    latestFinalized,
+    unassignable,
+  ] = await Promise.all([
+    buildExportBundle(month),
+    listExports(),
+    listUnknownInScopeReceipts(month),
+    listAmexLines(month),
+    getExport(month),
+    getLatestFinalizedExport(month),
+    listUnassignableReceipts(),
+  ]);
   // ADR 0006 (PR #2): tile counting set = in-scope receipts for M = the bundle
   // (matched AMEX + CASH/DIGITAL assigned to M) ∪ UNKNOWN in M's natural window
   // — the same set the finalize gate (validateMonthReadyForExport) uses for its
@@ -163,20 +172,24 @@ export default async function ExportPage({
         statementWindow={statementWindow}
         unassignableReceipts={unassignable}
       />
-      {currentExport?.status === "finalized" && (
+      {/* Sealed bundle — latest FINALIZED revision. Served even while a
+          revision draft is open (getLatestFinalizedExport, NOT getExport, so an
+          open draft never makes the sealed package undownloadable). */}
+      {latestFinalized && (
         <div className="border-t border-gray-200 bg-white px-8 py-6">
-          <h2 className="text-sm font-bold text-gray-900">Download bundle</h2>
+          <h2 className="text-sm font-bold text-gray-900">
+            Download sealed bundle
+            {latestFinalized.export_revision && latestFinalized.export_revision > 1
+              ? ` (revision ${latestFinalized.export_revision})`
+              : ""}
+          </h2>
           <p className="mt-1 text-xs text-gray-500">
-            Finalized {monthLabel} archive files, served byte-for-byte as
-            sealed in R2 — SHA-256 hashes match the manifest.
+            Finalized {monthLabel} archive files, served byte-for-byte as sealed in
+            R2 — SHA-256 hashes match the manifest.
           </p>
           <div className="mt-3 flex flex-wrap gap-3">
             {BUNDLE_DOWNLOAD_LINKS.filter(
-              // 証憑ZIP (proofs) only exists for exports rebuilt after the
-              // proofs code shipped — hide it for proofless finalized exports
-              // (e.g. a month sealed before proofs were added) so the link is
-              // never a dead 404.
-              ({ file }) => file !== "proofs" || !!currentExport?.proofs_r2_key,
+              ({ file }) => file !== "proofs" || !!latestFinalized.proofs_r2_key,
             ).map(({ file, label }) => (
               <a
                 key={file}
@@ -187,13 +200,58 @@ export default async function ExportPage({
               </a>
             ))}
           </div>
-          {!currentExport?.proofs_r2_key && (
+          {!latestFinalized.proofs_r2_key && (
             <p className="mt-2 text-[11px] text-gray-500">
-              証憑ZIP (proofs) is absent — this export was sealed before proofs were
-              added. Create a revision and rebuild to generate it (see the runbook).
+              証憑ZIP (proofs) is absent — this revision was sealed before proofs
+              were added. Create a revision and rebuild to generate it.
             </p>
           )}
-          <CreateRevisionButton month={month} monthLabel={monthLabel} />
+          {/* No open draft yet → offer to create a revision (e.g. to add proofs). */}
+          {currentExport?.status !== "draft" && (
+            <CreateRevisionButton month={month} monthLabel={monthLabel} />
+          )}
+        </div>
+      )}
+
+      {/* Draft bundle — the open revision (verify-before-finalize). Bytes are
+          the candidate seal; only the DRAFT- filename prefix signals it isn't. */}
+      {currentExport?.status === "draft" && (
+        <div className="border-t border-amber-200 bg-amber-50/40 px-8 py-6">
+          <h2 className="text-sm font-bold text-amber-900">
+            下書きダウンロード (DRAFT)
+            {currentExport.export_revision
+              ? ` — revision ${currentExport.export_revision}`
+              : ""}
+          </h2>
+          {currentExport.bundle_built_at ? (
+            <>
+              <p className="mt-1 text-xs text-amber-800">
+                Open draft, NOT yet sealed. These are the candidate-seal bytes
+                (identical to what Finalize will seal). Downloaded filenames are
+                prefixed <code>DRAFT-</code> so they&apos;re unmistakable — verify,
+                then finalize.
+              </p>
+              <div className="mt-3 flex flex-wrap gap-3">
+                {BUNDLE_DOWNLOAD_LINKS.filter(
+                  ({ file }) => file !== "proofs" || !!currentExport.proofs_r2_key,
+                ).map(({ file, label }) => (
+                  <a
+                    key={file}
+                    href={`/api/receipts/export/${month}/download?file=${file}&draft=true`}
+                    className="rounded-xl border border-amber-400 bg-amber-100 px-4 py-2 text-xs font-semibold text-amber-900 hover:bg-amber-200"
+                  >
+                    {`DRAFT-${label}`}
+                  </a>
+                ))}
+              </div>
+            </>
+          ) : (
+            <p className="mt-1 text-xs text-amber-800">
+              Draft revision created but not yet rebuilt. Click{" "}
+              <strong>Rebuild draft</strong> to stage the bundle (CSV + proofs ZIP +
+              notice) for download.
+            </p>
+          )}
         </div>
       )}
       <div className="border-t border-amber-100 bg-amber-50 px-8 py-4 text-xs text-amber-900">

--- a/app/api/receipts/export/[month]/download/route.ts
+++ b/app/api/receipts/export/[month]/download/route.ts
@@ -2,12 +2,13 @@ import { NextResponse } from "next/server";
 import { requireReceiptsActor } from "@/lib/receipts/auth";
 import { createAuditEntry } from "@/lib/receipts/audit";
 import { stringifyJson } from "@/lib/receipts/db-utils";
-import { getExport } from "@/lib/receipts/db";
+import { getExport, getLatestFinalizedExport } from "@/lib/receipts/db";
 import {
   EXPORT_DOWNLOAD_FILES,
   isExportDownloadFile,
-  resolveExportDownload,
+  resolveBundleDownload,
 } from "@/lib/receipts/export";
+import type { ReceiptExport } from "@/lib/receipts/types";
 import {
   getReceiptsArchiveBucket,
   getReceiptsDb,
@@ -16,12 +17,23 @@ import {
 type RouteContext = { params: Promise<{ month: string }> };
 
 /**
- * GET /api/receipts/export/[month]/download?file=receipts|manifest|summary|readme
+ * GET /api/receipts/export/[month]/download?file=receipts|manifest|summary|readme|proofs[&draft=true]
  *
- * Streams one of the four finalized-bundle artifacts from the archive bucket.
- * The body is served byte-for-byte as sealed at finalize (BOM+CRLF CSVs whose
- * SHA-256 is recorded in the manifest) — no re-encoding, or integrity
- * verification against the manifest breaks.
+ * Streams one of the bundle artifacts from the archive bucket, byte-for-byte —
+ * no transform (the SHA-256 in the manifest must match the bytes served).
+ *
+ * - Default (no `draft`): the latest FINALIZED revision's sealed artifact
+ *   (getLatestFinalizedExport — so an open revision draft never makes the
+ *   sealed package undownloadable). 404 if no finalized revision exists.
+ * - `?draft=true`: the open draft revision's STAGED artifact, for the operator's
+ *   verify-before-finalize workflow. 404 if there's no draft, the draft hasn't
+ *   been rebuilt, or the file isn't staged. Filename is prefixed `DRAFT-` so a
+ *   draft file is unmistakable; the finalized path keeps clean names.
+ *
+ * Byte-identity: a draft's staged bytes are bit-identical to what finalize
+ * seals (finalize re-uses the staged R2 objects — it does not rebuild). Draft
+ * labeling lives ONLY in the filename prefix, the audit entry, and the UI —
+ * nothing is marked inside any artifact.
  */
 export async function GET(request: Request, { params }: RouteContext) {
   try {
@@ -32,7 +44,8 @@ export async function GET(request: Request, { params }: RouteContext) {
       return NextResponse.json({ error: "Invalid month format." }, { status: 400 });
     }
 
-    const file = new URL(request.url).searchParams.get("file");
+    const url = new URL(request.url);
+    const file = url.searchParams.get("file");
     if (!file || !isExportDownloadFile(file)) {
       return NextResponse.json(
         {
@@ -41,42 +54,32 @@ export async function GET(request: Request, { params }: RouteContext) {
         { status: 400 },
       );
     }
+    const draft = url.searchParams.get("draft") === "true";
 
-    const exportRecord = await getExport(month);
-    if (!exportRecord) {
-      return NextResponse.json(
-        { error: "No export found for this month." },
-        { status: 404 },
-      );
+    // Draft path needs the OPEN draft (the highest-revision row when it's a
+    // draft). Default path needs the latest FINALIZED revision — NOT getExport,
+    // which returns the open draft when one exists and would 409 the sealed
+    // package (the mid-revision gap this fixes).
+    let draftRecord: ReceiptExport | null = null;
+    if (draft) {
+      const latest = await getExport(month);
+      draftRecord = latest?.status === "draft" ? latest : null;
     }
-    // Only finalized bundles are downloadable — a draft is not sealed, its
-    // artifacts can still be rebuilt, and handing it to the accountant would
-    // circulate an unverified bundle.
-    if (exportRecord.status !== "finalized") {
-      return NextResponse.json(
-        {
-          error:
-            "Export for this month is still a draft. Finalize the month before downloading the bundle.",
-        },
-        { status: 409 },
-      );
-    }
+    const finalizedRecord = !draft ? await getLatestFinalizedExport(month) : null;
 
-    const target = resolveExportDownload(month, exportRecord, file);
-    if (!target.r2Key) {
-      // The proofs ZIP only exists for exports rebuilt after the proofs code
-      // shipped. A finalized export sealed before that (e.g. revision 1) has no
-      // proofs key — point the operator at the revision flow rather than a bare
-      // "key recorded" message.
-      const message =
-        file === "proofs"
-          ? "This export was sealed before the proofs ZIP existed (no proofs_r2_key). Create a revision and rebuild to generate it."
-          : `No archived ${file} key recorded for this export.`;
-      return NextResponse.json({ error: message }, { status: 404 });
+    const resolution = resolveBundleDownload({
+      month,
+      file,
+      draft,
+      draftRecord,
+      finalizedRecord,
+    });
+    if (!resolution.ok) {
+      return NextResponse.json({ error: resolution.message }, { status: resolution.status });
     }
 
     const bucket = getReceiptsArchiveBucket();
-    const object = await bucket.get(target.r2Key);
+    const object = await bucket.get(resolution.r2Key);
     if (!object) {
       return NextResponse.json(
         { error: `Archived ${file} file not found in storage.` },
@@ -88,15 +91,17 @@ export async function GET(request: Request, { params }: RouteContext) {
       actor,
       action: "export.downloaded",
       objectType: "export",
-      objectId: exportRecord.id,
-      newValueJson: stringifyJson({ month, file }),
+      objectId: resolution.exportId,
+      newValueJson: stringifyJson({ month, file, draft: resolution.draft }),
     });
 
-    // Stream the archived bytes as-is — do NOT transform the body.
+    // Stream the bytes VERBATIM. For a draft, the only outward signal that it
+    // isn't sealed is the DRAFT- filename prefix — the bytes themselves are the
+    // candidate seal (identical to what finalize will seal).
     return new Response(object.body, {
       headers: {
-        "Content-Type": target.contentType,
-        "Content-Disposition": `attachment; filename="${target.filename}"`,
+        "Content-Type": resolution.contentType,
+        "Content-Disposition": `attachment; filename="${resolution.filename}"`,
       },
     });
   } catch (error) {

--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -1794,6 +1794,31 @@ export async function getExport(month: string): Promise<ReceiptExport | null> {
     .first<ReceiptExport>();
 }
 
+/**
+ * Latest FINALIZED export for a month (highest revision), or null.
+ *
+ * Distinct from {@link getExport} (which returns the highest-revision row
+ * regardless of status): when a revision draft is open, getExport returns the
+ * DRAFT, but the sealed package the operator/accountant should download is the
+ * latest FINALIZED revision. The download route's default path uses this so an
+ * open draft never makes the sealed package undownloadable (the mid-revision
+ * gap: getExport returning the draft caused a 409 on the sealed rev-N package).
+ */
+export async function getLatestFinalizedExport(
+  month: string,
+): Promise<ReceiptExport | null> {
+  const db = getReceiptsDb();
+  return db
+    .prepare(
+      `SELECT * FROM receipt_exports
+       WHERE export_month = ? AND status = 'finalized'
+       ORDER BY COALESCE(export_revision, 1) DESC, created_at DESC
+       LIMIT 1`,
+    )
+    .bind(month)
+    .first<ReceiptExport>();
+}
+
 export async function listExports(): Promise<ReceiptExport[]> {
   const db = getReceiptsDb();
   const result = await db

--- a/lib/receipts/export.ts
+++ b/lib/receipts/export.ts
@@ -392,6 +392,121 @@ export function resolveExportDownload(
   }
 }
 
+// ─── Bundle download resolution (draft ⇄ finalized) ─────────────────────────
+// Pure decision the download route uses to pick which revision's staged artifact
+// to serve. Extracted so the draft/finalized logic, the rebuild-precondition
+// check, and the DRAFT- filename prefix are unit-testable without R2/D1.
+//
+// BYTE-IDENTITY (hard requirement): drafts are the candidate seal. The artifact
+// BYTES are identical between a staged draft and what finalize seals — finalize
+// re-uses the staged R2 objects, it does not rebuild. So draft labeling lives
+// ONLY outside the bytes: the DRAFT- filename prefix (here), the UI label, and
+// the audit entry. No builder takes a draft flag; nothing is marked inside an
+// artifact.
+
+export type DownloadExportRecord = {
+  id: string;
+  archive_r2_key: string | null;
+  manifest_r2_key: string | null;
+  proofs_r2_key?: string | null;
+  /** NULL until the draft is rebuilt (recordExportBundle sets it). */
+  bundle_built_at?: string | null;
+};
+
+export type BundleDownloadResolution =
+  | {
+      ok: true;
+      r2Key: string;
+      contentType: string;
+      filename: string;
+      exportId: string;
+      draft: boolean;
+    }
+  | { ok: false; status: number; message: string };
+
+/**
+ * Resolve a bundle download request to an R2 key + content-type + filename, or
+ * an error {status, message}.
+ *
+ * - Default (draft=false): serve the latest FINALIZED revision's artifact.
+ *   404 if no finalized revision exists.
+ * - ?draft=true: serve the open DRAFT revision's staged artifact. 404 if there
+ *   is no draft, the draft hasn't been rebuilt (no bundle_built_at), or the
+ *   specific file isn't staged yet.
+ *
+ * Draft filenames are prefixed `DRAFT-` (e.g. `DRAFT-export-2026-06-proofs.zip`)
+ * so a draft file is unmistakable at a glance / in an attachment list. The
+ * finalized path keeps clean names. Bytes are served verbatim either way.
+ */
+export function resolveBundleDownload(opts: {
+  month: string;
+  file: ExportDownloadFile;
+  draft: boolean;
+  draftRecord: DownloadExportRecord | null;
+  finalizedRecord: DownloadExportRecord | null;
+}): BundleDownloadResolution {
+  const { month, file, draft, draftRecord, finalizedRecord } = opts;
+
+  if (draft) {
+    if (!draftRecord) {
+      return {
+        ok: false,
+        status: 404,
+        message: `No draft revision for ${month}. Create one from the export page.`,
+      };
+    }
+    if (!draftRecord.bundle_built_at) {
+      return {
+        ok: false,
+        status: 404,
+        message: "Draft not rebuilt yet — click Rebuild draft first.",
+      };
+    }
+    const target = resolveExportDownload(month, draftRecord, file);
+    if (!target.r2Key) {
+      return {
+        ok: false,
+        status: 404,
+        message: `Draft ${file} is not staged yet — rebuild the draft.`,
+      };
+    }
+    return {
+      ok: true,
+      r2Key: target.r2Key,
+      contentType: target.contentType,
+      filename: `DRAFT-${target.filename}`,
+      exportId: draftRecord.id,
+      draft: true,
+    };
+  }
+
+  // Default path: latest finalized revision.
+  if (!finalizedRecord) {
+    return {
+      ok: false,
+      status: 404,
+      message: `No finalized export for ${month} yet.`,
+    };
+  }
+  const target = resolveExportDownload(month, finalizedRecord, file);
+  if (!target.r2Key) {
+    // file-aware message (proofs was sealed before the proofs code shipped).
+    const message =
+      file === "proofs"
+        ? "This export was sealed before the proofs ZIP existed (no proofs_r2_key). Create a revision and rebuild to generate it."
+        : `No archived ${file} key recorded for this export.`;
+    return { ok: false, status: 404, message };
+  }
+  return {
+    ok: true,
+    r2Key: target.r2Key,
+    contentType: target.contentType,
+    filename: target.filename,
+    exportId: finalizedRecord.id,
+    draft: false,
+  };
+}
+
 export function buildExportReadme(opts: {
   exportId: string;
   month: string;

--- a/tests/receipts/bundle-download.test.ts
+++ b/tests/receipts/bundle-download.test.ts
@@ -1,0 +1,302 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  EXPORT_DOWNLOAD_FILES,
+  resolveBundleDownload,
+  buildMonthlyExportCsv,
+  buildExportSummaryCsv,
+  buildManifestCsv,
+  buildExportReadme,
+} from "@/lib/receipts/export";
+import { assembleProofsZip } from "@/lib/receipts/proofs";
+import { computeSha256Hex } from "@/lib/receipts/storage";
+import type { DownloadExportRecord } from "@/lib/receipts/export";
+import type { ExportRow } from "@/lib/receipts/types";
+
+const month = "2026-06";
+
+// Fixtures: a finalized rev-1, a rebuilt draft rev-2, and an un-rebuilt draft.
+const finalized: DownloadExportRecord = {
+  id: "exp-fin",
+  archive_r2_key: "exports/2026-06/exp-fin-receipts.csv",
+  manifest_r2_key: "exports/2026-06/exp-fin-manifest.csv",
+  proofs_r2_key: "exports/2026-06/exp-fin-proofs.zip",
+  bundle_built_at: "2026-07-01T00:00:00Z",
+};
+const draftRebuilt: DownloadExportRecord = {
+  id: "exp-draft",
+  archive_r2_key: "exports/2026-06/exp-draft-receipts.csv",
+  manifest_r2_key: "exports/2026-06/exp-draft-manifest.csv",
+  proofs_r2_key: "exports/2026-06/exp-draft-proofs.zip",
+  bundle_built_at: "2026-07-10T00:00:00Z",
+};
+const draftUnbuilt: DownloadExportRecord = {
+  id: "exp-draft2",
+  archive_r2_key: null,
+  manifest_r2_key: null,
+  proofs_r2_key: null,
+  bundle_built_at: null,
+};
+
+function ok(r: ReturnType<typeof resolveBundleDownload>) {
+  assert.ok(r.ok, "expected resolution to succeed");
+  return r as Extract<typeof r, { ok: true }>;
+}
+
+// ─── Default path: latest FINALIZED (not the open draft) ────────────────────
+
+test("default path serves the finalized revision, not the open draft, when both exist", () => {
+  const r = ok(
+    resolveBundleDownload({
+      month,
+      file: "receipts",
+      draft: false,
+      draftRecord: draftRebuilt,
+      finalizedRecord: finalized,
+    }),
+  );
+  assert.equal(r.exportId, "exp-fin", "must resolve to the finalized record");
+  assert.equal(r.draft, false);
+  assert.equal(r.r2Key, finalized.archive_r2_key);
+  assert.equal(r.filename, "export-2026-06-receipts.csv", "finalized names are clean (no DRAFT-)");
+});
+
+test("default path 404s when no finalized revision exists yet", () => {
+  const r = resolveBundleDownload({
+    month,
+    file: "receipts",
+    draft: false,
+    draftRecord: draftRebuilt,
+    finalizedRecord: null,
+  });
+  assert.equal(r.ok, false);
+  if (!r.ok) {
+    assert.equal(r.status, 404);
+    assert.match(r.message, /No finalized export/);
+  }
+});
+
+test("default proofs 404 gives the revision guidance (sealed before proofs)", () => {
+  const r = resolveBundleDownload({
+    month,
+    file: "proofs",
+    draft: false,
+    draftRecord: null,
+    finalizedRecord: { ...finalized, proofs_r2_key: null },
+  });
+  assert.equal(r.ok, false);
+  if (!r.ok) assert.match(r.message, /sealed before the proofs ZIP existed/);
+});
+
+// ─── ?draft=true path ───────────────────────────────────────────────────────
+
+test("draft=true serves the rebuilt draft's artifact with DRAFT- prefix", () => {
+  const r = ok(
+    resolveBundleDownload({
+      month,
+      file: "proofs",
+      draft: true,
+      draftRecord: draftRebuilt,
+      finalizedRecord: finalized,
+    }),
+  );
+  assert.equal(r.exportId, "exp-draft", "must resolve to the draft record");
+  assert.equal(r.draft, true);
+  assert.equal(r.r2Key, draftRebuilt.proofs_r2_key);
+  assert.equal(
+    r.filename,
+    "DRAFT-export-2026-06-proofs.zip",
+    "draft filenames are prefixed DRAFT-",
+  );
+});
+
+test("draft=true 404s before rebuild (no bundle_built_at)", () => {
+  const r = resolveBundleDownload({
+    month,
+    file: "receipts",
+    draft: true,
+    draftRecord: draftUnbuilt,
+    finalizedRecord: finalized,
+  });
+  assert.equal(r.ok, false);
+  if (!r.ok) {
+    assert.equal(r.status, 404);
+    assert.match(r.message, /Draft not rebuilt yet/);
+  }
+});
+
+test("draft=true 404s when there is no draft revision", () => {
+  const r = resolveBundleDownload({
+    month,
+    file: "receipts",
+    draft: true,
+    draftRecord: null,
+    finalizedRecord: finalized,
+  });
+  assert.equal(r.ok, false);
+  if (!r.ok) {
+    assert.equal(r.status, 404);
+    assert.match(r.message, /No draft revision/);
+  }
+});
+
+// ─── DRAFT- prefix on EVERY file kind ───────────────────────────────────────
+
+test("draft=true prefixes DRAFT- on every file kind; default never does", () => {
+  for (const file of EXPORT_DOWNLOAD_FILES) {
+    const d = ok(
+      resolveBundleDownload({
+        month,
+        file,
+        draft: true,
+        draftRecord: draftRebuilt,
+        finalizedRecord: finalized,
+      }),
+    );
+    assert.ok(
+      d.filename.startsWith("DRAFT-"),
+      `draft ${file} must be DRAFT- prefixed (got ${d.filename})`,
+    );
+    assert.equal(d.draft, true);
+
+    const f = ok(
+      resolveBundleDownload({
+        month,
+        file,
+        draft: false,
+        draftRecord: draftRebuilt,
+        finalizedRecord: finalized,
+      }),
+    );
+    assert.ok(
+      !f.filename.startsWith("DRAFT-"),
+      `finalized ${file} must NOT be DRAFT- prefixed (got ${f.filename})`,
+    );
+    assert.equal(f.draft, false);
+  }
+});
+
+// ─── Byte-identity: no draft/finalize-conditional content ───────────────────
+// Drafts are the candidate seal. finalize re-uses the staged R2 objects (it
+// does not rebuild), so a staged draft's bytes == the sealed bytes. This test
+// guards the precondition: every artifact BUILDER is deterministic for
+// identical inputs (no `if (draft)` branch, no per-call randomness) — so the
+// draft build and the finalize build (same inputs) produce identical bytes.
+// The DRAFT- filename prefix + audit flag are the ONLY draft signals.
+
+function makeRow(over: Partial<ExportRow> = {}): ExportRow {
+  return {
+    rowType: "amex_line",
+    lineId: "l-1",
+    matchStatus: null,
+    receiptStatus: null,
+    missingReceiptReason: null,
+    cardholderName: null,
+    businessTripStatus: null,
+    receiptId: "r-1",
+    status: "reviewed",
+    originalR2Key: null,
+    transactionDate: "2026-06-11",
+    merchant: "OpenAI",
+    amountMinor: 108341,
+    currency: "JPY",
+    expenseType: "UNKNOWN",
+    expenseCategoryCode: "rd",
+    expenseCategoryJa: "研究開発費",
+    expenseCategoryEn: "R&D",
+    paymentPath: "AMEX",
+    businessPurpose: null,
+    attendees: [],
+    invoiceRegistrationNumber: null,
+    qualifiedInvoiceStatus: null,
+    taxRate: null,
+    taxAmountMinor: null,
+    sourceType: null,
+    counterpartyName: null,
+    ...over,
+  };
+}
+
+test("byte-identity: text artifacts are deterministic (no draft-conditional content)", async () => {
+  const rows = [makeRow(), makeRow({ receiptId: "r-2", merchant: "屋形舟", amountMinor: 69000 })];
+  const attendeeMap = new Map<string, string[]>();
+  const generatedAt = "2026-07-15T00:00:00Z";
+
+  // Same inputs twice → identical bytes (and identical SHA-256).
+  const csvA = buildMonthlyExportCsv(rows, attendeeMap);
+  const csvB = buildMonthlyExportCsv(rows, attendeeMap);
+  assert.equal(csvA, csvB);
+
+  const sumA = buildExportSummaryCsv(rows, month, generatedAt);
+  const sumB = buildExportSummaryCsv(rows, month, generatedAt);
+  assert.equal(sumA, sumB);
+
+  const manifestOpts = {
+    proofsArtifact: {
+      r2Key: "p",
+      sha256Hash: "psha",
+      originalFilename: "proofs.zip",
+    },
+  } as const;
+  const manA = buildManifestCsv("e1", month, "k", "sha", rows.length, generatedAt, null, manifestOpts);
+  const manB = buildManifestCsv("e1", month, "k", "sha", rows.length, generatedAt, null, manifestOpts);
+  assert.equal(manA, manB);
+
+  const readmeOpts = {
+    exportId: "e1",
+    month,
+    rowCount: rows.length,
+    generatedAt,
+    exportRevision: 1,
+    archiveSha256: "a",
+    manifestSha256: "m",
+    summarySha256: "s",
+    proofsSha256: "p",
+  };
+  assert.equal(buildExportReadme(readmeOpts), buildExportReadme(readmeOpts));
+
+  // SHA-256 equality is the operator's sign-off check — same bytes ⇒ same hash.
+  const enc = new TextEncoder();
+  assert.equal(
+    await computeSha256Hex(enc.encode(csvA)),
+    await computeSha256Hex(enc.encode(csvB)),
+  );
+});
+
+test("byte-identity: the proofs ZIP builder takes no draft flag (draft⇄seal can't diverge at build time)", async () => {
+  // assembleProofsZip(month, entries, noticeInput) — no draft/finalize param.
+  // A draft and a finalize that stage the same entries produce the same zip;
+  // finalize re-uses the staged object rather than rebuilding, so the operator's
+  // downloaded draft zip and the sealed zip are the same bytes.
+  const enc = new TextEncoder();
+  const entries = [
+    {
+      no: 3,
+      categoryJa: "研究開発費",
+      merchant: "OpenAI",
+      amountMinor: 108341,
+      currency: "JPY",
+      ext: "pdf" as const,
+      source: "proof_copy" as const,
+      bytes: enc.encode("%PDF-1.4 test"),
+      transactionDate: "2026-06-11",
+      receiptId: "r-1",
+      statementLineId: "l-1",
+      sha256: "abc",
+      paymentPath: "AMEX" as const,
+    },
+  ];
+  const notice = {
+    monthLabel: "2026年6月",
+    rowCount: 1,
+    receiptCount: 1,
+    missingReceiptLines: [],
+    icAdvisories: [],
+    exportRevision: 1,
+  };
+  const a = assembleProofsZip(month, entries, notice);
+  assert.ok(a instanceof Uint8Array && a.length > 0);
+  // The builder has no draft parameter to branch on — draft and finalize share
+  // it. (Cross-call byte equality is not asserted because the zip's own
+  // finalize step re-uses the staged object; the guarantee is flow-level.)
+});

--- a/tests/receipts/export-revision-flow.test.ts
+++ b/tests/receipts/export-revision-flow.test.ts
@@ -115,5 +115,21 @@ test(
   )[0]!;
   assert.equal(latest.id, "rev2", "getExport ordering must pick revision 2");
 
+  // getLatestFinalizedExport (download route's default path): with BOTH rev1
+  // and rev2 finalized, it must return rev2 (latest finalized). This is the
+  // mid-revision fix — the default download serves the latest finalized, not an
+  // open draft. (Selection: status='finalized' ORDER BY revision DESC.)
+  const latestFin = d1(
+    `SELECT id, export_revision FROM receipt_exports
+     WHERE export_month = '${TEST_MONTH}' AND status = 'finalized'
+     ORDER BY COALESCE(export_revision, 1) DESC, created_at DESC LIMIT 1;`,
+  )[0]!;
+  assert.equal(
+    latestFin.id,
+    "rev2",
+    "getLatestFinalizedExport returns the latest finalized revision",
+  );
+  assert.equal(latestFin.export_revision, 2);
+
   d1(`DELETE FROM receipt_exports WHERE export_month = '${TEST_MONTH}';`);
 });


### PR DESCRIPTION
Drafts are working material the operator must verify **before** sealing; the old 409-on-draft blocked the verify-before-finalize workflow (operator needed wrangler). This replaces denial with **labeling** — the bytes stay the candidate seal.

## Changes
- **Default path → latest FINALIZED revision** (new `getLatestFinalizedExport`), not `getExport` (which returns the open draft). Fixes the mid-revision gap: an open rev-N+1 draft no longer makes the sealed rev-N package undownloadable (409). 404 if no finalized revision exists.
- **`?draft=true` → open draft revision's staged artifacts.** 404 if no draft / draft not rebuilt (`bundle_built_at`) / file not staged. Filename prefixed **`DRAFT-`** on every file kind (e.g. `DRAFT-export-2026-06-proofs.zip`); finalized path keeps clean names. Audit `export.downloaded` now carries `draft:true/false` + `exportId`.
- **Byte-identity (hard requirement):** no marking inside any artifact. Draft labeling lives ONLY in the `DRAFT-` filename prefix, the UI label, and the audit entry. `finalize` re-uses the staged R2 objects (does not rebuild) ⇒ draft bytes == sealed bytes. Bodies stream verbatim. No builder takes a draft flag.
- **UI:** export page shows a 下書きダウンロード (DRAFT) section when a draft is rebuilt (`?draft=true` links, `DRAFT-` visual), alongside the sealed section which keeps serving the latest finalized during an open draft. Create-revision button hidden while a draft is open.
- Pure `resolveBundleDownload()` holds the draft/finalized decision + rebuild-precondition + `DRAFT-` prefix. No migration; no gate-semantics changes; no prod writes.

## Tests
`bundle-download.test.ts` — default serves finalized not draft; default 404 (no finalized) + proofs-404 guidance; `?draft=true` serves rebuilt draft / 404 before rebuild / 404 no-draft; **`DRAFT-` prefix on every file kind** (and never on finalized); **byte-identity** (text builders deterministic — no draft-conditional content; zip builder takes no draft flag). Gated D1 test: `getLatestFinalizedExport` returns rev-2 when both revs finalized.

`tsc` ✅ `lint` ✅ `npm test` **368 (367 pass, 1 D1-skip)**; gated test passes. No prod writes/deploys (per task constraints) — left for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)