### PR TITLE
chore(receipts): codify queue policy and drift verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,11 +212,16 @@ starts. Design consequences:
    POSTs /api/receipts/:id/extraction-failed (processor-key guarded),
    acks; failed receipts show a red pill in the queue, terminal until
    operator action. (b) shipped — DLQ
-   dazbeez-receipts-extraction-dlq + max_retries=5 (settings documented in
-   wrangler.jsonc; NOT introspectable via CLI). (a) failed-state marking
-   still open. Note: consumer-level visibility_timeout_ms is 12h — benign
-   because consumer.py overrides per-pull (5 min), but a trap for any
-   future consumer that doesn't.
+   dazbeez-receipts-extraction-dlq + max_retries=5. The expected HTTP-pull
+   consumer policy lives in scripts/receipts-consumer/queue_policy.py +
+   docs/runbooks/receipts-queue-control-plane.md, with a safe read-only REST
+   verifier (scripts/receipts-consumer/audit-queue-config.sh); live settings
+   were verified matching on 2026-07-16. HTTP pull is configured out of band
+   (control plane), not declarative in wrangler.jsonc. Note: the configured
+   HTTP-consumer default visibility_timeout_ms is 43200000 (12 hours); the
+   Mac consumer sends an explicit per-pull override of 300000 (5 minutes),
+   which wins for the current consumer — the 12-hour default remains a trap
+   for any future consumer that omits the override.
 10. **Source provenance: desktop uploads tagged "mobile_capture".** DONE
     (e1005cd, 5514501). `source` is now a typed `VALID_SOURCES` value
     (`mobile_capture` | `desktop_upload`) in the client-safe

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@ Step-by-step operational procedures. Owner: operator (David) + architect.
 | [runbooks/clerk-auth-migration.md](runbooks/clerk-auth-migration.md) | Clerk auth **migration history/status** (replaced Basic/CF Access). Not the current auth spec — for that see [architecture.md](architecture.md) and [receipt-module.md](receipt-module.md). |
 | [runbooks/cf-access-app.md](runbooks/cf-access-app.md) | Cloudflare Access setup for receipts. |
 | [runbooks/receipts-extraction-rollout.md](runbooks/receipts-extraction-rollout.md) | Mac-side rollout of the ADR 0001 store-and-forward extraction consumer. |
+| [runbooks/receipts-queue-control-plane.md](runbooks/receipts-queue-control-plane.md) | Cloudflare Queues HTTP-pull consumer policy, read-only drift verifier, and first-time provisioning. **Current.** |
 | [month-close-runbook.md](month-close-runbook.md) | Operator runbook for closing a receipts month (incl. finalize notification email). |
 
 ## 3. Decisions (ADRs)

--- a/docs/runbooks/receipts-extraction-rollout.md
+++ b/docs/runbooks/receipts-extraction-rollout.md
@@ -1,6 +1,6 @@
 # Runbook — Receipts extraction rollout (ADR 0001)
 
-Steps to take the store-and-forward extraction live. **All steps run on the Mac M4** with live Cloudflare credentials — the code is already on branch `feat/receipts-extraction-queue-mlx`. Do them in order; each is idempotent unless noted.
+Steps to take the store-and-forward extraction live. **All steps run on the Mac M4** with live Cloudflare credentials — the code is already on branch `feat/receipts-extraction-queue-mlx`. Do them in order. **Not all steps are idempotent**: `wrangler queues create` and `wrangler queues consumer http add/remove` error or have side effects if the resource already exists — see [receipts-queue-control-plane.md](receipts-queue-control-plane.md) for the full policy, the read-only drift verifier, and first-time provisioning.
 
 ## 0. Prerequisites
 
@@ -16,13 +16,32 @@ npx wrangler queues create dazbeez-receipts-extraction
 
 The producer binding (`RECEIPTS_QUEUE`) is already declared in `wrangler.jsonc`.
 
-## 2. Create the HTTP pull consumer + API token
+## 2. Create the DLQ, attach the HTTP pull consumer, and create an API token
 
-Pull consumers are not declared in `wrangler.jsonc`; create one and note its IDs:
+The HTTP-pull consumer and its policy are **control-plane configuration** (not
+`wrangler.jsonc`). Create the **DLQ before** attaching the consumer so the
+consumer can reference it. The full policy table and the read-only drift
+verifier live in [receipts-queue-control-plane.md](receipts-queue-control-plane.md);
+the intended attach flags are:
 
 ```bash
-# Register an HTTP pull consumer on the queue
-npx wrangler queues consumer http add dazbeez-receipts-extraction
+# DLQ first (must exist before the consumer references it)
+npx wrangler queues create dazbeez-receipts-extraction-dlq
+
+# Attach the HTTP pull consumer with the full intended policy
+# (not idempotent — errors if a consumer already exists)
+npx wrangler queues consumer http add dazbeez-receipts-extraction \
+  --batch-size 10 \
+  --message-retries 5 \
+  --dead-letter-queue dazbeez-receipts-extraction-dlq \
+  --visibility-timeout-secs 43200 \
+  --retry-delay-secs 0
+```
+
+After setup, verify the live config matches policy:
+
+```bash
+scripts/receipts-consumer/audit-queue-config.sh   # expect 7 MATCH rows, exit 0
 ```
 
 Then in the Cloudflare dashboard (or via API), create an **API token** scoped to

