### PR TITLE
docs: repair information architecture and current-system documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,18 +122,24 @@ Workers Logs 20M events, 7-day retention (use for per-route CPU
 attribution); Workers AI 10K/day and Durable Objects unlocked (unused —
 candidates for future extraction/processing phases, not current design).
 
-## Receipts Data Lifecycle (operator-confirmed, 2026-07)
+## Receipts Data Lifecycle (operator-confirmed, 2026-07; policy per ADR 0005)
 
-Steady state once monthly reconciliation is habitual: **at most 2 statement
-months open at a time**. When a new month starts, the previous month should be
-closed — all receipts reconciled against the monthly AMEX statement and the
-reconciliation finalized. Design consequences:
+Steady state once monthly reconciliation is habitual: the module is designed
+and tested for **3–4 concurrent open statement months** with overlapping
+statement windows (ADR 0005). There is **no hard runtime cap** on open months
+— the design still holds if a fifth month opens — but the normal operator
+habit favors closing the previous month (reconciling all receipts against the
+monthly AMEX statement and finalizing the reconciliation) once a new month
+starts. Design consequences:
 
-- Hot working set is bounded (≤2 open months). Prefer **month-scoped queries**
-  over global `LIMIT n` pagination in list/queue/reconcile views.
+- Hot working set is small in practice. Prefer **month-scoped queries** over
+  global `LIMIT n` pagination in list/queue/reconcile views.
 - Closed months are immutable (finalized-reconciliation guard already enforces
   this) → candidates for archival (R2 `RECEIPTS_ARCHIVE_BUCKET`) and exclusion
   from default views, keeping hot D1 size flat regardless of system age.
+- Out-of-order finalize is allowed with a non-blocking warning (sealing April
+  while March is open is legitimate); a receipt matched to AMEX lines in two
+  statement months blocks finalize on both until disambiguated.
 - Month-close should eventually be a visible gate/checklist in the UI, not
   just operator habit.
 
@@ -211,18 +217,31 @@ reconciliation finalized. Design consequences:
    still open. Note: consumer-level visibility_timeout_ms is 12h — benign
    because consumer.py overrides per-pull (5 min), but a trap for any
    future consumer that doesn't.
-10. **Source provenance: desktop uploads tagged "mobile_capture".** The
-    upload route doesn't validate `source` (free-form string) and the
-    desktop client hardcodes "mobile_capture". Follow-up per worker report
-    (4a08f92): desktop sends source="desktop_upload"; add a VALID_SOURCES
-    constant + route validation; extend the deriveSourceType heuristic so
-    a phone-scanned paper receipt dropped via desktop isn't mislabeled
-    manual_upload. Existing rows keep their historical values.
-11. **Capture client test coverage + cleanup.** No tests existed for
-    use-receipt-upload.ts / receipt-capture-form.tsx — the multi-drop data
-    loss shipped unnoticed. Backfill unit tests: mobile single-flight,
-    desktop concurrent pool (limit 3, FIFO), abort/cancel paths, error
-    rows never silent. Same PR: remove CaptureDesktop's dead `phase` prop.
+10. **Source provenance: desktop uploads tagged "mobile_capture".** DONE
+    (e1005cd, 5514501). `source` is now a typed `VALID_SOURCES` value
+    (`mobile_capture` | `desktop_upload`) in the client-safe
+    `lib/receipts/upload-policy.ts`; the upload route requires and validates
+    it (rejects missing/invalid instead of silently defaulting to
+    `mobile_capture`); the desktop client sends `desktop_upload`, mobile web
+    sends `mobile_capture`. `deriveSourceType` and `VALID_SOURCE_TYPES` are
+    shared/single-sourced (explicit valid `sourceType` wins; else
+    mobile_capture→paper_scanned, PDF→electronic_receipt, otherwise
+    manual_upload). Note: filename-based "paper-scan" detection was
+    deliberately NOT added — the system lacks the information to infer that
+    reliably (architect decision). Existing rows keep their historical values.
+11. **Capture client test coverage + cleanup.** DONE (ee0e5e7). The
+    hand-rolled desktop pool, mobile single-flight guard, AbortController
+    collection, and SessionUpload row transitions were extracted into
+    client-safe, unit-tested modules (`lib/receipts/upload-pool.ts`,
+    `single-flight.ts`, `abort-registry.ts`, `session-upload.ts`). Coverage:
+    desktop concurrency exactly 3 + FIFO ordering + slot release on
+    resolve/reject; mobile single-flight; abort-registry lifecycle
+    (register/unregister/abortAll, unregister-after-abort harmless);
+    success/error/cancellation row transitions (rows never silently removed;
+    BatchTile renders the message). Dead props removed from
+    `CaptureDesktopProps` (`phase` and `initialPayment`); their mobile/form
+    usage is retained. 15 new tests; no jsdom/Testing Library added (pure
+    extraction).
 12. **Error-surfacing hardening pass (theme).** Three loss incidents share
     one property — failures that don't announce themselves: swallowed
     receipt_files manifest writes (#5), silent queue max-deliveries drops

--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ The system is several cooperating Cloudflare units (detail in
 - **Networking card** (`networking-card/`, Cloudflare Pages) — NFC/QR contact
   capture; shares `CRM_DB`.
 - **Email reply capture** (`workers/email-reply-capture/`, a separate Worker on
-  Cloudflare Email Routing) — ingests inbound email replies into `CRM_DB`.
+  Cloudflare Email Routing) — configured to ingest inbound email replies into
+  `CRM_DB`. It has its own `wrangler.jsonc`; **live deployment is not verified
+  from this tree** (do not assume it is running).
 - **Receipts extraction consumer** (`scripts/receipts-consumer/`, Mac M4) —
   off-platform HTTP pull consumer that drains `RECEIPTS_QUEUE` and runs MLX VLM
   extraction ([ADR 0001](docs/adr/0001-receipt-extraction-runtime.md)).
@@ -44,7 +46,8 @@ replaced.)
 
 Key runtime integrations:
 
-- `/api/contact` persists submissions into the `DB` D1 database.
+- `/api/contact` writes each submission to the `DB` D1 table **and** upserts it
+  into `CRM_DB` (`lib/crm.ts`).
 - `/admin/batches` runs business-card batch ingestion against the shared
   `CRM_DB`; Cloudflare AI does card detection and OCR field extraction.
 - Receipts capture is async store-and-forward: the Worker stores the file in

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 AI, Automation & Data Solutions website built with Next.js 16.2.3.
 
-> A consulting site with service pages, direct contact intake, an internal admin page, and NFC-enabled micro-pages.
+> A consulting site with service pages, direct contact intake, an internal admin CRM, a receipts reconciliation module, and NFC-enabled micro-pages.
 
 ## Tech Stack
 
