### PR TITLE
feat(receipts): harden capture upload policy and reliability

### DIFF
--- a/app/api/mobile/business-cards/upload/route.ts
+++ b/app/api/mobile/business-cards/upload/route.ts
@@ -1,7 +1,10 @@
 import { NextResponse } from "next/server";
 import { createMobileBusinessCardCapture } from "@/lib/crm";
 import { extractBusinessCardDetails } from "@/lib/crm-provider";
-import { getImageSizeValidationError } from "@/lib/crm-upload-limits";
+import {
+  getBusinessCardFileTypeError,
+  getImageSizeValidationError,
+} from "@/lib/crm-upload-limits";
 import { requireMobileActor } from "@/lib/receipts/trusted-devices";
 
 export async function POST(request: Request) {
@@ -20,6 +23,11 @@ export async function POST(request: Request) {
     });
     if (sizeError) {
       return NextResponse.json({ error: sizeError }, { status: 413 });
+    }
+
+    const typeError = getBusinessCardFileTypeError(file);
+    if (typeError) {
+      return NextResponse.json({ error: typeError }, { status: 415 });
     }
 
     const clientCaptureId = formData.get("client_capture_id")?.toString().trim();

--- a/app/api/receipts/[id]/route.ts
+++ b/app/api/receipts/[id]/route.ts
@@ -24,16 +24,7 @@ import type {
   QualifiedInvoiceStatus,
   SourceType,
 } from "@/lib/receipts/types";
-
-const VALID_SOURCE_TYPES: SourceType[] = [
-  "paper_scanned",
-  "electronic_receipt",
-  "digital_invoice",
-  "credit_card_statement",
-  "email_attachment",
-  "manual_upload",
-  "amex_csv",
-];
+import { VALID_SOURCE_TYPES } from "@/lib/receipts/upload-policy";
 
 type RouteContext = { params: Promise<{ id: string }> };
 

--- a/app/api/receipts/upload/route.ts
+++ b/app/api/receipts/upload/route.ts
@@ -1,13 +1,19 @@
 import { NextResponse } from "next/server";
 import { requireReceiptsActor } from "@/lib/receipts/auth";
-import { validateReceiptFile } from "@/lib/receipts/validation";
+import {
+  validateReceiptFile,
+  VALID_SOURCES,
+  deriveSourceType,
+  isValidSource,
+  type Source,
+} from "@/lib/receipts/upload-policy";
 import { generateR2Key, uploadOriginal } from "@/lib/receipts/storage";
 import { createReceiptRecord, hardDeleteReceipt, updateReceiptRecord } from "@/lib/receipts/db";
 import { createReceiptFile } from "@/lib/receipts/files";
 import { ExportFinalizedError } from "@/lib/receipts/month-lock";
 import { buildExtractionJob, enqueueExtractionJob } from "@/lib/receipts/queue";
 import { getReceiptsBucket, getReceiptsDb } from "@/lib/cloudflare-runtime";