--- a/docs/runbooks/receipts-queue-control-plane.md
+++ b/docs/runbooks/receipts-queue-control-plane.md
@@ -1,0 +1,117 @@
+# Receipts queue control-plane runbook
+
+**Status: Current operator runbook.** Canonical operator procedure for the
+receipts extraction-queue HTTP-pull consumer (ADR 0001).
+
+## Where the configuration lives
+
+HTTP pull consumers are **Cloudflare control-plane configuration**. By current
+Cloudflare design they are configured through the dashboard, the Queues REST
+API, or `wrangler queues consumer http`, and are **NOT supported in
+`wrangler.jsonc`** (no `queues.consumers[]` block for HTTP pull; existing
+`type: "http_pull"` in a Wrangler config file is no longer supported and should
+be removed). The Worker holds only the **producer** binding (`RECEIPTS_QUEUE`
+→ `dazbeez-receipts-extraction`).
+
+The checked-in *expected* policy is the single source of truth:
+`scripts/receipts-consumer/queue_policy.py`. This runbook mirrors it for humans.
+
+## Policy table — expected HTTP-pull consumer
+
+| setting | expected value |
+|---|---|
+| consumer type | `http_pull` |
+| queue | `dazbeez-receipts-extraction` |
+| dead-letter queue | `dazbeez-receipts-extraction-dlq` |
+| `batch_size` | 10 |
+| `max_retries` | 5 |
+| `retry_delay` | 0 |
+| `visibility_timeout_ms` | 43 200 000 (12 hours) |
+
+The DLQ (`dazbeez-receipts-extraction-dlq`) has **no consumer**; messages that
+exhaust `max_retries` land there for operator investigation.
+
+## Runtime table — Mac MLX consumer
+
+| behavior | value |
+|---|---|
+| Mac per-pull batch size | 10 |
+| Mac per-pull visibility timeout | 5 minutes (300 000 ms) |
+| Mac polling interval (empty/error sleep) | 20 seconds |
+| launchd `StartInterval` | 600 seconds (10 minutes) |
+
+**Per-pull override:** the Mac consumer sends `visibility_timeout_ms` and
+`batch_size` in each `/messages/pull` body. The **5-minute per-pull value
+overrides the 12-hour configured consumer default for the current Mac
+consumer.** The 12-hour default therefore does not affect today's processing,
+but it remains a risk for any future consumer that omits the per-pull override
+— do not lower it without runtime evidence of model cold-start and full-batch
+processing duration.
+
+## Verifying the live configuration (read-only)
+
+```bash
+scripts/receipts-consumer/audit-queue-config.sh
+```
+
+This performs **exactly one metadata `GET` to the queue's `/consumers`
+endpoint** and prints `field | expected | live | MATCH/DRIFT` for the seven
+non-secret fields above. It **never** pulls, leases, acknowledges, retries,
+sends, or inspects messages (no `/messages/*` call), and never prints the
+token, account id, queue id, consumer id, or raw response.
+
+Exit codes:
+
+| code | meaning |
+|---|---|
+| 0 | every field matches the expected policy |
+| 1 | drift, HTTP error, timeout, malformed response, or wrong consumer count/type |
+| 2 | missing environment (`CF_ACCOUNT_ID` / `CF_QUEUE_ID` / `CF_API_TOKEN`), or no `.env` / `python3` |
+
+### Drift procedure
+
+If the verifier reports **any DRIFT, or exits nonzero, stop.** Do not change
+live queue configuration from a code PR or an automated job. Obtain explicit
+operator authorization, then reconcile via the control plane (dashboard or
+`wrangler queues consumer http` — see provisioning below). Re-run the verifier
+after any change.
+
+> Do **not** use `wrangler queues message list` to verify configuration —
+> listing messages can lease them and is not a read-only configuration check.
+
+## First-time provisioning / disaster recovery
+
+**Every command in this section is MUTATING. Do not run any of them for
+verification — verification is `audit-queue-config.sh` only.** `queue create`
+and `consumer http add/remove` are **not idempotent**: re-running them on
+existing resources errors or has side effects. Provision the DLQ **before**
+attaching the primary consumer, so the consumer can reference it.
+
+```bash
+# 1. Create the primary queue.   (MUTATING, not idempotent)
+npx wrangler queues create dazbeez-receipts-extraction
+
+# 2. Create the DLQ FIRST.        (MUTATING, not idempotent)
+npx wrangler queues create dazbeez-receipts-extraction-dlq
+
+# 3. Attach the HTTP pull consumer with the full intended policy.
+#    (MUTATING, not idempotent — errors if a consumer already exists;
+#     remove it first with `wrangler queues consumer http remove`.)
+npx wrangler queues consumer http add dazbeez-receipts-extraction \
+  --batch-size 10 \
+  --message-retries 5 \
+  --dead-letter-queue dazbeez-receipts-extraction-dlq \
+  --visibility-timeout-secs 43200 \
+  --retry-delay-secs 0
+```
+
+Then issue the Mac consumer's `CF_API_TOKEN` (scoped `queues_read` +
+`queues_write`) and `RECEIPTS_PROCESSOR_KEY` (Worker secret) per
+[receipts-extraction-rollout.md](receipts-extraction-rollout.md), and verify
+with `audit-queue-config.sh` (expect seven MATCH rows, exit 0).
+
+## Related
+
+- [receipts-extraction-rollout.md](receipts-extraction-rollout.md) — end-to-end extraction rollout (ADR 0001).
+- `scripts/receipts-consumer/queue_policy.py` — machine-readable expected policy.
+- `docs/adr/0001-receipt-extraction-runtime.md` — store-and-forward extraction decision.

--- a/docs/runbooks/receipts-queue-control-plane.md
+++ b/docs/runbooks/receipts-queue-control-plane.md
@@ -56,9 +56,13 @@ scripts/receipts-consumer/audit-queue-config.sh
 
 This performs **exactly one metadata `GET` to the queue's `/consumers`
 endpoint** and prints `field | expected | live | MATCH/DRIFT` for the seven
-non-secret fields above. It **never** pulls, leases, acknowledges, retries,
-sends, or inspects messages (no `/messages/*` call), and never prints the
-token, account id, queue id, consumer id, or raw response.
+non-secret fields above. Each field is type-checked (numeric fields reject
+`bool`; strings are never printed verbatim on drift) and the live column uses
+bounded placeholders on drift — `<missing>`, `<invalid-type>`, or
+`<different>` — so malformed or misplaced values never emit raw response
+content. It **never** pulls, leases, acknowledges, retries, sends, or inspects
+messages (no `/messages/*` call), and never prints the token, account id,
+queue id, consumer id, or raw response.
 
 Exit codes:
 

--- a/scripts/receipts-consumer/audit-queue-config.sh
+++ b/scripts/receipts-consumer/audit-queue-config.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Safe launcher for the read-only queue-configuration verifier
+# (audit_queue_config.py). Performs ONE metadata GET against the queue
+# /consumers endpoint. It never pulls, leases, acknowledges, retries, sends,
+# or inspects messages.
+set -euo pipefail
+set +x  # explicitly disable shell tracing before any secret is sourced
+
+# Resolve this script's directory so the launcher works from the repo root or
+# the consumer directory.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+ENV_FILE="$SCRIPT_DIR/.env"
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "ERROR: $ENV_FILE not found. It is the gitignored runtime config" \
+       "(see docs/runbooks/receipts-queue-control-plane.md)." >&2
+  exit 2
+fi
+
+# Source the gitignored .env in THIS process so the verifier inherits the
+# credentials via the environment. Values are never echoed and never placed in
+# argv. No temporary credential files are created.
+set -a
+# shellcheck source=/dev/null
+. "$ENV_FILE"
+set +a
+
+# The verifier is standard-library only; any python3 works. Prefer the
+# consumer venv if present, else the system python3.
+if [[ -x "$SCRIPT_DIR/.venv/bin/python3" ]]; then
+  PY="$SCRIPT_DIR/.venv/bin/python3"
+else
+  PY="$(command -v python3 || true)"
+fi
+if [[ -z "$PY" ]]; then
+  echo "ERROR: python3 not found on PATH." >&2
+  exit 2
+fi
+
+exec "$PY" "$SCRIPT_DIR/audit_queue_config.py"

--- a/scripts/receipts-consumer/audit_queue_config.py
+++ b/scripts/receipts-consumer/audit_queue_config.py
@@ -14,10 +14,16 @@ Safety:
   * Output is restricted to the seven non-secret policy fields. The token,
     account id, queue id, consumer id, raw response body, and response headers
     are never printed.
