### PR TITLE
feat(receipts): real notify recipient (admin@) + test-send endpoint

### DIFF
--- a/app/api/receipts/notify/test/route.ts
+++ b/app/api/receipts/notify/test/route.ts
@@ -1,0 +1,97 @@
+import { NextResponse } from "next/server";
+import { requireReceiptsActor } from "@/lib/receipts/auth";
+import { createAuditEntry } from "@/lib/receipts/audit";
+import { stringifyJson } from "@/lib/receipts/db-utils";
+import { getLatestFinalizedExport, listExports } from "@/lib/receipts/db";
+import { buildExportBundle } from "@/lib/receipts/month-closing";
+import {
+  authorizeNotifyTest,
+  composeFinalizeNoticeData,
+  notifyAccountantOfFinalize,
+} from "@/lib/receipts/notify";
+import { getReceiptsDb } from "@/lib/cloudflare-runtime";
+
+/**
+ * POST /api/receipts/notify/test[?month=YYYY-MM]
+ *
+ * Exercises the FULL production notification path (binding + template +
+ * destination) WITHOUT finalizing anything — so the operator can verify Email
+ * Routing end to end before a real close. Auth is Clerk-session ONLY (an
+ * operator action); a processor key alone is rejected (the Mac consumer must
+ * never trigger a notification).
+ *
+ * Reads the real bundle for the month (read-only) so the body reflects an actual
+ * close, but the subject is prefixed 【テスト送信】 and the body opens with a
+ * "this is a channel test, not a close notification" banner. Returns the notify
+ * result verbatim — {ok:true} or {ok:false, error} with the raw Cloudflare
+ * rejection text so the operator can diagnose (unverified destination, bad
+ * from-domain, missing binding) without log-diving.
+ */
+export async function POST(request: Request) {
+  try {
+    // Clerk session ONLY — resolve the actor without throwing so a
+    // processor-key-only request (no session) is caught by authorizeNotifyTest.
+    let clerkActor: string | null = null;
+    try {
+      clerkActor = await requireReceiptsActor(request.headers);
+    } catch {
+      clerkActor = null;
+    }
+    const actor = authorizeNotifyTest(clerkActor);
+
+    const url = new URL(request.url);
+    let month = url.searchParams.get("month") ?? "";
+    if (!month) {
+      // Accept month from a JSON body as well (?month= takes precedence).
+      const body = (await request.json().catch(() => ({}))) as { month?: string };
+      month = body.month?.trim() ?? "";
+    }
+    if (!month) {
+      // Default: the most-recent finalized month.
+      const all = await listExports();
+      const finalized = all
+        .filter((e) => e.status === "finalized")
+        .sort((a, b) => (b.finalized_at ?? "").localeCompare(a.finalized_at ?? ""));
+      if (finalized.length === 0) {
+        return NextResponse.json(
+          { ok: false, error: "No finalized month to test against." },
+          { status: 404 },
+        );
+      }
+      month = finalized[0]!.export_month;
+    }
+
+    const exportRecord = await getLatestFinalizedExport(month);
+    if (!exportRecord) {
+      return NextResponse.json(
+        { ok: false, error: `No finalized export for ${month}.` },
+        { status: 404 },
+      );
+    }
+    const bundle = await buildExportBundle(month);
+    const data = composeFinalizeNoticeData(month, bundle, exportRecord);
+
+    const result = await notifyAccountantOfFinalize(data, { test: true });
+
+    await createAuditEntry(getReceiptsDb(), {
+      actor,
+      action: "export.notification_test",
+      objectType: "export",
+      objectId: exportRecord.id,
+      newValueJson: stringifyJson(
+        result.ok ? { month, ok: true } : { month, ok: false, error: result.error },
+      ),
+    });
+
+    return NextResponse.json(result, { status: 200 });
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Unauthorized")) {
+      return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+    }
+    console.error("[api/receipts/notify/test] POST failed", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Test send failed." },
+      { status: 500 },
+    );
+  }
+}

--- a/docs/month-close-runbook.md
+++ b/docs/month-close-runbook.md
@@ -114,37 +114,63 @@ After ADR 0008, 2026-06's export is **32 AMEX lines + 11 June-dated cash/digital
 flow above. Reconcile the 20 lines (categorize, match receipts, resolve
 missing-receipt reasons) and sign off the reconciliation before finalizing.
 
