### PR TITLE
refactor(crm): centralize scoring policy

### DIFF
--- a/lib/crm-dedupe.ts
+++ b/lib/crm-dedupe.ts
@@ -1,4 +1,5 @@
 import { inferDomainFromEmail, inferDomainFromUrl, normalizeEmail, normalizeLinkedInUrl, normalizePhone } from "@/lib/crm-normalization";
+import { CRM_DEDUPE_SCORING_POLICY } from "@/lib/crm-scoring-policy";
 import type { DuplicateCandidate, ExtractedContactFields } from "@/lib/crm-types";
 
 export interface DedupeComparableContact {
@@ -77,7 +78,7 @@ export function buildDuplicateCandidates(
       const contactCompany = normalizeText(contact.company);
 
       if (extractedEmail && contactEmail && extractedEmail === contactEmail) {
-        score = Math.max(score, 0.99);
+        score = Math.max(score, CRM_DEDUPE_SCORING_POLICY.exactEmailConfidence);
         reasons.push("Exact email match");
       }
 
@@ -85,31 +86,34 @@ export function buildDuplicateCandidates(
         (extractedPhone && contactPhone && extractedPhone === contactPhone) ||
         (extractedMobile && contactMobile && extractedMobile === contactMobile)
       ) {
-        score = Math.max(score, 0.93);
+        score = Math.max(score, CRM_DEDUPE_SCORING_POLICY.exactPhoneConfidence);
         reasons.push("Exact phone match");
       }
 
       if (extractedLinkedIn && contactLinkedIn && extractedLinkedIn === contactLinkedIn) {
-        score = Math.max(score, 0.96);
+        score = Math.max(score, CRM_DEDUPE_SCORING_POLICY.exactLinkedInConfidence);
         reasons.push("Exact LinkedIn URL match");
       }
 
       const nameScore = diceCoefficient(extractedName, contactName);
       const companyScore = diceCoefficient(extractedCompany, contactCompany);
-      if (nameScore >= 0.9 && companyScore >= 0.85) {
-        score = Math.max(score, 0.87);
+      if (
+        nameScore >= CRM_DEDUPE_SCORING_POLICY.strongNameSimilarityThreshold &&
+        companyScore >= CRM_DEDUPE_SCORING_POLICY.strongCompanySimilarityThreshold
+      ) {
+        score = Math.max(score, CRM_DEDUPE_SCORING_POLICY.strongNameCompanyConfidence);
         reasons.push("Strong name + company match");
-      } else if (nameScore >= 0.9) {
-        score = Math.max(score, 0.73);
+      } else if (nameScore >= CRM_DEDUPE_SCORING_POLICY.strongNameSimilarityThreshold) {
+        score = Math.max(score, CRM_DEDUPE_SCORING_POLICY.strongNameOnlyConfidence);
         reasons.push("Strong name match");
       }
 
       if (extractedDomain && contactDomain && extractedDomain === contactDomain) {
-        score = Math.max(score, 0.72);
+        score = Math.max(score, CRM_DEDUPE_SCORING_POLICY.matchingDomainConfidence);
         reasons.push("Matching company domain");
       }
 
-      if (reasons.length === 0 || score < 0.55) {
+      if (reasons.length === 0 || score < CRM_DEDUPE_SCORING_POLICY.minimumCandidateConfidence) {
         return null;
       }
 
@@ -122,5 +126,5 @@ export function buildDuplicateCandidates(
     })
     .filter((candidate): candidate is DuplicateCandidate => Boolean(candidate))
     .sort((left, right) => right.confidence - left.confidence)
-    .slice(0, 5);
+    .slice(0, CRM_DEDUPE_SCORING_POLICY.maxCandidates);
 }

--- a/lib/crm-scoring-policy.ts
+++ b/lib/crm-scoring-policy.ts
@@ -1,0 +1,43 @@
+// Deterministic CRM scoring policy. Dependency-free and safe to import from any
+// CRM code (no server-only, runtime-binding, React, or Next.js imports).
+//
+// These constants name the previously inline magic numbers used to construct
+// duplicate candidates and to choose synergy CTA/rationale language. They are
+// NOT operator-configurable: no environment configuration, setters, classes, or
+// mutable state.
+
+/**
+ * The synergy score boundary where the recommended CTA and the draft's
+ * rationale label switch from low-pressure to high-fit. Scores at or above this
+ * value are treated as high-fit.
+ */
+export const CRM_SYNERGY_HIGH_FIT_SCORE = 70;
+
+/** True when a synergy score is at or above the high-fit boundary. */
+export function isHighFitSynergyScore(score: number): boolean {
+  return score >= CRM_SYNERGY_HIGH_FIT_SCORE;
+}
+
+/**
+ * Deterministic duplicate-candidate construction policy: the confidences
+ * assigned to each kind of match, the similarity thresholds that qualify a
+ * "strong" name/company match, the minimum confidence to emit a candidate, and
+ * the maximum number of candidates returned.
+ *
+ * This controls deterministic duplicate-candidate CONSTRUCTION only. It is not
+ * `CrmThresholdSettings` and does not control whether a candidate is routed for
+ * human review — `dedupe_review_threshold` remains persisted/operator-
+ * configurable elsewhere (lib/crm.ts DEFAULT_THRESHOLDS + admin settings).
+ */
+export const CRM_DEDUPE_SCORING_POLICY = {
+  exactEmailConfidence: 0.99,
+  exactPhoneConfidence: 0.93,
+  exactLinkedInConfidence: 0.96,
+  strongNameSimilarityThreshold: 0.9,
+  strongCompanySimilarityThreshold: 0.85,
+  strongNameCompanyConfidence: 0.87,
+  strongNameOnlyConfidence: 0.73,
+  matchingDomainConfidence: 0.72,
+  minimumCandidateConfidence: 0.55,
+  maxCandidates: 5,
+} as const;

--- a/lib/crm-synergy.ts
+++ b/lib/crm-synergy.ts
@@ -6,6 +6,7 @@ import type {
   SynergyAnalysisPayload,
   SynergyReason,
 } from "@/lib/crm-types";
+import { isHighFitSynergyScore } from "@/lib/crm-scoring-policy";
 
 export interface SynergyInput {
   contactName: string | null;
@@ -134,7 +135,7 @@ export function analyzeSynergy(input: SynergyInput): SynergyAnalysisPayload {
       : "Keep the note warm and specific to the event context, and position the connection as a useful ongoing relationship rather than an immediate project ask.";
 
   const recommendedCta =
-    totalScore >= 70
+    isHighFitSynergyScore(totalScore)
       ? "Suggest a short follow-up conversation to compare notes on a practical workflow or transformation problem."
       : "Suggest staying in touch and invite a low-pressure follow-up if a relevant need comes up.";
 
@@ -171,7 +172,7 @@ export function createEmailDraft(args: {
     "The overlap seems to be in practical, maintainable AI and workflow improvement rather than hype-heavy experimentation.";
 
   const softCta =
-    args.synergy.synergyScore >= 70
+    isHighFitSynergyScore(args.synergy.synergyScore)
       ? "If useful, I'd be glad to compare notes on where a small, grounded automation or AI step could create leverage."
       : "If it ever helps, I'd be happy to stay in touch and compare notes on practical AI or workflow improvement.";
 
@@ -205,7 +206,7 @@ export function createEmailDraft(args: {
       : "Good meeting you",
     plainTextBody: body,
     htmlBody: null,
-    rationaleSummary: `${args.synergy.synergyScore >= 70 ? "High-fit" : "Low-pressure"} follow-up grounded in event context and the strongest documented fit signal.`,
+    rationaleSummary: `${isHighFitSynergyScore(args.synergy.synergyScore) ? "High-fit" : "Low-pressure"} follow-up grounded in event context and the strongest documented fit signal.`,
     status:
       hasAllRequiredLinks && args.contactName && args.synergy.reasons.length > 0
         ? "ready"

--- a/tests/crm-dedupe.test.ts
+++ b/tests/crm-dedupe.test.ts
@@ -4,6 +4,7 @@ import duplicateFixture from "@/tests/fixtures/duplicate-contacts.json";
 import mixedFixture from "@/tests/fixtures/mixed-ja-en-card.json";
 import { buildDuplicateCandidates } from "@/lib/crm-dedupe";
 import { normalizeExtractedFields } from "@/lib/crm-normalization";
+import { CRM_DEDUPE_SCORING_POLICY } from "@/lib/crm-scoring-policy";
 
 test("buildDuplicateCandidates ranks exact identity matches highest", () => {
   const normalized = normalizeExtractedFields(mixedFixture.fields);
@@ -11,6 +12,6 @@ test("buildDuplicateCandidates ranks exact identity matches highest", () => {
 
   assert.equal(candidates.length, 1);
   assert.equal(candidates[0].contactId, 11);
-  assert.ok(candidates[0].confidence >= 0.95);
+  assert.equal(candidates[0].confidence, CRM_DEDUPE_SCORING_POLICY.exactEmailConfidence);
   assert.ok(candidates[0].reasons.includes("Exact LinkedIn URL match"));
 });

--- a/tests/crm-scoring-policy.test.ts
+++ b/tests/crm-scoring-policy.test.ts
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  CRM_DEDUPE_SCORING_POLICY,
+  CRM_SYNERGY_HIGH_FIT_SCORE,
+  isHighFitSynergyScore,
+} from "@/lib/crm-scoring-policy";
+
+test("CRM_SYNERGY_HIGH_FIT_SCORE is exactly 70", () => {
+  assert.equal(CRM_SYNERGY_HIGH_FIT_SCORE, 70);
+});
+
+test("isHighFitSynergyScore returns false for 69 and true for 70 and 71", () => {
+  assert.equal(isHighFitSynergyScore(69), false);
+  assert.equal(isHighFitSynergyScore(70), true);
+  assert.equal(isHighFitSynergyScore(71), true);
+});
+
+test("CRM_DEDUPE_SCORING_POLICY deep-equals the specified policy object", () => {
+  assert.deepEqual(CRM_DEDUPE_SCORING_POLICY, {
+    exactEmailConfidence: 0.99,
+    exactPhoneConfidence: 0.93,
+    exactLinkedInConfidence: 0.96,
+    strongNameSimilarityThreshold: 0.9,
+    strongCompanySimilarityThreshold: 0.85,
+    strongNameCompanyConfidence: 0.87,
+    strongNameOnlyConfidence: 0.73,
+    matchingDomainConfidence: 0.72,
+    minimumCandidateConfidence: 0.55,
+    maxCandidates: 5,
+  });
+});


### PR DESCRIPTION
## Summary

P5-4 (behavior-preserving parameterization): name the previously inline CRM
scoring magic numbers in a dependency-free policy module. Every value and
operator is unchanged — only inline literals become named policy.

## What's included

- **`lib/crm-scoring-policy.ts`** (new, dependency-free) exports:
  - `CRM_SYNERGY_HIGH_FIT_SCORE = 70` — the boundary where CTA/rationale switch
    from low-pressure to high-fit, plus `isHighFitSynergyScore(score)`.
  - `CRM_DEDUPE_SCORING_POLICY` (`as const`) — the deterministic duplicate-
    candidate construction values (exact email/phone/LinkedIn confidences, strong
    name/company similarity thresholds, name+company / name-only / domain
    confidences, minimum candidate confidence, max candidates). Documented as
    **not** `CrmThresholdSettings` — it does not control human-review routing;
    `dedupe_review_threshold` stays persisted/operator-configurable elsewhere.
- **`lib/crm-dedupe.ts`** imports the policy and replaces all 11 inline literals
  with descriptive property access (no local aliases). Dice math, `Math.max`,
  `>=`/`<`, `toFixed(2)`, sort, reasons, and return types are unchanged.
- **`lib/crm-synergy.ts`** imports `isHighFitSynergyScore` and replaces all three
  `score >= 70` decisions (recommended CTA, soft CTA, High-fit/Low-pressure
  rationale label). Reason contributions, base 8, bounds 20/100, max-five-reasons,
  copy, and draft-status rules are unchanged.

## Out of scope (unchanged)

`DEFAULT_THRESHOLDS` (`ocr_review_threshold` 0.72, `dedupe_review_threshold`
0.75, `draft_review_threshold` 0.7, `detection_min_cards` 6), settings UI/DB,
CRM types/schemas, synergy reason-contribution values, Dice implementation,
email copy, and any receipt-domain or Next.js route/component code.

## Tests

- New `tests/crm-scoring-policy.test.ts` (3): high-fit = 70; `isHighFitSynergy
  Score` false@69 / true@70 / true@71; policy deep-equals the spec object.
- `tests/crm-dedupe.test.ts` strengthened: the top candidate's confidence is now
  asserted exactly `=== CRM_DEDUPE_SCORING_POLICY.exactEmailConfidence`
  (LinkedIn-reason assertion retained).

## Verification

- `npm test`: **453 total / 452 pass / 1 skipped / 0 fail** (+3)
- `npm run lint`: clean
- `npm run build:cf`: complete
- `git diff --check origin/master...HEAD`: clean

Audits: no raw `>= 70` remains in `crm-synergy.ts`; no specified dedupe literal
remains inline in `crm-dedupe.ts`; CRM review thresholds unchanged.
