### PR TITLE
feat(receipts): 目次.csv rework + 集計 breakdown (pkg pass 1)

### DIFF
--- a/app/api/receipts/export/month/route.ts
+++ b/app/api/receipts/export/month/route.ts
@@ -32,6 +32,7 @@ import {
   type ProofPaymentPath,
 } from "@/lib/receipts/proofs";
 import { listFilesForObject } from "@/lib/receipts/files";
+import { requiresAttendees } from "@/lib/receipts/categories";
 import { composeFinalizeNoticeData, notifyAccountantOfFinalize } from "@/lib/receipts/notify";
 import {
   buildExportBundle,
@@ -104,6 +105,16 @@ export async function POST(request: Request) {
     const csvShipped = bomPrefixedCrlf(csvPure);
     const sha256 = await hashCsvContent(csvShipped);
 
+    // generatedAt is baked into the summary, manifest, and README — compute it
+    // once here so every artifact shares the same timestamp.
+    const generatedAt = new Date().toISOString();
+    // Summary (集計) is built up front: its shipped bytes (BOM+CRLF) are also
+    // embedded in the proofs ZIP as 集計.csv — same bytes, so the accountant who
+    // only opens the ZIP still gets the breakdown.
+    const summaryPure = buildExportSummaryCsv(bundle.rows, month, generatedAt);
+    const summaryShipped = bomPrefixedCrlf(summaryPure);
+    const summarySha256 = await hashCsvContent(summaryShipped);
+
     // Create or retrieve export record, then reload to pick up revision
     // metadata (export_revision / supersedes_export_id / correction_reason).
     // createExport() returns just the id; the row's revision fields are needed
@@ -172,6 +183,12 @@ export async function POST(request: Request) {
         chosen.sha256_hash,
         `Receipt ${row.receiptId}: proof file "${chosen.r2_key}"`,
       );
+      // 出席者 (目次 only): meeting/entertainment categories list attendees,
+      // from the same attendeeMap the receipts CSV uses ("; "-joined). Blank
+      // for other categories. No new gate — emit what the bundle provides.
+      const attendees = requiresAttendees(row.expenseCategoryCode)
+        ? (bundle.attendeeMap.get(row.receiptId) ?? row.attendees ?? []).join("; ")
+        : "";
       proofsEntries.push({
         no: i + 1,
         categoryJa: row.expenseCategoryJa ?? row.expenseCategoryCode ?? "",
@@ -179,12 +196,9 @@ export async function POST(request: Request) {
         amountMinor: row.amountMinor ?? 0,
         currency: row.currency,
         ext: chosen.content_type === "application/pdf" ? "pdf" : "jpg",
-        source: chosen.role === "proof_copy" ? "proof_copy" : "original",
         bytes: fileBytes,
         transactionDate: row.transactionDate,
-        receiptId: row.receiptId,
-        statementLineId: row.lineId,
-        sha256: chosen.sha256_hash,
+        attendees,
         paymentPath: (row.paymentPath === "DIGITAL"
           ? "DIGITAL"
           : row.paymentPath === "CASH"
@@ -204,7 +218,12 @@ export async function POST(request: Request) {
     );
 
     const proofsKey = buildProofsKey(month, exportId);
-    const proofsZipBytes = assembleProofsZip(month, proofsEntries, proofsNoticeInput);
+    const proofsZipBytes = assembleProofsZip(
+      month,
+      proofsEntries,
+      proofsNoticeInput,
+      summaryShipped,
+    );
     const proofsSha256 = await computeSha256Hex(proofsZipBytes);
     await getReceiptsArchiveBucket().put(proofsKey, proofsZipBytes, {
       httpMetadata: { contentType: "application/zip" },
@@ -233,7 +252,6 @@ export async function POST(request: Request) {
       }
     }
     const amexArtifact = await getAmexArtifactByMonth(month);
-    const generatedAt = new Date().toISOString();
 
     // Generate and upload manifest
     const manifest = buildManifestCsv(
@@ -273,12 +291,8 @@ export async function POST(request: Request) {
     const manifestSha256 = await hashCsvContent(manifest);
     await archiveManifest(manifestKey, manifestBytes.buffer as ArrayBuffer);
 
-    // Summary CSV (audit A5): per-category and per-PaymentPath totals for
-    // a quick reconciliation check. Same BOM/CRLF treatment as the main
-    // archive so the accountant can open it in Excel without mojibake.
-    const summaryPure = buildExportSummaryCsv(bundle.rows, month, generatedAt);
-    const summaryShipped = bomPrefixedCrlf(summaryPure);
-    const summarySha256 = await hashCsvContent(summaryShipped);
+    // Summary CSV (集計) — same bytes embedded in the proofs ZIP. Uploaded as
+    // the standalone summary artifact; BOM+CRLF for Excel on Windows.
     await getReceiptsArchiveBucket().put(
       summaryKey,
       encoder.encode(summaryShipped).buffer as ArrayBuffer,

--- a/lib/receipts/export.ts
+++ b/lib/receipts/export.ts
@@ -144,16 +144,25 @@ export function bomPrefixedCrlf(csvText: string): string {
 }
 
 /**
- * Summary CSV: per-expense-category count + total, then a PaymentPath
- * breakdown, then a grand total. Generated from the same ExportRow list
- * as the main CSV so the two cannot drift.
+ * 集計 (summary) CSV — a full cost breakdown the accountant reconciles against
+ * their own statement prep: per-勘定科目 (count + subtotal, sorted by subtotal
+ * desc), per-payment-path (AMEX/現金/デジタル), and a grand-total row.
+ *
+ * Amounts are raw amountMinor (yen integers) — the grand total is the EXACT sum
+ * of the receipts CSV's amounts (same arithmetic; no float re-derivation).
+ * Generated from the same ExportRow list as the main CSV so the two cannot drift.
+ * Shipped in two places: the standalone summary artifact (BOM+CRLF applied by
+ * the route) and a byte-identical 集計.csv inside the proofs ZIP.
  */
 export function buildExportSummaryCsv(
   rows: ExportRow[],
   month: string,
   generatedAt: string,
 ): string {
-  const catTotals = new Map<string, { count: number; totalMinor: number }>();
+  const catTotals = new Map<
+    string,
+    { ja: string; count: number; totalMinor: number }
+  >();
   let amexCount = 0;
   let amexTotal = 0;
   let cashCount = 0;
@@ -165,7 +174,11 @@ export function buildExportSummaryCsv(
 
   for (const row of rows) {
     const code = row.expenseCategoryCode ?? "uncategorized";
-    const cat = catTotals.get(code) ?? { count: 0, totalMinor: 0 };
+    const cat = catTotals.get(code) ?? {
+      ja: row.expenseCategoryJa ?? code,
+      count: 0,
+      totalMinor: 0,
+    };
     cat.count += 1;
     cat.totalMinor += row.amountMinor ?? 0;
     catTotals.set(code, cat);
@@ -186,23 +199,23 @@ export function buildExportSummaryCsv(
   }
 
   const lines: string[] = [
-    `Field,Value`,
+    "Field,Value",
     `Month,${csvEscape(month)}`,
     `GeneratedAt,${csvEscape(generatedAt)}`,
-    `RowCount,${grandCount}`,
-    `GrandTotalMinor,${grandTotal}`,
-    ``,
-    `ExpenseCategoryCode,Count,TotalMinor`,
+    "",
+    "勘定科目,件数,合計金額",
   ];
-  const sorted = [...catTotals.entries()].sort((a, b) => b[1].totalMinor - a[1].totalMinor);
-  for (const [code, v] of sorted) {
-    lines.push(`${csvEscape(code)},${v.count},${v.totalMinor}`);
+  const sorted = [...catTotals.values()].sort((a, b) => b.totalMinor - a.totalMinor);
+  for (const c of sorted) {
+    lines.push(`${csvEscape(c.ja)},${c.count},${c.totalMinor}`);
   }
-  lines.push(``);
-  lines.push(`PaymentPath,Count,TotalMinor`);
+  lines.push("");
+  lines.push("支払方法,件数,合計金額");
   lines.push(`AMEX,${amexCount},${amexTotal}`);
-  lines.push(`CASH,${cashCount},${cashTotal}`);
-  lines.push(`DIGITAL,${digitalCount},${digitalTotal}`);
+  lines.push(`現金,${cashCount},${cashTotal}`);
+  lines.push(`デジタル,${digitalCount},${digitalTotal}`);
+  lines.push("");
+  lines.push(`総合計,${grandCount},${grandTotal}`);
   return lines.join("\n");
 }
 

--- a/lib/receipts/proofs.ts
+++ b/lib/receipts/proofs.ts
@@ -75,10 +75,9 @@ export interface ProofMokuziRow {
   amountMinor: number;
   currency: string;
   categoryJa: string;
-  statementLineId: string | null;
-  receiptId: string;
-  sha256: string;
-  source: "proof_copy" | "original";
+  /** 出席者: "; "-joined attendees for 会議費/接待交際費 entries (caller-resolved
+   *  from the same attendeeMap the receipts CSV uses); blank for other rows. */
+  attendees: string;
 }
 
 function csvQuote(value: string | null | undefined): string {
@@ -90,12 +89,17 @@ function csvQuote(value: string | null | undefined): string {
   return s;
 }
 
-/** 目次.csv — one row per proof, Excel-safe (BOM + CRLF + quoted comma fields).
- *  `No` is the join key to the receipts CSV; `sha256` is the hash of the file
- *  ACTUALLY shipped in this ZIP (the proof_copy derivative when one ships, the
- *  original on fallback) — the adjacent 出典 column states which (原本 vs
- *  圧縮コピー). Labeling a derivative's hash "original_sha256" would be a false
- *  claim an auditor trips on, so the column is just `sha256`. */
+/** 目次.csv — the accountant's human table of contents (one row per proof),
+ *  Excel-safe (BOM + CRLF + quoted comma fields). Columns:
+ *    No, ファイル名, 取引日, 店舗, 金額, 勘定科目, 出席者
+ *  `No` is the join key to the receipts CSV. 出席者 lists attendees for 会議費 /
+ *  接待交際費 entries (caller-resolved from the receipts CSV's attendee source),
+ *  blank for other categories.
+ *
+ *  Machine fields (statement_line_id, receipt_id, sha256, source) are
+ *  intentionally NOT here — they have no value to a human reader and already
+ *  live in the manifest (per-file SHAs, IDs). 目次 = human layer, manifest =
+ *  machine layer. */
 export function buildProofsMokuziCsv(rows: ProofMokuziRow[]): string {
   const header = [
     "No",
@@ -104,10 +108,7 @@ export function buildProofsMokuziCsv(rows: ProofMokuziRow[]): string {
     "店舗",
     "金額",
     "勘定科目",
-    "statement_line_id",
-    "receipt_id",
-    "sha256",
-    "出典",
+    "出席者",
   ].join(",");
   const body = rows
     .slice()
@@ -120,10 +121,7 @@ export function buildProofsMokuziCsv(rows: ProofMokuziRow[]): string {
         csvQuote(r.merchant),
         csvQuote(formatYenAmount(r.amountMinor, r.currency)),
         csvQuote(r.categoryJa),
-        csvQuote(r.statementLineId),
-        csvQuote(r.receiptId),
-        csvQuote(r.sha256),
-        r.source === "original" ? "原本" : "圧縮コピー",
+        csvQuote(r.attendees),
       ].join(","),
     );
   // BOM (Excel on Windows detects UTF-8 → Japanese renders) + CRLF.
@@ -290,12 +288,10 @@ export interface ProofZipEntry {
   amountMinor: number;
   currency: string;
   ext: "jpg" | "pdf";
-  source: "proof_copy" | "original";
   bytes: Uint8Array;
   transactionDate: string | null;
-  receiptId: string;
-  statementLineId: string | null;
-  sha256: string;
+  /** 出席者 for the 目次 (会議費/接待交際費 only); blank otherwise. */
+  attendees: string;
   paymentPath: ProofPaymentPath;
 }
 
@@ -309,13 +305,18 @@ function folderFor(paymentPath: ProofPaymentPath): string {
 
 /** Build the sealed proofs ZIP. fflate uses a single compression level; we use
  *  level 0 (store) so the bulk JPEG/PDF bytes aren't recompressed (wasted CPU,
- *  ~0 size gain). The two index files are tiny, so storing them uncompressed is
+ *  ~0 size gain). The index files are tiny, so storing them uncompressed is
  *  negligible. UTF-8 entry names: fflate sets the UTF-8 general-purpose bit for
- *  non-ASCII paths, so the Japanese names open correctly in Windows Explorer. */
+ *  non-ASCII paths, so the Japanese names open correctly in Windows Explorer.
+ *
+ *  `summaryCsv` is the SAME bytes as the standalone summary artifact (BOM+CRLF),
+ *  embedded as 集計.csv so the accountant who only opens the ZIP still gets the
+ *  cost breakdown. */
 export function assembleProofsZip(
   month: string,
   entries: ProofZipEntry[],
   noticeInput: TransitionNoticeInput,
+  summaryCsv: string,
 ): Uint8Array {
   const root = ROOT_PREFIX(month);
   const files: Record<string, Uint8Array> = {};
@@ -361,14 +362,12 @@ export function assembleProofsZip(
       amountMinor: entry.amountMinor,
       currency: entry.currency,
       categoryJa: entry.categoryJa,
-      statementLineId: entry.statementLineId,
-      receiptId: entry.receiptId,
-      sha256: entry.sha256,
-      source: entry.source,
+      attendees: entry.attendees,
     });
   }
 
   files[`${root}目次.csv`] = encoder.encode(buildProofsMokuziCsv(mokuziRows));
+  files[`${root}集計.csv`] = encoder.encode(summaryCsv);
   files[`${root}お知らせ.txt`] = encoder.encode(buildTransitionNotice(noticeInput));
 
   return zipSync(files, { level: 0 });

--- a/tests/receipts/bundle-download.test.ts
+++ b/tests/receipts/bundle-download.test.ts
@@ -277,12 +277,9 @@ test("byte-identity: the proofs ZIP builder takes no draft flag (draft⇄seal ca
       amountMinor: 108341,
       currency: "JPY",
       ext: "pdf" as const,
-      source: "proof_copy" as const,
       bytes: enc.encode("%PDF-1.4 test"),
       transactionDate: "2026-06-11",
-      receiptId: "r-1",
-      statementLineId: "l-1",
-      sha256: "abc",
+      attendees: "",
       paymentPath: "AMEX" as const,
     },
   ];
@@ -294,7 +291,7 @@ test("byte-identity: the proofs ZIP builder takes no draft flag (draft⇄seal ca
     icAdvisories: [],
     exportRevision: 1,
   };
-  const a = assembleProofsZip(month, entries, notice);
+  const a = assembleProofsZip(month, entries, notice, "﻿Field,Value\r\nMonth,2026-06\r\n");
   assert.ok(a instanceof Uint8Array && a.length > 0);
   // The builder has no draft parameter to branch on — draft and finalize share
   // it. (Cross-call byte equality is not asserted because the zip's own

--- a/tests/receipts/export.test.ts
+++ b/tests/receipts/export.test.ts
@@ -226,7 +226,7 @@ test("bomPrefixedCrlf: handles text that already has CRLF", () => {
 
 // ─── buildExportSummaryCsv (A5 summary CSV) ───────────────────────────────────
 
-test("buildExportSummaryCsv: grand total + PaymentPath breakdown", () => {
+test("buildExportSummaryCsv: 集計 — per-category + payment-path + grand total", () => {
   const rows: ExportRow[] = [
     makeAmexLineRow({ amountMinor: 5000, expenseCategoryCode: "entertainment" }),
     makeReceiptRow({
@@ -242,15 +242,19 @@ test("buildExportSummaryCsv: grand total + PaymentPath breakdown", () => {
   ];
   const csv = buildExportSummaryCsv(rows, "2026-05", "2026-05-19T12:00:00Z");
   assert.match(csv, /Month,2026-05/);
-  assert.match(csv, /RowCount,3/);
-  assert.match(csv, /GrandTotalMinor,9500/);
-  assert.match(csv, /PaymentPath,Count,TotalMinor/);
-  assert.match(csv, /AMEX,1,5000/);
-  assert.match(csv, /CASH,1,1500/);
-  assert.match(csv, /DIGITAL,1,3000/);
-  assert.match(csv, /entertainment,1,5000/);
+  assert.match(csv, /勘定科目,件数,合計金額/);
+  assert.match(csv, /支払方法,件数,合計金額/);
+  // Per-category (Japanese name when present; code fallback when JA is null).
+  assert.match(csv, /接待（飲酒あり）,1,5000/);
   assert.match(csv, /meeting,1,1500/);
   assert.match(csv, /software,1,3000/);
+  // Per-payment-path.
+  assert.match(csv, /AMEX,1,5000/);
+  assert.match(csv, /現金,1,1500/);
+  assert.match(csv, /デジタル,1,3000/);
+  // Grand total = exact sum of the rows' amountMinor (5000+1500+3000 = 9500),
+  // matching what the receipts CSV's amounts sum to — no float re-derivation.
+  assert.match(csv, /総合計,3,9500/);
 });
 
 test("buildExportSummaryCsv: uncategorized bucket when category null", () => {

--- a/tests/receipts/proofs.test.ts
+++ b/tests/receipts/proofs.test.ts
@@ -110,7 +110,7 @@ test("buildProofFilename: No zero-pads to 2, 3 digits naturally", () => {
 
 // ─── buildProofsMokuziCsv (目次) ────────────────────────────────────────────
 
-test("buildProofsMokuziCsv: BOM + CRLF + header + 出典 mapping", () => {
+test("buildProofsMokuziCsv: human TOC columns — no machine fields", () => {
   const csv = buildProofsMokuziCsv([
     {
       no: 3,
@@ -120,10 +120,7 @@ test("buildProofsMokuziCsv: BOM + CRLF + header + 出典 mapping", () => {
       amountMinor: 108341,
       currency: "JPY",
       categoryJa: "研究開発費",
-      statementLineId: "amex-line-3",
-      receiptId: "r-3",
-      sha256: "abc123",
-      source: "proof_copy",
+      attendees: "",
     },
     {
       no: 7,
@@ -133,29 +130,48 @@ test("buildProofsMokuziCsv: BOM + CRLF + header + 出典 mapping", () => {
       amountMinor: 69000,
       currency: "JPY",
       categoryJa: "接待交際費",
-      statementLineId: null,
-      receiptId: "r-7",
-      sha256: "def456",
-      source: "original",
+      attendees: "山田太郎; 鈴木花子",
     },
   ]);
   assert.ok(csv.startsWith("﻿"), "目次 must be BOM-prefixed for Excel");
   assert.ok(csv.includes("\r\n"), "目次 must use CRLF for Windows Excel");
-  assert.ok(csv.includes("No,ファイル名,取引日"), "目次 header row");
-  // sha256 column = hash of the file actually shipped (not "original_sha256" —
-  // a derivative's hash mislabeled "original" is a false claim). 出典 states
-  // whether it's 原本 (original) or 圧縮コピー (proof_copy).
-  assert.ok(csv.includes(",sha256,"), "目次 sha256 column (renamed from original_sha256)");
-  assert.ok(!csv.includes("original_sha256"), "目次 must not claim original_sha256");
-  // 出典 maps proof_copy → 圧縮コピー, original → 原本.
-  assert.ok(csv.includes("圧縮コピー"), "proof_copy source label");
-  assert.ok(csv.includes("原本"), "original source label");
+  // Exact header — the accountant's table of contents only.
+  assert.ok(
+    csv.includes("No,ファイル名,取引日,店舗,金額,勘定科目,出席者"),
+    "目次 header is the human TOC",
+  );
+  // Machine fields removed (they live in the manifest).
+  assert.ok(!csv.includes("statement_line_id"), "no statement_line_id column");
+  assert.ok(!csv.includes("receipt_id"), "no receipt_id column");
+  assert.ok(!csv.includes("出典"), "no 出典 column");
+  // 出席者 populated for 接待交際費.
+  assert.ok(csv.includes("山田太郎; 鈴木花子"), "attendees listed for 接待交際費");
   // Quoted filename field (contains a comma in the amount).
   assert.ok(csv.includes('"No03_研究開発費_OpenAI_¥108,341.pdf"'));
-  // Sorted by No ascending.
-  const a = csv.indexOf("No03");
-  const b = csv.indexOf("r-7");
-  assert.ok(a < b, "rows sorted by No");
+});
+
+test("buildProofsMokuziCsv: 出席者 populated for 会議費/接待交際費, empty otherwise", () => {
+  const row = (categoryJa: string, attendees: string) => ({
+    no: 1,
+    filename: "f.jpg",
+    transactionDate: "2026-06-01",
+    merchant: "M",
+    amountMinor: 1000,
+    currency: "JPY",
+    categoryJa,
+    attendees,
+  });
+  assert.ok(
+    buildProofsMokuziCsv([row("会議費", "Alice; Bob")]).includes(",会議費,Alice; Bob"),
+    "会議費 attendees populated",
+  );
+  assert.ok(
+    buildProofsMokuziCsv([row("接待交際費", "Carol")]).includes(",接待交際費,Carol"),
+    "接待交際費 attendees populated",
+  );
+  // Non-meeting/entertainment category → empty 出席者 (trailing empty field).
+  const other = buildProofsMokuziCsv([row("旅費交通費", "")]);
+  assert.match(other, /旅費交通費,\r\n/, "non-meeting category has empty 出席者");
 });
 
 // ─── buildTransitionNotice (お知らせ) ───────────────────────────────────────
@@ -218,18 +234,21 @@ function fakeEntry(over: Partial<ProofZipEntry>): ProofZipEntry {
     amountMinor: 108341,
     currency: "JPY",
     ext: "pdf",
-    source: "proof_copy",
     bytes: enc.encode("%PDF-1.4 test"),
     transactionDate: "2026-03-04",
-    receiptId: "r-1",
-    statementLineId: "amex-line-1",
-    sha256: "abc123",
+    attendees: "",
     paymentPath: "AMEX",
     ...over,
   };
 }
 
-test("assembleProofsZip: UTF-8 names round-trip + folders + index/notice present", () => {
+// The summaryCsv passed to assembleProofsZip == the standalone summary artifact
+// bytes (BOM+CRLF). Embedded as 集計.csv so a ZIP-only accountant gets the
+// breakdown too.
+const SUMMARY_CSV =
+  "﻿Field,Value\r\nMonth,2026-06\r\n\r\n勘定科目,件数,合計金額\r\n研究開発費,1,108341\r\n\r\n総合計,1,108341\r\n";
+
+test("assembleProofsZip: UTF-8 names round-trip + 目次/集計/お知らせ present", () => {
   const entries = [
     fakeEntry({ no: 3, ext: "pdf", paymentPath: "AMEX" }),
     fakeEntry({
@@ -238,13 +257,16 @@ test("assembleProofsZip: UTF-8 names round-trip + folders + index/notice present
       merchant: "セブン-イレブン 東中野末広橋店",
       amountMinor: 10000,
       ext: "jpg",
-      source: "original",
       paymentPath: "CASH",
-      receiptId: "r-33",
       bytes: new Uint8Array([0xff, 0xd8, 0xff, 0xe0]),
     }),
   ];
-  const zip = assembleProofsZip("2026-06", entries, { ...baseNotice, receiptCount: 2 });
+  const zip = assembleProofsZip(
+    "2026-06",
+    entries,
+    { ...baseNotice, receiptCount: 2 },
+    SUMMARY_CSV,
+  );
   const files = unzipSync(zip);
   const names = Object.keys(files);
 
@@ -261,18 +283,35 @@ test("assembleProofsZip: UTF-8 names round-trip + folders + index/notice present
     names.some((n) => n.includes("No33_旅費交通費_セブン-イレブン東中野末広橋店_¥10,000.jpg")),
     "cash proof filename (whitespace-stripped merchant) round-trips",
   );
-  // Index + notice.
+  // Index + summary + notice.
   assert.ok(names.some((n) => n.endsWith("目次.csv")), "目次.csv present");
+  assert.ok(names.some((n) => n.endsWith("集計.csv")), "集計.csv present");
   assert.ok(names.some((n) => n.endsWith("お知らせ.txt")), "お知らせ.txt present");
+  // 集計.csv bytes == the standalone summary artifact (same bytes passed in).
+  // Compare raw bytes — TextDecoder would strip the leading BOM and skew the
+  // comparison.
+  const shukeiKey = names.find((n) => n.endsWith("集計.csv"))!;
+  const shukeiBytes = files[shukeiKey];
+  const expectedShukei = enc.encode(SUMMARY_CSV);
+  assert.equal(shukeiBytes.length, expectedShukei.length, "集計.csv byte length");
+  assert.ok(
+    shukeiBytes.every((b, i) => b === expectedShukei[i]),
+    "集計.csv bytes identical to the standalone summary artifact",
+  );
 });
 
 test("assembleProofsZip: 目次 No column matches entry nos (CSV⇄目次 continuity)", () => {
   const entries = [
-    fakeEntry({ no: 3, receiptId: "r-3" }),
-    fakeEntry({ no: 7, receiptId: "r-7", merchant: "屋形舟", amountMinor: 69000 }),
-    fakeEntry({ no: 33, receiptId: "r-33", merchant: "セブン", amountMinor: 10000 }),
+    fakeEntry({ no: 3 }),
+    fakeEntry({ no: 7, merchant: "屋形舟", amountMinor: 69000 }),
+    fakeEntry({ no: 33, merchant: "セブン", amountMinor: 10000 }),
   ];
-  const zip = assembleProofsZip("2026-06", entries, { ...baseNotice, receiptCount: 3 });
+  const zip = assembleProofsZip(
+    "2026-06",
+    entries,
+    { ...baseNotice, receiptCount: 3 },
+    SUMMARY_CSV,
+  );
   const files = unzipSync(zip);
   const mokuziKey = Object.keys(files).find((k) => k.endsWith("目次.csv"))!;
   const mokuzi = new TextDecoder().decode(files[mokuziKey]);


### PR DESCRIPTION
First operator-review pass on the accountant package. Two builder changes; the manifest (machine layer) is untouched.

## 1. 目次.csv — human table of contents only
- **Drop** `statement_line_id`, `receipt_id`, `sha256`, `出典` (machine fields — no value to a human; they remain in the manifest). **Add** `出席者`.
- New columns: `No, ファイル名, 取引日, 店舗, 金額, 勘定科目, 出席者`.
- `出席者` = attendees (`; `-joined) for 会議費/接待交際費, gated on `requiresAttendees` and sourced from the **same attendeeMap** the receipts CSV uses (no re-derivation); blank for other categories. No new gate — emits what the bundle provides.

## 2. 集計.csv — full cost breakdown (reworked `buildExportSummaryCsv`)
- Per-**勘定科目** 件数 + 合計金額 (sorted desc by subtotal); per-payment-path **AMEX/現金/デジタル**; a **総合計** grand-total row = exact sum of the receipts CSV's `amountMinor` (raw integer arithmetic, no float re-derivation). BOM+CRLF + month/generatedAt header preserved.
- Shipped in **both** the standalone `summary` artifact (same key) **and** a copy at the proofs-ZIP root as `集計.csv` — identical bytes, so a ZIP-only accountant still gets the breakdown. `assembleProofsZip` gains a `summaryCsv` param; the route builds the summary bytes once (up front) and passes them to both the upload and the zip.

## Constraints honored
- Byte-identity preserved: builders take **no draft flag**, no conditional content; draft⇄seal identity holds (finalize re-uses staged objects).
- No gate-semantics changes, no migration, no prod writes/deploys.

## Tests
- 目次 exact-header; `出席者` populated for 会議費/接待交際費, blank otherwise; no machine columns.
- 集計 per-category / payment-path / 総合計 (= row sum `9500 = 5000+1500+3000`).
- ZIP contains `集計.csv` with **bytes identical** to the standalone summary.
- Updated zip-entry + summary fixtures.

`tsc` ✅ `lint` ✅ `npm test` **369 (368 pass, 1 D1-skip)**. Left for review (no merge, per task constraints).

🤖 Generated with [Claude Code](https://claude.com/claude-code)