@@ -12,25 +12,45 @@ AI, Automation & Data Solutions website built with Next.js 16.2.3.
 | Styling | [Tailwind CSS](https://tailwindcss.com) |
 | Fonts | Inter (Google Fonts) |
 | Runtime | Cloudflare Workers via [OpenNext Cloudflare](https://opennext.js.org/cloudflare) |
-| Persistence | Cloudflare D1 for contact submissions |
+| Auth | [Clerk](https://clerk.com) for `/admin`, `/receipts`, `/api/receipts` (see [docs/runbooks/clerk-auth-migration.md](docs/runbooks/clerk-auth-migration.md)) |
+| Persistence | Cloudflare D1 — `DB` (contact), `CRM_DB` (networking + CRM), `RECEIPTS_DB` (receipts) |
+| Object storage | Cloudflare R2 — `CRM_IMAGES`, `RECEIPTS_BUCKET`, `RECEIPTS_ARCHIVE_BUCKET` |
+| Async processing | Cloudflare Queue (`RECEIPTS_QUEUE`) drained by an off-platform Mac MLX consumer (ADR 0001) |
 | Optional local reference | Docker Compose + Dockerfile |
 | Optional LLM | [Ollama](https://ollama.com) |
 
 ## Production Architecture
 
-```text
-dazbeez.com → Cloudflare CDN → Cloudflare Worker → Next.js app
-                                            └→ D1 (contact submissions)
-```
+The system is several cooperating Cloudflare units (detail in
+[docs/architecture.md](docs/architecture.md)):
+
+- **Main site** (`dazbeez` Worker, repo root) — marketing site, `/contact`
+  intake, `/admin` CRM, and the **receipts module** (`/receipts`). Binds three
+  D1 databases (`DB`, `CRM_DB`, `RECEIPTS_DB`), three R2 buckets (`CRM_IMAGES`,
+  `RECEIPTS_BUCKET`, `RECEIPTS_ARCHIVE_BUCKET`), a Queue producer
+  (`RECEIPTS_QUEUE`), and Workers AI.
+- **Networking card** (`networking-card/`, Cloudflare Pages) — NFC/QR contact
+  capture; shares `CRM_DB`.
+- **Email reply capture** (`workers/email-reply-capture/`, a separate Worker on
+  Cloudflare Email Routing) — ingests inbound email replies into `CRM_DB`.
+- **Receipts extraction consumer** (`scripts/receipts-consumer/`, Mac M4) —
+  off-platform HTTP pull consumer that drains `RECEIPTS_QUEUE` and runs MLX VLM
+  extraction ([ADR 0001](docs/adr/0001-receipt-extraction-runtime.md)).
+
+Authentication: `/admin`, `/receipts`, and `/api/receipts` are gated by **Clerk**
+(Phase 2, PR #59; `middleware.ts` + `lib/receipts/auth.ts`); `/api/mobile/*`
+uses a device-bearer scheme. (The earlier HTTP-Basic auth for `/admin` has been
+replaced.)
 
 Key runtime integrations:
 
-- `/api/contact` persists submissions into a D1 database.
-- `/admin` uses HTTP Basic auth backed by runtime environment variables.
-- NFC dashboard data is fetched from the external NFC admin API.
-- `/admin/batches` runs business-card batch ingestion against the shared CRM D1.
-- The main site now binds both the local `DB` submission database and the shared `CRM_DB` used by the networking-card flow.
-- Cloudflare AI is used for card detection and OCR-style field extraction in the admin ingestion flow.
+- `/api/contact` persists submissions into the `DB` D1 database.
+- `/admin/batches` runs business-card batch ingestion against the shared
+  `CRM_DB`; Cloudflare AI does card detection and OCR field extraction.
+- Receipts capture is async store-and-forward: the Worker stores the file in
+  `RECEIPTS_BUCKET`, writes `RECEIPTS_DB`, and enqueues an extraction job; the
+  Mac consumer pulls, extracts, and writes results back. See the ADRs in
+  [docs/adr/](docs/adr/) and [docs/receipt-module.md](docs/receipt-module.md).
 
 ## Local Development
 
@@ -134,6 +154,12 @@ docker-compose --profile llm up -d
 | `/services` | Services list |
 | `/services/[slug]` | Service detail (ai, automation, data, governance, pm) |
 | `/contact` | Contact form |
+| `/admin` | Internal CRM + business-card ingestion (Clerk-authed) |
+| `/receipts` | Receipts reconciliation dashboard (Clerk-authed) |
+| `/receipts/capture` | Receipt capture (desktop + mobile web) |
+| `/receipts/review` | Receipt review queue |
+| `/receipts/reconcile` | AMEX statement reconciliation |
+| `/receipts/export` | Monthly export + compliance/finalize |
 | `/business-card` | NFC card explainer |
 | `/nfc` | NFC micro-page (widget-style) |
 | `/privacy-policy` | Privacy policy |

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,10 +21,9 @@ Authoritative descriptions of the system as deployed. Owner: architect + David.
 | [README.md](../README.md) | One-page root overview: tech stack, deployable units, routes, deploy commands. **Current.** |
 | [receipt-module.md](receipt-module.md) | Receipts subsystem route map. **Current (route map).** |
 | [business-card-crm-architecture.md](business-card-crm-architecture.md) | `/admin` CRM + paper business-card ingestion architecture. **Current.** |
-| [admin-dashboard.md](admin-dashboard.md) | `/admin` route data model + component reference. |
-| [nfc-module.md](nfc-module.md) | `/nfc` page + networking-card system. |
-| [ui-ux.md](ui-ux.md) | Design system: palette, typography, component inventory, layouts. |
-| [receipts-operating-manual-ja.pdf](receipts-operating-manual-ja.pdf) | Japanese operator manual for the receipts module (reference PDF; binary — not edited in tree). |
+| [nfc-module.md](nfc-module.md) | `/nfc` page + networking-card system. *Reference; currentness not revalidated.* |
+| [ui-ux.md](ui-ux.md) | Design system: palette, typography, component inventory, layouts. *Reference; currentness not revalidated.* |
+| receipts-operating-manual-ja.pdf | Japanese operator manual for the receipts module. **Local-only operator artifact — NOT in version control (untracked); obtain from the operator.** |
 
 ## 2. Operator Runbooks
 
@@ -32,7 +31,7 @@ Step-by-step operational procedures. Owner: operator (David) + architect.
 
 | Document | Description |
 |----------|-------------|
-| [runbooks/clerk-auth-migration.md](runbooks/clerk-auth-migration.md) | Clerk auth migration (replaced Basic auth); phase status recorded inline. **Authoritative for auth.** |
+| [runbooks/clerk-auth-migration.md](runbooks/clerk-auth-migration.md) | Clerk auth **migration history/status** (replaced Basic/CF Access). Not the current auth spec — for that see [architecture.md](architecture.md) and [receipt-module.md](receipt-module.md). |
 | [runbooks/cf-access-app.md](runbooks/cf-access-app.md) | Cloudflare Access setup for receipts. |
 | [runbooks/receipts-extraction-rollout.md](runbooks/receipts-extraction-rollout.md) | Mac-side rollout of the ADR 0001 store-and-forward extraction consumer. |
 | [month-close-runbook.md](month-close-runbook.md) | Operator runbook for closing a receipts month (incl. finalize notification email). |
@@ -56,6 +55,7 @@ doc is also linked from §1; treat as context for why the system looks as it doe
 |----------|-------------|
 | [prd.md](prd.md) | Original marketing-site PRD (v0.1.0). **Historical** — status banner + inline notes mark obsolete claims. |
 | [inquiry-workflow.md](inquiry-workflow.md) | Scripted `/inquiry` chat flow. **Historical/Retired** — route 308-redirects to `/contact`. |
+| [admin-dashboard.md](admin-dashboard.md) | The **former static, unauthenticated** admin dashboard. **Historical** — `/admin` is now a live Clerk-authed CRM; see [business-card-crm-architecture.md](business-card-crm-architecture.md). |
 | [dazbeez-receipt-module-prd.md](dazbeez-receipt-module-prd.md) | Receipts-module PRD. |
 | [receipt_PRD_update.md](receipt_PRD_update.md) | "Simplified Capture Flow" PRD update. |
 | [PRD_CaptureApp.md](PRD_CaptureApp.md) | iOS Capture-app PRD. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,17 +1,82 @@
-# Dazbeez Docs
+# Dazbeez Documentation
 
-Internal documentation for the Dazbeez consulting website and related systems.
+Index for the Dazbeez consulting site, its admin CRM, the receipts
+reconciliation module, and the supporting networking-card and email-reply
+components. Documents are grouped by role; status is noted where it can be
+verified from code or accepted ADRs. Unverified PRDs/plans are filed under
+**Product/Design History** rather than presented as current spec.
 
-## Contents
+Start with the [root README](../README.md) for a one-page overview and
+[architecture.md](architecture.md) for the system of deployable units.
+
+---
+
+## 1. Current Architecture
+
+Authoritative descriptions of the system as deployed. Owner: architect + David.
 
 | Document | Description |
 |----------|-------------|
-| [architecture.md](architecture.md) | System architecture, infrastructure, Docker services, traffic flow |
-| [ui-ux.md](ui-ux.md) | Design system, color palette, typography, component inventory, page layouts |
-| [prd.md](prd.md) | Product requirements, features, personas, goals, backlog |
-| [admin-dashboard.md](admin-dashboard.md) | Admin route, data model, component reference, security notes |
-| [inquiry-workflow.md](inquiry-workflow.md) | Chat flow, decision tree, routing logic, extension guide |
-| [nfc-module.md](nfc-module.md) | NFC `/nfc` page + networking card system (Cloudflare Pages, D1, OAuth) |
+| [architecture.md](architecture.md) | System of Cloudflare units (main Worker, networking-card Pages, email-reply Worker, Mac MLX consumer); D1/R2/Queue bindings; auth; detailed receipts export pipeline. **Current.** |
+| [README.md](../README.md) | One-page root overview: tech stack, deployable units, routes, deploy commands. **Current.** |
+| [receipt-module.md](receipt-module.md) | Receipts subsystem route map. **Current (route map).** |
+| [business-card-crm-architecture.md](business-card-crm-architecture.md) | `/admin` CRM + paper business-card ingestion architecture. **Current.** |
+| [admin-dashboard.md](admin-dashboard.md) | `/admin` route data model + component reference. |
+| [nfc-module.md](nfc-module.md) | `/nfc` page + networking-card system. |
+| [ui-ux.md](ui-ux.md) | Design system: palette, typography, component inventory, layouts. |
+| [receipts-operating-manual-ja.pdf](receipts-operating-manual-ja.pdf) | Japanese operator manual for the receipts module (reference PDF; binary — not edited in tree). |
+
+## 2. Operator Runbooks
+
+Step-by-step operational procedures. Owner: operator (David) + architect.
+
+| Document | Description |
+|----------|-------------|
+| [runbooks/clerk-auth-migration.md](runbooks/clerk-auth-migration.md) | Clerk auth migration (replaced Basic auth); phase status recorded inline. **Authoritative for auth.** |
+| [runbooks/cf-access-app.md](runbooks/cf-access-app.md) | Cloudflare Access setup for receipts. |
+| [runbooks/receipts-extraction-rollout.md](runbooks/receipts-extraction-rollout.md) | Mac-side rollout of the ADR 0001 store-and-forward extraction consumer. |
+| [month-close-runbook.md](month-close-runbook.md) | Operator runbook for closing a receipts month (incl. finalize notification email). |
+
+## 3. Decisions (ADRs)
+
+Architecture Decision Records. Full index, status, and supersession links in
+[adr/README.md](adr/README.md). New ADRs from [adr/template.md](adr/template.md).
+
+Headline decisions: **ADR 0001** store-and-forward extraction (Mac MLX consumer),
+**ADR 0002** export unit = statement month, **ADR 0005** 3–4 concurrent open
+months (no hard runtime cap), **ADR 0008** calendar-month membership for
+non-AMEX receipts (supersedes parts of ADR 0006).
+
+## 4. Product / Design History and Backlog
+
+Historical product intent and design material. **Not current spec** unless a
+doc is also linked from §1; treat as context for why the system looks as it does.
+
+| Document | Description |
+|----------|-------------|
+| [prd.md](prd.md) | Original marketing-site PRD (v0.1.0). **Historical** — status banner + inline notes mark obsolete claims. |
+| [inquiry-workflow.md](inquiry-workflow.md) | Scripted `/inquiry` chat flow. **Historical/Retired** — route 308-redirects to `/contact`. |
+| [dazbeez-receipt-module-prd.md](dazbeez-receipt-module-prd.md) | Receipts-module PRD. |
+| [receipt_PRD_update.md](receipt_PRD_update.md) | "Simplified Capture Flow" PRD update. |
+| [PRD_CaptureApp.md](PRD_CaptureApp.md) | iOS Capture-app PRD. |
+| [PRD_CaptureApp_Architecture.md](PRD_CaptureApp_Architecture.md) | iOS Capture-app architecture + implementation plan. |
+| [amex_requirements.md](amex_requirements.md) | AMEX / Netアンサー statement import requirements. |
+| [expenseCat_Requirements.md](expenseCat_Requirements.md) | Expense-category requirements. |
+| [receipt_review_feature_requests.md](receipt_review_feature_requests.md) | Receipt-review feature-request backlog. |
+| [design-handoff/](design-handoff/) | Receipts UI/UX handoff package (brief, current-state, flows, open questions). |
+| [AGENTS.md](../AGENTS.md) | AI-agent guidelines incl. the architect-tracked **Receipts Backlog** (items #1–#15) and the Receipts Data Lifecycle policy (per ADR 0005). |
+
+## 5. Audits and Implementation Reports
+
+Point-in-time audits and PR-implementation notes. Dated; read as snapshots.
+
+| Document | Description |
+|----------|-------------|
+| [audits/2026-07-05-error-surfacing.md](audits/2026-07-05-error-surfacing.md) | Error-surfacing audit — 15 findings + infra gaps. |
+| [audits/export-remediation-2026-07-pr-notes.md](audits/export-remediation-2026-07-pr-notes.md) | PR notes for the 2026-07-08 export remediation. |
+| [audits/export-review-2026-07-08-cli-prompt.md](audits/export-review-2026-07-08-cli-prompt.md) | CLI-agent prompt for the export remediation review. |
+
+---
 
 ## Quick Reference
 
@@ -31,14 +96,15 @@ npm run cf:dev        # OpenNext/Workers local preview (port 8787)
 cd networking-card && npm run dev   # Cloudflare Pages local (port 8788)
 ```
 
-### Routes
+### Key routes
 
 | URL | Purpose |
 |-----|---------|
 | `https://dazbeez.com/` | Home page |
 | `https://dazbeez.com/services` | Services listing |
 | `https://dazbeez.com/services/[slug]` | Service detail (ai, automation, data, governance, pm) |
-| `https://dazbeez.com/contact` | Contact form |
+| `https://dazbeez.com/contact` | Contact form (persists to `DB`) |
+| `https://dazbeez.com/admin` | Internal CRM + business-card ingestion (Clerk-authed) |
+| `https://dazbeez.com/receipts` | Receipts reconciliation module (Clerk-authed) |
 | `https://dazbeez.com/nfc` | NFC quick-access widget |
-| `https://dazbeez.com/admin` | Internal operations dashboard (not publicly linked) |
 | `https://dazbeez.com/hi/:token` | Networking card NFC landing (Cloudflare Pages) |

--- a/docs/adr/0006-statement-window-membership-for-non-amex-receipts.md
+++ b/docs/adr/0006-statement-window-membership-for-non-amex-receipts.md
@@ -9,6 +9,9 @@
   with export-seal guard, roll-forward, unassignable-undated, audit) is carried
   into ADR 0008 unchanged. This document is kept verbatim as the history of what
   shipped and what was reversed.
+- **Superseded by:** [ADR 0008](./0008-calendar-month-membership-for-non-amex-receipts.md)
+  (in part) — see the Status field above for exactly what is retired vs. carried
+  forward. Kept verbatim as decision history.
 - **Date:** 2026-07-13
 - **Owner:** David (PM) — policy operator-decided 2026-07-13
 - **Affects:** `db/receipts/0020_*` (new), `lib/receipts/statement-window.ts`, `lib/receipts/month-closing.ts`, `lib/receipts/blockers.ts`, `lib/receipts/db.ts`, `lib/receipts/types.ts`, `lib/receipts/audit.ts`, `app/api/receipts/amex/import/route.ts`, `app/api/receipts/[id]/route.ts`, `components/receipts/export/review-screen.tsx`, `components/receipts/review/form-pane.tsx`, `components/receipts/export/export-screen.tsx`, `docs/month-close-runbook.md`, new `scripts/backfill-export-statement-month.ts`

--- a/docs/adr/0008-calendar-month-membership-for-non-amex-receipts.md
+++ b/docs/adr/0008-calendar-month-membership-for-non-amex-receipts.md
@@ -16,8 +16,8 @@
   new `scripts/migrate-membership-to-calendar-month.ts`, deleted
   `scripts/backfill-export-statement-month.ts`
 - **Builds on:** [ADR 0002](./0002-statement-month-export-scope.md) (export unit
-  = statement month), [ADR 0005](./0005-multi-open-month-assumption.md) (≤2 open
-  months), the migration-0017 export-revision machinery
+  = statement month), [ADR 0005](./0005-multi-open-month-assumption.md) (3–4
+  concurrent open months), the migration-0017 export-revision machinery
 - **Supersedes (in part):** [ADR 0006](./0006-statement-window-membership-for-non-amex-receipts.md)
   — its window-based membership rule (§D1 close-anchor, §D2 `computeStatementWindows`,
   §D3 window recomputation, §D4 UNKNOWN-window scoping), §D8 import sweep + drift
@@ -103,7 +103,7 @@ export function assignReceiptMembership(
    are skipped by the caller before this is called.)
 2. `natural` not sealed ⇒ `{ natural, "natural" }`.
 3. `natural` sealed + `rollForward` ⇒ walk forward by calendar month to the first
-   non-sealed month (bounded at 24; with ≤2 open months per ADR 0005 this is never
+   non-sealed month (bounded at 24; with 3–4 concurrent open months per ADR 0005 this is never
    reached, and the fallback returns `natural` so a receipt is never left
    unassigned). `rollForward=false` (UNKNOWN) keeps `natural` and blocks at gate 2.
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,44 @@
+# Architecture Decision Records (ADR)
+
+Decisions that shape the Dazbeez receipts module and adjacent subsystems. Each
+ADR is a dated, status-stamped record; supersession is captured with first-class
+`Supersedes` / `Superseded by` fields (see [template.md](template.md)) and kept
+**bidirectional** — when an ADR supersedes another, both records point at each
+other, and the superseded ADR is preserved verbatim as decision history.
+
+## Index
+
+| # | Title | Status | Date | Supersedes / Superseded by |
+|---|-------|--------|------|----------------------------|
+| [0001](0001-receipt-extraction-runtime.md) | Store-and-forward extraction runtime (Cloudflare Queue + Mac MLX consumer) | Accepted | 2026-06-09 / 2026-06-20 | — |
+| [0001-brief](0001-decision-brief.md) | Decision brief that produced ADR 0001 | Approved (brief) | 2026-06-20 | — |
+| [0002](0002-statement-month-export-scope.md) | Export unit = statement month | Accepted | 2026-07-08 | Supersedes the pre-redesign tx-date scope |
+| [0003](0003-compliance-engine-finalize-gate.md) | Compliance engine gates finalize | Accepted | 2026-07-08 | — |
+| [0004](0004-split-lock-model-cash-receipts.md) | Split lock model: reconciliation-sealed vs export-finalized | Accepted | 2026-07-08 | — |
+| [0005](0005-multi-open-month-assumption.md) | 3–4 concurrent open months (no hard runtime cap) | Accepted | 2026-07-08 | Retires the pre-2026-07-08 "≤2 open months" assumption in AGENTS.md |
+| [0006](0006-statement-window-membership-for-non-amex-receipts.md) | Statement-window membership for non-AMEX receipts | **Superseded in part** | 2026-07-13 | Superseded by [0008](0008-calendar-month-membership-for-non-amex-receipts.md) (in part); kept as history |
+| [0008](0008-calendar-month-membership-for-non-amex-receipts.md) | Calendar-month membership for non-AMEX receipts | Accepted | 2026-07-14 | Supersedes [0006](0006-statement-window-membership-for-non-amex-receipts.md) (in part) |
+| [0009](0009-sealed-month-amendment-policy.md) | Sealed-month amendment policy | Proposed (design of record, not yet implemented) | 2026-07-14 | — |
+
+### Numbering
+
+ADRs are numbered sequentially in the order they were written. **Numbering gaps
+are permitted** — an unused number does not imply a missing or deleted record.
+**No ADR 0007 was recorded**; the sequence simply jumps 0006 → 0008. Do not
+back-fill a placeholder.
+
+## Status values
+
+- **Proposed** — design of record, not yet implemented or not yet ratified.
+- **Accepted** — ratified and reflected in the running system.
+- **Superseded** / **Superseded in part** — replaced (wholly or partly) by a
+  later ADR; the record is kept verbatim as history.
+
+## Authoring a new ADR
+
+1. Copy [template.md](template.md) to `00NN-short-title.md` (next free number;
+   gaps are fine).
+2. Fill in Status, Date, Owner/Deciders, and `Supersedes` / `Superseded by` if
+   applicable.
+3. If your ADR supersedes another, update **both** records' supersession fields.
+4. Do not rewrite or delete superseded ADRs — annotate them in place.

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,26 @@
+# ADR 00NN — <short title>
+
+- **Status:** Proposed | Accepted | Superseded | Superseded in part
+- **Date:** YYYY-MM-DD
+- **Deciders / Owner:** <names>
+- **Supersedes:** <ADR number(s) this replaces, with links; or "—" >
+- **Superseded by:** <ADR number(s) that replace this one, with links; or "—" >
+- **Related:** <linked ADRs / docs / PRs that provide context; or "—" >
+- **Affects:** <code paths / files / migrations this decision touches>
+
+## Context
+
+What is the problem? What constraints, forces, or prior decisions are in play?
+Reference earlier ADRs and the current state of the code.
+
+## Decision
+
+The change we are making — stated concretely enough to be enforceable. Name the
+functions / routes / migrations / policies involved. Note any explicit
+non-decisions (e.g., "no runtime cap", "no filename-based detection") so they
+are not later assumed to be gaps.
+
+## Consequences
+
+What becomes easier, harder, or newly possible? What follow-up work or backlog
+items does this create? What must operators or future maintainers know?

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -96,7 +96,8 @@ npm run cf:dev
 Current runtime configuration (verified from `wrangler.jsonc` + code):
 
 - **Clerk** — `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` (checked-in var) + `CLERK_SECRET_KEY` (wrangler secret). The active auth gate (`middleware.ts`, `lib/receipts/auth.ts`).
-- **Receipts extraction processor** — `RECEIPTS_PROCESSOR_KEY` (wrangler secret); authenticates the Mac consumer's queue pulls and `POST /api/receipts/[id]/extract` (ADR 0001).
+- **Receipts extraction — Worker auth** — `RECEIPTS_PROCESSOR_KEY` (wrangler secret); authenticates the Mac consumer's requests to the Worker (`/file`, `/extract`, `/extraction-failed`, `/proof`) via the `x-receipts-processor-key` header (ADR 0001). Does **not** authenticate queue operations.
+- **Receipts extraction — Queues API** — `CF_API_TOKEN` (Mac-side; scoped `queues_read` + `queues_write`); authenticates Cloudflare Queues `/messages/pull` and `/messages/ack`. (Optional Cloudflare Access service-token headers are a separate edge layer when an Access application is configured.)
 - **Resend** — `RESEND_API_KEY` (wrangler secret); sends the finalize notification email. `NOTIFY_FROM_ADDRESS` and `ACCOUNTANT_EMAIL` are checked-in vars.
 - **Workers AI** — `AI` binding (remote); business-card detection and OCR field extraction in admin ingestion.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,7 @@ off-platform processing component:
 |------|----------|---------|---------|
 | **Main site** | `/` (repo root) | Marketing, contact intake, admin CRM, and the **receipts module** | Cloudflare Worker (`dazbeez`) + D1 + R2 + Queue + Workers AI |
 | **Networking card** | `networking-card/` | NFC/QR contact capture → vCard / GIS / Discord / email | Cloudflare Pages + Functions + D1 |
-| **Email reply capture** | `workers/email-reply-capture/` | Inbound email-reply ingestion into the CRM | Cloudflare Worker (`dazbeez-email-reply-capture`, Email Routing) + D1 |
+| **Email reply capture** | `workers/email-reply-capture/` | Inbound email-reply ingestion into the CRM | Cloudflare Worker (Email Routing) + D1 — **own `wrangler.jsonc` present; live deployment not verified from this tree** |
 | **Receipts extraction consumer** | `scripts/receipts-consumer/` (Mac M4) | Drains the extraction queue and runs MLX VLM extraction | Off-platform HTTP pull consumer (ADR 0001) |
 
 The units share two D1 databases: `CRM_DB` (networking card + admin CRM + email
@@ -28,17 +28,28 @@ file ([Receipts Module — Export Pipeline](#receipts-module--export-pipeline)).
 
 ## Traffic Flow (Production)
 
-```
-Browser → Cloudflare CDN (dazbeez.com)
-            ↓
-        Cloudflare Worker (`dazbeez`)
-            ↓
-      OpenNext server bundle on Workers
-            ↓
-      Cloudflare D1 (`dazbeez-submissions`) for `/api/contact`
+All public traffic reaches the main Worker (`dazbeez`) via the Cloudflare CDN;
+`www.dazbeez.com` is a Worker custom domain alongside `dazbeez.com`. Within the
+Worker, request paths fan out to different bindings:
+
+```text
+Browser ─▶ Cloudflare CDN (dazbeez.com) ─▶ Worker `dazbeez` (OpenNext)
+                                              │
+  /api/contact ─── dual-write ──┬─▶ D1 `DB`        (contact_submissions)
+                                └─▶ D1 `CRM_DB`    (CRM upsert via lib/crm.ts)
+  /admin ─── Clerk-authed ──────▶ D1 `CRM_DB` + R2 `CRM_IMAGES` (card OCR via Workers AI)
+  /receipts, /api/receipts ─────▶ D1 `RECEIPTS_DB` + R2 `RECEIPTS_BUCKET`
+  /api/receipts/upload ─────────▶ R2 put + D1 insert + Queue send `RECEIPTS_QUEUE`
+                                                                     │
+  Mac MLX consumer (scripts/receipts-consumer/) ◀── HTTP pull ──────┘
+       └─▶ POST /api/receipts/[id]/extract (processor-key) ─▶ D1 update
+  finalize / export ────────────▶ R2 `RECEIPTS_ARCHIVE_BUCKET` (5-artifact bundle)
 ```
 
-`www.dazbeez.com` should be attached as a Worker custom domain alongside `dazbeez.com`.
+`/api/mobile/*` uses a device-bearer scheme, not Clerk. The networking-card
+Pages app and the email-reply-capture Worker are separate deployable units (see
+[Overview](#overview)) and share `CRM_DB`; the email-reply Worker's live
+deployment is not verified from this tree.
 
 ---
 
@@ -46,11 +57,12 @@ Browser → Cloudflare CDN (dazbeez.com)
 
 Core config files:
 
-- `wrangler.jsonc` — Worker entry, D1 binding, assets binding, self-reference binding
+- `wrangler.jsonc` — Worker entry + bindings: D1 (`DB`, `CRM_DB`, `RECEIPTS_DB`), R2 (`CRM_IMAGES`, `RECEIPTS_BUCKET`, `RECEIPTS_ARCHIVE_BUCKET`), Queue producer (`RECEIPTS_QUEUE`), Workers AI (`AI`), self-reference service; checked-in `vars` include the Clerk publishable key and the accountant/notify-from email addresses. Routes: `dazbeez.com/*`, `www.dazbeez.com/*`.
+- `middleware.ts` — Clerk middleware; the active auth gate for `/admin`, `/receipts`, `/api/receipts`. `/api/mobile/*` is intentionally not matched (device-bearer scheme).
 - `open-next.config.ts` — OpenNext adapter config
 - `next.config.ts` — OpenNext dev init, redirects, headers, unoptimized images
-- `db/schema.sql` — D1 schema for contact submissions
-- `lib/contact-submissions.ts` — D1 insert path using `getCloudflareContext()`
+- `db/schema.sql` — D1 schema for contact submissions (`DB`)
+- `lib/contact-submissions.ts` — `DB` insert path; `app/api/contact/route.ts` additionally upserts the same submission into `CRM_DB` via `lib/crm.ts`
 
 Deployment commands:
 
@@ -81,11 +93,17 @@ npm run cf:dev
 
 ### Environment / Secrets
 
-Runtime secrets configured in Cloudflare:
-- `ADMIN_PAGE_USERNAME`
-- `ADMIN_PAGE_PASSWORD`
-- `NFC_ADMIN_API_URL`
-- `NFC_ADMIN_API_KEY`
+Current runtime configuration (verified from `wrangler.jsonc` + code):
+
+- **Clerk** — `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` (checked-in var) + `CLERK_SECRET_KEY` (wrangler secret). The active auth gate (`middleware.ts`, `lib/receipts/auth.ts`).
+- **Receipts extraction processor** — `RECEIPTS_PROCESSOR_KEY` (wrangler secret); authenticates the Mac consumer's queue pulls and `POST /api/receipts/[id]/extract` (ADR 0001).
+- **Resend** — `RESEND_API_KEY` (wrangler secret); sends the finalize notification email. `NOTIFY_FROM_ADDRESS` and `ACCOUNTANT_EMAIL` are checked-in vars.
+- **Workers AI** — `AI` binding (remote); business-card detection and OCR field extraction in admin ingestion.
+
+Legacy / not active for human login — retained in `lib/receipts/auth.ts` as dead or local-only code (pending Phase 4 removal):
+
+- `CF_ACCESS_TEAM` / `CF_ACCESS_AUD` — Cloudflare Access JWT verification. **Legacy/dead** (no live callers; superseded by Clerk).
+- `RECEIPTS_AUTH_USERNAME` / `RECEIPTS_AUTH_PASSWORD` — HTTP Basic. **Local-dev only** (only advertised/accepted when set, e.g. in `.dev.vars`).
 
 ### `ollama` (profile: `llm`)
 - Image: `ollama/ollama:latest`
@@ -94,37 +112,19 @@ Runtime secrets configured in Cloudflare:
 
 ---
 
-## Next.js App Structure (App Router)
+## App Structure (conceptual module map)
 
-```
-app/
-├── layout.tsx              # Root layout: Inter font, SiteNavigation, Footer, OG metadata
-├── page.tsx                # Home — hero, services grid, CTA
-├── globals.css             # Tailwind base + custom globals
-├── opengraph-image.tsx     # OG image (1200×630)
-├── robots.ts               # robots.txt generation
-├── sitemap.ts              # sitemap.xml generation
-├── services/
-│   ├── page.tsx            # Services listing
-│   └── [slug]/page.tsx     # Service detail (SSG via generateStaticParams)
-├── contact/page.tsx        # Contact form (client component)
-├── nfc/page.tsx            # NFC landing widget (client component)
-└── admin/page.tsx          # Internal dashboard (server component, noindex)
+The literal file tree changes often; this is the stable conceptual map of the
+Next.js App Router app.
 
-components/
-├── site-navigation.tsx     # Sticky nav with mobile menu (client component)
-└── admin/
-    └── admin-dashboard.tsx # Dashboard presentation component
+- **Public marketing** — home, `/services` + `/services/[slug]` (SSG via `generateStaticParams`), `/contact`, `/nfc`, `/business-card`, plus legal pages. Mostly server components; the contact form and NFC widget are client components.
+- **Admin CRM** (`app/admin/*`, `app/admin/api/*`) — business-card batch ingestion, contacts/companies, review tasks, drafts, settings. Live D1-backed CRM (`CRM_DB`), Clerk-authed (not the former static seed-data dashboard).
+- **Receipts module** (`app/(receipt-system)/receipts/*` route group + `app/api/receipts/*`) — capture, review, reconcile, amex, export, settings; domain logic in `lib/receipts/*`.
+- **API routes** — `/api/contact` (dual-writes `DB` + `CRM_DB`), `/api/receipts/*` (Clerk), `/api/mobile/*` (device-bearer; iOS capture + business-card upload), `/api/vcard`.
+- **Shared libs** — `lib/receipts/*` (receipts domain + the client-safe `upload-policy.ts` capture policy), `lib/crm*` (CRM domain), `lib/cloudflare-runtime.ts` (binding accessors).
 
-lib/
-├── admin-dashboard-data.ts # Typed seed data for admin dashboard
-└── contact-submissions.ts  # D1-backed submission persistence
-```
-
-**Rendering pattern:**
-- Server components by default
-- `"use client"` only where interactivity is required (inquiry, contact, nfc, site-navigation)
-- Admin page: server component passing static data as props to a pure presentation component
+**Rendering pattern:** server components by default; `"use client"` only where
+interactivity is required (forms, capture, navigation, animations).
 
 ---
 
@@ -184,14 +184,17 @@ ADR: `docs/adr/0002-statement-month-export-scope.md`.
 
 `validateMonthReadyForExport(month, prebuiltBundle?, preloadedReconciliation?)` in `lib/receipts/month-closing.ts` is the **only** gate. Both finalize paths (`POST /api/receipts/export/month {finalize:true}` and `POST /api/receipts/export/[month]`) call it; UI tiles in `lib/receipts/blockers.ts` are presentation-only.
 
-The validator runs six checks, in order:
+The validator runs these gates in order (`validateMonthReadyForExportCore` in
+`lib/receipts/month-closing.ts`):
 
-1. Statement-sealed gate — a finalized reconciliation must exist for the month.
-2. UNKNOWN `payment_path` gate — any UNKNOWN receipt with `transaction_date` in M blocks finalize.
-3. Receipt-level checks (date, merchant, amount, category, attendees-where-required) on every CASH/DIGITAL receipt in the bundle.
-4. AMEX-line checks via `validateAmexLinesForSignoff`.
-5. Compliance-engine gate (`summarizeOpenChecksForMonth`): open `blocker` checks always block; open `warning` checks block only when `receipt_settings.export_block_on_warnings` is true.
-6. Cross-month match integrity — a receipt matched to AMEX lines in two statement months blocks both months.
+1. **Statement-sealed** — a finalized reconciliation must exist for the month.
+2. **UNKNOWN `payment_path`** — any UNKNOWN receipt with `transaction_date` in M blocks finalize.
+2.5. **Unreviewed** — any in-month `needs_review` receipt blocks finalize (pending-processing receipts are excluded, matching the review tile).
+3. **Receipt-level** — date, merchant, amount, expense category, and attendees-where-required on every CASH/DIGITAL receipt in the bundle.
+4. **AMEX-line checks** via `validateAmexLinesForSignoff`.
+5. **Compliance-engine** (`summarizeOpenChecksForMonth`): open `blocker` checks always block; open `warning` checks block only when `receipt_settings.export_block_on_warnings` is true.
+6. **Cross-month match integrity** — a receipt matched to AMEX lines in two statement months blocks both months.
+7. **Proofs presence** — every shipped receipt must have a proof file (original or `proof_copy`) on record; a receipt with zero `receipt_files` rows has nothing to include in the proofs ZIP.
 
 ADR: `docs/adr/0003-compliance-engine-finalize-gate.md`.
 
@@ -220,13 +223,14 @@ The accountant opens the monthly CSV in **Excel on Windows**. Three hardening ru
 
 The route applies all three via `bomPrefixedCrlf(csvText)` before hashing and upload; the SHA-256 in the manifest matches the bytes in R2 exactly. Tests exercise the pure CSV form; the BOM/CRLF wrapper is a route-layer concern.
 
-Each bundle ships four artifacts into the `RECEIPTS_ARCHIVE_BUCKET`:
+Each bundle ships five artifacts into the `RECEIPTS_ARCHIVE_BUCKET`:
 
 | Key | Contents |
 |-----|----------|
 | `exports/<M>/<id>-receipts.csv` | The main CSV (BOM+CRLF) |
 | `exports/<M>/<id>-manifest.csv` | Metadata + per-file SHA-256 table |
-| `exports/<M>/<id>-summary.csv` | Per-category and per-PaymentPath totals |
+| `exports/<M>/<id>-summary.csv` | 集計 — per-category and per-PaymentPath totals |
+| `exports/<M>/<id>-proofs.zip` | Proofs bundle — one proof image per shipped receipt (with the 集計 summary and a transition notice embedded) |
 | `exports/<M>/<id>-README.txt` | Disclaimers (EN/JA), revision context, SHA-256 chain |
 
 Compliance columns on the main CSV (電子帳簿保存法 / インボイス制度): `InvoiceRegistrationNumber`, `QualifiedInvoiceStatus`, `TaxRate`, `TaxAmount`, `SourceType`, `CounterpartyName`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,12 +2,27 @@
 
 ## Overview
 
-Dazbeez is a Next.js 16.2.3 consulting website deployed on Cloudflare Workers via OpenNext. It consists of two independent deployable units:
+Dazbeez is a Next.js 16.2.3 consulting website deployed on Cloudflare Workers
+via OpenNext. It is a small system of cooperating Cloudflare units plus one
+off-platform processing component:
 
-| Unit | Purpose | Runtime |
-|------|---------|---------|
-| **Main site** (`/`) | Marketing, inquiry, contact, admin | Cloudflare Workers + D1 |
-| **Networking card** (`networking-card/`) | NFC/QR contact capture | Cloudflare Pages + Functions |
+| Unit | Location | Purpose | Runtime |
+|------|----------|---------|---------|
+| **Main site** | `/` (repo root) | Marketing, contact intake, admin CRM, and the **receipts module** | Cloudflare Worker (`dazbeez`) + D1 + R2 + Queue + Workers AI |
+| **Networking card** | `networking-card/` | NFC/QR contact capture → vCard / GIS / Discord / email | Cloudflare Pages + Functions + D1 |
+| **Email reply capture** | `workers/email-reply-capture/` | Inbound email-reply ingestion into the CRM | Cloudflare Worker (`dazbeez-email-reply-capture`, Email Routing) + D1 |
+| **Receipts extraction consumer** | `scripts/receipts-consumer/` (Mac M4) | Drains the extraction queue and runs MLX VLM extraction | Off-platform HTTP pull consumer (ADR 0001) |
+
+The units share two D1 databases: `CRM_DB` (networking card + admin CRM + email
+replies) and `RECEIPTS_DB` (receipts); the main site additionally owns the
+contact-submission `DB`. R2 holds `CRM_IMAGES`, `RECEIPTS_BUCKET`, and
+`RECEIPTS_ARCHIVE_BUCKET`. Authentication on the main site is **Clerk** for
+`/admin`, `/receipts`, and `/api/receipts` (Phase 2 shipped, PR #59;
+`middleware.ts` + `lib/receipts/auth.ts`); `/api/mobile/*` uses a separate
+device-bearer scheme. Receipts capture is async store-and-forward: the Worker
+enqueues onto `RECEIPTS_QUEUE` and the Mac consumer pulls and extracts
+(ADR 0001). The detailed receipts export pipeline is documented later in this
+file ([Receipts Module — Export Pipeline](#receipts-module--export-pipeline)).
 
 ---
 

--- a/docs/inquiry-workflow.md
+++ b/docs/inquiry-workflow.md
@@ -1,5 +1,11 @@
 # Inquiry Workflow
 
+> **Status: HISTORICAL / RETIRED.** The `/inquiry` route has been retired and
+> now 308-redirects to `/contact`. This document describes the original
+> scripted chat flow and is kept as design history; it does not describe a live
+> route. Current intake is the `/contact` form (see [prd.md](./prd.md) F3, and
+> the current architecture in [architecture.md](./architecture.md)).
+
 ## Overview
 
 The inquiry flow at `/inquiry` is a chat-style interface that guides prospective clients toward the right Dazbeez service through a scripted decision tree, with a freeform text fallback for unscripted input.

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1,5 +1,14 @@
 # Product Requirements Document (PRD)
 
+> **Status: HISTORICAL — early marketing-site PRD (v0.1.0).** This document
+> captures the original product vision for the public marketing site and has
+> not been kept current with the deployed system. Several specific claims below
+> are obsolete; inline `Current state` notes mark the known ones rather than
+> rewriting the history. For current architecture see
+> [architecture.md](./architecture.md) and the [root README](../README.md); for
+> the receipts subsystem see the ADRs in [adr/](./adr/) and
+> [dazbeez-receipt-module-prd.md](./dazbeez-receipt-module-prd.md).
+
 ## Product Overview
 
 **Product:** Dazbeez  
@@ -76,6 +85,11 @@ A solo consultant needs a professional web presence that:
 
 **Route:** `/inquiry`
 
+> **Current state (2026-07): RETIRED.** `/inquiry` now 308-redirects to
+> `/contact`. The scripted chat flow below was the original design and is kept
+> here as history (see also [inquiry-workflow.md](./inquiry-workflow.md),
+> likewise historical). Current intake is the `/contact` form.
+
 | Requirement | Detail |
 |-------------|--------|
 | Chat-style UI | Scrollable message thread, user and assistant bubbles |
@@ -107,7 +121,7 @@ greeting
 | Fields | First name, last name, email (required); company, service interest, message |
 | Validation | HTML5 native `required` attributes |
 | Success state | Replaces form with green checkmark card |
-| Backend | Currently front-end only; `handleSubmit` logs to console (TODO: persist) |
+| Backend | ~~Currently front-end only; `handleSubmit` logs to console (TODO: persist)~~ **Current state (2026-07): persists to D1 via `POST /api/contact`** (`DB` binding, `lib/contact-submissions.ts`) |
 | Response SLA | "Within 24 hours" shown in UI |
 
 ### F4: NFC Landing Page
@@ -150,7 +164,7 @@ greeting
 | Lead statuses | new, contacted, proposal, won, lost (color-coded badges) |
 | Recent activity | Timestamped activity feed |
 | Pending actions | Priority-coded todo list (high=red, medium=amber, low=green) |
-| Data source | Static typed seed data in `lib/admin-dashboard-data.ts` (no live DB yet) |
+| Data source | ~~Static typed seed data in `lib/admin-dashboard-data.ts` (no live DB yet)~~ **Current state (2026-07): `/admin` is a live D1-backed CRM** (`CRM_DB`), authenticated via **Clerk**; see [business-card-crm-architecture.md](./business-card-crm-architecture.md) |
 | Rendering | Server component — no client-side data fetching |
 
 ---
@@ -178,4 +192,4 @@ greeting
 | Ollama chatbot integration | Container reserved (`llm` profile); inquiry flow has hook |
 | Admin dashboard live data | Replace seed data with real inquiry/lead sources |
 | Networking card analytics | Tap counts by country/city visible in D1 but not surfaced in admin |
-| Middleware deprecation cleanup | Blocked: Next.js 16 deprecates `middleware.ts`, but the current OpenNext Cloudflare build still rejects `proxy.ts` as unsupported Node middleware |
+| Middleware deprecation cleanup | ~~Blocked: Next.js 16 deprecates `middleware.ts`, but the current OpenNext Cloudflare build still rejects `proxy.ts` as unsupported Node middleware~~ **Current state (2026-07): resolved — `middleware.ts` (not `proxy.ts`) is what ships with OpenNext and runs the Clerk middleware; this item is moot.** |

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -192,4 +192,4 @@ greeting
 | Ollama chatbot integration | Container reserved (`llm` profile); inquiry flow has hook |
 | Admin dashboard live data | Replace seed data with real inquiry/lead sources |
 | Networking card analytics | Tap counts by country/city visible in D1 but not surfaced in admin |
-| Middleware deprecation cleanup | ~~Blocked: Next.js 16 deprecates `middleware.ts`, but the current OpenNext Cloudflare build still rejects `proxy.ts` as unsupported Node middleware~~ **Current state (2026-07): resolved — `middleware.ts` (not `proxy.ts`) is what ships with OpenNext and runs the Clerk middleware; this item is moot.** |
+| Middleware deprecation cleanup | **Current state (2026-07): `middleware.ts` (not `proxy.ts`) is the required OpenNext-compatible Edge auth path today and runs the Clerk middleware.** The underlying Next.js-deprecation / proxy-compatibility risk is **not resolved or moot** — it must be revisited when OpenNext supports the Node `proxy.ts` runtime or Next.js removes `middleware.ts`. *(Original entry: "Blocked: Next.js 16 deprecates `middleware.ts`, but the current OpenNext Cloudflare build still rejects `proxy.ts` as unsupported Node middleware".)* |

--- a/docs/receipt-module.md
+++ b/docs/receipt-module.md
@@ -18,21 +18,27 @@ All routes and `/api/receipts/*` are protected, noindexed, and not linked from t
 
 ## Authentication
 
-**Production:** Cloudflare Access application protecting `dazbeez.com/receipts*` and `dazbeez.com/api/receipts*`. The Worker validates `Cf-Access-Jwt-Assertion` JWT signatures against the Access JWKS endpoint, checks issuer, expiry, and audience, and production disables direct `workers.dev` and preview URLs. Set as Wrangler secrets:
+**Active human gate — Clerk.** `/receipts` and `/api/receipts/*` are
+authenticated via Clerk (`middleware.ts` + `lib/receipts/auth.ts` →
+`requireReceiptsActor`). Human users no longer go through a separate
+Cloudflare Access or Basic-auth step in production. Migration history/status is
+in [runbooks/clerk-auth-migration.md](runbooks/clerk-auth-migration.md).
 
-```
-npx wrangler secret put CF_ACCESS_TEAM   # e.g. yourteam.cloudflareaccess.com
-npx wrangler secret put CF_ACCESS_AUD    # from the CF Access application settings
-```
+**Separate, still-active machine paths:**
 
-**Local dev:** HTTP Basic Auth fallback. Add to `.dev.vars`:
+- **Processor key** — the Mac MLX consumer authenticates its queue pulls and
+  `POST /api/receipts/[id]/extract` / `extraction-failed` writes with
+  `RECEIPTS_PROCESSOR_KEY` (ADR 0001), independent of Clerk.
+- **Device bearer** — `/api/mobile/*` (iOS capture + business-card upload) uses
+  a trusted-device cookie/bearer scheme (`lib/receipts/trusted-devices.ts`),
+  also independent of Clerk.
 
-```
-RECEIPTS_AUTH_USERNAME=receipts
-RECEIPTS_AUTH_PASSWORD=<your-local-password>
-```
-
-If neither `CF_ACCESS_TEAM` nor `RECEIPTS_AUTH_USERNAME` is configured, the module denies all access (fail-closed).
+**Legacy (not active for login).** Cloudflare Access JWT verification
+(`CF_ACCESS_TEAM` / `CF_ACCESS_AUD`) and HTTP Basic
+(`RECEIPTS_AUTH_USERNAME` / `RECEIPTS_AUTH_PASSWORD`, local-dev only) remain in
+`lib/receipts/auth.ts` as dead / local-only code pending Phase 4 removal. If a
+request is not authenticated by Clerk or any machine path, the module denies
+access (fail-closed).
 
 ## Cloudflare Bindings
 
@@ -98,7 +104,7 @@ The application does not expose hard-delete flows for retained tax records. Soft
 | File | Purpose |
 |------|---------|
 | `types.ts` | All TypeScript types |
-| `auth.ts` | CF Access JWT validation + basic auth fallback |
+| `auth.ts` | Clerk session auth (active human gate); legacy CF-Access/Basic helpers retained as dead/local-only code |
 | `auth-request.ts` | Server-side `assertReceiptsPageAccess()` helper |
 | `db.ts` | D1 data access |
 | `storage.ts` | R2 upload/download/archive |

--- a/docs/receipt-module.md
+++ b/docs/receipt-module.md
@@ -26,9 +26,14 @@ in [runbooks/clerk-auth-migration.md](runbooks/clerk-auth-migration.md).
 
 **Separate, still-active machine paths:**
 
-- **Processor key** — the Mac MLX consumer authenticates its queue pulls and
-  `POST /api/receipts/[id]/extract` / `extraction-failed` writes with
-  `RECEIPTS_PROCESSOR_KEY` (ADR 0001), independent of Clerk.
+- **Processor key (Worker auth)** — the Mac MLX consumer authenticates its
+  requests to the Worker (`/file`, `/extract`, `/extraction-failed`, `/proof`)
+  with `RECEIPTS_PROCESSOR_KEY` via the `x-receipts-processor-key` header
+  (ADR 0001), independent of Clerk. This does **not** authenticate queue pulls.
+- **Queues API** — the consumer's Cloudflare Queues `/messages/pull` and
+  `/messages/ack` calls use a separate `CF_API_TOKEN` (scoped `queues_read` +
+  `queues_write`), not the processor key. (Optional Cloudflare Access
+  service-token headers are a separate edge layer.)
 - **Device bearer** — `/api/mobile/*` (iOS capture + business-card upload) uses
   a trusted-device cookie/bearer scheme (`lib/receipts/trusted-devices.ts`),
   also independent of Clerk.

--- a/lib/receipts/auth.ts
+++ b/lib/receipts/auth.ts
@@ -278,10 +278,11 @@ export async function isReceiptsAuthorized(
 // Middleware-safe: no DB calls. Cookie via HMAC only; CF Access via decode.
 //
 // Phase 2 Clerk cutover: the entire CF-Access/cookie/Basic-auth chain above
-// is now bypassed — auth is enforced by `proxy.ts` via clerkMiddleware.
-// `auth()` here reads the Clerk session that the proxy already established.
-// The legacy helpers (isCfAccessTokenAcceptable, decodeBasicAuthorization,
-// verifyDeviceCookieLight) are kept as dead code, deleted in Phase 4.
+// is now bypassed — auth is enforced by `middleware.ts` via clerkMiddleware.
+// `auth()` here reads the Clerk session that the middleware already
+// established. The legacy helpers (isCfAccessTokenAcceptable,
+// decodeBasicAuthorization, verifyDeviceCookieLight) are kept as dead code,
+// deleted in Phase 4.
 export async function isReceiptsAuthorizedLight(
   _requestHeaders: Headers,
 ): Promise<boolean> {
@@ -294,9 +295,10 @@ export async function isReceiptsAuthorizedLight(
 // route called, which performed verifyDeviceCookie (HMAC + D1 lookup for
 // revocation) twice per request.
 //
-// Phase 2 Clerk cutover: identity comes from Clerk. The proxy gates the route,
-// so by the time we get here the session is valid; the userId check is
-// defense-in-depth. The legacy verification chain above is dead code (Phase 4).
+// Phase 2 Clerk cutover: identity comes from Clerk. Clerk middleware
+// (`middleware.ts`) gates the route, so by the time we get here the session is
+// valid; the userId check is defense-in-depth. The legacy verification chain
+// above is dead code (Phase 4).
 export async function requireReceiptsActor(
   _requestHeaders: Headers,
 ): Promise<string> {

--- a/lib/receipts/statement-window.ts
+++ b/lib/receipts/statement-window.ts
@@ -130,8 +130,9 @@ export interface AssignmentResult {
   rolledFrom?: string;
 }
 
-/** Upper bound on the roll-forward walk. With ≤2 open months (ADR 0005) this is
- *  never reached; it only guards against a pathological all-months-sealed state. */
+/** Upper bound on the roll-forward walk. With 3–4 concurrent open months
+ *  (ADR 0005, no hard runtime cap) this is never reached; it only guards
+ *  against a pathological all-months-sealed state. */
 const ROLL_FORWARD_MAX_MONTHS = 24;
 
 /**
@@ -144,7 +145,7 @@ const ROLL_FORWARD_MAX_MONTHS = 24;
  *   3. natural sealed + rollForward ⇒ walk forward by calendar month to the
  *      first month NOT in sealedMonths:
  *        found  ⇒ { that month, "roll-forward", rolledFrom: natural }
- *        bounded walk exhausted (cannot happen with ≤2 open months) ⇒ fall back
+ *        bounded walk exhausted (cannot happen with 3–4 concurrent open months) ⇒ fall back
  *        to { natural, "natural" } so the receipt is never left unassigned.
  *   4. natural sealed + !rollForward ⇒ { natural, "natural" } (UNKNOWN path: an
  *      UNKNOWN receipt must be classified before it gets a real export month, so


### PR DESCRIPTION
Stacked on PR #113. Review only the four commits unique to this branch.

## Summary

Repairs the documentation information architecture and corrects current-system
documentation so it matches the deployed code. Historical PRDs are preserved as
history rather than rewritten as current specifications.

## What's included

- **Open-month policy corrected** to ADR 0005 (designed/tested for 3–4 concurrent
  open months, no hard runtime cap) across `AGENTS.md`, ADR 0008, and the
  `statement-window.ts` comments; capture backlog items #10/#11 marked DONE with
  accurate summaries.
- **Canonical documentation index** — `docs/README.md` rewritten into five
  sections (Current Architecture, Operator Runbooks, Decisions/ADRs, Product/
  Design History and Backlog, Audits and Implementation Reports) with
  status/ownership notes.
- **ADR index/template and supersession** — `docs/adr/README.md` (index, status,
  bidirectional supersession links, numbering-gap note) and `docs/adr/template.md`.
- **Current vs historical/retired classifications** — `prd.md` and
  `inquiry-workflow.md` carry status banners; `admin-dashboard.md` moved to
  history; `nfc`/`ui` marked "reference; currentness not revalidated";
  `clerk-auth-migration.md` labeled migration history rather than the current
  auth spec.
- **Current production architecture** in `architecture.md` and the root
  `README.md`: deployable units, D1/R2 bindings, routes, Clerk authentication,
  the five export artifacts (incl. `proofs.zip`), and the actual finalize gates
  (1, 2, 2.5, 3, 4, 5, 6, 7).
- **Credential trust boundary corrected** — `CF_API_TOKEN` authenticates the
  Cloudflare Queues API (pull/ack); `RECEIPTS_PROCESSOR_KEY` authenticates the
  Mac consumer's Worker calls (`/file`, `/extract`, `/extraction-failed`,
  `/proof`). Optional Cloudflare Access service-token headers are a separate edge
  layer. Stale `auth.ts`/`receipt-module.md`/`architecture.md` wording fixed.
- **Historical PRDs preserved**, not rewritten as current spec.

## Verification

Baseline unchanged by this branch:

- `npm test`: **437 / 436 pass / 1 skipped**
- `npm run lint`: clean
- `npm run build:cf`: complete

No runtime or live-state change. (The two `.ts` edits in this branch —
`lib/receipts/auth.ts` and `lib/receipts/statement-window.ts` — are comment-only.)
