### PR TITLE
fix(crm): freeze dedupe scoring policy

### DIFF
--- a/lib/crm-scoring-policy.ts
+++ b/lib/crm-scoring-policy.ts
@@ -29,7 +29,7 @@ export function isHighFitSynergyScore(score: number): boolean {
  * human review — `dedupe_review_threshold` remains persisted/operator-
  * configurable elsewhere (lib/crm.ts DEFAULT_THRESHOLDS + admin settings).
  */
-export const CRM_DEDUPE_SCORING_POLICY = {
+export const CRM_DEDUPE_SCORING_POLICY = Object.freeze({
   exactEmailConfidence: 0.99,
   exactPhoneConfidence: 0.93,
   exactLinkedInConfidence: 0.96,
@@ -40,4 +40,4 @@ export const CRM_DEDUPE_SCORING_POLICY = {
   matchingDomainConfidence: 0.72,
   minimumCandidateConfidence: 0.55,
   maxCandidates: 5,
-} as const;
+} as const);

--- a/tests/crm-scoring-policy.test.ts
+++ b/tests/crm-scoring-policy.test.ts
@@ -30,3 +30,16 @@ test("CRM_DEDUPE_SCORING_POLICY deep-equals the specified policy object", () => 
     maxCandidates: 5,
   });
 });
+
+test("CRM_DEDUPE_SCORING_POLICY is frozen — mutation throws and value is unchanged", () => {
+  assert.equal(Object.isFrozen(CRM_DEDUPE_SCORING_POLICY), true);
+  assert.throws(
+    () => {
+      (
+        CRM_DEDUPE_SCORING_POLICY as { exactEmailConfidence: number }
+      ).exactEmailConfidence = 0.01;
+    },
+    TypeError,
+  );
+  assert.equal(CRM_DEDUPE_SCORING_POLICY.exactEmailConfidence, 0.99);
+});


### PR DESCRIPTION
## Summary

Wraps `CRM_DEDUPE_SCORING_POLICY` in `Object.freeze` so the deterministic scoring
policy is runtime-immutable. Literal values, readonly typing, consumers,
thresholds, and behavior are otherwise unchanged.

## What changed

- `lib/crm-scoring-policy.ts`: `CRM_DEDUPE_SCORING_POLICY` is now
  `Object.freeze({ ... } as const)`. No property names, values, or literal types
  changed. Consumers (`lib/crm-dedupe.ts`) read the frozen object unchanged.
  `CRM_SYNERGY_HIGH_FIT_SCORE` and `isHighFitSynergyScore` untouched.
- `tests/crm-scoring-policy.test.ts`: new immutability test asserts
  `Object.isFrozen` is true, a type-cast write to `exactEmailConfidence` throws
  `TypeError`, and the value remains `0.99` afterward. Existing policy tests
  retained.

## Verification

- Targeted tests (`crm-scoring-policy.test.ts` + `crm-dedupe.test.ts`): **5/5 pass**
- `npm test`: **456 total / 455 pass / 1 skipped / 0 fail** (+1)
- `npm run lint`: clean
- `npm run build:cf`: complete
- `git diff --check`: clean