-## Notification email (finalize → accountant)
+## Notification email (finalize → recipient)
 
-Finalizing a month sends the accountant a Japanese email (month label, revision,
-row/receipt counts, per-category totals, the full transition notice, and the
-download link) via Cloudflare Email Routing — no third-party vendor. **Email
-failure never fails finalize**: if the send is rejected, finalize still returns
-200, the failure surfaces as a warning in the response, and an
-`export.notification_failed` audit entry is written (`export.notification_sent`
-on success).
+Finalizing a month sends a Japanese email (month label, revision, row/receipt
+counts, per-category totals, the full transition notice, and the download link)
+via Cloudflare Email Routing — no third-party vendor. **Email failure never fails
+finalize**: if the send is rejected, finalize still returns 200, the failure
+surfaces as a warning in the response, and an `export.notification_failed` audit
+entry is written (`export.notification_sent` on success).
+
+**Recipient rollout:** the var is named `ACCOUNTANT_EMAIL` (the
+notification-recipient *role*), but for the first rollout it points at the
+**business manager** (`admin@dazbeez.com`) while the package is signed off. Swap
+in the accountant's address later — one value change in `ACCOUNTANT_EMAIL` and
+the `NOTIFY_EMAIL` binding's `destination_address` (they must match), then verify
+the new destination.
 
 ### Ops prerequisites (one-time)
 
 Email Routing sends are **rejected by Cloudflare** until these are in place:
 
-1. **Email Routing enabled** on the `dazbeez.com` zone (Cloudflare dashboard →
-   Email → Email Routing).
-2. **Destination address verified** — the accountant's address must be verified
-   as a destination (Email Routing sends a one-time confirmation email to it).
-3. **`ACCOUNTANT_EMAIL` var** set to the verified accountant address (in
-   `wrangler.jsonc` vars). This is the runtime `to`.
-4. **`NOTIFY_EMAIL` binding `destination_address`** in `wrangler.jsonc` set to
-   the **same** address — Cloudflare requires the runtime `to` to be authorized
-   by the binding. These two must match; if they diverge the send is rejected
-   (caught + audited, finalize unaffected).
-5. **`NOTIFY_FROM_ADDRESS` var** set to a sender on the `dazbeez.com` zone (e.g.
-   `receipts@dazbeez.com`) — the from address must be on the zone.
+1. **Email Routing enabled** on the `dazbeez.com` zone (MX → `route*.mx.cloudflare.net`) — live.
+2. **Destination address verified** — the recipient (`admin@dazbeez.com` for now)
+   must be verified as a destination in the Cloudflare dashboard (Email Routing
+   sends a one-time confirmation email to it).
+3. **`ACCOUNTANT_EMAIL` var** = the verified recipient (`admin@dazbeez.com` for
+   now, in `wrangler.jsonc` vars). This is the runtime `to`. A committed var, not
+   a secret — the recipient is a role, not a secret value.
+4. **`NOTIFY_EMAIL` binding `destination_address`** = the **same** address (in
+   `wrangler.jsonc`). Cloudflare requires the runtime `to` to be authorized by
+   the binding; if they diverge the send is rejected (caught + audited, finalize
+   unaffected).
+5. **`NOTIFY_FROM_ADDRESS`** = an on-zone sender (`receipts@dazbeez.com`).
 
 If any are unset/unverified, every finalize records `export.notification_failed`
-with the rejection reason. The bundle still seals; resend manually after fixing
-the config (there is no auto-retry — re-finalize is impossible without a
-revision, so treat the warning as "the email didn't go out, send it by hand").
+with the rejection reason. The bundle still seals.
+
+### Test-send (verify the channel before a real close)
+
+`POST /api/receipts/notify/test` exercises the **full production send path**
+(binding + real template + destination) WITHOUT finalizing anything. Clerk-session
+auth only — an operator action; a processor key alone is rejected. The subject is
+prefixed 【テスト送信】 and the body opens with a "this is a channel test, not a
+close notification" banner. The response passes the notify result through
+verbatim so the operator can diagnose rejections without log-diving:
+
+```bash
+# Default month = the latest finalized month; or pass ?month=YYYY-MM.
+curl -X POST 'https://dazbeez.com/api/receipts/notify/test?month=2026-06' \
+  -H 'Cookie: <clerk session cookie>'
+# → {"ok":true}   (send accepted)
+# → {"ok":false,"error":"<raw Cloudflare rejection, e.g. destination not verified>"}
+```
+
+Audited as `export.notification_test` (`{month, ok, error?}`). Run this to confirm
+the destination is verified and the binding/from/to resolve **before** the first
+real finalize.
+
 
 ## Proofs bundle (証憑ZIP)
 