+  * Each field is type-checked: numeric fields require a real int (bool is
+    rejected), string fields require a str. Drift renders bounded placeholders
+    (<missing> / <invalid-type> / <different>) — mismatching strings and
+    containers are never printed verbatim, so identifiers/control characters
+    in the response cannot reach the table.
   * Exits 0 only when every expected field matches; nonzero for drift, missing
     environment, malformed response, unexpected consumer count/type, HTTP error,
     timeout, or JSON failure. Error output stays redacted (HTTP status is OK;
-    response body is not).
+    response body is not). An unexpected exception prints only a fixed message
+    and the exception class name — never str(e), repr, traceback, URL, or body.
 
 Run via audit-queue-config.sh (which sources the gitignored .env), or directly
 with CF_ACCOUNT_ID / CF_QUEUE_ID / CF_API_TOKEN already in the environment.
@@ -75,24 +81,69 @@ def live_for(consumer: dict, label: str):
     return consumer.get(label)
 
 
+# Numeric policy fields must be a real int (bool is an int subclass in Python,
+# so it is rejected explicitly). The remaining FIELDS labels are string fields.
+NUMERIC_FIELDS = {
+    "settings.batch_size",
+    "settings.max_retries",
+    "settings.retry_delay",
+    "settings.visibility_timeout_ms",
+}
+
+# Bounded placeholders for the live column — never an arbitrary live string or
+# container, so malformed/misplaced identifiers, raw response content, or
+# control characters cannot be emitted.
+MISSING = "<missing>"
+INVALID_TYPE = "<invalid-type>"
+DIFFERENT = "<different>"
+
+
+def _is_real_int(value) -> bool:
+    """True only for an int that is not a bool (bool is an int subclass)."""
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def evaluate(label: str, expected, live):
+    """Return (is_match, rendered_live). Pure.
+
+    Strict typing: numeric fields require a real int; string fields require a
+    str. Missing values and wrong types are DRIFT. The rendered live value is
+    always a bounded token or number — never an arbitrary live string/container
+    — so mismatching/typed-wrong values cannot leak identifiers or content."""
+    if live is None:
+        return False, MISSING
+    if label in NUMERIC_FIELDS:
+        if not _is_real_int(live):
+            return False, INVALID_TYPE
+        return (live == expected), str(live)
+    # string field (type / queue_name / dead_letter_queue)
+    if not isinstance(live, str):
+        return False, INVALID_TYPE
+    if live == expected:
+        return True, expected  # print the checked-in expected value
+    return False, DIFFERENT  # never print the live string
+
+
 def compare(consumer: dict):
-    """Return [(label, expected, live, is_match), ...]. Pure."""
+    """Return [(label, expected, rendered_live, is_match), ...]. Pure."""
     rows = []
     for label, expected in FIELDS:
         live = live_for(consumer, label)
