### PR TITLE
refactor(receipts): extract queue-state data access

### DIFF
--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -461,56 +461,13 @@ export async function listAllReceiptsInMonth(
   }
 }
 
-/**
- * Receipts whose extraction has not finished (ADR 0001). Queries
- * `extraction_state` directly rather than prefiltering by status, so it catches
- * a pending receipt regardless of its lifecycle status — e.g. a non-queued
- * insert path that left the column at its default, or a receipt advanced to
- * reviewed without clearing the queue state. The month-close gate relies on
- * this being exhaustive.
- */
-export async function listPendingProcessingReceipts(
-  limit = 1000,
-): Promise<ReceiptRecord[]> {
-  const db = getReceiptsDb();
-  const result = await db
-    .prepare(
-      `SELECT * FROM receipt_records
-       WHERE deleted_at IS NULL
-         AND extraction_state IN ('captured', 'queued', 'processing')
-       ORDER BY captured_at DESC LIMIT ?`,
-    )
-    .bind(limit)
-    .all<ReceiptRecord>();
-  return result.results ?? [];
-}
-
-/**
- * Reconcile a stale pending extraction_state to a terminal one (ADR 0001).
- * Idempotent: only touches rows still in a pending state, so it is safe to call
- * defensively. Used by the extract route when a queued message arrives for a
- * receipt that can no longer be extracted (already reviewed → 'processed') or
- * whose image was unreadable (→ 'failed'), so the consumer can ack the poison
- * pill without leaving the month-close gate blocked. Deliberately bypasses the
- * finalized-reconciliation guard — this only fixes the queue-state mirror, it
- * does not touch business fields.
- */
-export async function reconcileExtractionState(
-  id: string,
-  finalState: "processed" | "failed",
-): Promise<void> {
-  const db = getReceiptsDb();
-  const now = nowIso();
-  await db
-    .prepare(
-      `UPDATE receipt_records
-         SET extraction_state = ?, extraction_processed_at = ?, updated_at = ?
-       WHERE id = ?
-         AND extraction_state IN ('captured', 'queued', 'processing')`,
-    )
-    .bind(finalState, now, now, id)
-    .run();
-}
+// Extraction-queue data access (listPendingProcessingReceipts +
+// reconcileExtractionState) lives in lib/receipts/extraction-queue-db.ts now;
+// re-exported here so existing @/lib/receipts/db import sites are unchanged.
+export {
+  listPendingProcessingReceipts,
+  reconcileExtractionState,
+} from "@/lib/receipts/extraction-queue-db";
 
 export async function listReceiptRecordsByIds(
   ids: string[],

--- a/lib/receipts/extraction-queue-db.ts
+++ b/lib/receipts/extraction-queue-db.ts
@@ -1,0 +1,97 @@
+// Extraction-queue data access for receipt_records.
+//
+// The pending extraction_state mirror (captured / queued / processing) is its
+// own small domain: a list query (the month-close gate's "is the queue empty?"
+// check) and an idempotent reconcile update (ADR 0001 poison-pill handling).
+// Extracted from lib/receipts/db.ts so the pending-state filter has a single
+// source (PENDING_EXTRACTION_STATES) instead of two raw SQL literals.
+//
+// Re-exported from lib/receipts/db.ts; existing callers are unchanged.
+
+import { getReceiptsDb } from "@/lib/cloudflare-runtime";
+import { nowIso } from "@/lib/receipts/db-utils";
+import { PENDING_EXTRACTION_STATES } from "@/lib/receipts/types";
+import type { ReceiptRecord } from "@/lib/receipts/types";
+
+// One bind placeholder per pending state, e.g. "?, ?, ?". Derived from the
+// typed constant so the SQL and the bindings cannot drift apart.
+const PENDING_STATE_PLACEHOLDERS = PENDING_EXTRACTION_STATES.map(
+  () => "?",
+).join(", ");
+
+/** Terminal states a pending extraction_state may be reconciled to. */
+export type TerminalExtractionState = "processed" | "failed";
+
+/**
+ * Pure spec for the pending-processing list query. Bindings are in D1 bind
+ * order: the pending states first (the IN clause precedes LIMIT in the SQL),
+ * then the limit.
+ *
+ * [...PENDING_EXTRACTION_STATES, limit]
+ */
+export function buildPendingProcessingQuery(limit = 1000): {
+  sql: string;
+  bindings: readonly unknown[];
+} {
+  const sql = `SELECT * FROM receipt_records
+     WHERE deleted_at IS NULL
+       AND extraction_state IN (${PENDING_STATE_PLACEHOLDERS})
+     ORDER BY captured_at DESC LIMIT ?`;
+  return { sql, bindings: [...PENDING_EXTRACTION_STATES, limit] };
+}
+
+/**
+ * Pure spec for the idempotent extraction_state reconcile update. Bindings are
+ * in D1 bind order: the SET columns, then the id, then the pending states that
+ * gate the WHERE clause.
+ *
+ * [finalState, now, now, id, ...PENDING_EXTRACTION_STATES]
+ */
+export function buildReconcileExtractionStateQuery(
+  id: string,
+  finalState: TerminalExtractionState,
+  now: string,
+): { sql: string; bindings: readonly unknown[] } {
+  const sql = `UPDATE receipt_records
+       SET extraction_state = ?, extraction_processed_at = ?, updated_at = ?
+     WHERE id = ?
+       AND extraction_state IN (${PENDING_STATE_PLACEHOLDERS})`;
+  return { sql, bindings: [finalState, now, now, id, ...PENDING_EXTRACTION_STATES] };
+}
+
+/**
+ * List receipts still in a pending extraction_state (ADR 0001). The month-close
+ * gate relies on this being exhaustive over captured/queued/processing.
+ * Default limit 1000.
+ */
+export async function listPendingProcessingReceipts(
+  limit = 1000,
+): Promise<ReceiptRecord[]> {
+  const db = getReceiptsDb();
+  const { sql, bindings } = buildPendingProcessingQuery(limit);
+  const result = await db.prepare(sql).bind(...bindings).all<ReceiptRecord>();
+  return result.results ?? [];
+}
+
+/**
+ * Reconcile a stale pending extraction_state to a terminal one (ADR 0001).
+ * Idempotent: only touches rows still in a pending state, so it is safe to call
+ * defensively. Used by the extract route when a queued message arrives for a
+ * receipt that can no longer be extracted (already reviewed → 'processed') or
+ * whose image was unreadable (→ 'failed'), so the consumer can ack the poison
+ * pill without leaving the month-close gate blocked. Deliberately bypasses the
+ * finalized-reconciliation guard — this only fixes the queue-state mirror, it
+ * does not touch business fields.
+ */
+export async function reconcileExtractionState(
+  id: string,
+  finalState: TerminalExtractionState,
+): Promise<void> {
+  const db = getReceiptsDb();
+  const { sql, bindings } = buildReconcileExtractionStateQuery(
+    id,
+    finalState,
+    nowIso(),
+  );
+  await db.prepare(sql).bind(...bindings).run();
+}

--- a/tests/receipts/extraction-queue-db.test.ts
+++ b/tests/receipts/extraction-queue-db.test.ts
@@ -1,0 +1,93 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildPendingProcessingQuery,
+  buildReconcileExtractionStateQuery,
+} from "@/lib/receipts/extraction-queue-db";
+import { PENDING_EXTRACTION_STATES } from "@/lib/receipts/types";
+
+// Pending states as a plain array for comparison (the source is readonly).
+const STATES = [...PENDING_EXTRACTION_STATES];
+
+/** Count of "?" inside the single `IN (...)` clause of a SQL string. */
+function inClausePlaceholderCount(sql: string): number {
+  const match = sql.match(/IN \(([^)]*)\)/);
+  assert.ok(match, "expected an IN (...) clause in the SQL");
+  return (match[1]!.match(/\?/g) ?? []).length;
+}
+
+// ─── list query ─────────────────────────────────────────────────────────────
+
+test("buildPendingProcessingQuery: one IN placeholder per pending state", () => {
+  const { sql } = buildPendingProcessingQuery();
+  assert.equal(inClausePlaceholderCount(sql), STATES.length);
+});
+
+test("buildPendingProcessingQuery: placeholders, not embedded state literals; states carried as bindings", () => {
+  const { sql, bindings } = buildPendingProcessingQuery();
+  for (const state of STATES) {
+    assert.ok(
+      !sql.includes(`'${state}'`),
+      `SQL must not embed literal '${state}'`,
+    );
+  }
+  assert.deepEqual(bindings.slice(0, STATES.length), STATES);
+});
+
+test("buildPendingProcessingQuery: bindings order = states..., custom limit", () => {
+  const { bindings } = buildPendingProcessingQuery(50);
+  assert.deepEqual([...bindings], [...STATES, 50]);
+});
+
+test("buildPendingProcessingQuery: defaults to limit 1000", () => {
+  const { bindings } = buildPendingProcessingQuery();
+  assert.equal(bindings[bindings.length - 1], 1000);
+});
+
+test("buildPendingProcessingQuery: SQL retains deleted-row filter, ordering, LIMIT", () => {
+  const { sql } = buildPendingProcessingQuery();
+  assert.match(sql, /deleted_at IS NULL/);
+  assert.match(sql, /ORDER BY captured_at DESC/);
+  assert.match(sql, /LIMIT \?/);
+});
+
+// ─── reconcile update ───────────────────────────────────────────────────────
+
+test("buildReconcileExtractionStateQuery: bindings order for terminal 'processed'", () => {
+  const { bindings } = buildReconcileExtractionStateQuery(
+    "rid-1",
+    "processed",
+    "NOW",
+  );
+  assert.deepEqual([...bindings], ["processed", "NOW", "NOW", "rid-1", ...STATES]);
+});
+
+test("buildReconcileExtractionStateQuery: bindings order for terminal 'failed'", () => {
+  const { bindings } = buildReconcileExtractionStateQuery(
+    "rid-2",
+    "failed",
+    "NOW",
+  );
+  assert.deepEqual([...bindings], ["failed", "NOW", "NOW", "rid-2", ...STATES]);
+});
+
+test("buildReconcileExtractionStateQuery: one IN placeholder per state, no embedded literals", () => {
+  const { sql } = buildReconcileExtractionStateQuery("rid", "processed", "NOW");
+  assert.equal(inClausePlaceholderCount(sql), STATES.length);
+  for (const state of STATES) {
+    assert.ok(
+      !sql.includes(`'${state}'`),
+      `SQL must not embed literal '${state}'`,
+    );
+  }
+});
+
+test("buildReconcileExtractionStateQuery: SQL retains SET columns, id condition, pending guard", () => {
+  const { sql } = buildReconcileExtractionStateQuery("rid", "processed", "NOW");
+  assert.match(
+    sql,
+    /SET extraction_state = \?, extraction_processed_at = \?, updated_at = \?/,
+  );
+  assert.match(sql, /WHERE id = \?/);
+  assert.match(sql, /AND extraction_state IN \(/);
+});


### PR DESCRIPTION
## Summary

P5-1 (modularity/parameterization): moves the extraction-queue data access out
of `lib/receipts/db.ts` into `lib/receipts/extraction-queue-db.ts` and
parameterizes both pending-state SQL clauses so they derive from
`PENDING_EXTRACTION_STATES` instead of two raw `('captured','queued','processing')`
literals. Narrow refactor — no caller changes, no behavior change, no schema or
config change.

## What's included

- **New module** `lib/receipts/extraction-queue-db.ts` exports the two public
  data-access functions plus two pure query builders used by the runtime paths:
  - `buildPendingProcessingQuery(limit = 1000)` → `{ sql, bindings }`, bindings `[...PENDING_EXTRACTION_STATES, limit]`
  - `buildReconcileExtractionStateQuery(id, finalState, now)` → `{ sql, bindings }`, bindings `[finalState, now, now, id, ...PENDING_EXTRACTION_STATES]`
  - Placeholder list = `PENDING_EXTRACTION_STATES.map(() => "?").join(", ")` — the raw literals are gone.
- **`lib/receipts/db.ts`** drops the two implementations and re-exports the
  public functions, so the three existing `@/lib/receipts/db` callers are
  unchanged.
- **Behavior preserved exactly:** list default limit 1000, `captured_at DESC`
  ordering, `deleted_at` filtering, `ReceiptRecord` mapping; reconcile
  idempotence (pending-state guard), finalized-reconciliation bypass, update
  columns, no business fields touched. No `db.batch`/transaction involved.

## Tests

`tests/receipts/extraction-queue-db.test.ts` (9 cases, `node:test`, no D1 mock)
verify the production query specs: IN-placeholder count equals
`PENDING_EXTRACTION_STATES.length`; no embedded state literals; exact binding
orders for list (custom + default 1000) and reconcile (`processed` and `failed`);
SQL retains deleted-row filter, ordering, LIMIT, SET columns, id condition, and
pending-state guard.

## Verification

- `npm test`: **446 total / 445 pass / 1 skipped / 0 fail** (+9)
- `npm run lint`: clean
- `npm run build:cf`: complete
- `git diff --check`: clean

No caller or unrelated tracked-file changes; no dependency cycle. P5-2
(receipt-list limit constants) will follow on a separate branch after this
merges — not stacked.
