### PR TITLE
refactor(receipts): centralize list query limits

### DIFF
--- a/app/(receipt-system)/receipts/capture/page.tsx
+++ b/app/(receipt-system)/receipts/capture/page.tsx
@@ -1,6 +1,7 @@
 import { ReceiptCaptureForm } from "@/components/receipts/receipt-capture-form";
 import { assertReceiptsPageAccess } from "@/lib/receipts/auth-request";
 import { listReceiptRecords } from "@/lib/receipts/db";
+import { RECEIPT_VIEW_LIMIT } from "@/lib/receipts/list-policy";
 import type { PaymentPath } from "@/lib/receipts/types";
 
 export const dynamic = "force-dynamic";
@@ -45,7 +46,7 @@ export default async function CapturePage({
 // null and the UI shows "—" with a "count unavailable" title attr.
 async function countCapturedToday(): Promise<number | null> {
   try {
-    const rows = await listReceiptRecords({ limit: 200 });
+    const rows = await listReceiptRecords({ limit: RECEIPT_VIEW_LIMIT });
     const startOfDay = new Date();
     startOfDay.setHours(0, 0, 0, 0);
     const startIso = startOfDay.toISOString();

--- a/app/(receipt-system)/receipts/page.tsx
+++ b/app/(receipt-system)/receipts/page.tsx
@@ -5,6 +5,7 @@ import {
   listExports,
   listReceiptRecords,
 } from "@/lib/receipts/db";
+import { RECEIPT_BULK_LIMIT } from "@/lib/receipts/list-policy";
 import { requireReceiptsActor } from "@/lib/receipts/auth";
 import { assertReceiptsPageAccess } from "@/lib/receipts/auth-request";
 import { headers } from "next/headers";
@@ -82,7 +83,7 @@ export default async function ReceiptsDashboardPage() {
   }
 
   const [monthReceipts, allLines, exports, complianceSummary] = await Promise.all([
-    listReceiptRecords({ month, limit: 1000 }),
+    listReceiptRecords({ month, limit: RECEIPT_BULK_LIMIT }),
     listAmexLineCountsByMonth(),
     listExports(),
     summarizeOpenChecksForMonth(getReceiptsDb(), month).catch(() => ({

--- a/app/(receipt-system)/receipts/reconcile/page.tsx
+++ b/app/(receipt-system)/receipts/reconcile/page.tsx
@@ -6,6 +6,7 @@ import {
   listReconciliationStatusByMonth,
   listAttendeeNamesByReceiptIds,
 } from "@/lib/receipts/db";
+import { RECEIPT_VIEW_LIMIT } from "@/lib/receipts/list-policy";
 import { matchAmexToReceipts } from "@/lib/receipts/reconciliation";
 import {
   deriveStatementWindow,
@@ -51,7 +52,7 @@ export default async function ReconcilePage({
 
   const [amexLines, receipts, reconciliation] = await Promise.all([
     listAmexLines(month),
-    listReceiptRecords({ paymentPath: "AMEX", limit: 200 }),
+    listReceiptRecords({ paymentPath: "AMEX", limit: RECEIPT_VIEW_LIMIT }),
     getReconciliationForMonth(month),
   ]);
 

--- a/app/(receipt-system)/receipts/review/[id]/page.tsx
+++ b/app/(receipt-system)/receipts/review/[id]/page.tsx
@@ -5,6 +5,7 @@ import {
   listAttendees,
   listReceiptRecords,
 } from "@/lib/receipts/db";
+import { RECEIPT_VIEW_LIMIT } from "@/lib/receipts/list-policy";
 import { assertReceiptsPageAccess } from "@/lib/receipts/auth-request";
 import { ReviewLayout } from "@/components/receipts/review/review-layout";
 import { QueueRail } from "@/components/receipts/review/queue-rail";
@@ -51,7 +52,7 @@ async function renderReceiptPage(params: Promise<{ id: string }>) {
   const [receipt, attendees, all] = await Promise.all([
     getReceiptRecord(id),
     listAttendees(id),
-    listReceiptRecords({ limit: 200 }),
+    listReceiptRecords({ limit: RECEIPT_VIEW_LIMIT }),
   ]);
   if (!receipt) notFound();
 

--- a/app/(receipt-system)/receipts/review/page.tsx
+++ b/app/(receipt-system)/receipts/review/page.tsx
@@ -4,6 +4,7 @@ import {
   getAmexMatchFlagsByReceiptIds,
   listReceiptRecords,
 } from "@/lib/receipts/db";
+import { RECEIPT_VIEW_LIMIT } from "@/lib/receipts/list-policy";
 import { assertReceiptsPageAccess } from "@/lib/receipts/auth-request";
 import { ReviewLayout } from "@/components/receipts/review/review-layout";
 import { QueueRail } from "@/components/receipts/review/queue-rail";
@@ -47,7 +48,7 @@ async function renderReviewPage(
   const paymentPathFilter =
     typeof params.payment_path === "string" ? params.payment_path : undefined;
 
-  const receipts = await listReceiptRecords({ limit: 200 });
+  const receipts = await listReceiptRecords({ limit: RECEIPT_VIEW_LIMIT });
   const queue = filterQueue(receipts, filter, statusFilter, paymentPathFilter);
   const amexFlags = await getAmexMatchFlagsByReceiptIds(queue.map((r) => r.id));
   const reReviewIds = new Set(

--- a/app/api/receipts/reconcile/finalize/route.ts
+++ b/app/api/receipts/reconcile/finalize/route.ts
@@ -11,6 +11,7 @@ import {
   listPendingProcessingReceipts,
   listReceiptRecordsByIds,
 } from "@/lib/receipts/db";
+import { RECEIPT_BULK_LIMIT } from "@/lib/receipts/list-policy";
 import { hashCsvContent } from "@/lib/receipts/export";
 import { buildReconciliationManifestCsv, validateAmexLinesForSignoff } from "@/lib/receipts/reconciliation-signoff";
 import { deriveStatementWindow, isReceiptInWindow } from "@/lib/receipts/statement-window";
@@ -54,7 +55,7 @@ export async function POST(request: Request) {
     // backlog masquerades as missing receipts. Captured receipts have no date
     // yet, so isReceiptInWindow treats them as in-window (conservative).
     const window = deriveStatementWindow(amexLines, month);
-    const pendingReceipts = await listPendingProcessingReceipts(1000);
+    const pendingReceipts = await listPendingProcessingReceipts(RECEIPT_BULK_LIMIT);
     const pendingInWindow = pendingReceipts.filter((r) => isReceiptInWindow(r, window));
     if (pendingInWindow.length > 0) {
       return NextResponse.json(

--- a/app/api/receipts/route.ts
+++ b/app/api/receipts/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { requireReceiptsActor } from "@/lib/receipts/auth";
 import { listReceiptRecords } from "@/lib/receipts/db";
+import { RECEIPT_VIEW_LIMIT } from "@/lib/receipts/list-policy";
 
 function intOrUndef(value: string | null): number | undefined {
   if (value === null || value === "") return undefined;
@@ -24,7 +25,7 @@ export async function GET(request: Request) {
       url.searchParams.get("invoiceRegistrationNumber") ?? undefined;
     const minAmountMinor = intOrUndef(url.searchParams.get("minAmountMinor"));
     const maxAmountMinor = intOrUndef(url.searchParams.get("maxAmountMinor"));
-    const limit = Math.min(Number(url.searchParams.get("limit") ?? 100), 200);
+    const limit = Math.min(Number(url.searchParams.get("limit") ?? 100), RECEIPT_VIEW_LIMIT);
     const offset = Number(url.searchParams.get("offset") ?? 0);
 
     const records = await listReceiptRecords({

--- a/lib/receipts/extraction-queue-db.ts
+++ b/lib/receipts/extraction-queue-db.ts
@@ -10,6 +10,7 @@
 
 import { getReceiptsDb } from "@/lib/cloudflare-runtime";
 import { nowIso } from "@/lib/receipts/db-utils";
+import { RECEIPT_BULK_LIMIT } from "@/lib/receipts/list-policy";
 import { PENDING_EXTRACTION_STATES } from "@/lib/receipts/types";
 import type { ReceiptRecord } from "@/lib/receipts/types";
 
@@ -29,7 +30,7 @@ export type TerminalExtractionState = "processed" | "failed";
  *
  * [...PENDING_EXTRACTION_STATES, limit]
  */
-export function buildPendingProcessingQuery(limit = 1000): {
+export function buildPendingProcessingQuery(limit = RECEIPT_BULK_LIMIT): {
   sql: string;
   bindings: readonly unknown[];
 } {
@@ -65,7 +66,7 @@ export function buildReconcileExtractionStateQuery(
  * Default limit 1000.
  */
 export async function listPendingProcessingReceipts(
-  limit = 1000,
+  limit = RECEIPT_BULK_LIMIT,
 ): Promise<ReceiptRecord[]> {
   const db = getReceiptsDb();
   const { sql, bindings } = buildPendingProcessingQuery(limit);

--- a/lib/receipts/extraction-queue-db.ts
+++ b/lib/receipts/extraction-queue-db.ts
@@ -61,9 +61,9 @@ export function buildReconcileExtractionStateQuery(
 }
 
 /**
- * List receipts still in a pending extraction_state (ADR 0001). The month-close
- * gate relies on this being exhaustive over captured/queued/processing.
- * Default limit 1000.
+ * List receipts still in a pending extraction_state (ADR 0001).
+ * Returns at most `limit` rows; the default is RECEIPT_BULK_LIMIT. This is a
+ * bounded operational check, not an exhaustive paging primitive.
  */
 export async function listPendingProcessingReceipts(
   limit = RECEIPT_BULK_LIMIT,

--- a/lib/receipts/list-policy.ts
+++ b/lib/receipts/list-policy.ts
@@ -1,0 +1,19 @@
+// Receipt list-query limit policy. Client-safe and dependency-free: no
+// server-only, runtime-binding, React, or Next.js imports. The constants below
+// are the policy authority for bounded receipt reads — they are not a config
+// object, env override, parsing helper, or clamp function.
+
+/**
+ * Maximum bounded receipt set used by operator-facing views (capture, review,
+ * reconcile) and the receipt-list API clamp. These views fetch a finite working
+ * set and do not claim exhaustive retrieval.
+ */
+export const RECEIPT_VIEW_LIMIT = 200;
+
+/**
+ * Broader safety ceiling used for current-month dashboard aggregation and
+ * pending-extraction checks. It is intentionally larger than the view limit,
+ * but it is NOT an exhaustive export/compliance primitive — exhaustive month
+ * reads must continue using `listAllReceiptsInMonth`.
+ */
+export const RECEIPT_BULK_LIMIT = 1000;

--- a/tests/receipts/extraction-queue-db.test.ts
+++ b/tests/receipts/extraction-queue-db.test.ts
@@ -4,6 +4,7 @@ import {
   buildPendingProcessingQuery,
   buildReconcileExtractionStateQuery,
 } from "@/lib/receipts/extraction-queue-db";
+import { RECEIPT_BULK_LIMIT } from "@/lib/receipts/list-policy";
 import { PENDING_EXTRACTION_STATES } from "@/lib/receipts/types";
 
 // Pending states as a plain array for comparison (the source is readonly).
@@ -39,9 +40,9 @@ test("buildPendingProcessingQuery: bindings order = states..., custom limit", ()
   assert.deepEqual([...bindings], [...STATES, 50]);
 });
 
-test("buildPendingProcessingQuery: defaults to limit 1000", () => {
+test("buildPendingProcessingQuery: defaults to the bulk policy limit", () => {
   const { bindings } = buildPendingProcessingQuery();
-  assert.equal(bindings[bindings.length - 1], 1000);
+  assert.equal(bindings[bindings.length - 1], RECEIPT_BULK_LIMIT);
 });
 
 test("buildPendingProcessingQuery: SQL retains deleted-row filter, ordering, LIMIT", () => {

--- a/tests/receipts/list-policy.test.ts
+++ b/tests/receipts/list-policy.test.ts
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { RECEIPT_BULK_LIMIT, RECEIPT_VIEW_LIMIT } from "@/lib/receipts/list-policy";
+
+test("RECEIPT_VIEW_LIMIT is exactly 200", () => {
+  assert.equal(RECEIPT_VIEW_LIMIT, 200);
+});
+
+test("RECEIPT_BULK_LIMIT is exactly 1000", () => {
+  assert.equal(RECEIPT_BULK_LIMIT, 1000);
+});
+
+test("RECEIPT_BULK_LIMIT is greater than RECEIPT_VIEW_LIMIT (distinct semantics)", () => {
+  assert.ok(
+    RECEIPT_BULK_LIMIT > RECEIPT_VIEW_LIMIT,
+    "bulk limit must remain the larger, intentionally distinct ceiling",
+  );
+});


### PR DESCRIPTION
## Summary

P5-2 (behavior-preserving parameterization): centralize the scattered receipt
list-query limit literals (200 / 1000) into named constants in a client-safe,
dependency-free policy module. No pagination, query restructuring, validation
repair, or DB work.

## What's included

- **`lib/receipts/list-policy.ts`** exports exactly `RECEIPT_VIEW_LIMIT` (200)
  and `RECEIPT_BULK_LIMIT` (1000), documenting their distinct semantics: a
  bounded operator-facing view set vs. a broader safety ceiling. Exhaustive
  month reads continue to use `listAllReceiptsInMonth`.
- **`RECEIPT_VIEW_LIMIT` (5 consumers):** capture / reconcile / review /
  review[id] pages and the `/api/receipts` clamp
  (`Math.min(... ?? 100, RECEIPT_VIEW_LIMIT)` — API default `100` and parsing
  behavior unchanged).
- **`RECEIPT_BULK_LIMIT` (4 uses):** dashboard page; the finalize gate
  `listPendingProcessingReceipts(RECEIPT_BULK_LIMIT)` (explicit argument kept to
  document the bounded gate read); and both defaults in
  `lib/receipts/extraction-queue-db.ts` (`buildPendingProcessingQuery`,
  `listPendingProcessingReceipts`).
- **Comment-only follow-up:** the `listPendingProcessingReceipts` JSDoc is
  clarified to describe it as a bounded operational check (default
  `RECEIPT_BULK_LIMIT`), not an exhaustive paging primitive.

## Intentionally unchanged

`listReceiptRecords` default limit `100` / offset `0`; API default `100`;
`listAllReceiptsInMonth` `PAGE = 500` / `hardCap = 10000`; all D1 chunk sizes
(incl. `90`); the 1000-char `reason` length; time/ms constants; reconciliation
fixtures; all SQL/ordering/filters/pagination/returned data; all CRM limits.

## Tests

- New `tests/receipts/list-policy.test.ts` (3): view=200, bulk=1000, bulk>view.
- `tests/receipts/extraction-queue-db.test.ts` updated to assert the policy
  default (`RECEIPT_BULK_LIMIT`) instead of a hardcoded 1000; binding-order
  tests unchanged.

## Verification

- `npm test`: **449 total / 448 pass / 1 skipped / 0 fail** (+3)
- `npm run lint`: clean
- `npm run build:cf`: complete
- `git diff --check origin/master...HEAD`: clean

No caller behavior change; the policy module is client-safe and dependency-free
(no server-only / runtime-binding / React / Next.js imports).