--- a/lib/receipts/notify.ts
+++ b/lib/receipts/notify.ts
@@ -108,8 +108,15 @@ function formatYen(minor: number): string {
   return `¥${minor.toLocaleString("ja-JP")}`;
 }
 
-/** Build the Japanese email body. Pure + snapshot-tested. */
-export function buildFinalizeEmailBody(d: FinalizeNoticeData): string {
+/** Build the Japanese email body. Pure + snapshot-tested. In test mode
+ *  (opts.test) the body OPENS with a banner stating this is a channel test, not
+ *  a close notification — so a test send can never be mistaken for the real
+ *  thing. The rest of the body is the real template (the point of a test send is
+ *  to exercise the actual template + binding + destination end to end). */
+export function buildFinalizeEmailBody(
+  d: FinalizeNoticeData,
+  opts?: { test?: boolean },
+): string {
   const lines: string[] = [];
   lines.push("毎月の領収証憑一式の確定（ファイナライズ）が完了しましたのでお知らせします。");
   lines.push("");
@@ -131,7 +138,27 @@ export function buildFinalizeEmailBody(d: FinalizeNoticeData): string {
   lines.push(`https://dazbeez.com/receipts/export?month=${d.month}`);
   lines.push("");
   lines.push("本メールは自動送信されています。ご不明な点があれば別途ご連絡ください。");
-  return lines.join("\r\n");
+  const body = lines.join("\r\n");
+  if (opts?.test) {
+    return (
+      "※これは通知チャネルのテスト送信です。月次確定の通知ではありません。\r\n\r\n" +
+      body
+    );
+  }
+  return body;
+}
+
+/** Build the email subject. In test mode (opts.test) it is prefixed
+ *  【テスト送信】 so a test send is unmistakable in the inbox. Pure. */
+export function buildFinalizeEmailSubject(
+  d: FinalizeNoticeData,
+  opts?: { test?: boolean },
+): string {
+  const base =
+    d.revision > 1
+      ? `【領収証憑】${d.monthLabel}分 確定通知（改訂${d.revision}）`
+      : `【領収証憑】${d.monthLabel}分 確定通知`;
+  return opts?.test ? `【テスト送信】${base}` : base;
 }
 
 export type NotifyResult = { ok: true } | { ok: false; error: string };
@@ -147,25 +174,22 @@ export async function sendFinalizeNotification(
   from: string | null,
   to: string | null,
   data: FinalizeNoticeData,
+  opts?: { test?: boolean },
 ): Promise<NotifyResult> {
   if (!binding) return { ok: false, error: "NOTIFY_EMAIL binding not configured" };
   if (!from) return { ok: false, error: "NOTIFY_FROM_ADDRESS not configured" };
   if (!to) return { ok: false, error: "ACCOUNTANT_EMAIL not configured" };
 
-  const subject =
-    data.revision > 1
-      ? `【領収証憑】${data.monthLabel}分 確定通知（改訂${data.revision}）`
-      : `【領収証憑】${data.monthLabel}分 確定通知`;
   try {
     const msg = createMimeMessage();
     msg.setSender({ addr: from });
     msg.setRecipient({ addr: to });
-    msg.setSubject(subject);
+    msg.setSubject(buildFinalizeEmailSubject(data, opts));
     msg.addMessage({
       // mimetext wants exactly "text/plain" / "text/html" (no charset suffix);
       // it encodes the body as UTF-8 and emits charset=utf-8 in the MIME.
       contentType: "text/plain",
-      data: buildFinalizeEmailBody(data),
+      data: buildFinalizeEmailBody(data, opts),
     });
     await binding.send(msg);
     return { ok: true };
@@ -178,16 +202,34 @@ export async function sendFinalizeNotification(
 }
 
 /**
+ * Test-send (POST /api/receipts/notify/test) is an operator action: Clerk
+ * session ONLY. Unlike /extract, a processor key alone is NOT accepted — the Mac
+ * consumer must never be able to trigger a notification. `clerkActor` is the
+ * resolved Clerk actor (null when there's no session, e.g. a processor-key-only
+ * request). Returns the actor, or throws Unauthorized. Pure + unit-testable.
+ */
+export function authorizeNotifyTest(clerkActor: string | null): string {
+  if (!clerkActor) {
+    throw new Error("Unauthorized receipts request.");
+  }
+  return clerkActor;
+}
+
+/**
  * Production wrapper: reads the NOTIFY_EMAIL binding + env vars and sends.
- * Callers (both finalize routes) use this; it never throws.
+ * Callers (both finalize routes) use this; it never throws. The test-send
+ * endpoint passes { test: true } so the subject is prefixed 【テスト送信】 and the
+ * body opens with a test banner.
  */
 export async function notifyAccountantOfFinalize(
   data: FinalizeNoticeData,
+  opts?: { test?: boolean },
 ): Promise<NotifyResult> {
   return sendFinalizeNotification(
     getNotifyEmail(),
     getNotifyFromAddress(),
     getAccountantEmail(),
     data,
+    opts,
   );
 }

--- a/lib/receipts/types.ts
+++ b/lib/receipts/types.ts
@@ -136,6 +136,7 @@ export type AuditAction =
   | "export.downloaded"
   | "export.notification_sent"
   | "export.notification_failed"
+  | "export.notification_test"
   | "archive.created"
   | "settings.updated"
   | "receipt.export_statement_month_assigned"

--- a/tests/receipts/notify.test.ts
+++ b/tests/receipts/notify.test.ts
@@ -1,7 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  authorizeNotifyTest,
   buildFinalizeEmailBody,
+  buildFinalizeEmailSubject,
   sendFinalizeNotification,
   summarizeByCategory,
   type FinalizeNoticeData,
@@ -90,6 +92,49 @@ test("buildFinalizeEmailBody: revision 1 shows 新規 not 差替え", () => {
   const body = buildFinalizeEmailBody({ ...fixtureData, revision: 1 });
   assert.ok(body.includes("改訹: 新規"));
   assert.ok(!body.includes("差替え"));
+});
+
+// ─── Test-send mode (POST /api/receipts/notify/test) ────────────────────────
+
+test("buildFinalizeEmailSubject: test mode prefixes 【テスト送信】", () => {
+  const real = buildFinalizeEmailSubject(fixtureData);
+  const testSubj = buildFinalizeEmailSubject(fixtureData, { test: true });
+  assert.ok(testSubj.startsWith("【テスト送信】"), "test subject is prefixed");
+  assert.ok(testSubj.endsWith(real), "test subject preserves the real subject");
+  // Non-test subject has no test prefix.
+  assert.ok(!real.startsWith("【テスト送信】"));
+});
+
+test("buildFinalizeEmailBody: test mode opens with a test banner line", () => {
+  const body = buildFinalizeEmailBody(fixtureData, { test: true });
+  // First line states this is a channel test, not a close notification.
+  assert.ok(
+    body.startsWith("※これは通知チャネルのテスト送信です。月次確定の通知ではありません。"),
+    "body opens with the test banner",
+  );
+  // The real template body still follows (the point is to exercise the real template).
+  assert.ok(body.includes("【勘定科目別集計】"), "real template body follows the banner");
+  // Non-test body has no banner.
+  assert.ok(
+    !buildFinalizeEmailBody(fixtureData).startsWith("※これは通知チャネル"),
+    "non-test body has no test banner",
+  );
+});
+
+// ─── Test-send auth: Clerk session ONLY (processor-key-only rejected) ───────
+
+test("authorizeNotifyTest: rejects a processor-key-only request (no Clerk session)", () => {
+  // A processor-key-only request has no Clerk session → clerkActor is null.
+  // authorizeNotifyTest throws — the Mac consumer must never trigger a notify.
+  assert.throws(
+    () => authorizeNotifyTest(null),
+    /Unauthorized/,
+    "no Clerk actor → rejected",
+  );
+});
+
+test("authorizeNotifyTest: accepts a Clerk-authenticated operator", () => {
+  assert.equal(authorizeNotifyTest("op@dazbeez.com"), "op@dazbeez.com");
 });
 
 // ─── sendFinalizeNotification (never throws; non-fatal on failure) ──────────

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -18,13 +18,18 @@
     "NEXT_PUBLIC_CLERK_SIGN_UP_URL": "/receipts/sign-in",
     "NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL": "/receipts",
     "NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL": "/receipts",
-    // Finalize notification email (PR 3). Recipient + sender for the Cloudflare
-    // Email Routing send_email binding. The NOTIFY_EMAIL binding's
-    // destination_address MUST match ACCOUNTANT_EMAIL (CF requires the runtime
-    // `to` to be authorized by the binding). NOTIFY_FROM_ADDRESS must be a
-    // verified sender on the dazbeez.com zone. Replace the placeholders before
-    // enabling — see docs/month-close-runbook.md §Notification email.
-    "ACCOUNTANT_EMAIL": "accountant@example.com",
+    // Finalize notification email. Recipient + sender for the Cloudflare Email
+    // Routing send_email binding. The NOTIFY_EMAIL binding's destination_address
+    // MUST match ACCOUNTANT_EMAIL (CF requires the runtime `to` to be authorized
+    // by the binding). NOTIFY_FROM_ADDRESS must be a verified sender on the
+    // dazbeez.com zone. These are committed vars (not secrets) — the recipient
+    // is a role, not a secret.
+    //
+    // Rollout: the var is named ACCOUNTANT_EMAIL (the notification-recipient
+    // ROLE) but for the first rollout it points at the business manager
+    // (admin@dazbeez.com) while the package is signed off. Swap in the
+    // accountant's address later — one value change here + in the binding below.
+    "ACCOUNTANT_EMAIL": "admin@dazbeez.com",
     "NOTIFY_FROM_ADDRESS": "receipts@dazbeez.com"
   },
   // Manual secret setup:
@@ -115,7 +120,7 @@
   "send_email": [
     {
       "name": "NOTIFY_EMAIL",
-      "destination_address": "accountant@example.com"
+      "destination_address": "admin@dazbeez.com"
     }
   ],
   "routes": [


### PR DESCRIPTION
Wires the finalize-email recipient to the business manager for the first rollout and adds a production test-send endpoint to exercise the full send path without finalizing.

## 1. Config (committed vars — NOT secrets)
The recipient is a *role*, not a secret, so it lives in `wrangler.jsonc` (no `wrangler secret put` needed):
- `NOTIFY_EMAIL` binding `destination_address` **and** `ACCOUNTANT_EMAIL` var → **`admin@dazbeez.com`** (placeholder replaced). CF requires the runtime `to` to match the binding's `destination_address`; both set to the same value.
- `NOTIFY_FROM_ADDRESS` stays `receipts@dazbeez.com` (on-zone).
- The var name `ACCOUNTANT_EMAIL` is the notification-recipient *role* — for the first rollout it's the business manager; the accountant's address swaps in later (one value change in both places + re-verify). Noted in the runbook.

## 2. `POST /api/receipts/notify/test` (the reason for this PR)
- **Auth: Clerk session ONLY** — `requireReceiptsActor`, no processor-key path. `authorizeNotifyTest()` makes the Clerk-only policy explicit + unit-testable (the Mac consumer must never trigger a notify).
- Calls `notifyAccountantOfFinalize(data, {test:true})` — reuses the **real template + binding + destination** end to end, but the subject is prefixed **【テスト送信】** and the body opens with a *"this is a channel test, not a close notification"* banner.
- `?month=YYYY-MM` (default = latest finalized); read-only real-data readout. Response passes the notify result through verbatim — `{ok:true}` or `{ok:false,error}` with the **raw Cloudflare rejection text**. Audited as `export.notification_test`.
- Runbook documents the exact `curl` invocation.

## Constraints honored
- No finalize-path / gate / builder / artifact changes; email failure semantics unchanged (result-typed, never throws).
- No deploys, no real sends from tests.

## Tests
`【テスト送信】` subject prefix; test-banner opening line (real template still follows); `authorizeNotifyTest` rejects processor-key-only (no Clerk actor) + accepts a Clerk operator.

`tsc` ✅ `lint` ✅ `npm test` **373 (372 pass, 1 D1-skip)**. Left for review (no merge/deploy, per task constraints).

🤖 Generated with [Claude Code](https://claude.com/claude-code)