-import type { PaymentPath, SourceType } from "@/lib/receipts/types";
+import type { PaymentPath } from "@/lib/receipts/types";
 
 async function sha256Hex(data: ArrayBuffer): Promise<string> {
   const hash = await crypto.subtle.digest("SHA-256", data);
@@ -17,30 +23,6 @@ async function sha256Hex(data: ArrayBuffer): Promise<string> {
 }
 
 const VALID_PAYMENT_PATHS: PaymentPath[] = ["AMEX", "CASH", "DIGITAL", "UNKNOWN"];
-const VALID_SOURCE_TYPES: SourceType[] = [
-  "paper_scanned",
-  "electronic_receipt",
-  "digital_invoice",
-  "credit_card_statement",
-  "email_attachment",
-  "manual_upload",
-  "amex_csv",
-];
-
-function deriveSourceType(
-  formValue: string | undefined,
-  source: string,
-  contentType: string,
-): SourceType {
-  if (formValue && VALID_SOURCE_TYPES.includes(formValue as SourceType)) {
-    return formValue as SourceType;
-  }
-  // Heuristic fallback: mobile camera capture → paper scan; PDF →
-  // electronic receipt; anything else → manual upload.
-  if (source === "mobile_capture") return "paper_scanned";
-  if (contentType === "application/pdf") return "electronic_receipt";
-  return "manual_upload";
-}
 
 export async function POST(request: Request) {
   try {
@@ -66,7 +48,23 @@ export async function POST(request: Request) {
         : "UNKNOWN";
 
     const expenseType = formData.get("expenseType")?.toString() || undefined;
-    const source = formData.get("source")?.toString() || "mobile_capture";
+    // source is required provenance — the capture client always sends one
+    // (mobile_capture | desktop_upload). Reject rather than silently default,
+    // since defaulting to "mobile_capture" previously mislabeled every desktop
+    // upload (and corrupted its source_type classification downstream).
+    const rawSource = formData.get("source")?.toString();
+    if (!isValidSource(rawSource)) {
+      return NextResponse.json(
+        {
+          error:
+            "Invalid or missing 'source'. Expected one of: " +
+            VALID_SOURCES.join(", ") +
+            ".",
+        },
+        { status: 400 },
+      );
+    }
+    const source: Source = rawSource;
     const contentType = file.type || "application/octet-stream";
     const sourceType = deriveSourceType(
       formData.get("sourceType")?.toString(),

--- a/components/receipts/capture/capture-desktop.tsx
+++ b/components/receipts/capture/capture-desktop.tsx
@@ -10,7 +10,6 @@ import {
   UploadIcon,
   WarningIcon,
 } from "@/components/ui/icons";
-import type { PaymentPath } from "@/lib/receipts/types";
 import {
   MAX_DESKTOP_BATCH_FILES,
   MAX_RECEIPT_FILE_BYTES,
@@ -18,27 +17,16 @@ import {
   formatFileSize,
   partitionBatch,
 } from "@/lib/receipts/upload-policy";
-import type { CapturePhase } from "./use-receipt-upload";
+import type { SessionUpload } from "@/lib/receipts/session-upload";
+
+// SessionUpload lives in the client-safe session-upload module (shared with
+// ReceiptCaptureForm and its pure row transitions); re-exported for importers.
+export type { SessionUpload };
 
 export interface CaptureDesktopProps {
-  initialPayment: PaymentPath | null;
-  phase: CapturePhase;
   onPickFile: (file: File) => void;
   sessionUploads: SessionUpload[];
 }
-
-export type SessionUpload = {
-  id: string;
-  fileName: string;
-  fileSizeBytes: number;
-  state: "uploading" | "ready" | "review" | "error";
-  merchant?: string;
-  amount?: string;
-  date?: string;
-  pct: number;
-  receiptId?: string;
-  errorMessage?: string;
-};
 
 export function CaptureDesktop(props: CaptureDesktopProps) {
   const fileRef = useRef<HTMLInputElement>(null);

--- a/components/receipts/capture/capture-desktop.tsx
+++ b/components/receipts/capture/capture-desktop.tsx
@@ -16,6 +16,7 @@ import {
   MAX_RECEIPT_FILE_BYTES,
   RECEIPT_ACCEPT_ATTR,
   formatFileSize,
+  partitionBatch,
 } from "@/lib/receipts/upload-policy";
 import type { CapturePhase } from "./use-receipt-upload";
 
@@ -48,16 +49,17 @@ export function CaptureDesktop(props: CaptureDesktopProps) {
     fileRef.current?.click();
   }
 
-  // Enforce the desktop batch cap at the drop/pick boundary, where the full
-  // file list is known atomically. Files beyond the remaining room are rejected
-  // with a visible count rather than silently dropped.
+  // Per-drop batch cap: at most MAX_DESKTOP_BATCH_FILES from this event,
+  // regardless of what's already in the session (a session-cumulative cap
+  // would lock the session out as ready/review rows accumulate). The remainder
+  // is surfaced as a visible count rather than silently dropped.
   function acceptFiles(files: File[]) {
-    const room = Math.max(
-      MAX_DESKTOP_BATCH_FILES - props.sessionUploads.length,
-      0,
+    const { accepted, rejected } = partitionBatch(
+      files,
+      MAX_DESKTOP_BATCH_FILES,
     );
-    setOverflow(files.length > room ? { rejected: files.length - room } : null);
-    files.slice(0, room).forEach(props.onPickFile);
+    setOverflow(rejected > 0 ? { rejected } : null);
+    accepted.forEach(props.onPickFile);
   }
 
   function onFile(e: ChangeEvent<HTMLInputElement>) {

--- a/components/receipts/capture/capture-desktop.tsx
+++ b/components/receipts/capture/capture-desktop.tsx
@@ -11,6 +11,12 @@ import {
   WarningIcon,
 } from "@/components/ui/icons";
 import type { PaymentPath } from "@/lib/receipts/types";
+import {
+  MAX_DESKTOP_BATCH_FILES,
+  MAX_RECEIPT_FILE_BYTES,
+  RECEIPT_ACCEPT_ATTR,
+  formatFileSize,
+} from "@/lib/receipts/upload-policy";
 import type { CapturePhase } from "./use-receipt-upload";
 
 export interface CaptureDesktopProps {
@@ -36,22 +42,35 @@ export type SessionUpload = {
 export function CaptureDesktop(props: CaptureDesktopProps) {
   const fileRef = useRef<HTMLInputElement>(null);
   const [dragOver, setDragOver] = useState(false);
+  const [overflow, setOverflow] = useState<{ rejected: number } | null>(null);
 
   function onPick() {
     fileRef.current?.click();
   }
 
+  // Enforce the desktop batch cap at the drop/pick boundary, where the full
+  // file list is known atomically. Files beyond the remaining room are rejected
+  // with a visible count rather than silently dropped.
+  function acceptFiles(files: File[]) {
+    const room = Math.max(
+      MAX_DESKTOP_BATCH_FILES - props.sessionUploads.length,
+      0,
+    );
+    setOverflow(files.length > room ? { rejected: files.length - room } : null);
+    files.slice(0, room).forEach(props.onPickFile);
+  }
+
   function onFile(e: ChangeEvent<HTMLInputElement>) {
     const files = Array.from(e.target.files ?? []);
     e.target.value = "";
-    files.forEach(props.onPickFile);
+    acceptFiles(files);
   }
 
   function onDrop(e: DragEvent<HTMLDivElement>) {
     e.preventDefault();
     setDragOver(false);
     const files = Array.from(e.dataTransfer.files ?? []);
-    files.forEach(props.onPickFile);
+    acceptFiles(files);
   }
 
   return (
@@ -59,7 +78,7 @@ export function CaptureDesktop(props: CaptureDesktopProps) {
       <input
         ref={fileRef}
         type="file"
-        accept="image/*,application/pdf,.eml,.html"
+        accept={RECEIPT_ACCEPT_ATTR}
         multiple
         className="sr-only"
         onChange={onFile}
@@ -93,7 +112,7 @@ export function CaptureDesktop(props: CaptureDesktopProps) {
             <div className="relative flex flex-col items-center gap-3.5">
               <div className="relative h-[84px] w-[110px]">
                 <FileGlyph kind="PDF" rotate="-9deg" left={6} top={4} />
-                <FileGlyph kind="EML" rotate="2deg" left={36} top={0} />
+                <FileGlyph kind="JPG" rotate="2deg" left={36} top={0} />
                 <FileGlyph kind="PNG" rotate="14deg" left={66} top={2} />
               </div>
               <div className="text-2xl font-bold tracking-[-0.4px] text-gray-900">
@@ -118,11 +137,33 @@ export function CaptureDesktop(props: CaptureDesktopProps) {
                 </Btn>
               </div>
               <div className="mt-2.5 text-xs text-gray-400">
-                Up to 25 files at once · 20&nbsp;MB max per file · HEIC
+                Up to {MAX_DESKTOP_BATCH_FILES} files at once ·{" "}
+                {formatFileSize(MAX_RECEIPT_FILE_BYTES)} max per file · HEIC
                 auto-converted
               </div>
             </div>
           </div>
+
+          {overflow && (
+            <div
+              role="status"
+              className="flex items-center gap-2 rounded-xl border border-amber-200 bg-amber-50 px-4 py-2.5 text-[13px] text-amber-800"
+            >
+              <WarningIcon size={14} className="shrink-0 text-amber-600" />
+              <span>
+                {overflow.rejected} file{overflow.rejected === 1 ? "" : "s"} not
+                added — a desktop batch is limited to {MAX_DESKTOP_BATCH_FILES}{" "}
+                files at once.
+              </span>
+              <button
+                type="button"
+                onClick={() => setOverflow(null)}
+                className="ml-auto text-[11px] font-semibold text-amber-700 hover:text-amber-800"
+              >
+                Dismiss
+              </button>
+            </div>
+          )}
 
           <div className="grid grid-cols-3 gap-3">
             <AltInputCard
@@ -207,15 +248,14 @@ function DesktopSubHeader() {
         Digital receipts
       </span>
       <span className="hidden text-xs text-gray-500 sm:inline">
-        PDFs, e-mail receipts, screenshots — anything that didn&rsquo;t come from
-        a camera
+        PDFs, screenshots, digital receipts — anything that didn&rsquo;t come
+        from a camera
       </span>
       <span className="flex-1" />
       <div className="hidden gap-1.5 sm:flex">
         <Pill tone="outline">PDF</Pill>
-        <Pill tone="outline">EML / .msg</Pill>
         <Pill tone="outline">PNG · JPG</Pill>
-        <Pill tone="outline">HTML</Pill>
+        <Pill tone="outline">HEIC</Pill>
       </div>
       <div className="hidden h-[18px] w-px bg-gray-200 sm:block" />
       <Link
@@ -234,14 +274,14 @@ function FileGlyph({
   left,
   top,
 }: {
-  kind: "PDF" | "EML" | "PNG";
+  kind: "PDF" | "JPG" | "PNG";
   rotate: string;
   left: number;
   top: number;
 }) {
   const tints: Record<typeof kind, { bg: string; label: string }> = {
     PDF: { bg: "bg-red-100", label: "text-red-600" },
-    EML: { bg: "bg-blue-100", label: "text-blue-700" },
+    JPG: { bg: "bg-blue-100", label: "text-blue-700" },
     PNG: { bg: "bg-amber-100", label: "text-amber-700" },
   };
   const t = tints[kind];

--- a/components/receipts/capture/use-receipt-upload.ts
+++ b/components/receipts/capture/use-receipt-upload.ts
@@ -4,6 +4,7 @@ import { useCallback, useRef, useState } from "react";
 import { maybeResizeImage } from "@/lib/receipts/client-image";
 import type { PaymentPath } from "@/lib/receipts/types";
 import type { Source } from "@/lib/receipts/upload-policy";
+import { AbortRegistry } from "@/lib/receipts/abort-registry";
 
 // ADR 0001: extraction is store-and-forward. Capture no longer runs OCR inline
 // — the image is uploaded, enqueued, and processed later by the Mac MLX
@@ -30,7 +31,7 @@ export function useReceiptUpload() {
   // them. The previous design kept a single controller and aborted it on
   // every new upload — which silently killed all but the last file when the
   // desktop drop handler called upload() N times back-to-back.
-  const controllersRef = useRef<Set<AbortController>>(new Set());
+  const registryRef = useRef(new AbortRegistry());
 
   const upload = useCallback(
     async (
@@ -39,7 +40,7 @@ export function useReceiptUpload() {
       source: Source,
     ): Promise<UploadResult> => {
       const abort = new AbortController();
-      controllersRef.current.add(abort);
+      registryRef.current.register(abort);
 
       setPhase({
         kind: "uploading",
@@ -105,15 +106,14 @@ export function useReceiptUpload() {
         setPhase({ kind: "error", message });
         return { ok: false, message };
       } finally {
-        controllersRef.current.delete(abort);
+        registryRef.current.unregister(abort);
       }
     },
     [],
   );
 
   const abortAll = useCallback(() => {
-    controllersRef.current.forEach((c) => c.abort());
-    controllersRef.current.clear();
+    registryRef.current.abortAll();
   }, []);
 
   const reset = useCallback(() => {

--- a/components/receipts/capture/use-receipt-upload.ts
+++ b/components/receipts/capture/use-receipt-upload.ts
@@ -3,6 +3,7 @@
 import { useCallback, useRef, useState } from "react";
 import { maybeResizeImage } from "@/lib/receipts/client-image";
 import type { PaymentPath } from "@/lib/receipts/types";
+import type { Source } from "@/lib/receipts/upload-policy";
 
 // ADR 0001: extraction is store-and-forward. Capture no longer runs OCR inline
 // — the image is uploaded, enqueued, and processed later by the Mac MLX
@@ -35,6 +36,7 @@ export function useReceiptUpload() {
     async (
       file: File,
       paymentPath: PaymentPath | null,
+      source: Source,
     ): Promise<UploadResult> => {
       const abort = new AbortController();
       controllersRef.current.add(abort);
@@ -57,11 +59,7 @@ export function useReceiptUpload() {
 
         const fd = new FormData();
         fd.append("file", uploadFile);
-        // NOTE: provenance mislabel — desktop uploads also send source=
-        // "mobile_capture" here. The upload route accepts any string for
-        // source (free-form column, no validation) so it doesn't break, but
-        // the value is wrong for desktop. Tracked for a follow-up.
-        fd.append("source", "mobile_capture");
+        fd.append("source", source);
         if (paymentPath) fd.append("paymentPath", paymentPath);
 
         const res = await fetch("/api/receipts/upload", {

--- a/components/receipts/receipt-capture-form.tsx
+++ b/components/receipts/receipt-capture-form.tsx
@@ -4,15 +4,19 @@ import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "
 import { useIsMobile } from "@/lib/receipts/use-viewport";
 import { useReceiptUpload } from "@/components/receipts/capture/use-receipt-upload";
 import { CaptureMobile } from "@/components/receipts/capture/capture-mobile";
-import {
-  CaptureDesktop,
-  type SessionUpload,
-} from "@/components/receipts/capture/capture-desktop";
+import { CaptureDesktop } from "@/components/receipts/capture/capture-desktop";
 import type { PaymentPath } from "@/lib/receipts/types";
 import {
   DESKTOP_MAX_CONCURRENT_UPLOADS,
   type Source,
 } from "@/lib/receipts/upload-policy";
+import { UploadPool } from "@/lib/receipts/upload-pool";
+import { SingleFlight } from "@/lib/receipts/single-flight";
+import {
+  applyUploadFailure,
+  applyUploadSuccess,
+  type SessionUpload,
+} from "@/lib/receipts/session-upload";
 
 export type PaymentChip = PaymentPath | null;
 
@@ -78,11 +82,6 @@ function persistQueue(items: SessionUpload[]) {
 
 const subscribeNoop = () => () => {};
 
-interface UploadPool {
-  active: number;
-  waiters: Array<() => void>;
-}
-
 export function ReceiptCaptureForm({
   initialPayment = null,
   rapidMode = false,
@@ -100,10 +99,11 @@ export function ReceiptCaptureForm({
     () => EMPTY_QUEUE,
   );
   const [sessionUploads, setSessionUploads] = useState<SessionUpload[]>(persisted);
-  // Per-form concurrency pool — limits simultaneous uploads so a 25-file
-  // drop doesn't fire 25 fetches at once. Held in a ref so waiters survive
-  // re-renders without restarting.
-  const poolRef = useRef<UploadPool>({ active: 0, waiters: [] });
+  // Desktop FIFO concurrency pool (limit DESKTOP_MAX_CONCURRENT_UPLOADS) and
+  // the mobile single-flight gate. Both held in refs so they survive re-renders
+  // without restarting in-flight work.
+  const desktopPoolRef = useRef(new UploadPool(DESKTOP_MAX_CONCURRENT_UPLOADS));
+  const mobileSingleFlightRef = useRef(new SingleFlight());
 
   // Persist on every change so a hard reload doesn't lose the day's work.
   useEffect(() => {
@@ -116,14 +116,23 @@ export function ReceiptCaptureForm({
       // Provenance: mobile web captures are camera-origin, desktop drops are
       // not. The upload route requires this value (no silent default).
       const source: Source = isMobile ? "mobile_capture" : "desktop_upload";
+
       if (isMobile) {
-        await upload(file, initialPayment, source);
+        // Mobile single-flight (explicit rejection): a second capture while one
+        // is uploading is ignored so it cannot overwrite the active upload's
+        // phase. The normal capture -> upload -> re-arm flow is unchanged.
+        if (!mobileSingleFlightRef.current.start()) return;
+        try {
+          await upload(file, initialPayment, source);
+        } finally {
+          mobileSingleFlightRef.current.finish();
+        }
         return;
       }
 
-      // Desktop: register a session row immediately so the user sees the
-      // file appear in the batch grid + sidebar queue, then run the upload
-      // through the concurrency pool and patch the row from the result.
+      // Desktop: register a session row immediately so the user sees the file
+      // appear in the batch grid + sidebar queue, then acquire a concurrency
+      // slot (FIFO) and patch the row from the result via pure transitions.
       const id = crypto.randomUUID();
       setSessionUploads((prev) => [
         {
@@ -136,46 +145,20 @@ export function ReceiptCaptureForm({
         ...prev,
       ]);
 
-      // Acquire a slot. Resolves immediately if under the cap, otherwise
-      // queues until a prior upload releases.
-      const pool = poolRef.current;
-      await new Promise<void>((resolve) => {
-        if (pool.active < DESKTOP_MAX_CONCURRENT_UPLOADS) {
-          pool.active += 1;
-          resolve();
-        } else {
-          pool.waiters.push(() => {
-            pool.active += 1;
-            resolve();
-          });
-        }
-      });
-
+      const slot = await desktopPoolRef.current.acquire();
       try {
         const result = await upload(file, initialPayment, source);
         setSessionUploads((prev) =>
           prev.map((u) =>
             u.id === id
               ? result.ok
-                ? {
-                    ...u,
-                    state: "ready",
-                    pct: 100,
-                    receiptId: result.receiptId,
-                  }
-                : {
-                    ...u,
-                    state: "error",
-                    pct: 100,
-                    errorMessage: result.message,
-                  }
+                ? applyUploadSuccess(u, result.receiptId)
+                : applyUploadFailure(u, result.message)
               : u,
           ),
         );
       } finally {
-        pool.active -= 1;
-        const next = pool.waiters.shift();
-        if (next) next();
+        slot.release();
       }
     },
     [isMobile, upload, initialPayment],
@@ -197,8 +180,6 @@ export function ReceiptCaptureForm({
 
   return (
     <CaptureDesktop
-      initialPayment={initialPayment}
-      phase={phase}
       onPickFile={onPickFile}
       sessionUploads={sessionUploads}
     />

--- a/components/receipts/receipt-capture-form.tsx
+++ b/components/receipts/receipt-capture-form.tsx
@@ -9,6 +9,10 @@ import {
   type SessionUpload,
 } from "@/components/receipts/capture/capture-desktop";
 import type { PaymentPath } from "@/lib/receipts/types";
+import {
+  DESKTOP_MAX_CONCURRENT_UPLOADS,
+  type Source,
+} from "@/lib/receipts/upload-policy";
 
 export type PaymentChip = PaymentPath | null;
 
@@ -27,10 +31,6 @@ const SESSION_QUEUE_TTL_MS = 1000 * 60 * 60 * 6;
 /** Stable empty array reference so useSyncExternalStore doesn't tear when
  *  the server snapshot is read repeatedly. */
 const EMPTY_QUEUE: SessionUpload[] = [];
-/** Max concurrent uploads on the desktop drop path. Drops beyond this are
- *  queued in order (FIFO). 3 is a conservative cap that keeps the browser's
- *  HTTP/2 connection to the Worker saturated without overwhelming it. */
-const MAX_CONCURRENT_UPLOADS = 3;
 
 // useSyncExternalStore requires the snapshot getter to return a
 // referentially-stable value, so we memoise across renders. The cache is
@@ -113,8 +113,11 @@ export function ReceiptCaptureForm({
 
   const onPickFile = useCallback(
     async (file: File) => {
+      // Provenance: mobile web captures are camera-origin, desktop drops are
+      // not. The upload route requires this value (no silent default).
+      const source: Source = isMobile ? "mobile_capture" : "desktop_upload";
       if (isMobile) {
-        await upload(file, initialPayment);
+        await upload(file, initialPayment, source);
         return;
       }
 
@@ -137,7 +140,7 @@ export function ReceiptCaptureForm({
       // queues until a prior upload releases.
       const pool = poolRef.current;
       await new Promise<void>((resolve) => {
-        if (pool.active < MAX_CONCURRENT_UPLOADS) {
+        if (pool.active < DESKTOP_MAX_CONCURRENT_UPLOADS) {
           pool.active += 1;
           resolve();
         } else {
@@ -149,7 +152,7 @@ export function ReceiptCaptureForm({
       });
 
       try {
-        const result = await upload(file, initialPayment);
+        const result = await upload(file, initialPayment, source);
         setSessionUploads((prev) =>
           prev.map((u) =>
             u.id === id

--- a/lib/crm-upload-limits.ts
+++ b/lib/crm-upload-limits.ts
@@ -52,16 +52,27 @@ export const ALLOWED_BUSINESS_CARD_EXTENSIONS = [
   ".heif",
 ] as const;
 
+/** Lowercased ".ext" (including the dot) from a filename; "" if there is none. */
+function fileExtensionOf(name: string): string {
+  const dot = name.lastIndexOf(".");
+  if (dot < 0) return "";
+  return name.slice(dot).toLowerCase();
+}
+
 export function getBusinessCardFileTypeError(file: File): string | null {
-  const ext = `.${file.name.split(".").pop()?.toLowerCase() ?? ""}`;
-  const mimeOk = (
-    ALLOWED_BUSINESS_CARD_MIME_TYPES as readonly string[]
-  ).includes(file.type);
-  const extOk = (
-    ALLOWED_BUSINESS_CARD_EXTENSIONS as readonly string[]
-  ).includes(ext);
-  if (!mimeOk && !extOk) {
-    return "Business card must be an image (JPEG, PNG, or HEIC).";
+  const ext = fileExtensionOf(file.name);
+  const mime = file.type;
+  const errMsg = "Business card must be an image (JPEG, PNG, or HEIC).";
+
+  // Extension is only a fallback when the MIME is absent/generic. A specific
+  // MIME must itself be allowlisted, so a text/html payload named *.jpg or an
+  // image/gif cannot slip through on extension alone.
+  if (mime === "" || mime === "application/octet-stream") {
+    return (ALLOWED_BUSINESS_CARD_EXTENSIONS as readonly string[]).includes(ext)
+      ? null
+      : errMsg;
   }
-  return null;
+  return (ALLOWED_BUSINESS_CARD_MIME_TYPES as readonly string[]).includes(mime)
+    ? null
+    : errMsg;
 }

--- a/lib/crm-upload-limits.ts
+++ b/lib/crm-upload-limits.ts
@@ -34,3 +34,34 @@ export function getImageSizeValidationError(
 
   return `${args.label} is ${formatFileSize(args.fileSize)}. Maximum allowed size is ${formatFileSize(maxBytes)}. Resize or compress the image before uploading.`;
 }
+
+// Business-card capture accepts images only. Previously the route validated size
+// but accepted ANY content type into the AI-vision extraction pipeline.
+export const ALLOWED_BUSINESS_CARD_MIME_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/heic",
+  "image/heif",
+] as const;
+
+export const ALLOWED_BUSINESS_CARD_EXTENSIONS = [
+  ".jpg",
+  ".jpeg",
+  ".png",
+  ".heic",
+  ".heif",
+] as const;
+
+export function getBusinessCardFileTypeError(file: File): string | null {
+  const ext = `.${file.name.split(".").pop()?.toLowerCase() ?? ""}`;
+  const mimeOk = (
+    ALLOWED_BUSINESS_CARD_MIME_TYPES as readonly string[]
+  ).includes(file.type);
+  const extOk = (
+    ALLOWED_BUSINESS_CARD_EXTENSIONS as readonly string[]
+  ).includes(ext);
+  if (!mimeOk && !extOk) {
+    return "Business card must be an image (JPEG, PNG, or HEIC).";
+  }
+  return null;
+}

--- a/lib/receipts/abort-registry.ts
+++ b/lib/receipts/abort-registry.ts
@@ -1,0 +1,38 @@
+// Client-safe registry of in-flight AbortControllers for capture uploads.
+// Extracted from useReceiptUpload so the cancel/reset lifecycle is testable
+// without a React harness. Uses only the AbortController global.
+
+/**
+ * Tracks AbortControllers for in-flight uploads so cancel()/reset() can abort
+ * every one at once. register/unregister are paired around each upload;
+ * abortAll() aborts every registered controller and clears the registry.
+ *
+ * Invariants:
+ *   - abortAll() clears the registry, so a later unregister() is a harmless
+ *     no-op (Set.delete on a missing key).
+ *   - unregister() never throws, even after abortAll().
+ */
+export class AbortRegistry {
+  private readonly controllers = new Set<AbortController>();
+
+  register(controller: AbortController): void {
+    this.controllers.add(controller);
+  }
+
+  unregister(controller: AbortController): void {
+    this.controllers.delete(controller);
+  }
+
+  /** Abort every registered controller, then clear the registry. */
+  abortAll(): void {
+    for (const controller of this.controllers) {
+      controller.abort();
+    }
+    this.controllers.clear();
+  }
+
+  /** Number of currently registered controllers. */
+  get size(): number {
+    return this.controllers.size;
+  }
+}

--- a/lib/receipts/session-upload.ts
+++ b/lib/receipts/session-upload.ts
@@ -1,0 +1,50 @@
+// Client-safe model for a desktop capture session row + its pure state
+// transitions. Extracted from ReceiptCaptureForm so the desktop upload
+// state machine is unit-testable without a DOM harness. No React, no server
+// imports.
+
+export type SessionUploadState = "uploading" | "ready" | "review" | "error";
+
+export interface SessionUpload {
+  id: string;
+  fileName: string;
+  fileSizeBytes: number;
+  state: SessionUploadState;
+  pct: number;
+  merchant?: string;
+  amount?: string;
+  date?: string;
+  receiptId?: string;
+  errorMessage?: string;
+}
+
+/**
+ * Pure transitions for a desktop session row. Each returns a NEW row (never
+ * undefined) — there is no "remove" transition, so a cancelled/failed upload
+ * can never be silently dropped from the batch. Callers apply these via
+ * sessionUploads.map((u) => (u.id === id ? transition(u, ...) : u)).
+ */
+
+export function applyUploadSuccess(
+  row: SessionUpload,
+  receiptId: string,
+): SessionUpload {
+  return { ...row, state: "ready", pct: 100, receiptId };
+}
+
+export function applyUploadFailure(
+  row: SessionUpload,
+  message: string,
+): SessionUpload {
+  return { ...row, state: "error", pct: 100, errorMessage: message };
+}
+
+/**
+ * Cancellation transition. The row is RETAINED (returned, not removed) and
+ * surfaced as a visible error tile carrying a "Cancelled" message. This is the
+ * pure-function guarantee that cancellation never silently drops a row;
+ * BatchTile already renders errorMessage, so no DOM harness is required.
+ */
+export function applyUploadCancellation(row: SessionUpload): SessionUpload {
+  return applyUploadFailure(row, "Cancelled");
+}

--- a/lib/receipts/single-flight.ts
+++ b/lib/receipts/single-flight.ts
@@ -1,0 +1,35 @@
+// Client-side mobile capture guard. Pure, no React.
+
+/**
+ * A one-slot gate used to enforce mobile single-flight: at most one mobile
+ * upload runs at a time, so a second capture tap while one is uploading cannot
+ * overwrite the active upload's phase.
+ *
+ * Behavior chosen (mobile re-entry policy): EXPLICIT REJECTION. `start()`
+ * returns false when busy; the caller must skip the second invocation rather
+ * than queue it. This keeps the normal camera UI (capture -> upload -> re-arm)
+ * unchanged while guaranteeing the in-flight phase is never clobbered. Rejection
+ * is silent to the camera UI (no error tile) because the steady-state flow never
+ * triggers it — it only guards a rapid double-tap during upload.
+ */
+export class SingleFlight {
+  private inFlight = false;
+
+  /** Try to begin a run. Returns true if this call won the start; false if one
+   *  is already in flight (caller should reject/skip). */
+  start(): boolean {
+    if (this.inFlight) return false;
+    this.inFlight = true;
+    return true;
+  }
+
+  /** Mark the current run finished, re-enabling start(). */
+  finish(): void {
+    this.inFlight = false;
+  }
+
+  /** True while a run is in progress. */
+  get busy(): boolean {
+    return this.inFlight;
+  }
+}

--- a/lib/receipts/upload-policy.ts
+++ b/lib/receipts/upload-policy.ts
@@ -1,0 +1,143 @@
+// Client-safe shared upload policy for receipt capture.
+//
+// This module is imported by BOTH client components (capture UI) and server
+// routes (enforcement) so the two cannot drift apart. It must stay free of any
+// server-only import (no cloudflare-runtime, no Node-only APIs) — it runs in
+// the browser bundle.
+//
+// Architect decisions captured here (2026-07-16):
+//   - EML/HTML are NOT accepted: no email/HTML ingestion pipeline exists, so
+//     advertising them would let users drop files the server then rejects.
+//   - The 5 MiB limit is kept (extraction request body is base64 ≈1.33× and
+//     JSON-stringified; larger files risk Error 1102 under back-to-back runs).
+//   - Desktop batches are capped at 25 files; overflow is rejected visibly.
+//   - Desktop upload concurrency is 3 (FIFO beyond that).
+//   - Provenance (`source`) is required and must be a known value; the route
+//     no longer silently defaults to "mobile_capture", which had mislabeled
+//     every desktop upload.
+
+import type { SourceType } from "@/lib/receipts/types";
+
+// ─── Accepted file types ───────────────────────────────────────────────────
+
+export const ALLOWED_RECEIPT_MIME_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/heic",
+  "image/heif",
+  "application/pdf",
+] as const;
+
+export const ALLOWED_RECEIPT_EXTENSIONS = [
+  ".jpg",
+  ".jpeg",
+  ".png",
+  ".heic",
+  ".heif",
+  ".pdf",
+] as const;
+
+// `<input accept>` for the desktop dropzone, derived from the same source list
+// as the server validator. Deliberately excludes .eml/.html (see header).
+export const RECEIPT_ACCEPT_ATTR = "image/*,application/pdf";
+
+// ─── Size / batch / concurrency limits ─────────────────────────────────────
+
+// 5 MiB cap on both upload and extraction. See header for the 1102 rationale.
+export const MAX_RECEIPT_FILE_BYTES = 5 * 1024 * 1024; // 5 MiB
+
+// Desktop drop batch cap. Enforced at the dropzone; overflow is surfaced as a
+// visible rejection rather than silently dropped.
+export const MAX_DESKTOP_BATCH_FILES = 25;
+
+// Max concurrent uploads on the desktop path. Drops beyond this queue in order
+// (FIFO) — see receipt-capture-form.tsx's UploadPool.
+export const DESKTOP_MAX_CONCURRENT_UPLOADS = 3;
+
+// ─── Capture source / provenance ───────────────────────────────────────────
+
+// The `source` column records how a receipt entered the system. The upload
+// route requires an explicit, valid value — it no longer silently defaults to
+// "mobile_capture". The capture client selects the value: mobile web →
+// mobile_capture, desktop → desktop_upload. (The native iOS path uses a
+// separate route and hardcodes mobile_capture.)
+export const VALID_SOURCES = ["mobile_capture", "desktop_upload"] as const;
+export type Source = (typeof VALID_SOURCES)[number];
+
+export function isValidSource(value: string | undefined): value is Source {
+  return !!value && (VALID_SOURCES as readonly string[]).includes(value);
+}
+
+// `source_type` is the document classification. An explicit valid value from
+// the client wins; otherwise it is derived. This is the single source of truth
+// — previously duplicated in app/api/receipts/upload and [id] routes.
+export const VALID_SOURCE_TYPES: readonly SourceType[] = [
+  "paper_scanned",
+  "electronic_receipt",
+  "digital_invoice",
+  "credit_card_statement",
+  "email_attachment",
+  "manual_upload",
+  "amex_csv",
+];
+
+/**
+ * Classify a receipt's source_type. Rules (architect-confirmed 2026-07-16):
+ *   1. An explicit, valid sourceType from the client wins.
+ *   2. mobile_capture → paper_scanned (camera capture, regardless of content).
+ *   3. application/pdf → electronic_receipt.
+ *   4. otherwise → manual_upload (e.g. a desktop image drop).
+ *
+ * No filename-based "paper scan" detection — the system lacks the information
+ * to infer that reliably (a phone-scanned paper receipt dropped via desktop
+ * stays manual_upload until the operator says otherwise).
+ */
+export function deriveSourceType(
+  explicitSourceType: string | undefined,
+  source: Source,
+  contentType: string,
+): SourceType {
+  if (
+    explicitSourceType &&
+    VALID_SOURCE_TYPES.includes(explicitSourceType as SourceType)
+  ) {
+    return explicitSourceType as SourceType;
+  }
+  if (source === "mobile_capture") return "paper_scanned";
+  if (contentType === "application/pdf") return "electronic_receipt";
+  return "manual_upload";
+}
+
+// ─── Validation ────────────────────────────────────────────────────────────
+
+export function validateReceiptFile(file: File): string | null {
+  if (file.size > MAX_RECEIPT_FILE_BYTES) {
+    const mb = (file.size / (1024 * 1024)).toFixed(1);
+    return `File is too large (${mb} MB). Maximum allowed size is ${formatFileSize(MAX_RECEIPT_FILE_BYTES)}.`;
+  }
+
+  const ext = `.${file.name.split(".").pop()?.toLowerCase() ?? ""}`;
+  const mimeOk = (ALLOWED_RECEIPT_MIME_TYPES as readonly string[]).includes(
+    file.type,
+  );
+  const extOk = (ALLOWED_RECEIPT_EXTENSIONS as readonly string[]).includes(ext);
+
+  if (!mimeOk && !extOk) {
+    return "File type not allowed. Accepted: JPEG, PNG, HEIC, PDF.";
+  }
+
+  return null;
+}
+
+// ─── Display formatting (client-safe; used in copy so it can't drift) ──────
+
+// Renders a byte count as a compact human string. Kept here (not inlined in
+// copy) so "20 MB" / "5 MB" style claims can never diverge from the real limit.
+export function formatFileSize(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+  if (bytes < 1024) return `${bytes} B`;
+  const kib = bytes / 1024;
+  if (kib < 1024) return `${kib.toFixed(1)} KB`;
+  const mib = bytes / (1024 * 1024);
+  return `${mib} MB`;
+}

--- a/lib/receipts/upload-policy.ts
+++ b/lib/receipts/upload-policy.ts
@@ -37,9 +37,11 @@ export const ALLOWED_RECEIPT_EXTENSIONS = [
   ".pdf",
 ] as const;
 
-// `<input accept>` for the desktop dropzone, derived from the same source list
-// as the server validator. Deliberately excludes .eml/.html (see header).
-export const RECEIPT_ACCEPT_ATTR = "image/*,application/pdf";
+// `<input accept>` for the desktop dropzone, derived from the same extension
+// list as the server validator. Enumerates accepted formats explicitly — no
+// `image/*` wildcard, which would advertise formats (GIF, BMP, SVG, …) the
+// server rejects. Deliberately excludes .eml/.html (see header).
+export const RECEIPT_ACCEPT_ATTR = ALLOWED_RECEIPT_EXTENSIONS.join(",");
 
 // ─── Size / batch / concurrency limits ─────────────────────────────────────
 
@@ -110,23 +112,50 @@ export function deriveSourceType(
 
 // ─── Validation ────────────────────────────────────────────────────────────
 
+/** Lowercased ".ext" (including the dot) from a filename; "" if there is none. */
+function fileExtensionOf(name: string): string {
+  const dot = name.lastIndexOf(".");
+  if (dot < 0) return "";
+  return name.slice(dot).toLowerCase();
+}
+
 export function validateReceiptFile(file: File): string | null {
   if (file.size > MAX_RECEIPT_FILE_BYTES) {
     const mb = (file.size / (1024 * 1024)).toFixed(1);
     return `File is too large (${mb} MB). Maximum allowed size is ${formatFileSize(MAX_RECEIPT_FILE_BYTES)}.`;
   }
 
-  const ext = `.${file.name.split(".").pop()?.toLowerCase() ?? ""}`;
-  const mimeOk = (ALLOWED_RECEIPT_MIME_TYPES as readonly string[]).includes(
-    file.type,
-  );
-  const extOk = (ALLOWED_RECEIPT_EXTENSIONS as readonly string[]).includes(ext);
+  const ext = fileExtensionOf(file.name);
+  const mime = file.type;
+  const errMsg = "File type not allowed. Accepted: JPEG, PNG, HEIC, PDF.";
 
-  if (!mimeOk && !extOk) {
-    return "File type not allowed. Accepted: JPEG, PNG, HEIC, PDF.";
+  // The extension is only a fallback when the MIME is absent or generic. A
+  // specific MIME must itself be allowlisted — otherwise a text/html payload
+  // named *.jpg, or an image/gif, would slip through on extension alone.
+  if (mime === "" || mime === "application/octet-stream") {
+    return (ALLOWED_RECEIPT_EXTENSIONS as readonly string[]).includes(ext)
+      ? null
+      : errMsg;
   }
+  return (ALLOWED_RECEIPT_MIME_TYPES as readonly string[]).includes(mime)
+    ? null
+    : errMsg;
+}
 
-  return null;
+/**
+ * Split a selection into an accepted prefix (≤ limit) and a rejected count.
+ * Pure. Used to enforce the per-drop desktop batch cap WITHOUT subtracting the
+ * existing session — a session-cumulative cap would lock the session out over
+ * time as ready/review rows accumulate. Each drop is independently capped.
+ */
+export function partitionBatch<T>(
+  items: readonly T[],
+  limit: number,
+): { accepted: T[]; rejected: number } {
+  if (items.length <= limit) {
+    return { accepted: items.slice(), rejected: 0 };
+  }
+  return { accepted: items.slice(0, limit), rejected: items.length - limit };
 }
 
 // ─── Display formatting (client-safe; used in copy so it can't drift) ──────

--- a/lib/receipts/upload-pool.ts
+++ b/lib/receipts/upload-pool.ts
@@ -1,0 +1,73 @@
+// Client-safe FIFO semaphore for desktop multi-file uploads. No React, no
+// server-only imports — pure logic extracted from ReceiptCaptureForm so it can
+// be unit-tested and reused.
+
+/**
+ * A concurrency-limited FIFO pool. At most `limit` acquires are active at once;
+ * further acquires resolve in arrival order (FIFO) as slots are released.
+ *
+ * Slot handoff model: when release() is called with waiters, the held slot is
+ * transferred directly to the next waiter (active count unchanged) — this is
+ * what guarantees no leaked active count and no stranded waiters, because every
+ * waiter corresponds to capacity currently held by a runner that will release.
+ *
+ * Contract: the caller MUST call slot.release() when its work ends — typically
+ * via try/finally, so a thrown/rejected task still frees its slot.
+ * slot.release() is idempotent (double-release is a no-op).
+ */
+export interface PoolSlot {
+  /** Release the slot. Idempotent: a second call is a no-op. */
+  release: () => void;
+}
+
+export class UploadPool {
+  private active = 0;
+  private readonly waiters: Array<() => void> = [];
+
+  constructor(private readonly limit: number) {
+    if (!Number.isInteger(limit) || limit < 1) {
+      throw new Error(
+        `UploadPool limit must be a positive integer (got ${limit})`,
+      );
+    }
+  }
+
+  /** Number of slots currently held by running work. */
+  get activeCount(): number {
+    return this.active;
+  }
+
+  /** Number of acquires waiting for a slot. */
+  get queuedCount(): number {
+    return this.waiters.length;
+  }
+
+  /** Resolve once a slot is available; release() the returned slot when done. */
+  async acquire(): Promise<PoolSlot> {
+    if (this.active < this.limit) {
+      this.active += 1;
+      return this.makeSlot();
+    }
+    // Queue: resolve only when a runner hands off its slot via release().
+    await new Promise<void>((resolve) => this.waiters.push(resolve));
+    // active was already counted for us by the handoff in release().
+    return this.makeSlot();
+  }
+
+  private makeSlot(): PoolSlot {
+    let released = false;
+    const release = () => {
+      if (released) return; // idempotent — defend against double-release
+      released = true;
+      const next = this.waiters.shift();
+      if (next) {
+        // Hand the slot directly to the next waiter; active stays the same.
+        next();
+      } else {
+        // No waiter — actually free the slot.
+        this.active -= 1;
+      }
+    };
+    return { release };
+  }
+}

--- a/lib/receipts/validation.ts
+++ b/lib/receipts/validation.ts
@@ -1,46 +1,17 @@
 import type { ImportAmexLineInput } from "@/lib/receipts/types";
 
-export const ALLOWED_RECEIPT_MIME_TYPES = [
-  "image/jpeg",
-  "image/png",
-  "image/heic",
-  "image/heif",
-  "application/pdf",
-];
-
-export const ALLOWED_RECEIPT_EXTENSIONS = [
-  ".jpg",
-  ".jpeg",
-  ".png",
-  ".heic",
-  ".heif",
-  ".pdf",
-];
-
-// 5 MiB cap on both upload and extraction. The Google Vision request body
-// is base64-encoded (≈ 1.33× the raw size) and JSON.stringified — anything
-// larger pins enough heap in the worker to trip 1102 during back-to-back
-// extractions. Clients should resize before upload (see client-image.ts).
-export const MAX_RECEIPT_FILE_BYTES = 5 * 1024 * 1024; // 5 MiB
+// Receipt file validation, accepted types, and size limits now live in the
+// client-safe upload-policy module (shared with capture components so the UI
+// contract and server enforcement can't drift). Re-exported here for existing
+// callers/tests that import from "@/lib/receipts/validation".
+export {
+  validateReceiptFile,
+  MAX_RECEIPT_FILE_BYTES,
+  ALLOWED_RECEIPT_MIME_TYPES,
+  ALLOWED_RECEIPT_EXTENSIONS,
+} from "@/lib/receipts/upload-policy";
 
 export const ALLOWED_CURRENCIES = ["JPY", "USD", "EUR", "GBP", "AUD", "CNY"];
-
-export function validateReceiptFile(file: File): string | null {
-  if (file.size > MAX_RECEIPT_FILE_BYTES) {
-    const mb = (file.size / (1024 * 1024)).toFixed(1);
-    return `File is too large (${mb} MB). Maximum allowed size is 5 MB.`;
-  }
-
-  const ext = `.${file.name.split(".").pop()?.toLowerCase() ?? ""}`;
-  const mimeOk = ALLOWED_RECEIPT_MIME_TYPES.includes(file.type);
-  const extOk = ALLOWED_RECEIPT_EXTENSIONS.includes(ext);
-
-  if (!mimeOk && !extOk) {
-    return `File type not allowed. Accepted: JPEG, PNG, HEIC, PDF.`;
-  }
-
-  return null;
-}
 
 export function validateReceiptDate(value: string): boolean {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "cf-typegen": "wrangler types cloudflare-env.d.ts --env-interface CloudflareEnv",
     "start": "next start",
     "lint": "eslint",
-    "test": "tsx --test tests/**/*.test.ts"
+    "test": "tsx --test \"tests/**/*.test.ts\""
   },
   "dependencies": {
     "@clerk/nextjs": "^7.5.12",

--- a/tests/crm-upload-limits.test.ts
+++ b/tests/crm-upload-limits.test.ts
@@ -1,10 +1,18 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  ALLOWED_BUSINESS_CARD_EXTENSIONS,
+  ALLOWED_BUSINESS_CARD_MIME_TYPES,
   formatFileSize,
+  getBusinessCardFileTypeError,
   getImageSizeValidationError,
   MAX_BATCH_AI_IMAGE_BYTES,
 } from "@/lib/crm-upload-limits";
+
+function makeFile(name: string, type: string, sizeBytes: number): File {
+  const content = new Uint8Array(sizeBytes);
+  return new File([content], name, { type });
+}
 
 test("formatFileSize renders human-readable values", () => {
   assert.equal(formatFileSize(0), "0 B");
@@ -28,5 +36,55 @@ test("getImageSizeValidationError rejects oversized uploads and accepts smaller 
       label: "The composite image",
     }) ?? "",
     /Maximum allowed size is 4\.0 MB/,
+  );
+});
+
+// ─── Business-card MIME policy ─────────────────────────────────────────────
+
+test("ALLOWED_BUSINESS_CARD_*: image-only, no pdf/html", () => {
+  assert.ok(!ALLOWED_BUSINESS_CARD_MIME_TYPES.includes("application/pdf"));
+  assert.ok(!ALLOWED_BUSINESS_CARD_EXTENSIONS.includes(".pdf"));
+  assert.ok(!ALLOWED_BUSINESS_CARD_EXTENSIONS.includes(".html"));
+});
+
+test("getBusinessCardFileTypeError: accepted image types pass", () => {
+  for (const mime of ALLOWED_BUSINESS_CARD_MIME_TYPES) {
+    const ext = mime === "image/jpeg" ? "jpg" : (mime.split("/")[1] ?? "jpg");
+    const file = makeFile(`card.${ext}`, mime, 1024);
+    assert.equal(
+      getBusinessCardFileTypeError(file),
+      null,
+      `expected null for ${mime}`,
+    );
+  }
+});
+
+test("getBusinessCardFileTypeError: non-image and spoofed types are rejected", () => {
+  // Specific non-allowlisted MIMEs are rejected outright.
+  assert.ok(
+    getBusinessCardFileTypeError(makeFile("card.pdf", "application/pdf", 1024)),
+  );
+  assert.ok(
+    getBusinessCardFileTypeError(makeFile("anim.gif", "image/gif", 1024)),
+  );
+  // text/html named *.jpg: MIME is specific and not allowlisted; the .jpg
+  // extension must not rescue it.
+  assert.ok(
+    getBusinessCardFileTypeError(makeFile("card.jpg", "text/html", 1024)),
+  );
+});
+
+test("getBusinessCardFileTypeError: extension fallback for empty/generic MIME", () => {
+  assert.equal(getBusinessCardFileTypeError(makeFile("card.jpg", "", 1024)), null);
+  assert.equal(
+    getBusinessCardFileTypeError(
+      makeFile("card.png", "application/octet-stream", 1024),
+    ),
+    null,
+  );
+  assert.ok(
+    getBusinessCardFileTypeError(
+      makeFile("card.exe", "application/octet-stream", 1024),
+    ),
   );
 });

--- a/tests/receipts/abort-registry.test.ts
+++ b/tests/receipts/abort-registry.test.ts
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { AbortRegistry } from "@/lib/receipts/abort-registry";
+
+test("AbortRegistry: register tracks size; abortAll aborts every controller and clears", () => {
+  const reg = new AbortRegistry();
+  const a = new AbortController();
+  const b = new AbortController();
+  assert.equal(reg.size, 0);
+
+  reg.register(a);
+  reg.register(b);
+  assert.equal(reg.size, 2);
+
+  reg.abortAll();
+  assert.equal(a.signal.aborted, true);
+  assert.equal(b.signal.aborted, true);
+  assert.equal(reg.size, 0); // cleared
+});
+
+test("AbortRegistry: unregister before abort removes only that controller", () => {
+  const reg = new AbortRegistry();
+  const a = new AbortController();
+  const b = new AbortController();
+  reg.register(a);
+  reg.register(b);
+
+  reg.unregister(a);
+  assert.equal(reg.size, 1);
+
+  reg.abortAll();
+  assert.equal(b.signal.aborted, true);
+  assert.equal(a.signal.aborted, false); // a was unregistered, so not aborted
+});
+
+test("AbortRegistry: unregister after abortAll is harmless", () => {
+  const reg = new AbortRegistry();
+  const a = new AbortController();
+  reg.register(a);
+  reg.abortAll();
+  assert.equal(reg.size, 0);
+
+  // No throw, no state change.
+  reg.unregister(a);
+  assert.equal(reg.size, 0);
+
+  // Unregistering something never registered is also harmless.
+  reg.unregister(new AbortController());
+  assert.equal(reg.size, 0);
+});

--- a/tests/receipts/session-upload.test.ts
+++ b/tests/receipts/session-upload.test.ts
@@ -1,0 +1,68 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  applyUploadCancellation,
+  applyUploadFailure,
+  applyUploadSuccess,
+  type SessionUpload,
+} from "@/lib/receipts/session-upload";
+
+function uploadingRow(): SessionUpload {
+  return {
+    id: "r1",
+    fileName: "a.jpg",
+    fileSizeBytes: 1024,
+    state: "uploading",
+    pct: 30,
+  };
+}
+
+test("applyUploadSuccess: ready, pct 100, receiptId retained, identity preserved", () => {
+  const out = applyUploadSuccess(uploadingRow(), "rid-9");
+  assert.equal(out.state, "ready");
+  assert.equal(out.pct, 100);
+  assert.equal(out.receiptId, "rid-9");
+  assert.equal(out.id, "r1");
+  assert.equal(out.fileName, "a.jpg"); // other fields preserved
+});
+
+test("applyUploadFailure: error, pct 100, non-empty errorMessage retained", () => {
+  const out = applyUploadFailure(uploadingRow(), "Upload failed");
+  assert.equal(out.state, "error");
+  assert.equal(out.pct, 100);
+  assert.equal(out.errorMessage, "Upload failed");
+  assert.equal(out.id, "r1");
+});
+
+test("applyUploadCancellation: row retained with a visible message, never removed", () => {
+  const row = uploadingRow();
+  const out = applyUploadCancellation(row);
+
+  // Cancellation returns a row (not undefined) — it must not silently drop it.
+  assert.ok(out, "cancellation must return a row, not remove it");
+  assert.equal(out.state, "error");
+  assert.ok(
+    typeof out.errorMessage === "string" && out.errorMessage.length > 0,
+    "cancelled row must carry a visible message",
+  );
+  assert.equal(out.id, "r1"); // same row, retained
+  assert.equal(out.pct, 100);
+
+  // Original is untouched (immutability).
+  assert.equal(row.state, "uploading");
+});
+
+test("transitions applied via .map never drop sibling rows", () => {
+  const rows: SessionUpload[] = [
+    { id: "a", fileName: "a.jpg", fileSizeBytes: 1, state: "uploading", pct: 5 },
+    { id: "b", fileName: "b.jpg", fileSizeBytes: 1, state: "uploading", pct: 5 },
+  ];
+  const updated = rows.map((u) =>
+    u.id === "a" ? applyUploadFailure(u, "err") : u,
+  );
+
+  assert.equal(updated.length, 2); // both rows still present
+  assert.equal(updated[0]!.state, "error");
+  assert.equal(updated[0]!.errorMessage, "err");
+  assert.equal(updated[1]!.state, "uploading"); // sibling untouched
+});

--- a/tests/receipts/single-flight.test.ts
+++ b/tests/receipts/single-flight.test.ts
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { SingleFlight } from "@/lib/receipts/single-flight";
+
+test("SingleFlight: first start wins, second is rejected while busy", () => {
+  const sf = new SingleFlight();
+  assert.equal(sf.busy, false);
+  assert.equal(sf.start(), true);
+  assert.equal(sf.busy, true);
+  // A second invocation while one is in flight must NOT win — this is the
+  // guarantee that a rapid double-tap cannot overwrite the active phase.
+  assert.equal(sf.start(), false);
+  assert.equal(sf.start(), false);
+  assert.equal(sf.busy, true);
+});
+
+test("SingleFlight: finish re-enables start", () => {
+  const sf = new SingleFlight();
+  sf.start();
+  assert.equal(sf.busy, true);
+  sf.finish();
+  assert.equal(sf.busy, false);
+  assert.equal(sf.start(), true); // re-enabled
+  sf.finish();
+});
+
+test("SingleFlight: finish without start is harmless (returns to idle)", () => {
+  const sf = new SingleFlight();
+  sf.finish(); // no-op, not busy
+  assert.equal(sf.busy, false);
+  assert.equal(sf.start(), true);
+});

--- a/tests/receipts/upload-policy.test.ts
+++ b/tests/receipts/upload-policy.test.ts
@@ -12,6 +12,7 @@ import {
   deriveSourceType,
   formatFileSize,
   isValidSource,
+  partitionBatch,
   validateReceiptFile,
 } from "@/lib/receipts/upload-policy";
 
@@ -119,6 +120,28 @@ test("validateReceiptFile: EML and HTML are rejected (no ingestion pipeline)", (
   assert.ok(validateReceiptFile(html), "HTML must be rejected");
 });
 
+test("validateReceiptFile: a specific non-allowlisted MIME is rejected even with an allowed extension", () => {
+  // text/html named *.jpg: the MIME is specific and not allowlisted, so the
+  // .jpg extension must NOT rescue it.
+  assert.ok(validateReceiptFile(makeFile("evil.jpg", "text/html", 1024)));
+  // image/gif is a real image MIME but not in the allowlist.
+  assert.ok(validateReceiptFile(makeFile("anim.gif", "image/gif", 1024)));
+});
+
+test("validateReceiptFile: extension is the fallback only for empty/generic MIME", () => {
+  // Empty MIME + .jpg → accepted via extension fallback.
+  assert.equal(validateReceiptFile(makeFile("photo.jpg", "", 1024)), null);
+  // Generic octet-stream + .png → accepted via extension fallback.
+  assert.equal(
+    validateReceiptFile(makeFile("photo.png", "application/octet-stream", 1024)),
+    null,
+  );
+  // Generic MIME + disallowed extension → rejected.
+  assert.ok(
+    validateReceiptFile(makeFile("malware.exe", "application/octet-stream", 1024)),
+  );
+});
+
 test("validateReceiptFile: oversize rejected, boundary passes", () => {
   assert.ok(validateReceiptFile(makeFile("big.jpg", "image/jpeg", MAX_RECEIPT_FILE_BYTES + 1)));
   assert.equal(
@@ -135,10 +158,42 @@ test("limits: desktop batch = 25, concurrency = 3, size = 5 MiB", () => {
   assert.equal(MAX_RECEIPT_FILE_BYTES, 5 * 1024 * 1024);
 });
 
-test("RECEIPT_ACCEPT_ATTR: advertises images + PDF only, never EML/HTML", () => {
-  assert.match(RECEIPT_ACCEPT_ATTR, /image\/\*/);
-  assert.match(RECEIPT_ACCEPT_ATTR, /application\/pdf/);
+test("RECEIPT_ACCEPT_ATTR: enumerates accepted formats only, never image/* or eml/html", () => {
+  // Derived from the extension allowlist — no image/* wildcard, which would
+  // advertise GIF/BMP/SVG/… the server rejects.
+  assert.equal(RECEIPT_ACCEPT_ATTR, ALLOWED_RECEIPT_EXTENSIONS.join(","));
+  assert.doesNotMatch(RECEIPT_ACCEPT_ATTR, /image\/\*/);
   assert.doesNotMatch(RECEIPT_ACCEPT_ATTR, /eml|html/i);
+  for (const ext of ALLOWED_RECEIPT_EXTENSIONS) {
+    assert.ok(RECEIPT_ACCEPT_ATTR.includes(ext), `should advertise ${ext}`);
+  }
+});
+
+// ─── partitionBatch (per-drop desktop batch cap) ────────────────────────────
+
+test("partitionBatch: empty input", () => {
+  assert.deepEqual(partitionBatch([], MAX_DESKTOP_BATCH_FILES), {
+    accepted: [],
+    rejected: 0,
+  });
+});
+
+test("partitionBatch: input at the limit is fully accepted", () => {
+  const items = Array.from({ length: MAX_DESKTOP_BATCH_FILES }, (_, i) => i);
+  const result = partitionBatch(items, MAX_DESKTOP_BATCH_FILES);
+  assert.equal(result.accepted.length, MAX_DESKTOP_BATCH_FILES);
+  assert.equal(result.rejected, 0);
+});
+
+test("partitionBatch: input over the limit splits accepted prefix + remainder", () => {
+  const items = Array.from(
+    { length: MAX_DESKTOP_BATCH_FILES + 5 },
+    (_, i) => i,
+  );
+  const result = partitionBatch(items, MAX_DESKTOP_BATCH_FILES);
+  assert.equal(result.accepted.length, MAX_DESKTOP_BATCH_FILES);
+  assert.deepEqual(result.accepted, items.slice(0, MAX_DESKTOP_BATCH_FILES));
+  assert.equal(result.rejected, 5);
 });
 
 test("ALLOWED_RECEIPT_EXTENSIONS: no eml/html entries", () => {

--- a/tests/receipts/upload-policy.test.ts
+++ b/tests/receipts/upload-policy.test.ts
@@ -1,0 +1,154 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  ALLOWED_RECEIPT_EXTENSIONS,
+  ALLOWED_RECEIPT_MIME_TYPES,
+  DESKTOP_MAX_CONCURRENT_UPLOADS,
+  MAX_DESKTOP_BATCH_FILES,
+  MAX_RECEIPT_FILE_BYTES,
+  RECEIPT_ACCEPT_ATTR,
+  VALID_SOURCES,
+  VALID_SOURCE_TYPES,
+  deriveSourceType,
+  formatFileSize,
+  isValidSource,
+  validateReceiptFile,
+} from "@/lib/receipts/upload-policy";
+
+function makeFile(name: string, type: string, sizeBytes: number): File {
+  const content = new Uint8Array(sizeBytes);
+  return new File([content], name, { type });
+}
+
+// ─── Provenance: VALID_SOURCES / isValidSource ──────────────────────────────
+
+test("VALID_SOURCES: exactly the two capture provenances", () => {
+  assert.deepEqual([...VALID_SOURCES], ["mobile_capture", "desktop_upload"]);
+});
+
+test("isValidSource: accepts the two known sources, rejects everything else", () => {
+  assert.equal(isValidSource("mobile_capture"), true);
+  assert.equal(isValidSource("desktop_upload"), true);
+  // The old DB default / stale values must NOT be accepted as a `source`.
+  assert.equal(isValidSource("upload"), false);
+  assert.equal(isValidSource("manual_upload"), false); // a source_type, not a source
+  assert.equal(isValidSource("web"), false);
+  assert.equal(isValidSource(""), false);
+  assert.equal(isValidSource(undefined), false);
+});
+
+// ─── Classification: deriveSourceType ───────────────────────────────────────
+
+test("deriveSourceType: explicit valid sourceType wins over heuristic", () => {
+  assert.equal(
+    deriveSourceType("digital_invoice", "desktop_upload", "application/pdf"),
+    "digital_invoice",
+  );
+  assert.equal(
+    deriveSourceType("email_attachment", "mobile_capture", "image/jpeg"),
+    "email_attachment",
+  );
+});
+
+test("deriveSourceType: an explicit but invalid sourceType is ignored", () => {
+  assert.equal(
+    deriveSourceType("nonsense", "desktop_upload", "application/pdf"),
+    "electronic_receipt",
+  );
+});
+
+test("deriveSourceType: mobile_capture → paper_scanned, even for a PDF", () => {
+  // Camera capture is paper-scanned regardless of content type; mobile beats
+  // the PDF rule (architect rule order).
+  assert.equal(
+    deriveSourceType(undefined, "mobile_capture", "application/pdf"),
+    "paper_scanned",
+  );
+  assert.equal(
+    deriveSourceType(undefined, "mobile_capture", "image/jpeg"),
+    "paper_scanned",
+  );
+});
+
+test("deriveSourceType: desktop PDF → electronic_receipt", () => {
+  assert.equal(
+    deriveSourceType(undefined, "desktop_upload", "application/pdf"),
+    "electronic_receipt",
+  );
+});
+
+test("deriveSourceType: desktop image → manual_upload (no paper-scan guessing)", () => {
+  // The classifier never sees the filename — and even for a paper-looking
+  // image, desktop origin stays manual_upload. The system lacks the
+  // information to infer "paper scan" reliably (architect decision).
+  assert.equal(
+    deriveSourceType(undefined, "desktop_upload", "image/png"),
+    "manual_upload",
+  );
+  assert.equal(
+    deriveSourceType(undefined, "desktop_upload", "image/jpeg"),
+    "manual_upload",
+  );
+  assert.equal(
+    deriveSourceType(undefined, "desktop_upload", "application/octet-stream"),
+    "manual_upload",
+  );
+});
+
+test("VALID_SOURCE_TYPES: covers the union used by both upload routes", () => {
+  assert.ok(VALID_SOURCE_TYPES.includes("paper_scanned"));
+  assert.ok(VALID_SOURCE_TYPES.includes("electronic_receipt"));
+  assert.ok(VALID_SOURCE_TYPES.includes("manual_upload"));
+  assert.ok(VALID_SOURCE_TYPES.includes("amex_csv"));
+});
+
+// ─── validateReceiptFile: the no-EML/HTML policy ────────────────────────────
+
+test("validateReceiptFile: accepted types pass", () => {
+  for (const mime of ALLOWED_RECEIPT_MIME_TYPES) {
+    const ext = mime === "image/jpeg" ? "jpg" : mime.split("/")[1] ?? "jpg";
+    const file = makeFile(`receipt.${ext}`, mime, 1024);
+    assert.equal(validateReceiptFile(file), null, `expected null for ${mime}`);
+  }
+});
+
+test("validateReceiptFile: EML and HTML are rejected (no ingestion pipeline)", () => {
+  const eml = makeFile("receipt.eml", "message/rfc822", 1024);
+  assert.ok(validateReceiptFile(eml), "EML must be rejected");
+  const html = makeFile("receipt.html", "text/html", 1024);
+  assert.ok(validateReceiptFile(html), "HTML must be rejected");
+});
+
+test("validateReceiptFile: oversize rejected, boundary passes", () => {
+  assert.ok(validateReceiptFile(makeFile("big.jpg", "image/jpeg", MAX_RECEIPT_FILE_BYTES + 1)));
+  assert.equal(
+    validateReceiptFile(makeFile("max.jpg", "image/jpeg", MAX_RECEIPT_FILE_BYTES)),
+    null,
+  );
+});
+
+// ─── Limits & formatting (lock the contract used in UI copy) ───────────────
+
+test("limits: desktop batch = 25, concurrency = 3, size = 5 MiB", () => {
+  assert.equal(MAX_DESKTOP_BATCH_FILES, 25);
+  assert.equal(DESKTOP_MAX_CONCURRENT_UPLOADS, 3);
+  assert.equal(MAX_RECEIPT_FILE_BYTES, 5 * 1024 * 1024);
+});
+
+test("RECEIPT_ACCEPT_ATTR: advertises images + PDF only, never EML/HTML", () => {
+  assert.match(RECEIPT_ACCEPT_ATTR, /image\/\*/);
+  assert.match(RECEIPT_ACCEPT_ATTR, /application\/pdf/);
+  assert.doesNotMatch(RECEIPT_ACCEPT_ATTR, /eml|html/i);
+});
+
+test("ALLOWED_RECEIPT_EXTENSIONS: no eml/html entries", () => {
+  assert.ok(!ALLOWED_RECEIPT_EXTENSIONS.includes(".eml"));
+  assert.ok(!ALLOWED_RECEIPT_EXTENSIONS.includes(".html"));
+});
+
+test("formatFileSize: renders the byte counts used in copy", () => {
+  assert.equal(formatFileSize(MAX_RECEIPT_FILE_BYTES), "5 MB");
+  assert.equal(formatFileSize(0), "0 B");
+  assert.equal(formatFileSize(512), "512 B");
+  assert.equal(formatFileSize(2048), "2.0 KB");
+});

--- a/tests/receipts/upload-pool.test.ts
+++ b/tests/receipts/upload-pool.test.ts
@@ -1,0 +1,116 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { UploadPool, type PoolSlot } from "@/lib/receipts/upload-pool";
+
+/** Flush the microtask queue + one macrotask so async acquire() resolves. */
+const tick = () => new Promise<void>((r) => setImmediate(r));
+
+test("UploadPool: limit must be a positive integer", () => {
+  assert.throws(() => new UploadPool(0), /positive integer/);
+  assert.throws(() => new UploadPool(-1), /positive integer/);
+  assert.throws(() => new UploadPool(1.5), /positive integer/);
+});
+
+test("UploadPool: admits exactly `limit` then FIFO-queues the rest", async () => {
+  const pool = new UploadPool(3);
+  const slots: PoolSlot[] = [];
+  const labels: string[] = [];
+
+  const acquire = (label: string) =>
+    pool.acquire().then((slot) => {
+      labels.push(label);
+      slots.push(slot);
+      return slot;
+    });
+
+  // Fire five acquires synchronously.
+  const pending = ["A", "B", "C", "D", "E"].map(acquire);
+  await tick(); // A,B,C resolve immediately; D,E queue.
+
+  assert.equal(pool.activeCount, 3);
+  assert.equal(pool.queuedCount, 2);
+  assert.deepEqual(labels, ["A", "B", "C"]);
+
+  // Release A → D acquires (FIFO handoff, active unchanged).
+  slots[0]!.release();
+  await tick();
+  assert.equal(pool.activeCount, 3);
+  assert.equal(pool.queuedCount, 1);
+  assert.deepEqual(labels, ["A", "B", "C", "D"]);
+
+  // Release B → E acquires.
+  slots[1]!.release();
+  await tick();
+  assert.deepEqual(labels, ["A", "B", "C", "D", "E"]);
+  assert.equal(pool.queuedCount, 0);
+
+  // Drain: active returns to 0, no leak.
+  for (const s of slots.slice(2)) s.release();
+  await tick();
+  assert.equal(pool.activeCount, 0);
+  assert.equal(pool.queuedCount, 0);
+  // All acquires settled (no stranded waiters).
+  await Promise.all(pending);
+});
+
+test("UploadPool: at most `limit` tasks run concurrently", async () => {
+  const pool = new UploadPool(3);
+  let active = 0;
+  let maxActive = 0;
+  const task = async () => {
+    active += 1;
+    maxActive = Math.max(maxActive, active);
+    await tick();
+    active -= 1;
+  };
+
+  await Promise.all(
+    Array.from({ length: 6 }, () =>
+      pool.acquire().then(async (slot) => {
+        try {
+          await task();
+        } finally {
+          slot.release();
+        }
+      }),
+    ),
+  );
+
+  assert.equal(maxActive, 3);
+  assert.equal(pool.activeCount, 0);
+});
+
+test("UploadPool: slot is released when the task rejects (try/finally)", async () => {
+  const pool = new UploadPool(1);
+  const run = async (shouldThrow: boolean) => {
+    const slot = await pool.acquire();
+    try {
+      if (shouldThrow) throw new Error("boom");
+      await tick();
+    } finally {
+      slot.release();
+    }
+  };
+
+  await assert.rejects(run(true), /boom/);
+  assert.equal(pool.activeCount, 0); // freed despite the throw
+
+  // A follow-up acquire works immediately — no leaked slot.
+  const slot = await pool.acquire();
+  assert.equal(pool.activeCount, 1);
+  slot.release();
+  assert.equal(pool.activeCount, 0);
+});
+
+test("UploadPool: double release is a no-op (no negative active)", async () => {
+  const pool = new UploadPool(2);
+  const slot = await pool.acquire();
+  assert.equal(pool.activeCount, 1);
+  slot.release();
+  slot.release(); // idempotent
+  assert.equal(pool.activeCount, 0);
+
+  const s2 = await pool.acquire();
+  assert.equal(pool.activeCount, 1);
+  s2.release();
+});


### PR DESCRIPTION
## Summary

Hardens the receipt capture upload contract and the capture layer's reliability.
Introduces a client-safe shared upload policy, corrects the desktop capture
contract and provenance, tightens MIME validation, and backfills regression
coverage that previously didn't exist.

## What's included

- **Shared client-safe receipt upload policy** (`lib/receipts/upload-policy.ts`):
  the single source for accepted types, the 5 MiB size limit, the per-drop
  25-file batch cap, desktop concurrency (3), `VALID_SOURCES`,
  `VALID_SOURCE_TYPES`, `deriveSourceType`, `validateReceiptFile`, and display
  formatting. Imported by both client components and server routes so the UI
  contract and server enforcement cannot drift apart.
- **Accurate capture contract**: desktop no longer advertises EML/HTML (there is
  no ingestion pipeline). `<input accept>`, the dropzone copy, and the type pills
  derive from the policy; the stale "20 MB" copy is corrected to the real 5 MiB;
  the 25-file batch is enforced per drop with a visible rejection count.
- **Strict MIME validation**: a specific non-empty MIME must itself be
  allowlisted; the extension is a fallback only for empty or
  `application/octet-stream` MIME. `text/html` named `*.jpg` and `image/gif` are
  rejected. The same tightening is applied to the business-card upload, which
  previously validated size only.
- **Correct provenance**: desktop sends `desktop_upload`, mobile web sends
  `mobile_capture`. The upload route requires a value from `VALID_SOURCES`
  instead of silently defaulting to `mobile_capture` (which had mislabeled every
  desktop upload and corrupted its `source_type`). `deriveSourceType`: an explicit
  valid `sourceType` wins; otherwise mobile_capture→paper_scanned,
  PDF→electronic_receipt, otherwise manual_upload. No filename-based guessing.
  `VALID_SOURCE_TYPES` is de-duplicated.
- **Capture reliability**: the hand-rolled desktop semaphore, the mobile
  single-flight guard, the AbortController collection, and the `SessionUpload`
  row transitions are extracted into client-safe, unit-tested modules
  (`upload-pool.ts`, `single-flight.ts`, `abort-registry.ts`, `session-upload.ts`).
  Rows are never silently removed on failure or cancellation; dead `phase` and
  `initialPayment` props are removed from `CaptureDesktop`.
- **Test discovery fix**: the `npm test` glob is quoted so the six top-level
  `tests/*.test.ts` CRM files actually execute.

## Verification

- `npm test`: **437 total / 436 pass / 1 skipped**
- `npm run lint`: clean
- `npm run build:cf`: complete

No deployment or live-data change.
