### PR TITLE
fix(receipts): harden finalization and D1 bind safety

### DIFF
--- a/app/api/receipts/reconcile/finalize/route.ts
+++ b/app/api/receipts/reconcile/finalize/route.ts
@@ -11,7 +11,7 @@ import {
   listPendingProcessingReceipts,
   listReceiptRecordsByIds,
 } from "@/lib/receipts/db";
-import { RECEIPT_BULK_LIMIT } from "@/lib/receipts/list-policy";
+import { RECEIPT_BULK_LIMIT, hasReceiptBulkOverflow } from "@/lib/receipts/list-policy";
 import { hashCsvContent } from "@/lib/receipts/export";
 import { buildReconciliationManifestCsv, validateAmexLinesForSignoff } from "@/lib/receipts/reconciliation-signoff";
 import { deriveStatementWindow, isReceiptInWindow } from "@/lib/receipts/statement-window";
@@ -55,7 +55,19 @@ export async function POST(request: Request) {
     // backlog masquerades as missing receipts. Captured receipts have no date
     // yet, so isReceiptInWindow treats them as in-window (conservative).
     const window = deriveStatementWindow(amexLines, month);
-    const pendingReceipts = await listPendingProcessingReceipts(RECEIPT_BULK_LIMIT);
+    const pendingReceipts = await listPendingProcessingReceipts(RECEIPT_BULK_LIMIT + 1);
+    if (hasReceiptBulkOverflow(pendingReceipts.length)) {
+      return NextResponse.json(
+        {
+          error:
+            `Cannot finalize ${month}: more than ${RECEIPT_BULK_LIMIT} receipts are still pending extraction. ` +
+            `The statement window cannot be verified safely while the backlog exceeds the safety ceiling. ` +
+            `Drain the Mac MLX consumer queue and retry.`,
+          pendingProcessingAtLeast: pendingReceipts.length,
+        },
+        { status: 409 },
+      );
+    }
     const pendingInWindow = pendingReceipts.filter((r) => isReceiptInWindow(r, window));
     if (pendingInWindow.length > 0) {
       return NextResponse.json(

--- a/lib/receipts/db-utils.ts
+++ b/lib/receipts/db-utils.ts
@@ -11,8 +11,20 @@ export function stringifyJson(value: unknown): string {
 }
 
 /**
- * Default chunk for D1 `IN` queries with one binding per ID. Ninety leaves
- * headroom for queries that also bind a small number of fixed values.
- * Query shapes with different bind math may use smaller local chunks.
+ * Cloudflare D1's current maximum bound parameters per query.
+ * See: https://developers.cloudflare.com/d1/platform/limits/
  */
-export const D1_ID_CHUNK_SIZE = 90;
+export const D1_MAX_BOUND_PARAMS = 100;
+
+/**
+ * Fixed, non-ID bindings deliberately reserved within the D1 bind budget.
+ * Query shapes requiring more fixed bindings must use a smaller local chunk.
+ */
+export const D1_ID_CHUNK_FIXED_BIND_HEADROOM = 10;
+
+/**
+ * Default chunk for D1 `IN` queries with one binding per ID. Derived from the
+ * bind budget minus the reserved headroom so that queries binding a few fixed
+ * values alongside the ID list stay within the D1 limit.
+ */
+export const D1_ID_CHUNK_SIZE = D1_MAX_BOUND_PARAMS - D1_ID_CHUNK_FIXED_BIND_HEADROOM;

--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -1990,7 +1990,9 @@ export async function finalizeExport(
       // Promote status + stamp exported_month. The status CHECK constraint
       // allows 'exported'. We do NOT touch 'archived' rows — once archived
       // the lifecycle is terminal and a re-finalize shouldn't unwind it.
-      // Chunk to respect D1's parameter limit per statement.
+      // Chunk to respect D1's parameter limit per statement. This query binds
+      // two fixed values (exportMonth, now) plus the ID list, so a full 90-ID
+      // chunk uses 92 of D1's 100-bind ceiling — within the ten-slot headroom.
       for (let i = 0; i < exportedReceiptIds.length; i += D1_ID_CHUNK_SIZE) {
         const chunk = exportedReceiptIds.slice(i, i + D1_ID_CHUNK_SIZE);
         const placeholders = chunk.map(() => "?").join(",");

--- a/lib/receipts/list-policy.ts
+++ b/lib/receipts/list-policy.ts
@@ -17,3 +17,15 @@ export const RECEIPT_VIEW_LIMIT = 200;
  * reads must continue using `listAllReceiptsInMonth`.
  */
 export const RECEIPT_BULK_LIMIT = 1000;
+
+/**
+ * True when a bounded pending-result count exceeds RECEIPT_BULK_LIMIT. Callers
+ * that fetch `RECEIPT_BULK_LIMIT + 1` rows can use this helper to distinguish a
+ * complete bounded result (at most RECEIPT_BULK_LIMIT) from an overflow
+ * sentinel indicating the backlog is deeper than the safety ceiling.
+ *
+ * This consumes an internal array length — it does not parse or validate input.
+ */
+export function hasReceiptBulkOverflow(resultCount: number): boolean {
+  return resultCount > RECEIPT_BULK_LIMIT;
+}

--- a/tests/receipts/db-utils.test.ts
+++ b/tests/receipts/db-utils.test.ts
@@ -1,14 +1,20 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { D1_ID_CHUNK_SIZE } from "@/lib/receipts/db-utils";
+import {
+  D1_ID_CHUNK_FIXED_BIND_HEADROOM,
+  D1_ID_CHUNK_SIZE,
+  D1_MAX_BOUND_PARAMS,
+} from "@/lib/receipts/db-utils";
 
-test("D1_ID_CHUNK_SIZE: exactly 90, a positive integer, below 100 (bind headroom)", () => {
+test("D1 bind-budget policy: values, positivity, and invariant", () => {
+  assert.equal(D1_MAX_BOUND_PARAMS, 100);
+  assert.equal(D1_ID_CHUNK_FIXED_BIND_HEADROOM, 10);
   assert.equal(D1_ID_CHUNK_SIZE, 90);
-  assert.ok(
-    Number.isInteger(D1_ID_CHUNK_SIZE) && D1_ID_CHUNK_SIZE > 0,
-    "must be a positive integer",
+  for (const v of [D1_MAX_BOUND_PARAMS, D1_ID_CHUNK_FIXED_BIND_HEADROOM, D1_ID_CHUNK_SIZE]) {
+    assert.ok(Number.isInteger(v) && v > 0, `${v} must be a positive integer`);
+  }
+  assert.equal(
+    D1_ID_CHUNK_SIZE + D1_ID_CHUNK_FIXED_BIND_HEADROOM,
+    D1_MAX_BOUND_PARAMS,
   );
-  // Stays below D1's ~100 bind-variable ceiling so queries that also bind a
-  // few fixed values keep headroom.
-  assert.ok(D1_ID_CHUNK_SIZE < 100, "must remain below 100");
 });

--- a/tests/receipts/list-policy.test.ts
+++ b/tests/receipts/list-policy.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { RECEIPT_BULK_LIMIT, RECEIPT_VIEW_LIMIT } from "@/lib/receipts/list-policy";
+import { RECEIPT_BULK_LIMIT, RECEIPT_VIEW_LIMIT, hasReceiptBulkOverflow } from "@/lib/receipts/list-policy";
 
 test("RECEIPT_VIEW_LIMIT is exactly 200", () => {
   assert.equal(RECEIPT_VIEW_LIMIT, 200);
@@ -15,4 +15,10 @@ test("RECEIPT_BULK_LIMIT is greater than RECEIPT_VIEW_LIMIT (distinct semantics)
     RECEIPT_BULK_LIMIT > RECEIPT_VIEW_LIMIT,
     "bulk limit must remain the larger, intentionally distinct ceiling",
   );
+});
+
+test("hasReceiptBulkOverflow: false below and at the limit, true above", () => {
+  assert.equal(hasReceiptBulkOverflow(RECEIPT_BULK_LIMIT - 1), false); // 999
+  assert.equal(hasReceiptBulkOverflow(RECEIPT_BULK_LIMIT), false);     // 1000
+  assert.equal(hasReceiptBulkOverflow(RECEIPT_BULK_LIMIT + 1), true);  // 1001
 });


### PR DESCRIPTION
## Summary

Two independent safety hardenings for the receipts domain, delivered as two
atomic commits.

## Commit 1 — Fail closed on pending backlog saturation

The reconciliation-finalize gate fetches `RECEIPT_BULK_LIMIT` pending receipts
to check whether any fall in the statement window. If the backlog exceeds that
ceiling, the bounded fetch silently truncates — the gate can no longer verify
that the window is clear, yet it proceeds as if the result were exhaustive.

**Fix:** fetch one extra row (`RECEIPT_BULK_LIMIT + 1` = 1001) as an overflow
sentinel; if `hasReceiptBulkOverflow` is true, return **HTTP 409** before
statement-window filtering, instructing the operator to drain the Mac MLX queue.
The response includes `pendingProcessingAtLeast` (a lower bound). The existing
in-window 409 for non-overflowing sets is preserved unchanged.

- `lib/receipts/list-policy.ts`: `hasReceiptBulkOverflow(resultCount)`.
- `app/api/receipts/reconcile/finalize/route.ts`: fetches 1001; overflow gate
  before `isReceiptInWindow`.
- `tests/receipts/list-policy.test.ts`: 999→false, 1000→false, 1001→true.

## Commit 2 — Encode the D1 bind budget and reserved headroom

Replace the standalone `D1_ID_CHUNK_SIZE = 90` with an explicit derived formula:

- `D1_MAX_BOUND_PARAMS = 100` (Cloudflare D1's current limit —
  [docs](https://developers.cloudflare.com/d1/platform/limits/))
- `D1_ID_CHUNK_FIXED_BIND_HEADROOM = 10` (reserved for fixed non-ID bindings)
- `D1_ID_CHUNK_SIZE = 100 − 10 = 90` (unchanged runtime batching)

A comment above the `finalizeExport` chunk loop documents that the query's two
fixed bindings (`exportMonth`, `now`) give 92 total at a full 90-ID chunk —
within the reserved ten-slot headroom.

- `lib/receipts/db-utils.ts`: three constants replacing the standalone 90.
- `tests/receipts/db-utils.test.ts`: asserts values, positivity, and the
  invariant `chunk + headroom === D1_MAX_BOUND_PARAMS`.
- `lib/receipts/db.ts`: comment only (loop/SQL/bindings unchanged).

## Verification

- `npm test`: **455 total / 454 pass / 1 skipped / 0 fail**
- `npm run lint`: clean
- `npm run build:cf`: complete
- `git diff --check origin/master...HEAD`: clean

`RECEIPT_BULK_LIMIT` unchanged (1000); all four D1 ID-chunk consumers unchanged;
the 4/20/30/50 query-specific chunks untouched; no API limit parsing, audit-log
LIMIT, pagination, or COUNT(*) changes.