-        rows.append((label, expected, live, live == expected))
+        is_match, rendered = evaluate(label, expected, live)
+        rows.append((label, expected, rendered, is_match))
     return rows
 
 
 def format_table(rows) -> str:
     """Render 'field | expected | live | MATCH/DRIFT'. Pure.
 
-    Prints only the seven policy fields — never identifiers, tokens, or the
-    raw response."""
+    The live column is a bounded placeholder or number (see evaluate). The
+    expected column prints only checked-in policy values. No identifier, token,
+    raw response content, or control character from the response is emitted."""
     lines = []
-    for label, expected, live, is_match in rows:
+    for label, expected, rendered_live, is_match in rows:
         verdict = "MATCH" if is_match else "DRIFT"
-        lines.append(f"{label} | {expected} | {live} | {verdict}")
+        lines.append(f"{label} | {expected} | {rendered_live} | {verdict}")
     return "\n".join(lines)
 
 
@@ -126,35 +177,44 @@ def run() -> int:
         reason = type(e.reason).__name__ if e.reason is not None else "URLError"
         print(f"ERROR: network {reason}", file=sys.stderr)
         return 1
+    except Exception as e:
+        # Redacted boundary: an unexpected failure must NOT print str(e),
+        # repr, a traceback, the URL, or any response body. Class name only.
+        # (KeyboardInterrupt / SystemExit are BaseException and propagate.)
+        print(f"ERROR: unexpected network failure ({type(e).__name__})", file=sys.stderr)
+        return 1
 
     try:
         data = json.loads(body.decode("utf-8", "replace"))
+        if not isinstance(data, dict) or not data.get("success"):
+            print("ERROR: API success=false or malformed envelope", file=sys.stderr)
+            return 1
+        result = data.get("result")
+        if not isinstance(result, list):
+            print("ERROR: malformed result (not a list)", file=sys.stderr)
+            return 1
+        if len(result) == 0:
+            print("ERROR: expected exactly 1 consumer, found 0", file=sys.stderr)
+            return 1
+        if len(result) > 1:
+            print(f"ERROR: expected exactly 1 consumer, found {len(result)}", file=sys.stderr)
+            return 1
+        consumer = result[0]
+        if not isinstance(consumer, dict):
+            print("ERROR: malformed consumer object", file=sys.stderr)
+            return 1
+        rows = compare(consumer)
+        rendered = format_table(rows)
     except (ValueError, UnicodeDecodeError):
         print("ERROR: malformed JSON response", file=sys.stderr)
         return 1
-
-    if not isinstance(data, dict) or not data.get("success"):
-        print("ERROR: API success=false or malformed envelope", file=sys.stderr)
+    except Exception as e:
+        # Redacted boundary for any unexpected response/decoding/comparison
+        # failure — never print str(e), repr, traceback, or response content.
+        print(f"ERROR: unexpected response failure ({type(e).__name__})", file=sys.stderr)
         return 1
 
-    result = data.get("result")
-    if not isinstance(result, list):
-        print("ERROR: malformed result (not a list)", file=sys.stderr)
-        return 1
-    if len(result) == 0:
-        print("ERROR: expected exactly 1 consumer, found 0", file=sys.stderr)
-        return 1
-    if len(result) > 1:
-        print(f"ERROR: expected exactly 1 consumer, found {len(result)}", file=sys.stderr)
-        return 1
-
-    consumer = result[0]
-    if not isinstance(consumer, dict):
-        print("ERROR: malformed consumer object", file=sys.stderr)
-        return 1
-
-    rows = compare(consumer)
-    print(format_table(rows))
+    print(rendered)
     return 0 if all(is_match for *_unused, is_match in rows) else 1
 
 

--- a/scripts/receipts-consumer/audit_queue_config.py
+++ b/scripts/receipts-consumer/audit_queue_config.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Read-only verifier for the receipts extraction-queue HTTP-pull consumer.
+
+Checks the LIVE Cloudflare control-plane configuration against the checked-in
+policy in queue_policy.py. It performs exactly ONE metadata GET to the queue's
+/consumers endpoint and prints a field-by-field MATCH/DRIFT table.
+
+It NEVER calls any /messages/* endpoint — no pull, lease, acknowledge, retry,
+list, or send. Verification is metadata-only and does not touch messages.
+
+Safety:
+  * CF_API_TOKEN is read from the environment and sent only in the
+    Authorization header. Its expanded value is never placed in argv.
+  * Output is restricted to the seven non-secret policy fields. The token,
+    account id, queue id, consumer id, raw response body, and response headers
+    are never printed.
+  * Exits 0 only when every expected field matches; nonzero for drift, missing
+    environment, malformed response, unexpected consumer count/type, HTTP error,
+    timeout, or JSON failure. Error output stays redacted (HTTP status is OK;
+    response body is not).
+
+Run via audit-queue-config.sh (which sources the gitignored .env), or directly
+with CF_ACCOUNT_ID / CF_QUEUE_ID / CF_API_TOKEN already in the environment.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+from queue_policy import (
+    DEAD_LETTER_QUEUE_NAME,
+    EXPECTED_CONSUMER_BATCH_SIZE,
+    EXPECTED_CONSUMER_MAX_RETRIES,
+    EXPECTED_CONSUMER_RETRY_DELAY,
+    EXPECTED_CONSUMER_TYPE,
+    EXPECTED_CONSUMER_VISIBILITY_TIMEOUT_MS,
+    PRIMARY_QUEUE_NAME,
+)
+
+NETWORK_TIMEOUT_S = 30
+REQUIRED_ENV = ("CF_ACCOUNT_ID", "CF_QUEUE_ID", "CF_API_TOKEN")
+
+# Ordered (label, expected) pairs. settings.* labels are read from the
+# consumer's `settings` sub-object; the rest are read top-level. A missing key
+# yields None, which is DRIFT (values are never silently defaulted).
+FIELDS = [
+    ("type", EXPECTED_CONSUMER_TYPE),
+    ("queue_name", PRIMARY_QUEUE_NAME),
+    ("dead_letter_queue", DEAD_LETTER_QUEUE_NAME),
+    ("settings.batch_size", EXPECTED_CONSUMER_BATCH_SIZE),
+    ("settings.max_retries", EXPECTED_CONSUMER_MAX_RETRIES),
+    ("settings.retry_delay", EXPECTED_CONSUMER_RETRY_DELAY),
+    ("settings.visibility_timeout_ms", EXPECTED_CONSUMER_VISIBILITY_TIMEOUT_MS),
+]
+
+
+def consumers_url(account_id: str, queue_id: str) -> str:
+    """The read-only consumer-metadata endpoint (never a /messages/ path)."""
+    return (
+        f"https://api.cloudflare.com/client/v4/accounts/{account_id}"
+        f"/queues/{queue_id}/consumers"
+    )
+
+
+def live_for(consumer: dict, label: str):
+    """Live value for a label, or None if absent (None => DRIFT). Pure."""
+    if label.startswith("settings."):
+        settings = consumer.get("settings")
+        if not isinstance(settings, dict):
+            return None
+        return settings.get(label.split(".", 1)[1])
+    return consumer.get(label)
+
+
+def compare(consumer: dict):
+    """Return [(label, expected, live, is_match), ...]. Pure."""
+    rows = []
+    for label, expected in FIELDS:
+        live = live_for(consumer, label)
+        rows.append((label, expected, live, live == expected))
+    return rows
+
+
+def format_table(rows) -> str:
+    """Render 'field | expected | live | MATCH/DRIFT'. Pure.
+
+    Prints only the seven policy fields — never identifiers, tokens, or the
+    raw response."""
+    lines = []
+    for label, expected, live, is_match in rows:
+        verdict = "MATCH" if is_match else "DRIFT"
+        lines.append(f"{label} | {expected} | {live} | {verdict}")
+    return "\n".join(lines)
+
+
+def _fetch(url: str, token: str):
+    """Perform the single GET. Returns (status, body_bytes). Network seam."""
+    req = urllib.request.Request(
+        url, headers={"Authorization": "Bearer " + token}
+    )
+    with urllib.request.urlopen(req, timeout=NETWORK_TIMEOUT_S) as resp:
+        return resp.status, resp.read()
+
+
+def run() -> int:
+    missing = [k for k in REQUIRED_ENV if not os.environ.get(k)]
+    if missing:
+        print("ERROR: missing environment: " + ",".join(missing), file=sys.stderr)
+        return 2
+
+    url = consumers_url(os.environ["CF_ACCOUNT_ID"], os.environ["CF_QUEUE_ID"])
+    token = os.environ["CF_API_TOKEN"]
+
+    try:
+        _status, body = _fetch(url, token)
+    except urllib.error.HTTPError as e:
+        print(f"ERROR: HTTP {e.code}", file=sys.stderr)
+        return 1
+    except TimeoutError:
+        print("ERROR: network timeout", file=sys.stderr)
+        return 1
+    except urllib.error.URLError as e:
+        reason = type(e.reason).__name__ if e.reason is not None else "URLError"
+        print(f"ERROR: network {reason}", file=sys.stderr)
+        return 1
+
+    try:
+        data = json.loads(body.decode("utf-8", "replace"))
+    except (ValueError, UnicodeDecodeError):
+        print("ERROR: malformed JSON response", file=sys.stderr)
+        return 1
+
+    if not isinstance(data, dict) or not data.get("success"):
+        print("ERROR: API success=false or malformed envelope", file=sys.stderr)
+        return 1
+
+    result = data.get("result")
+    if not isinstance(result, list):
+        print("ERROR: malformed result (not a list)", file=sys.stderr)
+        return 1
+    if len(result) == 0:
+        print("ERROR: expected exactly 1 consumer, found 0", file=sys.stderr)
+        return 1
+    if len(result) > 1:
+        print(f"ERROR: expected exactly 1 consumer, found {len(result)}", file=sys.stderr)
+        return 1
+
+    consumer = result[0]
+    if not isinstance(consumer, dict):
+        print("ERROR: malformed consumer object", file=sys.stderr)
+        return 1
+
+    rows = compare(consumer)
+    print(format_table(rows))
+    return 0 if all(is_match for *_unused, is_match in rows) else 1
+
+
+def main() -> None:
+    sys.exit(run())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/receipts-consumer/consumer.py
+++ b/scripts/receipts-consumer/consumer.py
@@ -42,6 +42,15 @@ from typing import Any
 
 import requests
 
+# Runtime tuning comes from the shared queue-policy module (single source of
+# truth for the Mac per-pull overrides of the HTTP-consumer defaults). Aliased
+# to the historical names so the rest of this file is unchanged.
+from queue_policy import (  # same-dir import; consumer.py runs as a script
+    MAC_PER_PULL_BATCH_SIZE as BATCH_SIZE,
+    MAC_PER_PULL_VISIBILITY_TIMEOUT_MS as VISIBILITY_TIMEOUT_MS,
+    MAC_POLL_INTERVAL_S as POLL_INTERVAL_S,
+)
+
 CF_ACCOUNT_ID = os.environ["CF_ACCOUNT_ID"]
 CF_QUEUE_ID = os.environ["CF_QUEUE_ID"]
 CF_API_TOKEN = os.environ["CF_API_TOKEN"]
@@ -64,10 +73,9 @@ QUEUES_API = (
 CF_HEADERS = {"Authorization": f"Bearer {CF_API_TOKEN}", "Content-Type": "application/json"}
 
 # Batch / lease tuning. The lease (visibility_timeout) must comfortably exceed
-# the model runtime per batch so jobs are not redelivered mid-process.
-BATCH_SIZE = 10
-VISIBILITY_TIMEOUT_MS = 5 * 60 * 1000
-POLL_INTERVAL_S = 20
+# the model runtime per batch so jobs are not redelivered mid-process. Values
+# are imported above from queue_policy.py (the Mac per-pull overrides of the
+# HTTP-consumer defaults).
 
 PROMPT = (
     "You are reading a receipt or tax invoice (Japanese or English). "

--- a/scripts/receipts-consumer/queue_policy.py
+++ b/scripts/receipts-consumer/queue_policy.py
@@ -1,0 +1,43 @@
+"""Machine-readable authority for the receipts extraction-queue policy.
+
+Single checked-in source of truth shared by:
+  * audit_queue_config.py — the read-only drift verifier
+  * consumer.py           — the Mac MLX consumer (runtime overrides)
+  * docs/runbooks/receipts-queue-control-plane.md — the human runbook
+
+The live Cloudflare HTTP-pull consumer is configured OUT OF BAND on the
+control plane (dashboard / API / `wrangler queues consumer http`). HTTP pull is
+NOT declarative in wrangler.jsonc by current Cloudflare design, so this module
+is the canonical *expected* policy; the verifier checks the live control plane
+against it.
+
+Name convention:
+  EXPECTED_CONSUMER_*  — the configured HTTP-consumer defaults (control plane).
+  MAC_PER_PULL_*       — the Mac consumer's per-pull overrides, sent in each
+                         /messages/pull body. These win over the defaults for
+                         the current consumer.
+
+Do not change a value here without also reconciling the live control-plane
+configuration (an explicitly authorized operator procedure) and the runbook.
+"""
+
+# ─── Queue names ────────────────────────────────────────────────────────────
+PRIMARY_QUEUE_NAME = "dazbeez-receipts-extraction"
+DEAD_LETTER_QUEUE_NAME = "dazbeez-receipts-extraction-dlq"
+
+# ─── Expected HTTP-pull consumer settings (control-plane configuration) ─────
+# These are the values the live Cloudflare HTTP-pull consumer MUST hold. They
+# are the configured consumer defaults, NOT the Mac per-pull overrides below.
+EXPECTED_CONSUMER_TYPE = "http_pull"
+EXPECTED_CONSUMER_BATCH_SIZE = 10
+EXPECTED_CONSUMER_MAX_RETRIES = 5
+EXPECTED_CONSUMER_RETRY_DELAY = 0
+EXPECTED_CONSUMER_VISIBILITY_TIMEOUT_MS = 43_200_000  # 12 hours
+
+# ─── Mac consumer per-pull runtime overrides ────────────────────────────────
+# Sent in each /messages/pull request body; they override the consumer defaults
+# above for THIS consumer. The 12-hour configured default remains a risk for
+# any future consumer that omits these overrides.
+MAC_PER_PULL_BATCH_SIZE = 10
+MAC_PER_PULL_VISIBILITY_TIMEOUT_MS = 300_000  # 5 minutes
+MAC_POLL_INTERVAL_S = 20

--- a/scripts/receipts-consumer/test_queue_config_audit.py
+++ b/scripts/receipts-consumer/test_queue_config_audit.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Unit tests for audit_queue_config.py and the consumer.py policy import.
+
+Standard library only (unittest + unittest.mock). No real network calls: the
+single GET is mocked at audit_queue_config._fetch.
+"""
+from __future__ import annotations
+
+import io
+import json
+import os
+import unittest
+import unittest.mock as mock
+import urllib.error
+
+import audit_queue_config as aqc
+import queue_policy as qp
+
+CONSUMER_DIR = os.path.dirname(os.path.abspath(__file__))
+
+# Canaries that must NEVER appear in any verifier output.
+TOK = "tok_SECRET_TOKEN_ABC"
+ACCT = "acct_SECRET_ACCOUNT_ID"
+QID = "qid_SECRET_QUEUE_ID"
+CID = "cid_SECRET_CONSUMER_ID"
+
+
+def good_consumer():
+    """A consumer dict that matches policy on all seven fields, plus
+    identifier fields that must never be printed."""
+    return {
+        "type": qp.EXPECTED_CONSUMER_TYPE,
+        "queue_name": qp.PRIMARY_QUEUE_NAME,
+        "dead_letter_queue": qp.DEAD_LETTER_QUEUE_NAME,
+        "settings": {
+            "batch_size": qp.EXPECTED_CONSUMER_BATCH_SIZE,
+            "max_retries": qp.EXPECTED_CONSUMER_MAX_RETRIES,
+            "retry_delay": qp.EXPECTED_CONSUMER_RETRY_DELAY,
+            "visibility_timeout_ms": qp.EXPECTED_CONSUMER_VISIBILITY_TIMEOUT_MS,
+        },
+        # identifiers — must be redacted from output
+        "consumer_id": CID,
+        "queue_id": QID,
+    }
+
+
+def envelope_bytes(result):
+    return json.dumps({"success": True, "errors": [], "messages": [], "result": result}).encode()
+
+
+def run_with(body_bytes=None, side_effect=None, env=None):
+    """Invoke aqc.run() with _fetch mocked and env controlled.
+
+    Returns (exit_code, stdout, stderr, fetch_mock)."""
+    if env is None:
+        env = {"CF_ACCOUNT_ID": ACCT, "CF_QUEUE_ID": QID, "CF_API_TOKEN": TOK}
+    with mock.patch.dict(os.environ, env, clear=True), \
+            mock.patch.object(aqc, "_fetch") as m:
+        if side_effect is not None:
+            m.side_effect = side_effect
+        else:
+            m.return_value = (200, body_bytes)
+        out, err = io.StringIO(), io.StringIO()
+        with mock.patch("sys.stdout", out), mock.patch("sys.stderr", err):
+            code = aqc.run()
+    return code, out.getvalue(), err.getvalue(), m
+
+
+class CompareAndFormat(unittest.TestCase):
+    def test_exact_match_table(self):
+        rows = aqc.compare(good_consumer())
+        self.assertEqual(len(rows), 7)
+        self.assertTrue(all(is_match for *_u, is_match in rows))
+        table = aqc.format_table(rows)
+        self.assertIn("| MATCH", table)
+        self.assertNotIn("DRIFT", table)
+
+    def test_format_table_has_four_columns(self):
+        table = aqc.format_table(aqc.compare(good_consumer()))
+        for line in table.splitlines():
+            parts = line.split(" | ")
+            self.assertEqual(len(parts), 4, line)
+
+    def test_identifiers_never_in_formatted_output(self):
+        consumer = good_consumer()
+        # Even if a secret-looking value sat in a policy field path, only the
+        # seven policy fields are read. Inject canaries in non-read spots.
+        consumer["__raw"] = "RAW_" + TOK
+        consumer["account_id"] = ACCT
+        table = aqc.format_table(aqc.compare(consumer))
+        for canary in (TOK, ACCT, QID, CID, "RAW_"):
+            self.assertNotIn(canary, table)
+
+
+class Drift(unittest.TestCase):
+    def _drift_case(self, mutate, expected_drift_label):
+        consumer = good_consumer()
+        mutate(consumer)
+        code, out, _err, _m = run_with(envelope_bytes([consumer]))
+        self.assertEqual(code, 1, f"expected nonzero for {expected_drift_label}")
+        self.assertIn("DRIFT", out)
+        # the specific row shows DRIFT
+        self.assertIn(f"{expected_drift_label} |", out)
+        self.assertIn("DRIFT", out.split(expected_drift_label)[1].splitlines()[0])
+
+    def test_type_drift(self):
+        self._drift_case(lambda c: c.update(type="worker"), "type")
+
+    def test_queue_name_drift(self):
+        self._drift_case(lambda c: c.update(queue_name="other-queue"), "queue_name")
+
+    def test_dead_letter_queue_drift(self):
+        self._drift_case(lambda c: c.update(dead_letter_queue=None), "dead_letter_queue")
+
+    def test_batch_size_drift(self):
+        self._drift_case(lambda c: c["settings"].update(batch_size=99), "settings.batch_size")
+
+    def test_max_retries_drift(self):
+        self._drift_case(lambda c: c["settings"].update(max_retries=1), "settings.max_retries")
+
+    def test_retry_delay_drift(self):
+        self._drift_case(lambda c: c["settings"].update(retry_delay=7), "settings.retry_delay")
+
+    def test_visibility_timeout_drift(self):
+        self._drift_case(
+            lambda c: c["settings"].update(visibility_timeout_ms=1000),
+            "settings.visibility_timeout_ms",
+        )
+
+    def test_missing_settings_object_is_drift_not_defaulted(self):
+        consumer = good_consumer()
+        del consumer["settings"]
+        code, out, _e, _m = run_with(envelope_bytes([consumer]))
+        self.assertEqual(code, 1)
+        # all four settings.* rows drift (live None), none silently match
+        for label in ("settings.batch_size", "settings.max_retries",
+                      "settings.retry_delay", "settings.visibility_timeout_ms"):
+            line = next(l for l in out.splitlines() if l.startswith(label + " |"))
+            self.assertTrue(line.endswith("None | DRIFT"), line)
+
+    def test_single_missing_setting_is_drift(self):
+        consumer = good_consumer()
+        del consumer["settings"]["batch_size"]
+        code, out, _e, _m = run_with(envelope_bytes([consumer]))
+        self.assertEqual(code, 1)
+        line = next(l for l in out.splitlines() if l.startswith("settings.batch_size |"))
+        self.assertTrue(line.endswith("None | DRIFT"), line)
+
+
+class ConsumerCountAndShape(unittest.TestCase):
+    def test_exact_match_exits_zero(self):
+        code, out, _e, _m = run_with(envelope_bytes([good_consumer()]))
+        self.assertEqual(code, 0)
+        self.assertEqual(out.count("MATCH"), 7)
+        self.assertNotIn("DRIFT", out)
+
+    def test_zero_consumers(self):
+        code, _o, err, _m = run_with(envelope_bytes([]))
+        self.assertNotEqual(code, 0)
+        self.assertIn("found 0", err)
+
+    def test_multiple_consumers(self):
+        code, _o, err, _m = run_with(envelope_bytes([good_consumer(), good_consumer()]))
+        self.assertNotEqual(code, 0)
+        self.assertIn("found 2", err)
+
+    def test_wrong_consumer_type_reports_drift(self):
+        consumer = good_consumer()
+        consumer["type"] = "worker"
+        code, out, _e, _m = run_with(envelope_bytes([consumer]))
+        self.assertNotEqual(code, 0)
+        type_line = next(l for l in out.splitlines() if l.startswith("type |"))
+        self.assertTrue(type_line.endswith("worker | DRIFT"), type_line)
+
+    def test_result_not_a_list(self):
+        code, _o, err, _m = run_with(envelope_bytes({"not": "a list"}))
+        self.assertNotEqual(code, 0)
+        self.assertIn("malformed result", err)
+
+    def test_success_false_is_error(self):
+        body = json.dumps({"success": False, "errors": [{"code": 1234}], "result": []}).encode()
+        code, _o, err, _m = run_with(body)
+        self.assertNotEqual(code, 0)
+        self.assertIn("success=false", err)
+
+    def test_consumer_not_a_dict(self):
+        code, _o, err, _m = run_with(envelope_bytes(["not-a-dict"]))
+        self.assertNotEqual(code, 0)
+        self.assertIn("malformed consumer", err)
+
+    def test_malformed_json(self):
+        code, _o, err, _m = run_with(b"not json {")
+        self.assertNotEqual(code, 0)
+        self.assertIn("malformed JSON", err)
+
+
+class SafetyAndUrl(unittest.TestCase):
+    def test_missing_environment_exits_nonzero(self):
+        code, _o, err, _m = run_with(envelope_bytes([good_consumer()]),
+                                     env={"CF_ACCOUNT_ID": ACCT})  # missing CF_QUEUE_ID + CF_API_TOKEN
+        self.assertNotEqual(code, 0)
+        # reports which names are missing, never their values
+        self.assertIn("missing environment", err)
+        self.assertNotIn(TOK, err)
+
+    def test_http_error_does_not_print_body(self):
+        canary = "CANARY_RESPONSE_BODY"
+        fp = io.BytesIO(canary.encode())
+        http_err = urllib.error.HTTPError(
+            "https://example.invalid", 500, "Server Error", {}, fp
+        )
+        code, _o, err, _m = run_with(side_effect=http_err)
+        self.assertNotEqual(code, 0)
+        self.assertIn("HTTP 500", err)
+        self.assertNotIn(canary, err)
+
+    def test_consumers_url_is_metadata_endpoint(self):
+        url = aqc.consumers_url(ACCT, QID)
+        self.assertTrue(url.endswith("/consumers"))
+        self.assertNotIn("/messages/", url)
+
+    def test_run_hits_consumers_endpoint_not_messages(self):
+        code, _o, _e, m = run_with(envelope_bytes([good_consumer()]))
+        self.assertEqual(code, 0)
+        called_url = m.call_args[0][0]
+        self.assertTrue(called_url.endswith("/consumers"), called_url)
+        self.assertNotIn("/messages/", called_url)
+
+    def test_token_sent_only_in_header_never_returned(self):
+        code, out, err, m = run_with(envelope_bytes([good_consumer()]))
+        self.assertEqual(code, 0)
+        # token was passed to _fetch as the 2nd arg (header), not in the URL
+        called_url, called_token = m.call_args[0]
+        self.assertNotIn(TOK, called_url)
+        self.assertEqual(called_token, TOK)
+        # and never appears in output
+        self.assertNotIn(TOK, out)
+        self.assertNotIn(TOK, err)
+        # account/queue ids are path components of the URL but never printed
+        self.assertNotIn(ACCT, out + err)
+        self.assertNotIn(QID, out + err)
+        self.assertNotIn(CID, out + err)
+
+
+class ConsumerImportsPolicy(unittest.TestCase):
+    """consumer.py must source its runtime constants from queue_policy (no
+    behavior change), without needing to import the heavy consumer module."""
+
+    def test_consumer_imports_policy_under_historical_names(self):
+        with open(os.path.join(CONSUMER_DIR, "consumer.py"), encoding="utf-8") as f:
+            src = f.read()
+        self.assertIn("from queue_policy import", src)
+        self.assertIn("MAC_PER_PULL_BATCH_SIZE as BATCH_SIZE", src)
+        self.assertIn("MAC_PER_PULL_VISIBILITY_TIMEOUT_MS as VISIBILITY_TIMEOUT_MS", src)
+        self.assertIn("MAC_POLL_INTERVAL_S as POLL_INTERVAL_S", src)
+        # the old literal assignments must be gone
+        for stale in ("BATCH_SIZE = 10", "VISIBILITY_TIMEOUT_MS = 5 * 60 * 1000",
+                      "POLL_INTERVAL_S = 20"):
+            self.assertNotIn(stale, src, f"stale literal still present: {stale}")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/receipts-consumer/test_queue_config_audit.py
+++ b/scripts/receipts-consumer/test_queue_config_audit.py
@@ -132,11 +132,11 @@ class Drift(unittest.TestCase):
         del consumer["settings"]
         code, out, _e, _m = run_with(envelope_bytes([consumer]))
         self.assertEqual(code, 1)
