### PR TITLE
chore(receipts-consumer): shrink proof derivative to 1280px/q70 + env fail-fast

### DIFF
--- a/docs/month-close-runbook.md
+++ b/docs/month-close-runbook.md
@@ -228,6 +228,9 @@ read-only dry-run first**:
 
 ```bash
 cd scripts/receipts-consumer
+# REQUIRED first: the backfill fails fast (exit 2) unless the consumer .env is
+# sourced — it posts via RECEIPTS_EXTRACT_URL / RECEIPTS_PROCESSOR_KEY.
+set -a; source .env; set +a
 # 1. Dry-run against LIVE D1 (read-only SELECT — no writes):
 .venv/bin/python3 backfill_proof_copies.py --remote --dry-run
 #   → prints id / merchant / original_r2_key for receipts lacking a proof_copy.
@@ -238,6 +241,13 @@ cd scripts/receipts-consumer
 # Re-generate existing ones (e.g. after a quality change): add --force.
 # Narrow to one receipt: --id <uuid>.
 ```
+
+**Derivative parameters** (`scripts/receipts-consumer/consumer.py`):
+`PROOF_MAX_DIM = 1280` (longest side, never upscaled) and
+`PROOF_JPEG_QUALITY = 70`; PDFs pass through unchanged. Tuning either only
+affects proofs generated AFTER the change — existing `proof_copy` rows keep
+their old bytes until you regenerate with `--force` (overwrites all via the
+upsert).
 
 Idempotent + resumable: by default it selects only receipts WITHOUT a
 `proof_copy`, so re-running after a partial `--write` picks up the rest. For a

--- a/scripts/receipts-consumer/backfill_proof_copies.py
+++ b/scripts/receipts-consumer/backfill_proof_copies.py
@@ -27,16 +27,39 @@ import os
 import sys
 import tempfile
 
-# consumer.py reads these at import time. Default them so --help / --dry-run
-# work without the full runtime env; --write (posting) needs real values.
-os.environ.setdefault("CF_ACCOUNT_ID", "d")
-os.environ.setdefault("CF_QUEUE_ID", "d")
-os.environ.setdefault("CF_API_TOKEN", "d")
-os.environ.setdefault("RECEIPTS_EXTRACT_URL", "http://d")
-os.environ.setdefault("RECEIPTS_PROCESSOR_KEY", "d")
-os.environ.setdefault("MLX_MODEL", "d")
+# consumer.py reads the runtime env at its own import time (bracket access →
+# KeyError if unset), so it is imported lazily inside main()/helpers AFTER the
+# fail-fast check below. That keeps this module importable without the runtime
+# env (tests, --help). The previous module-level setdefault("…", "d") sentinels
+# let a misconfigured run proceed and DNS-fail every fetch (2026-07-15 skip-all);
+# the check below replaces them.
 
