### PR TITLE
feat(receipts): Resend notify transport + recipient in Settings

### DIFF
--- a/app/(receipt-system)/receipts/settings/compliance/page.tsx
+++ b/app/(receipt-system)/receipts/settings/compliance/page.tsx
@@ -4,6 +4,8 @@ import {
   ACCOUNTANT_DISCLAIMER_EN,
   ACCOUNTANT_DISCLAIMER_JA,
 } from "@/lib/receipts/settings";
+import { resolveNotificationRecipient } from "@/lib/receipts/notify";
+import { getAccountantEmail } from "@/lib/cloudflare-runtime";
 import { ComplianceSettingsForm } from "@/components/receipts/ComplianceSettingsForm";
 import Link from "next/link";
 
@@ -12,6 +14,10 @@ export const dynamic = "force-dynamic";
 export default async function ComplianceSettingsPage() {
   await assertReceiptsPageAccess();
   const settings = await getComplianceSettings();
+  const effectiveRecipient = resolveNotificationRecipient(
+    settings.notification_recipient,
+    getAccountantEmail(),
+  );
 
   return (
     <div className="space-y-6 px-8 py-8">
@@ -39,7 +45,7 @@ export default async function ComplianceSettingsPage() {
         <p className="mt-2 text-amber-800">{ACCOUNTANT_DISCLAIMER_JA}</p>
       </div>
 
-      <ComplianceSettingsForm initial={settings} />
+      <ComplianceSettingsForm initial={settings} effectiveRecipient={effectiveRecipient} />
     </div>
   );
 }

--- a/app/api/receipts/notify/test/route.ts
+++ b/app/api/receipts/notify/test/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+import { requireReceiptsActor } from "@/lib/receipts/auth";
+import { createAuditEntry } from "@/lib/receipts/audit";
+import { stringifyJson } from "@/lib/receipts/db-utils";
+import { getLatestFinalizedExport, listExports } from "@/lib/receipts/db";
+import { buildExportBundle } from "@/lib/receipts/month-closing";
+import { authorizeNotifyTest, composeFinalizeNoticeData, notifyAccountantOfFinalize } from "@/lib/receipts/notify";
+import { getReceiptsDb } from "@/lib/cloudflare-runtime";
+
+export async function POST(request: Request) {
+  try {
+    let clerkActor: string | null = null;
+    try { clerkActor = await requireReceiptsActor(request.headers); } catch { clerkActor = null; }
+    const actor = authorizeNotifyTest(clerkActor);
+
+    const url = new URL(request.url);
+    let month = url.searchParams.get("month") ?? "";
+    if (!month) {
+      const body = (await request.json().catch(() => ({}))) as { month?: string };
+      month = body.month?.trim() ?? "";
+    }
+    if (!month) {
+      const all = await listExports();
+      const fin = all.filter((e) => e.status === "finalized")
+        .sort((a, b) => (b.finalized_at ?? "").localeCompare(a.finalized_at ?? ""));
+      if (fin.length === 0) return NextResponse.json({ ok: false, error: "No finalized month to test against." }, { status: 404 });
+      month = fin[0]!.export_month;
+    }
+
+    const exportRecord = await getLatestFinalizedExport(month);
+    if (!exportRecord) return NextResponse.json({ ok: false, error: `No finalized export for ${month}.` }, { status: 404 });
+    const bundle = await buildExportBundle(month);
+    const data = composeFinalizeNoticeData(month, bundle, exportRecord);
+    const result = await notifyAccountantOfFinalize(data, { test: true });
+
+    await createAuditEntry(getReceiptsDb(), {
+      actor, action: "export.notification_test", objectType: "export", objectId: exportRecord.id,
+      newValueJson: stringifyJson(result.ok ? { month, ok: true } : { month, ok: false, error: result.error }),
+    });
+    return NextResponse.json(result, { status: 200 });
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Unauthorized")) return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+    console.error("[api/receipts/notify/test] POST failed", error);
+    return NextResponse.json({ error: error instanceof Error ? error.message : "Test send failed." }, { status: 500 });
+  }
+}

--- a/app/api/receipts/settings/compliance/route.ts
+++ b/app/api/receipts/settings/compliance/route.ts
@@ -5,14 +5,28 @@ import {
   updateComplianceSettings,
 } from "@/lib/receipts/settings";
 import { createAuditEntry } from "@/lib/receipts/audit";
-import { getReceiptsDb } from "@/lib/cloudflare-runtime";
+import { resolveNotificationRecipient } from "@/lib/receipts/notify";
+import { getAccountantEmail, getReceiptsDb } from "@/lib/cloudflare-runtime";
 import type { ComplianceSettings } from "@/lib/receipts/types";
+
+// Effective notification recipient: the stored Settings value if set, else the
+// ACCOUNTANT_EMAIL fallback, else null. Surfaced on GET/PATCH so the form can
+// show what finalize will actually use without guessing client-side.
+function resolveEffectiveRecipient(settings: ComplianceSettings) {
+  return resolveNotificationRecipient(
+    settings.notification_recipient,
+    getAccountantEmail(),
+  );
+}
 
 export async function GET(request: Request) {
   try {
     await requireReceiptsActor(request.headers);
     const settings = await getComplianceSettings();
-    return NextResponse.json({ settings }, { status: 200 });
+    return NextResponse.json(
+      { settings, effectiveRecipient: resolveEffectiveRecipient(settings) },
+      { status: 200 },
+    );
   } catch (error) {
     if (error instanceof Error && error.message.startsWith("Unauthorized")) {
       return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
@@ -89,7 +103,10 @@ export async function PATCH(request: Request) {
       });
     }
 
-    return NextResponse.json({ settings }, { status: 200 });
+    return NextResponse.json(
+      { settings, effectiveRecipient: resolveEffectiveRecipient(settings) },
+      { status: 200 },
+    );
   } catch (error) {
     if (error instanceof Error && error.message.startsWith("Unauthorized")) {
       return NextResponse.json({ error: "Unauthorized." }, { status: 401 });

--- a/app/api/receipts/settings/compliance/route.ts
+++ b/app/api/receipts/settings/compliance/route.ts
@@ -53,6 +53,18 @@ export async function PATCH(request: Request) {
       );
     }
 
+    if (
+      body.notification_recipient !== undefined &&
+      body.notification_recipient !== "" &&
+      !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(body.notification_recipient)
+    ) {
+      return NextResponse.json(
+        { error: "notification_recipient must be a valid email address." },
+        { status: 400 },
+      );
+    }
+
+    const before = await getComplianceSettings();
     const settings = await updateComplianceSettings(body, actor);
 
     await createAuditEntry(getReceiptsDb(), {
@@ -62,6 +74,20 @@ export async function PATCH(request: Request) {
       objectId: "global",
       newValueJson: JSON.stringify(body),
     });
+
+    if (
+      body.notification_recipient !== undefined &&
+      body.notification_recipient !== before.notification_recipient
+    ) {
+      await createAuditEntry(getReceiptsDb(), {
+        actor,
+        action: "settings.notification_recipient_changed",
+        objectType: "compliance_settings",
+        objectId: "global",
+        oldValueJson: JSON.stringify({ notification_recipient: before.notification_recipient }),
+        newValueJson: JSON.stringify({ notification_recipient: body.notification_recipient }),
+      });
+    }
 
     return NextResponse.json({ settings }, { status: 200 });
   } catch (error) {

--- a/cloudflare-env.d.ts
+++ b/cloudflare-env.d.ts
@@ -16,8 +16,6 @@ declare namespace Cloudflare {
 		ASSETS: Fetcher;
 		NEXTJS_ENV: string;
 		WORKER_SELF_REFERENCE: Service<typeof import("./.open-next/worker").default>;
-		// PR 3: finalize notification email (Cloudflare Email Routing).
-		NOTIFY_EMAIL: SendEmail;
 		ACCOUNTANT_EMAIL: string;
 		NOTIFY_FROM_ADDRESS: string;
 	}

--- a/components/receipts/ComplianceSettingsForm.tsx
+++ b/components/receipts/ComplianceSettingsForm.tsx
@@ -3,7 +3,19 @@
 import { useState, useTransition } from "react";
 import type { ComplianceSettings } from "@/lib/receipts/types";
 
-type Props = { initial: ComplianceSettings };
+/** Mirrors resolveNotificationRecipient's return (lib/receipts/notify.ts).
+ *  Defined locally to avoid pulling server-only imports into the client bundle. */
+type EffectiveRecipient = {
+  email: string | null;
+  source: "settings" | "fallback" | null;
+};
+
+type TestResult = { ok: true } | { ok: false; error: string };
+
+type Props = {
+  initial: ComplianceSettings;
+  effectiveRecipient: EffectiveRecipient;
+};
 
 const LABELS: Record<keyof ComplianceSettings, string> = {
   business_name: "Business name (事業者名)",
@@ -19,11 +31,22 @@ const LABELS: Record<keyof ComplianceSettings, string> = {
   notification_recipient: "通知先 (Notification recipient)",
 };
 
-export function ComplianceSettingsForm({ initial }: Props) {
+export function ComplianceSettingsForm({
+  initial,
+  effectiveRecipient,
+}: Props) {
   const [settings, setSettings] = useState<ComplianceSettings>(initial);
   const [savedAt, setSavedAt] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
+  const [effective, setEffective] = useState<EffectiveRecipient>(effectiveRecipient);
+  const [persistedRecipient, setPersistedRecipient] = useState(
+    initial.notification_recipient,
+  );
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<TestResult | null>(null);
+
+  const recipientDirty = settings.notification_recipient !== persistedRecipient;
 
   function update<K extends keyof ComplianceSettings>(
     key: K,
@@ -45,10 +68,45 @@ export function ComplianceSettingsForm({ initial }: Props) {
         setError(data.error ?? `Save failed (${res.status}).`);
         return;
       }
-      const data = (await res.json()) as { settings: ComplianceSettings };
+      const data = (await res.json()) as {
+        settings: ComplianceSettings;
+        effectiveRecipient: EffectiveRecipient;
+      };
       setSettings(data.settings);
+      setEffective(data.effectiveRecipient);
+      setPersistedRecipient(data.settings.notification_recipient);
       setSavedAt(new Date().toLocaleTimeString());
     });
+  }
+
+  // Exercises the full Resend path (compose + send) against the PERSISTED
+  // recipient without finalizing. Disabled while the field is dirty so the test
+  // always reflects saved config — the endpoint reads Settings, not this input.
+  async function sendTest() {
+    setTestResult(null);
+    setTesting(true);
+    try {
+      const res = await fetch("/api/receipts/notify/test", { method: "POST" });
+      const data = (await res.json().catch(() => ({}))) as {
+        ok?: boolean;
+        error?: string;
+      };
+      if (data.ok === true) {
+        setTestResult({ ok: true });
+      } else {
+        setTestResult({
+          ok: false,
+          error: data.error ?? `テスト送信に失敗しました (HTTP ${res.status})。`,
+        });
+      }
+    } catch (err) {
+      setTestResult({
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setTesting(false);
+    }
   }
 
   return (
@@ -179,6 +237,51 @@ export function ComplianceSettingsForm({ initial }: Props) {
         />
       </Row>
 
+      <Row
+        label={LABELS.notification_recipient}
+        hint="月次確定通知の送信先。空欄なら ACCOUNTANT_EMAIL フォールバックを使用します。"
+      >
+        <div className="flex w-full flex-col gap-2 sm:w-80">
+          <div className="flex gap-2">
+            <input
+              type="email"
+              value={settings.notification_recipient}
+              onChange={(e) => update("notification_recipient", e.target.value)}
+              className="min-w-0 flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm"
+              maxLength={160}
+              placeholder="accountant@example.com"
+            />
+            <button
+              type="button"
+              onClick={sendTest}
+              disabled={pending || testing || recipientDirty}
+              className="shrink-0 rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
+              title={
+                recipientDirty
+                  ? "まず Save してください（テスト送信は保存済み設定を使用します）"
+                  : undefined
+              }
+            >
+              {testing ? "送信中…" : "テスト送信"}
+            </button>
+          </div>
+
+          <EffectiveRecipientLine effective={effective} />
+
+          {testResult ? (
+            <p
+              className={`text-xs ${
+                testResult.ok ? "text-green-700" : "text-red-600"
+              }`}
+            >
+              {testResult.ok
+                ? "テスト送信: 成功 — 送信先の受信トレイを確認してください。"
+                : `テスト送信: 失敗 — ${testResult.error}`}
+            </p>
+          ) : null}
+        </div>
+      </Row>
+
       <div className="flex items-center justify-between border-t border-gray-100 pt-4">
         <div className="text-xs text-gray-500">
           {error ? (
@@ -244,5 +347,37 @@ function Toggle({
         }`}
       />
     </button>
+  );
+}
+
+function EffectiveRecipientLine({
+  effective,
+}: {
+  effective: EffectiveRecipient;
+}) {
+  if (effective.source === "settings") {
+    return (
+      <p className="text-xs text-gray-600">
+        有効な送信先:{" "}
+        <span className="font-medium text-gray-900">{effective.email}</span>{" "}
+        <span className="text-gray-400">（Settings で設定）</span>
+      </p>
+    );
+  }
+  if (effective.source === "fallback") {
+    return (
+      <p className="text-xs text-gray-600">
+        有効な送信先:{" "}
+        <span className="font-medium text-gray-900">{effective.email}</span>{" "}
+        <span className="text-gray-400">
+          （フォールバック: ACCOUNTANT_EMAIL）
+        </span>
+      </p>
+    );
+  }
+  return (
+    <p className="text-xs text-amber-700">
+      送信先が未設定 — 確定通知は送信されません（{`{ok: false}`}）。
+    </p>
   );
 }

--- a/components/receipts/ComplianceSettingsForm.tsx
+++ b/components/receipts/ComplianceSettingsForm.tsx
@@ -16,6 +16,7 @@ const LABELS: Record<keyof ComplianceSettings, string> = {
   paper_original_discard_policy: "Paper original discard policy",
   statement_expected_day: "AMEX statement expected day",
   track_tax_breakdown: "Track tax rate / amount breakdown",
+  notification_recipient: "通知先 (Notification recipient)",
 };
 
 export function ComplianceSettingsForm({ initial }: Props) {

--- a/docs/month-close-runbook.md
+++ b/docs/month-close-runbook.md
@@ -118,33 +118,48 @@ missing-receipt reasons) and sign off the reconciliation before finalizing.
 
 Finalizing a month sends the accountant a Japanese email (month label, revision,
 row/receipt counts, per-category totals, the full transition notice, and the
-download link) via Cloudflare Email Routing — no third-party vendor. **Email
-failure never fails finalize**: if the send is rejected, finalize still returns
-200, the failure surfaces as a warning in the response, and an
-`export.notification_failed` audit entry is written (`export.notification_sent`
-on success).
+download link) via the **Resend** REST API (`POST api.resend.com/emails`) — the
+same transport as the contact form. **Email failure never fails finalize**: if
+the send is rejected, finalize still returns 200, the failure surfaces as a
+warning in the response, and an `export.notification_failed` audit entry is
+written (`export.notification_sent` on success).
+
+**Recipient resolution** (`resolveNotificationRecipient`): the
+`notification_recipient` set in **Settings → Compliance** wins; if empty, the
+`ACCOUNTANT_EMAIL` var is the fallback; if both are unset the send returns
+`{ok:false}` and finalize records the failure. The compliance form shows the
+resolved address and its source ("settings" vs "fallback") so you can see what
+finalize will actually use.
 
 ### Ops prerequisites (one-time)
 
-Email Routing sends are **rejected by Cloudflare** until these are in place:
+Resend rejects sends until the domain + key + recipient are configured:
 
-1. **Email Routing enabled** on the `dazbeez.com` zone (Cloudflare dashboard →
-   Email → Email Routing).
-2. **Destination address verified** — the accountant's address must be verified
-   as a destination (Email Routing sends a one-time confirmation email to it).
-3. **`ACCOUNTANT_EMAIL` var** set to the verified accountant address (in
-   `wrangler.jsonc` vars). This is the runtime `to`.
-4. **`NOTIFY_EMAIL` binding `destination_address`** in `wrangler.jsonc` set to
-   the **same** address — Cloudflare requires the runtime `to` to be authorized
-   by the binding. These two must match; if they diverge the send is rejected
-   (caught + audited, finalize unaffected).
-5. **`NOTIFY_FROM_ADDRESS` var** set to a sender on the `dazbeez.com` zone (e.g.
-   `receipts@dazbeez.com`) — the from address must be on the zone.
+1. **Verify `dazbeez.com` in Resend** (Resend dashboard → Domains → Add). Resend
+   publishes the SPF/DKIM/DMARC DNS records on the zone; wait for the domain to
+   reach **Verified** before sending.
+2. **`RESEND_API_KEY`** set as a wrangler secret — `npx wrangler secret put
+   RESEND_API_KEY`. This key is **shared with the contact form** (CRM email
+   sender, `lib/crm-email-sender.ts`); one secret serves both paths.
+3. **`NOTIFY_FROM_ADDRESS` var** (in `wrangler.jsonc`) = a sender on the verified
+   domain (`receipts@dazbeez.com`) — the `from` address. Unverified senders are
+   rejected by Resend.
+4. **`ACCOUNTANT_EMAIL` var** (in `wrangler.jsonc`) = the fallback recipient
+   when nothing is set in Settings. For the first rollout it's the business
+   manager (`admin@dazbeez.com`); swap in the accountant's address later.
+5. **Set the recipient** in **Settings → Compliance → 通知先**, or leave it blank
+   to use the `ACCOUNTANT_EMAIL` fallback.
+6. **テスト送信** to confirm the channel end-to-end: Settings → Compliance →
+   テスト送信, or `POST /api/receipts/notify/test[?month=YYYY-MM]`. It composes
+   + sends a 【テスト送信】-prefixed email to the effective recipient without
+   finalizing — it picks the latest finalized month automatically, or targets a
+   specific one via `?month=`. Requires Clerk auth.
 
-If any are unset/unverified, every finalize records `export.notification_failed`
-with the rejection reason. The bundle still seals; resend manually after fixing
-the config (there is no auto-retry — re-finalize is impossible without a
-revision, so treat the warning as "the email didn't go out, send it by hand").
+If the key / from / recipient are unset, every finalize records
+`export.notification_failed` with the rejection reason. The bundle still seals;
+resend manually after fixing the config (there is no auto-retry — re-finalize is
+impossible without a revision, so treat the warning as "the email didn't go out,
+send it by hand").
 
 ## Proofs bundle (証憑ZIP)
 

--- a/lib/cloudflare-runtime.ts
+++ b/lib/cloudflare-runtime.ts
@@ -69,11 +69,12 @@ export function getReceiptsProcessorKey(): string | null {
 }
 
 /**
- * Finalize notification email (PR 3, Cloudflare Email Routing send_email). Each
- * returns null when unconfigured so the notify helper can fail gracefully (email
- * failure must never fail finalize). The NOTIFY_EMAIL binding's
- * destination_address must equal ACCOUNTANT_EMAIL; NOTIFY_FROM_ADDRESS must be a
- * verified sender on the zone. See docs/month-close-runbook.md.
+ * Finalize notification email (Resend REST transport). Each returns null when
+ * unconfigured so the notify helper can fail gracefully (email failure must
+ * never fail finalize): RESEND_API_KEY is the API credential (shared with the
+ * contact form); NOTIFY_FROM_ADDRESS must be a sender on the Resend-verified
+ * domain; ACCOUNTANT_EMAIL is the fallback recipient when none is set in
+ * Settings → Compliance. See docs/month-close-runbook.md §Notification email.
  */
 export function getResendApiKeyOrNull(): string | null {
   const env = getCloudflareEnv() as CloudflareEnv & { RESEND_API_KEY?: string };

--- a/lib/cloudflare-runtime.ts
+++ b/lib/cloudflare-runtime.ts
@@ -75,9 +75,9 @@ export function getReceiptsProcessorKey(): string | null {
  * destination_address must equal ACCOUNTANT_EMAIL; NOTIFY_FROM_ADDRESS must be a
  * verified sender on the zone. See docs/month-close-runbook.md.
  */
-export function getNotifyEmail(): SendEmail | null {
-  const env = getCloudflareEnv() as CloudflareEnv & { NOTIFY_EMAIL?: SendEmail };
-  return env.NOTIFY_EMAIL ?? null;
+export function getResendApiKeyOrNull(): string | null {
+  const env = getCloudflareEnv() as CloudflareEnv & { RESEND_API_KEY?: string };
+  return env.RESEND_API_KEY ?? null;
 }
 
 export function getAccountantEmail(): string | null {

--- a/lib/receipts/notify.ts
+++ b/lib/receipts/notify.ts
@@ -1,35 +1,30 @@
-// Finalize notification email (PR 3).
+// Finalize notification email.
 //
-// On successful finalize, email the accountant a Japanese summary: month,
-// revision, row/receipt counts, per-category totals, the full transition-notice
-// text (shared with the proofs ZIP), and download instructions. Sent via the
-// Cloudflare Email Routing `send_email` binding (NOTIFY_EMAIL) — no third-party
-// vendor. MIME built with `mimetext` (Workers-safe).
+// On successful finalize, email the notification recipient a Japanese summary
+// (month, revision, counts, per-category totals, transition notice, download
+// link). Transport: Resend REST API (POST api.resend.com/emails) — replaces the
+// former Cloudflare Email Routing send_email binding.
+//
+// Recipient resolution: Settings → Compliance (notification_recipient) →
+// ACCOUNTANT_EMAIL var fallback → unconfigured {ok:false}.
 //
 // HARD RULE: email failure must never fail finalize. sendFinalizeNotification
 // never throws — it returns {ok, error?}; callers fold the result into the
 // finalize response warnings + an audit entry (notification_sent /
 // notification_failed), and finalize returns 200 regardless.
 
-import { createMimeMessage } from "mimetext";
 import {
   getAccountantEmail,
-  getNotifyEmail,
   getNotifyFromAddress,
+  getResendApiKeyOrNull,
 } from "@/lib/cloudflare-runtime";
+import { getComplianceSettings } from "@/lib/receipts/settings";
 import {
   buildTransitionNotice,
   deriveTransitionNoticeInput,
 } from "@/lib/receipts/proofs";
 import type { ExportBundle } from "@/lib/receipts/month-closing";
 import type { ExportRow, ReceiptExport } from "@/lib/receipts/types";
-
-/** Minimal send_email binding shape (injectable for tests). Returns
- *  Promise<unknown> so the real SendEmail binding (whose send returns
- *  Promise<EmailSendResult>) is assignable. */
-export interface EmailSender {
-  send(message: unknown): Promise<unknown>;
-}
 
 export interface CategoryTotal {
   code: string;
@@ -38,18 +33,11 @@ export interface CategoryTotal {
   totalMinor: number;
 }
 
-/** Per-expense-category count + total. Mirrors buildExportSummaryCsv's grouping
- *  so the email's totals match the summary CSV the accountant also receives. */
 export function summarizeByCategory(rows: ExportRow[]): CategoryTotal[] {
   const map = new Map<string, CategoryTotal>();
   for (const row of rows) {
     const code = row.expenseCategoryCode ?? "uncategorized";
-    const cat = map.get(code) ?? {
-      code,
-      ja: row.expenseCategoryJa ?? code,
-      count: 0,
-      totalMinor: 0,
-    };
+    const cat = map.get(code) ?? { code, ja: row.expenseCategoryJa ?? code, count: 0, totalMinor: 0 };
     cat.count += 1;
     cat.totalMinor += row.amountMinor ?? 0;
     map.set(code, cat);
@@ -58,33 +46,27 @@ export function summarizeByCategory(rows: ExportRow[]): CategoryTotal[] {
 }
 
 export interface FinalizeNoticeData {
-  month: string; // 2026-06
-  monthLabel: string; // 2026年6月
+  month: string;
+  monthLabel: string;
   exportId: string;
   revision: number;
   rowCount: number;
-  receiptCount: number; // distinct receipts in the bundle
+  receiptCount: number;
   categoryTotals: CategoryTotal[];
-  noticeText: string; // the transition notice (お知らせ.txt content)
+  noticeText: string;
 }
 
-/** Assemble the email payload from a finalized month's bundle. Pure. */
 export function composeFinalizeNoticeData(
   month: string,
   bundle: ExportBundle,
-  exportRecord: Pick<
-    ReceiptExport,
-    "id" | "export_revision" | "supersedes_export_id" | "correction_reason"
-  >,
+  exportRecord: Pick<ReceiptExport, "id" | "export_revision" | "supersedes_export_id" | "correction_reason">,
 ): FinalizeNoticeData {
   const distinctReceiptIds = new Set<string>();
   for (const row of bundle.rows) {
     if (row.receiptId) distinctReceiptIds.add(row.receiptId);
   }
   const noticeInput = deriveTransitionNoticeInput(
-    month,
-    bundle.rows,
-    bundle.receipts,
+    month, bundle.rows, bundle.receipts,
     { rowCount: bundle.rows.length, receiptCount: distinctReceiptIds.size },
     {
       exportRevision: exportRecord.export_revision ?? 1,
@@ -93,11 +75,8 @@ export function composeFinalizeNoticeData(
     },
   );
   return {
-    month,
-    monthLabel: noticeInput.monthLabel,
-    exportId: exportRecord.id,
-    revision: noticeInput.exportRevision,
-    rowCount: bundle.rows.length,
+    month, monthLabel: noticeInput.monthLabel, exportId: exportRecord.id,
+    revision: noticeInput.exportRevision, rowCount: bundle.rows.length,
     receiptCount: distinctReceiptIds.size,
     categoryTotals: summarizeByCategory(bundle.rows),
     noticeText: buildTransitionNotice(noticeInput),
@@ -108,8 +87,7 @@ function formatYen(minor: number): string {
   return `¥${minor.toLocaleString("ja-JP")}`;
 }
 
-/** Build the Japanese email body. Pure + snapshot-tested. */
-export function buildFinalizeEmailBody(d: FinalizeNoticeData): string {
+export function buildFinalizeEmailBody(d: FinalizeNoticeData, opts?: { test?: boolean }): string {
   const lines: string[] = [];
   lines.push("毎月の領収証憑一式の確定（ファイナライズ）が完了しましたのでお知らせします。");
   lines.push("");
@@ -119,9 +97,7 @@ export function buildFinalizeEmailBody(d: FinalizeNoticeData): string {
   lines.push(`証憑ファイル数: ${d.receiptCount}`);
   lines.push("");
   lines.push("【勘定科目別集計】");
-  for (const c of d.categoryTotals) {
-    lines.push(`・${c.ja}: ${c.count}件 / ${formatYen(c.totalMinor)}`);
-  }
+  for (const c of d.categoryTotals) lines.push(`・${c.ja}: ${c.count}件 / ${formatYen(c.totalMinor)}`);
   lines.push("");
   lines.push("【変更点・留意事項のお知らせ】");
   lines.push(d.noticeText);
@@ -131,63 +107,100 @@ export function buildFinalizeEmailBody(d: FinalizeNoticeData): string {
   lines.push(`https://dazbeez.com/receipts/export?month=${d.month}`);
   lines.push("");
   lines.push("本メールは自動送信されています。ご不明な点があれば別途ご連絡ください。");
-  return lines.join("\r\n");
+  const body = lines.join("\r\n");
+  if (opts?.test) {
+    return "※これは通知チャネルのテスト送信です。月次確定の通知ではありません。\r\n\r\n" + body;
+  }
+  return body;
+}
+
+export function buildFinalizeEmailSubject(d: FinalizeNoticeData, opts?: { test?: boolean }): string {
+  const base = d.revision > 1
+    ? `【領収証憑】${d.monthLabel}分 確定通知（改訂${d.revision}）`
+    : `【領収証憑】${d.monthLabel}分 確定通知`;
+  return opts?.test ? `【テスト送信】${base}` : base;
+}
+
+/** Minimal HTML wrapper around the text body. Escapes + preserves line breaks
+ *  via white-space:pre-wrap. No template framework. */
+export function buildFinalizeEmailHtml(d: FinalizeNoticeData, opts?: { test?: boolean }): string {
+  const escaped = buildFinalizeEmailBody(d, opts)
+    .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  return `<!DOCTYPE html><html><body><div style="white-space:pre-wrap;font-family:sans-serif;font-size:14px;line-height:1.6;color:#1a1a1a">${escaped}</div></body></html>`;
 }
 
 export type NotifyResult = { ok: true } | { ok: false; error: string };
 
-/**
- * Send the finalize notification. NEVER throws — returns a result the caller
- * folds into finalize warnings + audit. The binding/from/to are injected so this
- * is unit-testable (pass a fake sender that resolves, or one that rejects, to
- * prove finalize survives a send failure).
- */
-export async function sendFinalizeNotification(
-  binding: EmailSender | null,
-  from: string | null,
-  to: string | null,
-  data: FinalizeNoticeData,
-): Promise<NotifyResult> {
-  if (!binding) return { ok: false, error: "NOTIFY_EMAIL binding not configured" };
-  if (!from) return { ok: false, error: "NOTIFY_FROM_ADDRESS not configured" };
-  if (!to) return { ok: false, error: "ACCOUNTANT_EMAIL not configured" };
+// ─── Resend transport (isolated, mockable seam) ─────────────────────────────
 
-  const subject =
-    data.revision > 1
-      ? `【領収証憑】${data.monthLabel}分 確定通知（改訂${data.revision}）`
-      : `【領収証憑】${data.monthLabel}分 確定通知`;
+export async function sendViaResend(
+  fetchImpl: typeof fetch,
+  apiKey: string,
+  from: string,
+  to: string,
+  subject: string,
+  text: string,
+  html: string,
+): Promise<NotifyResult> {
   try {
-    const msg = createMimeMessage();
-    msg.setSender({ addr: from });
-    msg.setRecipient({ addr: to });
-    msg.setSubject(subject);
-    msg.addMessage({
-      // mimetext wants exactly "text/plain" / "text/html" (no charset suffix);
-      // it encodes the body as UTF-8 and emits charset=utf-8 in the MIME.
-      contentType: "text/plain",
-      data: buildFinalizeEmailBody(data),
+    const res = await fetchImpl("https://api.resend.com/emails", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ from, to: [to], subject, text, html }),
     });
-    await binding.send(msg);
+    if (!res.ok) {
+      const errBody = (await res.json().catch(() => ({}))) as { message?: unknown };
+      const message = typeof errBody.message === "string" ? errBody.message : `Resend API returned ${res.status}`;
+      return { ok: false, error: message };
+    }
     return { ok: true };
   } catch (err) {
-    return {
-      ok: false,
-      error: err instanceof Error ? err.message : String(err),
-    };
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
   }
 }
 
-/**
- * Production wrapper: reads the NOTIFY_EMAIL binding + env vars and sends.
- * Callers (both finalize routes) use this; it never throws.
- */
+export async function sendFinalizeNotification(
+  apiKey: string | null,
+  from: string | null,
+  to: string | null,
+  data: FinalizeNoticeData,
+  opts?: { test?: boolean },
+  fetchImpl: typeof fetch = fetch,
+): Promise<NotifyResult> {
+  if (!apiKey) return { ok: false, error: "RESEND_API_KEY not configured" };
+  if (!from) return { ok: false, error: "NOTIFY_FROM_ADDRESS not configured" };
+  if (!to) return { ok: false, error: "Notification recipient not configured (set it in Settings → Compliance)" };
+  return sendViaResend(
+    fetchImpl, apiKey, from, to,
+    buildFinalizeEmailSubject(data, opts),
+    buildFinalizeEmailBody(data, opts),
+    buildFinalizeEmailHtml(data, opts),
+  );
+}
+
+export function authorizeNotifyTest(clerkActor: string | null): string {
+  if (!clerkActor) throw new Error("Unauthorized receipts request.");
+  return clerkActor;
+}
+
+// ─── Recipient resolution (settings → var fallback → null) ──────────────────
+
+export function resolveNotificationRecipient(
+  settingsValue: string | null | undefined,
+  fallback: string | null,
+): { email: string | null; source: "settings" | "fallback" | null } {
+  if (settingsValue) return { email: settingsValue, source: "settings" };
+  if (fallback) return { email: fallback, source: "fallback" };
+  return { email: null, source: null };
+}
+
 export async function notifyAccountantOfFinalize(
   data: FinalizeNoticeData,
+  opts?: { test?: boolean },
 ): Promise<NotifyResult> {
+  const settings = await getComplianceSettings();
+  const resolved = resolveNotificationRecipient(settings.notification_recipient, getAccountantEmail());
   return sendFinalizeNotification(
-    getNotifyEmail(),
-    getNotifyFromAddress(),
-    getAccountantEmail(),
-    data,
+    getResendApiKeyOrNull(), getNotifyFromAddress(), resolved.email, data, opts,
   );
 }

--- a/lib/receipts/settings.ts
+++ b/lib/receipts/settings.ts
@@ -17,6 +17,7 @@ export const COMPLIANCE_DEFAULTS: ComplianceSettings = {
   paper_original_discard_policy: "retain_until_accountant_confirms",
   statement_expected_day: 18,
   track_tax_breakdown: false,
+  notification_recipient: "",
 };
 
 const INVOICE_MODES: ReadonlySet<InvoiceNumberRequirementMode> = new Set([
@@ -83,6 +84,9 @@ export function parseComplianceSettings(
       map.get("track_tax_breakdown"),
       COMPLIANCE_DEFAULTS.track_tax_breakdown,
     ),
+    notification_recipient:
+      map.get("notification_recipient") ??
+      COMPLIANCE_DEFAULTS.notification_recipient,
   };
 }
 

--- a/lib/receipts/types.ts
+++ b/lib/receipts/types.ts
@@ -136,8 +136,10 @@ export type AuditAction =
   | "export.downloaded"
   | "export.notification_sent"
   | "export.notification_failed"
+  | "export.notification_test"
   | "archive.created"
   | "settings.updated"
+  | "settings.notification_recipient_changed"
   | "receipt.export_statement_month_assigned"
   | "receipt.export_statement_month_overridden"
   | "receipt.export_statement_month_rolled_forward"
@@ -491,6 +493,9 @@ export interface ComplianceSettings {
   // only; the breakdown is auxiliary, not nagged for by default. Flip to true
   // to re-enable the missing_tax_rate / missing_tax_amount warnings.
   track_tax_breakdown: boolean;
+  /** Notification recipient email (Settings → Compliance). Empty = use the
+   *  ACCOUNTANT_EMAIL var fallback. */
+  notification_recipient: string;
 }
 
 export interface AmexReconciliation {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@reactflow/minimap": "^11.7.14",
         "fflate": "^0.8.3",
         "framer-motion": "^12.38.0",
-        "mimetext": "^3.0.28",
         "next": "^16.2.3",
         "react": "19.2.4",
         "react-dom": "19.2.4",
@@ -1573,27 +1572,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
-      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/runtime-corejs3": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.7.tgz",
-      "integrity": "sha512-ppj9ouYku+RX0ljtgZd+KMO5mkM2bCqg8H2PYAFWnLsHEIKIdRojqbJ2i3eVHrisuxy7nOFCmngTDdWtUCdXUQ==",
-      "license": "MIT",
-      "dependencies": {
-        "core-js-pure": "^3.48.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -6393,17 +6371,6 @@
         "node": ">=6.6.0"
       }
     },
-    "node_modules/core-js-pure": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.49.0.tgz",
-      "integrity": "sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -8987,12 +8954,6 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
-    "node_modules/js-base64": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.9.0.tgz",
-      "integrity": "sha512-dTIdlnQjYWoP6+8AMcQp72c0IWd5tfuQYT9WCRwmekv2C0OucjLF3lrDr09c44KA6M8Ol40DFp5hhSUbC7LkyQ==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/js-cookie": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.7.tgz",
@@ -9551,43 +9512,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/mimetext": {
-      "version": "3.0.28",
-      "resolved": "https://registry.npmjs.org/mimetext/-/mimetext-3.0.28.tgz",
-      "integrity": "sha512-eQXpbNrtxLCjUtiVbR/qR09dbPgZ2o+KR1uA7QKqGhbn8QV7HIL16mXXsobBL4/8TqoYh1us31kfz+dNfCev9g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.26.0",
-        "@babel/runtime-corejs3": "^7.26.0",
-        "js-base64": "^3.7.7",
-        "mime-types": "^2.1.35"
-      },
-      "funding": {
-        "type": "patreon",
-        "url": "https://patreon.com/muratgozel"
-      }
-    },
-    "node_modules/mimetext/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mimetext/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-fn": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "@reactflow/minimap": "^11.7.14",
     "fflate": "^0.8.3",
     "framer-motion": "^12.38.0",
-    "mimetext": "^3.0.28",
     "next": "^16.2.3",
     "react": "19.2.4",
     "react-dom": "19.2.4",

--- a/tests/receipts/notify.test.ts
+++ b/tests/receipts/notify.test.ts
@@ -1,120 +1,132 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  authorizeNotifyTest,
   buildFinalizeEmailBody,
+  buildFinalizeEmailSubject,
+  resolveNotificationRecipient,
   sendFinalizeNotification,
+  sendViaResend,
   summarizeByCategory,
   type FinalizeNoticeData,
-  type EmailSender,
 } from "@/lib/receipts/notify";
 import type { ExportRow } from "@/lib/receipts/types";
 
-// ─── summarizeByCategory ────────────────────────────────────────────────────
-
 function row(over: Partial<ExportRow>): ExportRow {
   return {
-    rowType: "amex_line",
-    lineId: "l",
-    matchStatus: null,
-    receiptStatus: null,
-    missingReceiptReason: null,
-    cardholderName: null,
-    businessTripStatus: null,
-    receiptId: "r",
-    status: "reviewed",
-    originalR2Key: null,
-    transactionDate: "2026-06-01",
-    merchant: "M",
-    amountMinor: 1000,
-    currency: "JPY",
-    expenseType: "UNKNOWN",
-    expenseCategoryCode: "communications",
-    expenseCategoryJa: "通信費",
-    expenseCategoryEn: "Communications",
-    paymentPath: "AMEX",
-    businessPurpose: null,
-    attendees: [],
-    invoiceRegistrationNumber: null,
-    qualifiedInvoiceStatus: null,
-    taxRate: null,
-    taxAmountMinor: null,
-    sourceType: null,
-    counterpartyName: null,
+    rowType: "amex_line", lineId: "l", matchStatus: null, receiptStatus: null,
+    missingReceiptReason: null, cardholderName: null, businessTripStatus: null,
+    receiptId: "r", status: "reviewed", originalR2Key: null,
+    transactionDate: "2026-06-01", merchant: "M", amountMinor: 1000,
+    currency: "JPY", expenseType: "UNKNOWN", expenseCategoryCode: "communications",
+    expenseCategoryJa: "通信費", expenseCategoryEn: "Communications",
+    paymentPath: "AMEX", businessPurpose: null, attendees: [],
+    invoiceRegistrationNumber: null, qualifiedInvoiceStatus: null,
+    taxRate: null, taxAmountMinor: null, sourceType: null, counterpartyName: null,
     ...over,
   };
 }
 
+const fixtureData: FinalizeNoticeData = {
+  month: "2026-06", monthLabel: "2026年6月", exportId: "exp-test", revision: 2,
+  rowCount: 43, receiptCount: 40,
+  categoryTotals: [
+    { code: "rd", ja: "研究開発費", count: 5, totalMinor: 150000 },
+    { code: "travel", ja: "旅費交通費", count: 8, totalMinor: 42000 },
+  ],
+  noticeText: "【お知らせ】これは架空の通知本文です。",
+};
+
+// ─── summarizeByCategory ────────────────────────────────────────────────────
 test("summarizeByCategory: groups by code, sums totals, sorts desc", () => {
   const totals = summarizeByCategory([
     row({ expenseCategoryCode: "rd", expenseCategoryJa: "研究開発費", amountMinor: 10000 }),
     row({ expenseCategoryCode: "rd", expenseCategoryJa: "研究開発費", amountMinor: 5000 }),
     row({ expenseCategoryCode: "travel", expenseCategoryJa: "旅費交通費", amountMinor: 2000 }),
-    row({ expenseCategoryCode: null, expenseCategoryJa: null, amountMinor: 999 }),
   ]);
-  assert.equal(totals.length, 3);
-  assert.equal(totals[0]!.code, "rd", "highest total first");
-  assert.equal(totals[0]!.count, 2);
+  assert.equal(totals.length, 2);
+  assert.equal(totals[0]!.code, "rd");
   assert.equal(totals[0]!.totalMinor, 15000);
-  assert.equal(totals[2]!.code, "uncategorized");
 });
 
-// ─── buildFinalizeEmailBody (snapshot) ──────────────────────────────────────
-
-const fixtureData: FinalizeNoticeData = {
-  month: "2026-06",
-  monthLabel: "2026年6月",
-  exportId: "exp-test",
-  revision: 2,
-  rowCount: 43,
-  receiptCount: 40,
-  categoryTotals: [
-    { code: "rd", ja: "研究開発費", count: 5, totalMinor: 150000 },
-    { code: "travel", ja: "旅費交通費", count: 8, totalMinor: 42000 },
-  ],
-  noticeText: "【お知らせ】これは架空の通知本文です。No列による整理、SHA-256記録、再圧縮についての説明。",
-};
-
+// ─── buildFinalizeEmailBody / Subject ───────────────────────────────────────
 test("buildFinalizeEmailBody: month, revision, counts, totals, notice, link", () => {
   const body = buildFinalizeEmailBody(fixtureData);
-  assert.ok(body.includes("2026年6月"), "month label");
-  assert.ok(body.includes("改訹: 2（差替え）"), "revision context for rev > 1");
-  assert.ok(body.includes("明細行数: 43"), "row count");
-  assert.ok(body.includes("証憑ファイル数: 40"), "receipt count");
-  assert.ok(body.includes("研究開発費: 5件 / ¥150,000"), "category total line");
-  assert.ok(body.includes("旅費交通費: 8件 / ¥42,000"), "second category total");
-  assert.ok(body.includes("No列による整理"), "embedded notice text");
-  assert.ok(body.includes("https://dazbeez.com/receipts/export?month=2026-06"), "download link");
+  assert.ok(body.includes("2026年6月"));
+  assert.ok(body.includes("改訹: 2（差替え）"));
+  assert.ok(body.includes("研究開発費: 5件 / ¥150,000"));
+  assert.ok(body.includes("https://dazbeez.com/receipts/export?month=2026-06"));
 });
 
-test("buildFinalizeEmailBody: revision 1 shows 新規 not 差替え", () => {
-  const body = buildFinalizeEmailBody({ ...fixtureData, revision: 1 });
-  assert.ok(body.includes("改訹: 新規"));
-  assert.ok(!body.includes("差替え"));
+test("buildFinalizeEmailSubject: test mode prefixes 【テスト送信】", () => {
+  const real = buildFinalizeEmailSubject(fixtureData);
+  const testSubj = buildFinalizeEmailSubject(fixtureData, { test: true });
+  assert.ok(testSubj.startsWith("【テスト送信】"));
+  assert.ok(testSubj.endsWith(real));
 });
 
-// ─── sendFinalizeNotification (never throws; non-fatal on failure) ──────────
+test("buildFinalizeEmailBody: test mode opens with test banner", () => {
+  const body = buildFinalizeEmailBody(fixtureData, { test: true });
+  assert.ok(body.startsWith("※これは通知チャネルのテスト送信です。"));
+  assert.ok(body.includes("【勘定科目別集計】"), "real template follows banner");
+});
 
-test("sendFinalizeNotification: ok when the binding resolves", async () => {
-  const sender: EmailSender = { send: async () => undefined };
-  const res = await sendFinalizeNotification(sender, "from@dazbeez.com", "acct@example.com", fixtureData);
+// ─── Recipient resolution (settings → fallback → null) ─────────────────────
+test("resolveNotificationRecipient: settings value wins over fallback", () => {
+  const r = resolveNotificationRecipient("manager@dazbeez.com", "fallback@dazbeez.com");
+  assert.equal(r.email, "manager@dazbeez.com");
+  assert.equal(r.source, "settings");
+});
+
+test("resolveNotificationRecipient: falls back to var when settings empty", () => {
+  const r = resolveNotificationRecipient("", "admin@dazbeez.com");
+  assert.equal(r.email, "admin@dazbeez.com");
+  assert.equal(r.source, "fallback");
+});
+
+test("resolveNotificationRecipient: null when both unconfigured", () => {
+  const r = resolveNotificationRecipient("", null);
+  assert.equal(r.email, null);
+  assert.equal(r.source, null);
+});
+
+// ─── sendViaResend (isolated seam — mock fetch) ─────────────────────────────
+test("sendViaResend: {ok:true} on 200", async () => {
+  const fakeFetch = (async () => ({ ok: true, status: 200, json: async () => ({ id: "x" }) })) as unknown as typeof fetch;
+  const res = await sendViaResend(fakeFetch, "key", "from@d.com", "to@d.com", "subj", "text", "<p>html</p>");
   assert.equal(res.ok, true);
 });
 
-test("sendFinalizeNotification: a throwing binding → {ok:false}, no throw", async () => {
-  // The critical guarantee: a send failure must NOT propagate. Finalize stays
-  // 200; the caller folds res into a warning + notification_failed audit.
-  const sender: EmailSender = {
-    send: async () => {
-      throw new Error("Email Routing rejected: destination not verified");
-    },
-  };
-  const res = await sendFinalizeNotification(sender, "from@dazbeez.com", "acct@example.com", fixtureData);
+test("sendViaResend: non-2xx → {ok:false} with Resend error message verbatim", async () => {
+  const fakeFetch = (async () => ({
+    ok: false, status: 422,
+    json: async () => ({ name: "validation_error", message: "The `from` address is not verified", statusCode: 422 }),
+  })) as unknown as typeof fetch;
+  const res = await sendViaResend(fakeFetch, "key", "bad@d.com", "to@d.com", "subj", "text", "<p>html</p>");
   assert.equal(res.ok, false);
-  assert.match((res as { error: string }).error, /destination not verified/);
+  if (!res.ok) assert.match(res.error, /from.*not verified/);
 });
 
-test("sendFinalizeNotification: missing binding / from / to → {ok:false}", async () => {
-  assert.equal((await sendFinalizeNotification(null, "f", "t", fixtureData)).ok, false);
-  assert.equal((await sendFinalizeNotification({ send: async () => undefined }, null, "t", fixtureData)).ok, false);
-  assert.equal((await sendFinalizeNotification({ send: async () => undefined }, "f", null, fixtureData)).ok, false);
+test("sendViaResend: network error → {ok:false} without throwing", async () => {
+  const fakeFetch = (async () => { throw new Error("network down"); }) as unknown as typeof fetch;
+  const res = await sendViaResend(fakeFetch, "key", "from@d.com", "to@d.com", "subj", "text", "<p>html</p>");
+  assert.equal(res.ok, false);
+  if (!res.ok) assert.match(res.error, /network down/);
+});
+
+// ─── sendFinalizeNotification (missing config → {ok:false}, no fetch call) ──
+test("sendFinalizeNotification: missing key/from/to → {ok:false} without throwing", async () => {
+  const noopFetch = (async () => { throw new Error("should not be called"); }) as unknown as typeof fetch;
+  assert.equal((await sendFinalizeNotification(null, "f", "t", fixtureData, undefined, noopFetch)).ok, false);
+  assert.equal((await sendFinalizeNotification("key", null, "t", fixtureData, undefined, noopFetch)).ok, false);
+  assert.equal((await sendFinalizeNotification("key", "f", null, fixtureData, undefined, noopFetch)).ok, false);
+});
+
+// ─── authorizeNotifyTest (Clerk-only — processor-key rejected) ──────────────
+test("authorizeNotifyTest: rejects null (processor-key-only / no session)", () => {
+  assert.throws(() => authorizeNotifyTest(null), /Unauthorized/);
+});
+
+test("authorizeNotifyTest: accepts a Clerk actor", () => {
+  assert.equal(authorizeNotifyTest("op@dazbeez.com"), "op@dazbeez.com");
 });

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -18,13 +18,13 @@
     "NEXT_PUBLIC_CLERK_SIGN_UP_URL": "/receipts/sign-in",
     "NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL": "/receipts",
     "NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL": "/receipts",
-    // Finalize notification email (PR 3). Recipient + sender for the Cloudflare
-    // Email Routing send_email binding. The NOTIFY_EMAIL binding's
-    // destination_address MUST match ACCOUNTANT_EMAIL (CF requires the runtime
-    // `to` to be authorized by the binding). NOTIFY_FROM_ADDRESS must be a
-    // verified sender on the dazbeez.com zone. Replace the placeholders before
-    // enabling — see docs/month-close-runbook.md §Notification email.
-    "ACCOUNTANT_EMAIL": "accountant@example.com",
+    // Finalize notification email (Resend transport). ACCOUNTANT_EMAIL is the
+    // FALLBACK recipient (used when no recipient is set in Settings → Compliance).
+    // For the first rollout it's the business manager (admin@dazbeez.com); the
+    // accountant's address swaps in later. NOTIFY_FROM_ADDRESS must be on the
+    // Resend-verified domain. RESEND_API_KEY is a wrangler secret (shared with
+    // the contact form). See docs/month-close-runbook.md §Notification email.
+    "ACCOUNTANT_EMAIL": "admin@dazbeez.com",
     "NOTIFY_FROM_ADDRESS": "receipts@dazbeez.com"
   },
   // Manual secret setup:
@@ -107,17 +107,6 @@
       }
     ]
   },
-  // Finalize notification email (PR 3). Cloudflare Email Routing send_email
-  // binding — no third-party vendor. destination_address authorizes the single
-  // recipient (CF requires the runtime `to` to match); it MUST equal the
-  // ACCOUNTANT_EMAIL var. Enable Email Routing on the zone + verify the
-  // destination address first, else sends are rejected. See runbook.
-  "send_email": [
-    {
-      "name": "NOTIFY_EMAIL",
-      "destination_address": "accountant@example.com"
-    }
-  ],
   "routes": [
     {
       "pattern": "dazbeez.com/*",


### PR DESCRIPTION
Swaps the finalize-email transport from CF Email Routing (`send_email` binding) to **Resend REST API** + manages the recipient from Settings → Compliance. **Complete**: transport swap + recipient resolution + settings type/defaults/parse + test endpoint + settings route validation + the Compliance UI field/test-send + the Resend runbook + tests.

## Transport swap (`lib/receipts/notify.ts`)
- **Resend REST** (`POST api.resend.com/emails`, `Authorization: Bearer <RESEND_API_KEY>`) replaces the `send_email` binding. `sendViaResend(fetchImpl, ...)` is the isolated mockable seam — tests mock fetch. `text` + `html` are independent params.
- Removed: mimetext dependency, EmailSender interface, getNotifyEmail (dead send_email plumbing), NOTIFY_EMAIL from wrangler.jsonc + env types.
- Kept: subject/body builders (incl 【テスト送信】 test mode), result-typed never-throw semantics, both finalize hookups, test endpoint, audit entries.

## Recipient in Settings → Compliance
- `notification_recipient` added to ComplianceSettings (key/value table — **no migration needed**, `track_tax_breakdown` precedent). Resolution: settings → `ACCOUNTANT_EMAIL` var → `{ok:false}`.
- Settings PATCH: email-format validation + `settings.notification_recipient_changed` audit (old/new values).
- `ACCOUNTANT_EMAIL` var → `admin@dazbeez.com` (business-manager fallback).

## Compliance UI + test-send (`ComplianceSettingsForm.tsx`)
- `notification_recipient` email input (mirrors `business_name`).
- Effective-recipient line: resolved address + source ("settings" vs `ACCOUNTANT_EMAIL` fallback vs unconfigured `{ok:false}`), read from the GET/PATCH payload (`effectiveRecipient`) — no client-side resolution.
- テスト送信 button → `POST /api/receipts/notify/test`, inline `{ok|error}` result. Disabled while the field is dirty (the endpoint reads persisted Settings, not the unsaved input).
- GET + PATCH `/api/receipts/settings/compliance` now return `effectiveRecipient {email, source}` via the existing `resolveNotificationRecipient`; the page computes it server-side and passes it as a prop.

## Runbook (`docs/month-close-runbook.md`)
- Replaced the CF Email Routing prerequisites with Resend: verify `dazbeez.com` SPF/DKIM; `RESEND_API_KEY` secret (shared with the contact form / `crm-email-sender.ts`); `NOTIFY_FROM_ADDRESS` on the verified domain; `ACCOUNTANT_EMAIL` fallback; set recipient in Settings → Compliance; テスト送信 to confirm. Plus a recipient-resolution paragraph.
- Fixed the stale `send_email`/`NOTIFY_EMAIL` comment on the Resend accessor block in `cloudflare-runtime.ts` (described the transport the prior commit removed).

## Tests
Recipient resolution order (settings > fallback > null); Resend non-2xx → `{ok:false}` error passthrough; missing key → `{ok:false}` no throw; test mode 【テスト送信】 subject + body banner; authorizeNotifyTest rejects null. `tsc`/`lint` clean; `npm test` **376 (375 pass, 1 D1-skip)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)