-        # all four settings.* rows drift (live None), none silently match
+        # all four settings.* rows render <missing>, none silently match
         for label in ("settings.batch_size", "settings.max_retries",
                       "settings.retry_delay", "settings.visibility_timeout_ms"):
             line = next(l for l in out.splitlines() if l.startswith(label + " |"))
-            self.assertTrue(line.endswith("None | DRIFT"), line)
+            self.assertTrue(line.endswith("<missing> | DRIFT"), line)
 
     def test_single_missing_setting_is_drift(self):
         consumer = good_consumer()
@@ -144,7 +144,7 @@ class Drift(unittest.TestCase):
         code, out, _e, _m = run_with(envelope_bytes([consumer]))
         self.assertEqual(code, 1)
         line = next(l for l in out.splitlines() if l.startswith("settings.batch_size |"))
-        self.assertTrue(line.endswith("None | DRIFT"), line)
+        self.assertTrue(line.endswith("<missing> | DRIFT"), line)
 
 
 class ConsumerCountAndShape(unittest.TestCase):
@@ -170,7 +170,8 @@ class ConsumerCountAndShape(unittest.TestCase):
         code, out, _e, _m = run_with(envelope_bytes([consumer]))
         self.assertNotEqual(code, 0)
         type_line = next(l for l in out.splitlines() if l.startswith("type |"))