-import consumer  # type: ignore  # noqa: E402
+# Env the backfill needs to do real work. Fail fast (exit 2) if any is missing
+# OR still holds a sentinel placeholder — NAMES only, never values.
+_REQUIRED_ENV = (
+    "RECEIPTS_EXTRACT_URL",
+    "RECEIPTS_PROCESSOR_KEY",
+    "CF_ACCOUNT_ID",
+    "CF_API_TOKEN",
+)
+# Sentinel placeholders the old setdefault block used; presence means .env was
+# never sourced.
+_SENTINEL_VALUES = {"d", "http://d"}
+
+
+def _missing_or_sentinel(name: str) -> bool:
+    value = os.environ.get(name)
+    return value is None or value == "" or value in _SENTINEL_VALUES
+
+
+def _assert_required_env() -> None:
+    missing = [name for name in _REQUIRED_ENV if _missing_or_sentinel(name)]
+    if missing:
+        sys.stderr.write(
+            "error: required env not configured: " + ", ".join(missing) + "\n"
+            "hint: source .env first (see run.sh)\n"
+        )
+        sys.exit(2)
 
 
 def list_receipts_needing_proof(
@@ -47,6 +70,7 @@ def list_receipts_needing_proof(
     Default: non-deleted receipts with an original file and NO proof_copy row.
     --force: all non-deleted receipts with an original file (regenerate existing).
     """
+    import consumer  # type: ignore  # lazy import; see _assert_required_env()
     where_id = f" AND r.id = {consumer._sql_escape(only_id)}" if only_id else ""
     if force:
         clause = ""
@@ -79,6 +103,7 @@ def build_proof_from_original(
     Writes the fetched bytes to a temp file with the right suffix so
     make_proof_derivative can branch (PDF pass-through vs JPEG recompress).
     """
+    import consumer  # type: ignore  # lazy import; see _assert_required_env()
     raw = consumer.fetch_original_bytes(receipt_id)
     if raw is None:
         return None
@@ -97,6 +122,8 @@ def build_proof_from_original(
 
 
 def main() -> None:
+    _assert_required_env()
+    import consumer  # type: ignore  # noqa: E402  — lazy; env validated just above
     args = sys.argv[1:]
     dry_run = "--write" not in args
     local = "--local" in args

--- a/scripts/receipts-consumer/consumer.py
+++ b/scripts/receipts-consumer/consumer.py
@@ -301,15 +301,15 @@ def post_extraction_failed(receipt_id: str, reason: str) -> None:
 # consumer builds + posts the derivative after a successful /extract, wrapped so
 # any error is logged and swallowed (backfill_proof_copies.py recovers misses).
 
-PROOF_MAX_LONGEST_SIDE = 1600
-PROOF_JPEG_QUALITY = 75
+PROOF_MAX_DIM = 1280
+PROOF_JPEG_QUALITY = 70
 
 
 def make_proof_derivative(image_path: str) -> tuple[bytes, str] | None:
     """Build a compact proof derivative from a local image file.
 
-    Raster images: resize the longest side to <=1600px (never upscale), JPEG
-    quality 75, EXIF stripped AFTER baking orientation into the pixels. Returns
+    Raster images: resize the longest side to <=1280px (never upscale), JPEG
+    quality 70, EXIF stripped AFTER baking orientation into the pixels. Returns
     (jpeg_bytes, "image/jpeg").
 
     PDFs: pass through unchanged (already compact; rasterizing legal documents
@@ -340,9 +340,9 @@ def make_proof_derivative(image_path: str) -> tuple[bytes, str] | None:
         if img.mode not in ("RGB", "L"):
             img = img.convert("RGB")
         # thumbnail() preserves aspect ratio, fits within the box (longest side
-        # <=1600), and never upsizes — exactly the proof sizing we want.
+        # <=1280), and never upsizes — exactly the proof sizing we want.
         img.thumbnail(
-            (PROOF_MAX_LONGEST_SIDE, PROOF_MAX_LONGEST_SIDE),
+            (PROOF_MAX_DIM, PROOF_MAX_DIM),
             Image.Resampling.LANCZOS,
         )
         buf = io.BytesIO()

--- a/scripts/receipts-consumer/test_proof_derivative.py
+++ b/scripts/receipts-consumer/test_proof_derivative.py
@@ -35,7 +35,7 @@ def _write_jpeg(path: str, size: tuple[int, int], exif=None) -> None:
 
 
 class TestMakeProofDerivative(unittest.TestCase):
-    def test_large_image_resized_to_1600_longest(self):
+    def test_large_image_capped_at_max_dim(self):
         fd, path = tempfile.mkstemp(suffix=".jpg")
         os.close(fd)
         try:
@@ -44,7 +44,7 @@ class TestMakeProofDerivative(unittest.TestCase):
             self.assertEqual(ct, "image/jpeg")
             self.assertEqual(data[:2], b"\xff\xd8")  # JPEG SOI magic
             out = Image.open(io.BytesIO(data))
-            self.assertLessEqual(max(out.size), consumer.PROOF_MAX_LONGEST_SIDE)
+            self.assertLessEqual(max(out.size), consumer.PROOF_MAX_DIM)
             # Aspect ratio preserved (3:2), not distorted.
             self.assertAlmostEqual(out.width / out.height, 3000 / 2000, places=2)
         finally:
@@ -62,14 +62,14 @@ class TestMakeProofDerivative(unittest.TestCase):
             os.unlink(path)
 
     def test_portrait_orientation_capped_on_shorter_axis(self):
-        # Portrait 2000x3000 → longest side (height) capped at 1600.
+        # Portrait 2000x3000 → longest side (height) capped at PROOF_MAX_DIM.
         fd, path = tempfile.mkstemp(suffix=".jpg")
         os.close(fd)
         try:
             _write_jpeg(path, (2000, 3000))
             data, _ = consumer.make_proof_derivative(path)
             out = Image.open(io.BytesIO(data))
-            self.assertLessEqual(max(out.size), consumer.PROOF_MAX_LONGEST_SIDE)
+            self.assertLessEqual(max(out.size), consumer.PROOF_MAX_DIM)
             self.assertAlmostEqual(out.width / out.height, 2000 / 3000, places=2)
         finally:
             os.unlink(path)
@@ -111,8 +111,8 @@ class TestMakeProofDerivative(unittest.TestCase):
             os.unlink(path)
 
     def test_derivative_is_smaller_than_a_high_quality_save(self):
-        # q75 recompression of a noisy-ish image must beat q95 — sanity check
-        # that the quality knob is actually applied (keeps the bundle small).
+        # Recompression at PROOF_JPEG_QUALITY of a noisy image must beat q95 —
+        # sanity check that the quality knob is actually applied (small bundle).
         fd, path = tempfile.mkstemp(suffix=".jpg")
         os.close(fd)
         try:


### PR DESCRIPTION
Operator confirmed the current 1600px/q75 `proof_copy` is "perfectly legible" — compress harder. Also folds in the pending env hardening so it all lands as one coherent PR.

## Derivative tuning (`consumer.py`)
- `PROOF_MAX_LONGEST_SIDE` (1600) → **renamed `PROOF_MAX_DIM`** (1280): longest-side cap, never upscaled. PDF pass-through unchanged.
- `PROOF_JPEG_QUALITY` 75 → **70**.
- Both are module constants → future tuning is a one-line diff.
- `test_proof_derivative.py` now asserts against `consumer.PROOF_MAX_DIM` and drops the `1600` literal from the method name (`test_large_image_capped_at_max_dim`), so it won't break on the next tuning pass.

## Folded-in: env fail-fast (was `fix/backfill-env-failfast`, 615d26d — not yet merged)
- `backfill_proof_copies.py`: replaced the `setdefault("…","d")` sentinels with `_assert_required_env()` in `main()` — exits 2 (NAMES only, never values + `hint: source .env first (see run.sh)`) if `RECEIPTS_EXTRACT_URL` / `RECEIPTS_PROCESSOR_KEY` / `CF_ACCOUNT_ID` / `CF_API_TOKEN` is missing or a sentinel. `consumer` is imported lazily after the check so the module stays importable without the runtime env. This was the root cause of the 2026-07-15 skip-all (ok=0/skip=69).
- `runbook` §Backfilling: added `set -a; source .env; set +a` before the commands (pairs with the fail-fast).

## Runbook (`docs/month-close-runbook.md`)
Documented the derivative parameters (`PROOF_MAX_DIM=1280`, `PROOF_JPEG_QUALITY=70`; PDFs unchanged) and that changing them only affects NEW proofs — existing `proof_copy` rows keep old bytes until regenerated with `--force`.

## Regenerate existing proofs (post-merge; operator runs on the Mac)
\`\`\`bash
cd scripts/receipts-consumer
set -a; source .env; set +a
.venv/bin/python3 backfill_proof_copies.py --remote --write --force
\`\`\`
Expect ~69 ok / 0 fail (`--force` overwrites all via the upsert — the designed path for parameter changes).

## Gates
`py_compile` OK; `unittest test_proof_derivative` 7/7 OK; `tsc --noEmit` clean (Python-only change).

Note: supersedes `fix/backfill-env-failfast` (its commit is cherry-picked in here) — that branch can be deleted after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)