### PR TITLE
refactor(receipts): centralize D1 id chunk size

### DIFF
--- a/lib/receipts/db-utils.ts
+++ b/lib/receipts/db-utils.ts
@@ -9,3 +9,10 @@ export function newUuid(): string {
 export function stringifyJson(value: unknown): string {
   return JSON.stringify(value);
 }
+
+/**
+ * Default chunk for D1 `IN` queries with one binding per ID. Ninety leaves
+ * headroom for queries that also bind a small number of fixed values.
+ * Query shapes with different bind math may use smaller local chunks.
+ */
+export const D1_ID_CHUNK_SIZE = 90;

--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -1,6 +1,6 @@
 import { getReceiptsDb } from "@/lib/cloudflare-runtime";
 import { createAuditEntry } from "@/lib/receipts/audit";
-import { nowIso, newUuid, stringifyJson } from "@/lib/receipts/db-utils";
+import { D1_ID_CHUNK_SIZE, nowIso, newUuid, stringifyJson } from "@/lib/receipts/db-utils";
 import {
   assertTransactionMonthEditable,
   transactionMonthOf,
@@ -477,10 +477,9 @@ export async function listReceiptRecordsByIds(
 
   const db = getReceiptsDb();
   const records: ReceiptRecord[] = [];
-  const CHUNK_SIZE = 90;
 
-  for (let i = 0; i < uniqueIds.length; i += CHUNK_SIZE) {
-    const chunk = uniqueIds.slice(i, i + CHUNK_SIZE);
+  for (let i = 0; i < uniqueIds.length; i += D1_ID_CHUNK_SIZE) {
+    const chunk = uniqueIds.slice(i, i + D1_ID_CHUNK_SIZE);
     const placeholders = chunk.map(() => "?").join(",");
     const result = await db
       .prepare(
@@ -1637,9 +1636,8 @@ export async function listAmexLinesForBusinessTripReports(
   const unique = [...new Set(reportIds.filter(Boolean))];
   if (unique.length === 0) return out;
   const db = getReceiptsDb();
-  const CHUNK = 90;
-  for (let i = 0; i < unique.length; i += CHUNK) {
-    const chunk = unique.slice(i, i + CHUNK);
+  for (let i = 0; i < unique.length; i += D1_ID_CHUNK_SIZE) {
+    const chunk = unique.slice(i, i + D1_ID_CHUNK_SIZE);
     const placeholders = chunk.map(() => "?").join(",");
     const result = await db
       .prepare(
@@ -1993,9 +1991,8 @@ export async function finalizeExport(
       // allows 'exported'. We do NOT touch 'archived' rows — once archived
       // the lifecycle is terminal and a re-finalize shouldn't unwind it.
       // Chunk to respect D1's parameter limit per statement.
-      const CHUNK_SIZE = 90;
-      for (let i = 0; i < exportedReceiptIds.length; i += CHUNK_SIZE) {
-        const chunk = exportedReceiptIds.slice(i, i + CHUNK_SIZE);
+      for (let i = 0; i < exportedReceiptIds.length; i += D1_ID_CHUNK_SIZE) {
+        const chunk = exportedReceiptIds.slice(i, i + D1_ID_CHUNK_SIZE);
         const placeholders = chunk.map(() => "?").join(",");
         await db
           .prepare(

--- a/lib/receipts/files.ts
+++ b/lib/receipts/files.ts
@@ -1,5 +1,5 @@
 import { getReceiptsDb } from "@/lib/cloudflare-runtime";
-import { newUuid, nowIso } from "@/lib/receipts/db-utils";
+import { D1_ID_CHUNK_SIZE, newUuid, nowIso } from "@/lib/receipts/db-utils";
 import type { ReceiptFile, ReceiptFileRole } from "@/lib/receipts/types";
 
 export interface CreateReceiptFileInput {
@@ -113,9 +113,8 @@ export async function countReceiptFilesByObjectIds(
   const counts = new Map<string, number>();
   if (receiptIds.length === 0) return counts;
   // Chunk to respect D1's parameter limit per statement.
-  const CHUNK_SIZE = 90;
-  for (let i = 0; i < receiptIds.length; i += CHUNK_SIZE) {
-    const chunk = receiptIds.slice(i, i + CHUNK_SIZE);
+  for (let i = 0; i < receiptIds.length; i += D1_ID_CHUNK_SIZE) {
+    const chunk = receiptIds.slice(i, i + D1_ID_CHUNK_SIZE);
     const placeholders = chunk.map(() => "?").join(",");
     const result = await db
       .prepare(

--- a/tests/receipts/db-utils.test.ts
+++ b/tests/receipts/db-utils.test.ts
@@ -1,0 +1,14 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { D1_ID_CHUNK_SIZE } from "@/lib/receipts/db-utils";
+
+test("D1_ID_CHUNK_SIZE: exactly 90, a positive integer, below 100 (bind headroom)", () => {
+  assert.equal(D1_ID_CHUNK_SIZE, 90);
+  assert.ok(
+    Number.isInteger(D1_ID_CHUNK_SIZE) && D1_ID_CHUNK_SIZE > 0,
+    "must be a positive integer",
+  );
+  // Stays below D1's ~100 bind-variable ceiling so queries that also bind a
+  // few fixed values keep headroom.
+  assert.ok(D1_ID_CHUNK_SIZE < 100, "must remain below 100");
+});


### PR DESCRIPTION
## Summary

P5-3 (behavior-preserving parameterization): replace the four duplicated 90-ID
chunk declarations with a single shared `D1_ID_CHUNK_SIZE` constant. The value
and all loop/slice math are unchanged — only the local declarations are removed.

## What's included

- **`lib/receipts/db-utils.ts`** exports `D1_ID_CHUNK_SIZE = 90` (dependency-free),
  documented as the default chunk for D1 `IN` queries with one binding per ID,
  staying below the ~100 bind-variable ceiling to leave headroom for queries that
  also bind a few fixed values.
- **Four consumers** now use `D1_ID_CHUNK_SIZE` directly (no local alias):
  - `db.ts` `listReceiptRecordsByIds`
  - `db.ts` `listAmexLinesForBusinessTripReports`
  - `db.ts` `finalizeExport` exported-receipt status update
  - `files.ts` `countReceiptFilesByObjectIds`

## Intentionally unchanged

Query-specific batching with different bind math: AMEX upsert `CHUNK_SIZE = 4`,
business-trip `TRIP_CHUNK = 20`, D1 batch `CHUNK = 30`, compliance-summary
`CHUNK = 50` (a unique conservative choice — changing 50→90 would alter
behavior, not deduplicate). Category `displayOrder: 90` is unrelated. All SQL,
placeholder construction, bind order, dedup/filtering, ordering, accumulation,
audit-entry, and transaction/batch behavior is untouched, as are the P5-2 list
limits.

## Test

New `tests/receipts/db-utils.test.ts` asserts `D1_ID_CHUNK_SIZE` is exactly 90,
a positive integer, and below 100. No source-text test, no generic chunking
helper.

## Verification

- `npm test`: **450 total / 449 pass / 1 skipped / 0 fail** (+1)
- `npm run lint`: clean
- `npm run build:cf`: complete
- `git diff --check origin/master...HEAD`: clean

No one-bind-per-ID local chunk of 90 remains (audit confirmed exactly the four
sites consolidated; no fifth found).