-        self.assertTrue(type_line.endswith("worker | DRIFT"), type_line)
+        # mismatching string renders <different>, never the live value
+        self.assertTrue(type_line.endswith("<different> | DRIFT"), type_line)
 
     def test_result_not_a_list(self):
         code, _o, err, _m = run_with(envelope_bytes({"not": "a list"}))
@@ -257,6 +258,101 @@ class ConsumerImportsPolicy(unittest.TestCase):
         for stale in ("BATCH_SIZE = 10", "VISIBILITY_TIMEOUT_MS = 5 * 60 * 1000",
                       "POLL_INTERVAL_S = 20"):
             self.assertNotIn(stale, src, f"stale literal still present: {stale}")
+
+
+class Hardening(unittest.TestCase):
+    """Strict type validation, bounded-placeholder rendering, and the redacted
+    exception boundary."""
+
+    def _set_field(self, consumer, label, value):
+        if label.startswith("settings."):
+            consumer.setdefault("settings", {})[label.split(".", 1)[1]] = value
+        else:
+            consumer[label] = value
+        return consumer
+
+    def test_retry_delay_false_is_drift_not_match(self):
+        # bool is an int subclass; False must NOT match expected integer 0.
+        consumer = good_consumer()
+        consumer["settings"]["retry_delay"] = False
+        code, out, _e, _m = run_with(envelope_bytes([consumer]))
+        self.assertEqual(code, 1)
+        line = next(l for l in out.splitlines() if l.startswith("settings.retry_delay |"))
+        self.assertTrue(line.endswith("<invalid-type> | DRIFT"), line)
+        row = next(r for r in aqc.compare(consumer) if r[0] == "settings.retry_delay")
+        self.assertFalse(row[3])
+
+    def test_bool_rejected_for_every_numeric_field(self):
+        for label in sorted(aqc.NUMERIC_FIELDS):
+            consumer = good_consumer()
+            self._set_field(consumer, label, True)
+            code, out, _e, _m = run_with(envelope_bytes([consumer]))
+            self.assertEqual(code, 1, label)
+            line = next(l for l in out.splitlines() if l.startswith(label + " |"))
+            self.assertTrue(line.endswith("<invalid-type> | DRIFT"), (label, line))
+
+    def test_containers_render_invalid_type_and_redact_canary(self):
+        canary = "NESTED_RAW_CANARY"
+        for label, _expected in aqc.FIELDS:
+            for bad in ({"raw_response_canary": canary}, [canary]):
+                consumer = good_consumer()
+                self._set_field(consumer, label, bad)
+                code, out, _e, _m = run_with(envelope_bytes([consumer]))
+                self.assertEqual(code, 1, (label, bad))
+                line = next(l for l in out.splitlines() if l.startswith(label + " |"))
+                self.assertTrue(line.endswith("<invalid-type> | DRIFT"), (label, line))
+                self.assertNotIn(canary, out)
+
+    def test_mismatching_string_redacts_canaries(self):
+        for label in ("type", "queue_name", "dead_letter_queue"):
+            for canary in (TOK, ACCT, QID, CID):
+                consumer = good_consumer()
+                self._set_field(consumer, label, "x-" + canary + "-y")
+                code, out, _e, _m = run_with(envelope_bytes([consumer]))
+                self.assertEqual(code, 1, (label, canary))
+                line = next(l for l in out.splitlines() if l.startswith(label + " |"))
+                self.assertTrue(line.endswith("<different> | DRIFT"), (label, line))
+                self.assertNotIn(canary, out)
+
+    def test_control_chars_cannot_inject_rows(self):
+        consumer = good_consumer()
+        consumer["queue_name"] = (
+            "a\nb\rc\td | INJECTED | MATCH\nfake-row | z | y | MATCH"
+        )
+        code, out, _e, _m = run_with(envelope_bytes([consumer]))
+        self.assertEqual(code, 1)
+        self.assertEqual(len(out.splitlines()), 7)  # still exactly seven rows
+        self.assertNotIn("INJECTED", out)
+        self.assertNotIn("fake-row", out)
+        qline = next(l for l in out.splitlines() if l.startswith("queue_name |"))
+        self.assertTrue(qline.endswith("<different> | DRIFT"), qline)
+
+    def test_missing_fields_render_missing_placeholder(self):
+        for label, _expected in aqc.FIELDS:
+            consumer = good_consumer()
+            if label.startswith("settings."):
+                del consumer["settings"][label.split(".", 1)[1]]
+            else:
+                del consumer[label]
+            code, out, _e, _m = run_with(envelope_bytes([consumer]))
+            self.assertEqual(code, 1, label)
+            line = next(l for l in out.splitlines() if l.startswith(label + " |"))
+            self.assertTrue(line.endswith("<missing> | DRIFT"), (label, line))
+
+    def test_unexpected_fetch_exception_is_redacted(self):
+        canary = "EXC_MSG_CANARY_" + TOK
+        code, out, err, _m = run_with(side_effect=RuntimeError(canary))
+        self.assertNotEqual(code, 0)
+        self.assertIn("unexpected network failure (RuntimeError)", err)
+        self.assertNotIn(canary, err)
+        self.assertNotIn(canary, out)
+        self.assertNotIn("Traceback", err)
+
+    def test_exact_match_still_seven_matches_exit_zero(self):
+        code, out, _e, _m = run_with(envelope_bytes([good_consumer()]))
+        self.assertEqual(code, 0)
+        self.assertEqual(out.count("MATCH"), 7)
+        self.assertNotIn("DRIFT", out)
 
 
 if __name__ == "__main__":

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -78,27 +78,16 @@
       "bucket_name": "dazbeez-receipts-archive"
     }
   ],
-  // ADR 0001: extraction queue. The Worker is a producer only; the Mac runs an
-  // HTTP pull consumer (configured via the Cloudflare API/dashboard, not here —
-  // wrangler has no `consumer http update`, only add/remove, so settings can't
-  // be checked in via code). Create the queue first:
-  //   `npx wrangler queues create dazbeez-receipts-extraction`
+  // ADR 0001: extraction queue. The Worker is a producer only (binding below);
+  // the Mac runs an HTTP pull consumer. By current Cloudflare design, HTTP pull
+  // consumers are configured out of band on the control plane (dashboard,
+  // `wrangler queues consumer http`, or the Queues API) and are NOT declarative
+  // in this file — no `queues.consumers[]` block belongs here.
   //
-  // Consumer settings live on the queue (not on the Worker) and are visible
-  // only via the API:
-  //   GET /accounts/{account_id}/queues
-  // As of 2026-07-05 (audit finding A4) the consumer is configured as:
-  //   type                    : http_pull
-  //   batch_size              : 10
-  //   max_retries             : 5      (was 3 before audit remediation)
-  //   visibility_timeout_ms   : 43200000 (12h — long enough for the Mac MLX
-  //                                       model load on a cold start)
-  //   retry_delay             : 0
-  //   dead_letter_queue       : dazbeez-receipts-extraction-dlq
-  // The DLQ is a separate queue with no consumer — messages that exhaust
-  // max_retries land there for investigation. Inspect with:
-  //   npx wrangler queues message list dazbeez-receipts-extraction-dlq
-  // (No worker binding for the DLQ — it's an operator-only inspection sink.)
+  // Expected policy (single source of truth): scripts/receipts-consumer/queue_policy.py.
+  // Operator procedure + first-time provisioning: docs/runbooks/receipts-queue-control-plane.md.
+  // Read-only drift verifier: scripts/receipts-consumer/audit-queue-config.sh.
+  // (Do not verify with `wrangler queues message list` — listing can lease messages.)
   "queues": {
     "producers": [
       {


### PR DESCRIPTION
Stacked on PR #114. Review only the two commits unique to this branch.

## Summary

Codifies the Cloudflare Queues HTTP-pull consumer policy as a checked-in
authority and adds a safe, read-only drift verifier, plus the operator
runbook and documentation repairs. No live queue configuration or messages are
touched.

## What's included

- **Machine-readable queue policy** (`scripts/receipts-consumer/queue_policy.py`)
  shared by the consumer runtime and the verifier — queue + DLQ names, expected
  consumer type/batch_size/max_retries/retry_delay/visibility_timeout_ms (the
  12 h configured default), and the Mac per-pull overrides (5 min). `consumer.py`
  imports its runtime constants from it; no behavior change.
- **Safe GET-only drift verifier** (`audit_queue_config.py`, standard library
  only): one request to the queue `/consumers` metadata endpoint, never a
  `/messages/*` call. Token is read from the environment and sent only in the
  Authorization header (never in argv).
- **Exact type validation and bounded/redacted output**: numeric fields require a
  real int (bool rejected); strings are never printed verbatim on drift. The live
  column uses bounded placeholders (`<missing>`, `<invalid-type>`, `<different>`)
  so malformed fields, identifiers, or control characters cannot leak. Unexpected
  exceptions print only a fixed message + class name — no traceback, URL, or
  body. Exit 0 only on a full seven-field match.
- **Operator launcher** (`audit-queue-config.sh`) that resolves its own dir,
  disables shell tracing, sources the gitignored `.env` in-process, and never
  echoes credential values.
- **Current queue control-plane runbook** (`docs/runbooks/receipts-queue-control-plane.md`)
  — policy table, runtime table (per-pull 5 min overrides the 12 h default),
  verifier command + exit codes, drift procedure, and first-time/DR provisioning
  (DLQ before consumer, full attach flags, commands labeled
  mutating/non-idempotent). Rollout instructions corrected accordingly.
- **HTTP pull remains control-plane configuration**, not `wrangler.jsonc` —
  confirmed against the installed Wrangler 4.83 schema (`queues.consumers[].type`
  is `const "worker"`). The `wrangler.jsonc` comments keep only the producer
  binding and point to the policy/runbook/verifier.
- **Live audit result: seven MATCH rows, exit 0** (performed once, read-only).

## Verification

- Python verifier tests: **34/34**
- `npm test`: **437 / 436 pass / 1 skipped**
- `npm run lint`: clean
- `npm run build:cf`: complete

No queue-message/configuration mutation, D1/R2 change, deployment, or Wrangler
upgrade.
