### PR TITLE
receipts: attendee directory in D1 + AttendeeIds column + 参加者一覧 export artifact

### DIFF
--- a/app/(receipt-system)/receipts/export/page.tsx
+++ b/app/(receipt-system)/receipts/export/page.tsx
@@ -48,6 +48,7 @@ const BUNDLE_DOWNLOAD_LINKS = [
   { file: "summary", label: "Summary" },
   { file: "readme", label: "README" },
   { file: "proofs", label: "領収書ZIP" },
+  { file: "attendees", label: "参加者一覧" },
 ] as const;
 
 export default async function ExportPage({
@@ -142,7 +143,12 @@ export default async function ExportPage({
   // Honest CSV size: build the pure CSV (same call the route makes before
   // applying BOM/CRLF) and measure its UTF-8 byte length. BOM+CRLF add a
   // small constant overhead we ignore — the operator only needs a ballpark.
-  const pureCsv = buildMonthlyExportCsv(bundle.rows, bundle.attendeeMap);
+  const pureCsv = buildMonthlyExportCsv(
+    bundle.rows,
+    bundle.attendeeMap,
+    bundle.attendeeDirectory,
+    bundle.amexAttendees,
+  );
   const manifestSize = {
     rowsTotal: draftStats.rows,
     sizeBytes: new TextEncoder().encode(pureCsv).byteLength,

--- a/app/api/receipts/attendee-directory/route.ts
+++ b/app/api/receipts/attendee-directory/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from "next/server";
+import { requireReceiptsActor } from "@/lib/receipts/auth";
+import {
+  listAttendeeDirectory,
+  createAttendeeDirectoryEntry,
+} from "@/lib/receipts/db";
+import type { ReceiptAttendeeDirectoryEntry } from "@/lib/receipts/attendee-directory";
+
+// Attendee directory (migration 0022): the company/title lookup the export
+// bundle's AttendeeIds column joins against. GET feeds the review-form
+// datalist; POST registers a new attendee from the review UI so adding one is
+// a data operation, not a code deploy. Resolution is by exact name match
+// (identity = directory name), so a name typed here is the same string the
+// finalize gate resolves against — no fuzzy matching.
+
+export async function GET(request: Request) {
+  try {
+    await requireReceiptsActor(request.headers);
+    const entries = await listAttendeeDirectory();
+    return NextResponse.json({ entries }, { status: 200 });
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Unauthorized")) {
+      return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+    }
+    console.error("[api/receipts/attendee-directory] GET failed", error);
+    return NextResponse.json(
+      { error: "Failed to load attendee directory." },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const actor = await requireReceiptsActor(request.headers);
+    const body = (await request.json().catch(() => ({}))) as {
+      name?: unknown;
+      company?: unknown;
+      title?: unknown;
+    };
+
+    const name = typeof body.name === "string" ? body.name.trim() : "";
+    const company = typeof body.company === "string" ? body.company.trim() : "";
+    const title = typeof body.title === "string" ? body.title.trim() : "";
+
+    if (!name || !company || !title) {
+      return NextResponse.json(
+        { error: "name, company, and title are all required." },
+        { status: 400 },
+      );
+    }
+
+    const entry: ReceiptAttendeeDirectoryEntry = await createAttendeeDirectoryEntry(
+      { name, company, title },
+      actor,
+    );
+    return NextResponse.json({ entry }, { status: 200 });
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Unauthorized")) {
+      return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+    }
+    // UNIQUE(name) violation → 409 "already registered" (friendly, actionable).
+    const msg = error instanceof Error ? error.message : String(error);
+    if (msg.includes("UNIQUE") || msg.includes("CONSTRAINT")) {
+      return NextResponse.json(
+        { error: "That attendee name is already registered." },
+        { status: 409 },
+      );
+    }
+    console.error("[api/receipts/attendee-directory] POST failed", error);
+    return NextResponse.json(
+      { error: msg || "Failed to register attendee." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/receipts/export/month/route.ts
+++ b/app/api/receipts/export/month/route.ts
@@ -14,10 +14,13 @@ import {
   bomPrefixedCrlf,
   buildMonthlyExportCsv,
   buildExportSummaryCsv,
+  buildAttendeesExportCsv,
+  resolveRowAttendees,
   hashCsvContent,
   buildArchiveKey,
   buildManifestKey,
   buildSummaryKey,
+  buildAttendeesKey,
   buildProofsKey,
   buildManifestCsv,
   buildReadmeKey,
@@ -101,7 +104,12 @@ export async function POST(request: Request) {
     // SHA-256 in the manifest matches the bytes in R2 exactly. The
     // accountant opens this CSV in Excel on Windows — without BOM/CRLF the
     // Japanese merchant names render as mojibake.
-    const csvPure = buildMonthlyExportCsv(bundle.rows, bundle.attendeeMap);
+    const csvPure = buildMonthlyExportCsv(
+      bundle.rows,
+      bundle.attendeeMap,
+      bundle.attendeeDirectory,
+      bundle.amexAttendees,
+    );
     const csvShipped = bomPrefixedCrlf(csvPure);
     const sha256 = await hashCsvContent(csvShipped);
 
@@ -114,6 +122,25 @@ export async function POST(request: Request) {
     const summaryPure = buildExportSummaryCsv(bundle.rows, month, generatedAt);
     const summaryShipped = bomPrefixedCrlf(summaryPure);
     const summarySha256 = await hashCsvContent(summaryShipped);
+
+    // 参加者一覧 (attendees) — maps the receipts CSV's AttendeeIds column to
+    // name/company/title. Built from the union of attendee names referenced
+    // across the bundle's rows (receipt attendees + the line-attendee fallback
+    // in resolveRowAttendees). Same BOM+CRLF bytes are embedded in the proofs
+    // ZIP as 参加者一覧.csv next to 集計.csv.
+    const referencedAttendeeNames = [
+      ...new Set(
+        bundle.rows.flatMap((r) =>
+          resolveRowAttendees(r, bundle.attendeeMap, bundle.amexAttendees),
+        ),
+      ),
+    ];
+    const attendeesPure = buildAttendeesExportCsv(
+      referencedAttendeeNames,
+      bundle.attendeeDirectory,
+    );
+    const attendeesShipped = bomPrefixedCrlf(attendeesPure);
+    const attendeesSha256 = await hashCsvContent(attendeesShipped);
 
     // Create or retrieve export record, then reload to pick up revision
     // metadata (export_revision / supersedes_export_id / correction_reason).
@@ -136,6 +163,7 @@ export async function POST(request: Request) {
     const archiveKey = buildArchiveKey(month, exportId);
     const manifestKey = buildManifestKey(month, exportId);
     const summaryKey = buildSummaryKey(month, exportId);
+    const attendeesKey = buildAttendeesKey(month, exportId);
 
     // Upload CSV to archive bucket
     const encoder = new TextEncoder();
@@ -223,6 +251,7 @@ export async function POST(request: Request) {
       proofsEntries,
       proofsNoticeInput,
       summaryShipped,
+      attendeesShipped,
     );
     const proofsSha256 = await computeSha256Hex(proofsZipBytes);
     await getReceiptsArchiveBucket().put(proofsKey, proofsZipBytes, {
@@ -302,6 +331,18 @@ export async function POST(request: Request) {
       },
     );
 
+    // Attendees CSV (参加者一覧) — same bytes embedded in the proofs ZIP. Derived
+    // key like summary (no column on receipt_exports); csv content type +
+    // retention metadata, mirroring the summary block.
+    await getReceiptsArchiveBucket().put(
+      attendeesKey,
+      encoder.encode(attendeesShipped).buffer as ArrayBuffer,
+      {
+        httpMetadata: { contentType: "text/csv; charset=utf-8" },
+        customMetadata: retentionMetadata(),
+      },
+    );
+
     // README accompanies every bundle. Disclaimer text + revision context.
     const readme = buildExportReadme({
       exportId,
@@ -314,6 +355,7 @@ export async function POST(request: Request) {
       archiveSha256: sha256,
       manifestSha256,
       summarySha256,
+      attendeesSha256,
       proofsSha256,
     });
     const readmeKey = buildReadmeKey(month, exportId);
@@ -410,10 +452,12 @@ export async function POST(request: Request) {
         sha256,
         manifestSha256,
         summarySha256,
+        attendeesSha256,
         proofsSha256,
         archiveKey,
         manifestKey,
         summaryKey,
+        attendeesKey,
         readmeKey,
         proofsKey,
         finalized: body.finalize ?? false,

--- a/app/api/receipts/reconcile/finalize/route.ts
+++ b/app/api/receipts/reconcile/finalize/route.ts
@@ -7,6 +7,7 @@ import {
   getFinalizedReconciliationForMonth,
   listAmexLineAttendeeNamesByMonth,
   listAmexLines,
+  listAttendeeDirectory,
   listAttendees,
   listPendingProcessingReceipts,
   listReceiptRecordsByIds,
@@ -85,6 +86,7 @@ export async function POST(request: Request) {
 
     // Validate: all lines must be resolved
     const amexAttendees = await listAmexLineAttendeeNamesByMonth(month);
+    const attendeeDirectory = await listAttendeeDirectory();
     const receiptIds = amexLines
       .map((line) => line.matched_receipt_id)
       .filter((id): id is string => Boolean(id));
@@ -101,7 +103,13 @@ export async function POST(request: Request) {
       if (entry) receiptAttendeeMap.set(entry[0], entry[1]);
     }
 
-    const blockers = validateAmexLinesForSignoff(amexLines, amexAttendees, receiptAttendeeMap, receiptMap);
+    const blockers = validateAmexLinesForSignoff(
+      amexLines,
+      amexAttendees,
+      receiptAttendeeMap,
+      receiptMap,
+      attendeeDirectory,
+    );
 
     if (blockers.length > 0) {
       return NextResponse.json(

--- a/components/receipts/attendee-editor.tsx
+++ b/components/receipts/attendee-editor.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { useId } from "react";
 import type { ReceiptAttendeeDirectoryEntry } from "@/lib/receipts/attendee-directory";
 
@@ -7,14 +8,28 @@ interface AttendeeEditorProps {
   attendees: string[];
   onChange: (names: string[]) => void;
   directory?: ReceiptAttendeeDirectoryEntry[];
+  /**
+   * Called when the operator registers a new attendee from this editor. The
+   * parent merges it into its directory list so the row resolves for the rest
+   * of the session (and the inline Company/Title inputs disappear).
+   */
+  onRegister?: (entry: ReceiptAttendeeDirectoryEntry) => void;
 }
 
 export function AttendeeEditor({
   attendees,
   onChange,
   directory = [],
+  onRegister,
 }: AttendeeEditorProps) {
   const listId = useId();
+  // Per-row company/title drafts for attendee names that don't resolve against
+  // the directory yet. Keyed by row index — these are ephemeral draft inputs
+  // that clear once the name resolves (registration adds it to the directory,
+  // so the matched branch takes over and the inputs unmount).
+  const [drafts, setDrafts] = useState<Record<number, { company: string; title: string }>>({});
+  const [registering, setRegistering] = useState<number | null>(null);
+  const [registerError, setRegisterError] = useState<string | null>(null);
 
   function add() {
     onChange([...attendees, ""]);
@@ -30,27 +45,118 @@ export function AttendeeEditor({
     onChange(attendees.filter((_, i) => i !== index));
   }
 
+  function setDraft(index: number, field: "company" | "title", value: string) {
+    setDrafts((prev) => {
+      const existing = prev[index] ?? { company: "", title: "" };
+      return { ...prev, [index]: { ...existing, [field]: value } };
+    });
+  }
+
+  async function register(index: number, name: string) {
+    const draft = drafts[index] ?? { company: "", title: "" };
+    const company = draft.company.trim();
+    const title = draft.title.trim();
+    if (!company || !title) return;
+    setRegistering(index);
+    setRegisterError(null);
+    try {
+      const res = await fetch("/api/receipts/attendee-directory", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: name.trim(), company, title }),
+      });
+      const json = (await res.json().catch(() => ({}))) as {
+        entry?: ReceiptAttendeeDirectoryEntry;
+        error?: string;
+      };
+      if (!res.ok || !json.entry) {
+        setRegisterError(json.error ?? "Registration failed");
+        return;
+      }
+      onRegister?.(json.entry);
+      // Clear this row's draft — the name now resolves, so the inline inputs
+      // unmount and the matched helper takes over.
+      setDrafts((prev) => {
+        const next = { ...prev };
+        delete next[index];
+        return next;
+      });
+    } catch {
+      setRegisterError("Network error");
+    } finally {
+      setRegistering(null);
+    }
+  }
+
   return (
     <div className="space-y-2">
-      {attendees.map((name, i) => (
-        <div key={i} className="flex gap-2">
-          <input
-            type="text"
-            value={name}
-            onChange={(e) => update(i, e.target.value)}
-            placeholder="Attendee name"
-            list={directory.length > 0 ? listId : undefined}
-            className="flex-1 rounded-xl border border-gray-300 px-3 py-2 text-sm focus:border-amber-500 focus:outline-none focus:ring-1 focus:ring-amber-500"
-          />
-          <button
-            type="button"
-            onClick={() => remove(i)}
-            className="rounded-xl border border-gray-200 px-3 py-2 text-xs text-gray-500 hover:bg-gray-50"
-          >
-            Remove
-          </button>
-        </div>
-      ))}
+      {attendees.map((name, i) => {
+        const trimmed = name.trim();
+        const matched = trimmed
+          ? directory.find((d) => d.name === trimmed)
+          : undefined;
+        return (
+          <div key={i} className="space-y-1.5">
+            <div className="flex gap-2">
+              <input
+                type="text"
+                value={name}
+                onChange={(e) => update(i, e.target.value)}
+                placeholder="Attendee name"
+                list={directory.length > 0 ? listId : undefined}
+                className="flex-1 rounded-xl border border-gray-300 px-3 py-2 text-sm focus:border-amber-500 focus:outline-none focus:ring-1 focus:ring-amber-500"
+              />
+              <button
+                type="button"
+                onClick={() => remove(i)}
+                className="rounded-xl border border-gray-200 px-3 py-2 text-xs text-gray-500 hover:bg-gray-50"
+              >
+                Remove
+              </button>
+            </div>
+            {matched ? (
+              <p className="pl-1 text-[11.5px] text-gray-500">
+                {matched.company} — {matched.title}
+              </p>
+            ) : trimmed ? (
+              <div className="ml-1 rounded-lg border border-dashed border-amber-300 bg-amber-50/60 px-3 py-2">
+                <p className="text-[11.5px] text-amber-800">
+                  Not in the directory — add company &amp; title to register this
+                  attendee (required for finalize).
+                </p>
+                <div className="mt-1.5 flex flex-col gap-1.5 sm:flex-row">
+                  <input
+                    type="text"
+                    value={drafts[i]?.company ?? ""}
+                    onChange={(e) => setDraft(i, "company", e.target.value)}
+                    placeholder="Company"
+                    className="flex-1 rounded-lg border border-gray-300 px-2.5 py-1.5 text-xs focus:border-amber-500 focus:outline-none"
+                  />
+                  <input
+                    type="text"
+                    value={drafts[i]?.title ?? ""}
+                    onChange={(e) => setDraft(i, "title", e.target.value)}
+                    placeholder="Title"
+                    className="flex-1 rounded-lg border border-gray-300 px-2.5 py-1.5 text-xs focus:border-amber-500 focus:outline-none"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => register(i, trimmed)}
+                    disabled={
+                      registering === i ||
+                      !drafts[i]?.company.trim() ||
+                      !drafts[i]?.title.trim()
+                    }
+                    className="rounded-lg border border-amber-400 bg-amber-100 px-3 py-1.5 text-xs font-medium text-amber-900 hover:bg-amber-200 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {registering === i ? "Registering…" : "Register attendee"}
+                  </button>
+                </div>
+              </div>
+            ) : null}
+          </div>
+        );
+      })}
       {directory.length > 0 && (
         <datalist id={listId}>
           {directory.map((entry) => (
@@ -61,6 +167,9 @@ export function AttendeeEditor({
             />
           ))}
         </datalist>
+      )}
+      {registerError && (
+        <p className="text-[11.5px] text-red-600">{registerError}</p>
       )}
       <button
         type="button"

--- a/components/receipts/review/form-pane.tsx
+++ b/components/receipts/review/form-pane.tsx
@@ -12,7 +12,7 @@ import { PaymentPathSeg } from "@/components/receipts/ui/payment-path-seg";
 import { AttendeeEditor } from "@/components/receipts/attendee-editor";
 import { useKeyboardShortcuts } from "@/lib/receipts/keyboard";
 import { isPendingProcessing } from "@/lib/receipts/extraction-state";
-import { RECEIPT_ATTENDEE_DIRECTORY } from "@/lib/receipts/attendee-directory";
+import type { ReceiptAttendeeDirectoryEntry } from "@/lib/receipts/attendee-directory";
 import {
   EXPENSE_CATEGORIES,
   getCategoryByCode,
@@ -113,6 +113,32 @@ export function FormPane(props: FormPaneProps) {
   // failed). Save succeeded, so this is a toast — not an error state.
   const [apiWarnings, setApiWarnings] = useState<string[]>([]);
   const [overrideBusy, setOverrideBusy] = useState(false);
+
+  // Attendee directory (migration 0022): loaded client-side from D1 on mount
+  // and passed to AttendeeEditor. The editor lets the operator register a new
+  // attendee inline (company/title); a freshly-registered entry is merged into
+  // this list so it resolves for the rest of the session without a reload.
+  const [directory, setDirectory] = useState<ReceiptAttendeeDirectoryEntry[]>([]);
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch("/api/receipts/attendee-directory");
+        if (!res.ok) return;
+        const json = (await res.json().catch(() => ({}))) as {
+          entries?: ReceiptAttendeeDirectoryEntry[];
+        };
+        if (!cancelled && Array.isArray(json.entries)) {
+          setDirectory(json.entries);
+        }
+      } catch {
+        // Non-fatal: the editor still works as free-text without the datalist.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   // ─── OCR extraction (delegated to the useExtraction hook) ───────────
   const {
@@ -608,7 +634,12 @@ export function FormPane(props: FormPaneProps) {
               <AttendeeEditor
                 attendees={attendees}
                 onChange={setAttendees}
-                directory={RECEIPT_ATTENDEE_DIRECTORY}
+                directory={directory}
+                onRegister={(entry) =>
+                  setDirectory((prev) =>
+                    prev.some((e) => e.id === entry.id) ? prev : [...prev, entry],
+                  )
+                }
               />
             </Field>
           </div>

--- a/db/receipts/0022_attendee_directory.sql
+++ b/db/receipts/0022_attendee_directory.sql
@@ -1,0 +1,90 @@
+-- 0022_attendee_directory.sql
+--
+-- Attendee directory: the company/title lookup the monthly export
+-- bundle joins attendee ids against. Seeded once from the hardcoded TS
+-- array (lib/receipts/attendee-directory.ts ATTENDEE_DIRECTORY_SEED), with
+-- ids 1-66 preserved verbatim — they are the join key the receipts CSV's
+-- AttendeeIds column carries, so renumbering would break sealed exports.
+-- Registering a new attendee is now a data operation (POST
+-- /api/receipts/attendee-directory), not a code deploy. Resolution against
+-- receipt_attendees / amex_line_attendees is by EXACT name match (no FK,
+-- no fuzzy matching — attendee identity = directory name).
+--
+-- created_at/updated_at use a fixed ISO literal so the seed is deterministic
+-- (re-running the migration produces identical rows).
+CREATE TABLE IF NOT EXISTS attendee_directory (
+  id INTEGER PRIMARY KEY,
+  name TEXT NOT NULL UNIQUE,
+  company TEXT NOT NULL,
+  title TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+-- Seed rows (ids 1-66, exact). INSERT OR IGNORE so re-running is a no-op.
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (1, '村上多寿子', '合同会社Dazbeez', '代表社員', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (2, 'クランデイビット', '合同会社Dazbeez', '代表社員', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (3, 'Murray Duke', 'Manulife', 'Program Director', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (4, 'Jose Orfao', 'Manulife', 'CFO', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (5, 'Stefan Goetzinger', 'Manulife', 'Program Manager', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (6, 'Shashidar Shetty', 'Manulife', 'Project Manager', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (7, 'Maki Phillips', 'Manulife', 'Project Management Officer', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (8, 'Casey Medsker', 'Manulife', 'Cognizant Test Lead', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (9, 'Nate Kemppainen', 'Manulife', 'Project Governance Manager', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (10, '山岸リカ', 'Manulife', 'Project Operation Manager', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (11, 'Mizuki Gagnet', 'Manulife', 'ETS Change Manager', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (12, 'Ferdinand Shimizu', 'Manulife', 'ETS Network Engineer', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (13, 'Miako Chiyo', 'Deloitte', 'Program Manager', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (14, 'Steve Dalrymple', 'Manulife', 'Project Finance Lead', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (15, 'Kenji Iyori', 'AIG Technologies KK', 'Infra Project Manager', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (16, '奥野和美', 'AIG Technologies KK', 'Tech Lead', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (17, 'Jason De Luka', 'Smart Partners', 'President', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (18, '高橋　遥', 'Smart Partners', 'Administrator', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (19, 'Stephan Kent', 'FMP Connect KK', 'President', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (20, 'Aaron Ward', 'NN Life', 'Project Manager', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (21, 'Jason Mostella', 'Microsoft Japan KK', 'Lead Developer', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (22, 'Ankit Shrimal', 'Orix Insurance Japan KK', 'Digital Transformation PM', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (23, 'Gary Binda', 'Paypay', 'Business Continuity Manager', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (24, 'Arnash Gupta', 'Asurion Japan KK', 'Rakuten', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (25, 'Vinoth Rajeswaran', 'Cognizant', 'Application Project Manager', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (26, 'Ali Tasbasi', 'Mammoth Istanbul co., ltd.', 'President', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (27, '下倉 淳介', '輝心堂', 'Owner', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (28, '滝沢　秀一', '一般社団法人ごみプロジェクト', '代表', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (29, '柴山佳世', 'Palette814', 'Staff', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (30, '千代　未亜子', 'ACkT Partners', 'Partner 取締役', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (31, '細川　環', 'PanOrient New Corporation', 'Editorial Assistant', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (32, '及川　雅人', 'Deloitte Tohmatsu Consulting', 'Manager', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (33, '中田　圭', '（株）パズルステージ', '代表取締役', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (34, 'David Isenga', 'ACT Laboratoreis', 'Test Manager', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (35, 'Luke Bossenbrook', 'K&H Consultation', 'Construction Manager', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (36, 'Mark Peckham', 'State of Michigan', 'Sr Software Engineer', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (37, 'Mike Post', 'State of Michigan FOC', 'Database Technician', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (38, 'Martha Llewellen', 'Knitty Gritty Treasures, LLC', 'Co-Founder', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (39, 'Grace Mayweather', 'Hopper Casual', 'Sales person', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (40, 'Payton Fredericksen', 'MITTEN Distribution', 'Account Manager', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (41, 'Deanna Helmlinger', 'Your IT Process', 'Owner', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (42, 'Monica Crothers', 'It works!', 'Independent Distributor', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (43, 'Zain Chang', 'GlobalPM', 'Program Director', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (44, 'Donald Dahl', 'Creative 3D', 'Design Director', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (45, 'George Otani', 'Da808Lounge', 'Owner', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (46, 'Mary Reilly', 'Floral Image', 'Owner', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (47, 'Stefano', 'FromFieldandFlower.co.uk', 'Owner', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (48, 'Julius Fielder', 'slowfood.org.uk', 'Ambassador', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (49, 'George Pumfrett', 'Enterprise Holdings', 'Management Assistant', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (50, 'Steven Delaney', 'Enterprise Holdings', 'Branch Manager', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (51, 'John Staniland', 'Staniland Press', 'Travel Writer', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (52, 'Luis Renteria', 'Tinto', 'Artisan Torrefacteur', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (53, 'Alizee Golfier', 'Culture Japon', 'Video Producer', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (54, 'Donald Gates', 'Schroders', 'Investment Finance', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (55, 'Bill Reed', 'Accenture', 'Consultant', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (56, 'Teren Smith', 'Computer Futures', 'Principle Consultant', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (57, 'Glenn Page', 'Hitachi Logistics', 'Sr Consultant', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (58, 'Hiroko Page', 'Hitachi Logistics', 'Sr Consultant', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (59, 'James Sharpe', 'Oshiro Models', 'Model Engineer', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (60, 'Machi Sharpe', 'All Nippon Airways', 'Flight Agent', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (61, 'Eric Soon', 'Manulife Japan', 'Project Manager', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (62, 'Nathan Klan', 'Palmer', 'Site Inspector', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (63, 'Tara Lamacchia', 'Haslett Schools', 'Interpreter', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (64, '森岡蘭多', '森岡株式会社', '代表取締役', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (65, '柴山哲也', 'Palette814', 'Owner', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');
+INSERT OR IGNORE INTO attendee_directory (id, name, company, title, created_at, updated_at) VALUES (66, '島　義行', '日進ビルサービス株式会社', '代表取締役', '2026-07-17T00:00:00Z', '2026-07-17T00:00:00Z');

--- a/lib/receipts/attendee-directory.ts
+++ b/lib/receipts/attendee-directory.ts
@@ -5,7 +5,14 @@ export interface ReceiptAttendeeDirectoryEntry {
   name: string;
 }
 
-export const RECEIPT_ATTENDEE_DIRECTORY: ReceiptAttendeeDirectoryEntry[] = [
+/**
+ * The seed reference for the `attendee_directory` D1 table (migration 0022).
+ * Runtime reads the directory from D1 via `listAttendeeDirectory()`; this array
+ * is the one-time seed data and the unit-test fixture. The 66 ids (1–66) are
+ * preserved verbatim — they are the join key the receipts CSV's `AttendeeIds`
+ * column carries, so renaming/renumbering here would break every sealed export.
+ */
+export const ATTENDEE_DIRECTORY_SEED: ReceiptAttendeeDirectoryEntry[] = [
   { id: 1, company: "合同会社Dazbeez", title: "代表社員", name: "村上多寿子" },
   { id: 2, company: "合同会社Dazbeez", title: "代表社員", name: "クランデイビット" },
   { id: 3, company: "Manulife", title: "Program Director", name: "Murray Duke" },
@@ -73,3 +80,35 @@ export const RECEIPT_ATTENDEE_DIRECTORY: ReceiptAttendeeDirectoryEntry[] = [
   { id: 65, company: "Palette814", title: "Owner", name: "柴山哲也" },
   { id: 66, company: "日進ビルサービス株式会社", title: "代表取締役", name: "島　義行" },
 ];
+
+/**
+ * Resolve attendee names against a directory by EXACT string equality after
+ * `.trim()` (no fuzzy matching — attendee identity = directory name, per the
+ * locked design). Shared by the receipts-CSV builder (`AttendeeIds` column),
+ * the finalize gate (receipt + AMEX-line attendee checks), and tests.
+ *
+ * Returns `entries[i]` aligned positionally to `names[i]` (null = unresolved)
+ * and the deduplicated list of unresolved names. Positional alignment is what
+ * keeps the CSV's `Attendees` and `AttendeeIds` columns in lockstep — the
+ * builder emits `?` for every unresolved position so the two stay parallel.
+ */
+export function resolveAttendeeNames(
+  names: string[],
+  directory: ReceiptAttendeeDirectoryEntry[],
+): { entries: (ReceiptAttendeeDirectoryEntry | null)[]; unresolved: string[] } {
+  const byName = new Map<string, ReceiptAttendeeDirectoryEntry>();
+  for (const entry of directory) {
+    // name is UNIQUE in the table; seed entries are unique by construction.
+    byName.set(entry.name.trim(), entry);
+  }
+  const entries: (ReceiptAttendeeDirectoryEntry | null)[] = [];
+  const unresolvedSet = new Set<string>();
+  for (const raw of names) {
+    const trimmed = raw.trim();
+    const found = trimmed.length > 0 ? byName.get(trimmed) ?? null : null;
+    entries.push(found);
+    if (!found && trimmed.length > 0) unresolvedSet.add(trimmed);
+  }
+  return { entries, unresolved: [...unresolvedSet] };
+}
+

--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -10,6 +10,7 @@ import { retentionUntilIso } from "@/lib/receipts/retention";
 import { assignMembershipForReceipt } from "@/lib/receipts/membership";
 import { deleteAmexArtifact } from "@/lib/receipts/storage";
 import { PENDING_EXTRACTION_STATES } from "@/lib/receipts/types";
+import type { ReceiptAttendeeDirectoryEntry } from "@/lib/receipts/attendee-directory";
 import type {
   AmexMatchStatus,
   AmexReceiptStatus,
@@ -616,6 +617,75 @@ export async function listAttendeeNamesByReceiptIds(
     arr.push(row.attendee_name);
   }
   return out;
+}
+
+// ─── Attendee directory (migration 0022) ──────────────────────────────────────
+// The company/title lookup the monthly export bundle joins attendee ids against.
+// Resolution against receipt_attendees / amex_line_attendees is by EXACT name
+// match (see resolveAttendeeNames); this table is the single source of those
+// names + their company/title. Runtime reads live data — the TS seed array
+// (ATTENDEE_DIRECTORY_SEED) populated the table once and is now a test fixture.
+
+export async function listAttendeeDirectory(): Promise<ReceiptAttendeeDirectoryEntry[]> {
+  const db = getReceiptsDb();
+  const result = await db
+    .prepare(`SELECT id, name, company, title FROM attendee_directory ORDER BY id ASC`)
+    .all<ReceiptAttendeeDirectoryEntry>();
+  return result.results ?? [];
+}
+
+/**
+ * Register a new attendee directory entry. Id is omitted (SQLite assigns a
+ * rowid > 66 so seeded ids 1–66 stay stable). Inputs are trimmed; empty
+ * strings are rejected before the call (the route validates), and this is the
+ * last line of defense. The UNIQUE(name) constraint is surfaced to the caller
+ * via a thrown Error whose message contains "UNIQUE" so the route can map it
+ * to a 409 "already registered".
+ */
+export async function createAttendeeDirectoryEntry(
+  input: { name: string; company: string; title: string },
+  actor: string,
+): Promise<ReceiptAttendeeDirectoryEntry> {
+  const name = input.name.trim();
+  const company = input.company.trim();
+  const title = input.title.trim();
+  if (!name || !company || !title) {
+    throw new Error("name, company, and title are all required (non-empty).");
+  }
+
+  const db = getReceiptsDb();
+  const now = nowIso();
+
+  // INSERT without id → SQLite picks the next rowid. RETURNING gives us the
+  // assigned id so the caller gets back the exact entry written.
+  const inserted = await db
+    .prepare(
+      `INSERT INTO attendee_directory (name, company, title, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?)
+       RETURNING id, name, company, title`,
+    )
+    .bind(name, company, title, now, now)
+    .first<ReceiptAttendeeDirectoryEntry>();
+
+  // D1 supports RETURNING; if it ever returned null, fall back to a lookup.
+  const entry = inserted ?? await db
+    .prepare(`SELECT id, name, company, title FROM attendee_directory WHERE name = ?`)
+    .bind(name)
+    .first<ReceiptAttendeeDirectoryEntry>();
+
+  if (!entry) {
+    throw new Error("attendee_directory insert returned no row unexpectedly.");
+  }
+
+  await createAuditEntry(db, {
+    actor,
+    action: "attendee_directory.created",
+    objectType: "attendee_directory",
+    objectId: String(entry.id),
+    newValueJson: stringifyJson({ name: entry.name, company: entry.company, title: entry.title }),
+  });
+
+  return entry;
 }
 
 // ─── AMEX statement lines ─────────────────────────────────────────────────────

--- a/lib/receipts/export.ts
+++ b/lib/receipts/export.ts
@@ -1,4 +1,6 @@
 import type { ExportRow, ReceiptFile } from "@/lib/receipts/types";
+import type { ReceiptAttendeeDirectoryEntry } from "@/lib/receipts/attendee-directory";
+import { resolveAttendeeNames } from "@/lib/receipts/attendee-directory";
 import {
   ACCOUNTANT_DISCLAIMER_EN,
   ACCOUNTANT_DISCLAIMER_JA,
@@ -53,6 +55,9 @@ const CSV_HEADERS = [
   "ExpenseCategoryEn",
   "BusinessPurpose",
   "Attendees",
+  // Directory id per attendee position ("; "-joined, "?" for unresolved),
+  // aligned 1:1 with the Attendees column. Joins to the attendees CSV.
+  "AttendeeIds",
   // Line identity / status
   "LineId",
   "StatementMonth", // unused on receipt rows; populated from line when present
@@ -77,20 +82,55 @@ const CSV_HEADERS = [
 ];
 
 /**
+ * The effective attendee-name list for a row. Receipt attendees come from
+ * `attendeeMap` (the bundle's batched lookup); for `amex_line` rows with NO
+ * receipt attendees we fall back to the line's direct attendees
+ * (`amexAttendees[lineId]`). That fallback closes the gap where line-level
+ * attendees satisfied the finalize gate but vanished from the CSV. Shared by
+ * the receipts CSV builder (Attendees + AttendeeIds columns) and the route
+ * (to collect the union of referenced names for the attendees CSV).
+ */
+export function resolveRowAttendees(
+  row: ExportRow,
+  attendeeMap: Map<string, string[]>,
+  amexAttendees: Record<string, string[]>,
+): string[] {
+  const receiptAttendees = row.receiptId
+    ? (attendeeMap.get(row.receiptId) ?? row.attendees ?? [])
+    : (row.attendees ?? []);
+  if (row.rowType === "amex_line" && receiptAttendees.length === 0 && row.lineId) {
+    return amexAttendees[row.lineId] ?? receiptAttendees;
+  }
+  return receiptAttendees;
+}
+
+/**
  * Build the monthly export CSV body (no BOM, LF newlines). The route
  * prepends the UTF-8 BOM and converts to CRLF before upload so Excel on
  * Windows parses Japanese text correctly. Tests exercise this pure form.
+ *
+ * `attendeeDirectory` + `amexAttendees` drive the new `AttendeeIds` column
+ * (directory ids joined "; ", "?" for unresolved, positionally aligned with
+ * the `Attendees` column) and the line-attendee fallback (see
+ * {@link resolveRowAttendees}).
  */
 export function buildMonthlyExportCsv(
   rows: ExportRow[],
   attendeeMap: Map<string, string[]>,
+  attendeeDirectory: ReceiptAttendeeDirectoryEntry[],
+  amexAttendees: Record<string, string[]>,
 ): string {
   const lines: string[] = [CSV_HEADERS.join(",")];
 
   rows.forEach((row, index) => {
-    const attendees = row.receiptId
-      ? (attendeeMap.get(row.receiptId) ?? row.attendees ?? [])
-      : (row.attendees ?? []);
+    const attendees = resolveRowAttendees(row, attendeeMap, amexAttendees);
+    // AttendeeIds: directory id per position ("?" when unresolved) so the two
+    // columns stay aligned. Unresolved names are expected in DRAFTS (the
+    // operator sees gaps); the finalize gate blocks them before sealing.
+    const { entries } = resolveAttendeeNames(attendees, attendeeDirectory);
+    const attendeeIds = entries
+      .map((e) => (e ? String(e.id) : "?"))
+      .join("; ");
     const line = [
       // No: 1-based row sequence. The join key between this CSV and the proofs
       // ZIP filenames (No03_研究開発費_OpenAI_¥108341.pdf) — the accountant
@@ -108,6 +148,7 @@ export function buildMonthlyExportCsv(
       csvEscape(row.expenseCategoryEn),
       csvEscape(row.businessPurpose),
       csvQuoteAlways(attendees.join("; ")),
+      csvQuoteAlways(attendeeIds),
       csvEscape(row.lineId),
       // StatementMonth column is intentionally empty here; line.statement_month
       // matches the bundle's month so it's redundant on line rows and
@@ -240,6 +281,38 @@ export function buildSummaryKey(month: string, exportId: string): string {
   return `exports/${month}/${exportId}-summary.csv`;
 }
 
+export function buildAttendeesKey(month: string, exportId: string): string {
+  return `exports/${month}/${exportId}-attendees.csv`;
+}
+
+/**
+ * 参加者一覧 (attendees) CSV — maps the receipts CSV's `AttendeeIds` column to
+ * each attendee's name/company/title. Contains ONLY directory entries
+ * referenced by this bundle's rows (the caller passes the union of attendee
+ * names across rows), deduped and sorted by id. `csvEscape` every cell: names
+ * and companies contain commas in Japanese punctuation contexts.
+ */
+export function buildAttendeesExportCsv(
+  referencedNames: string[],
+  directory: ReceiptAttendeeDirectoryEntry[],
+): string {
+  const { entries } = resolveAttendeeNames(referencedNames, directory);
+  const seen = new Set<number>();
+  const rows: ReceiptAttendeeDirectoryEntry[] = [];
+  for (const entry of entries) {
+    if (entry && !seen.has(entry.id)) {
+      seen.add(entry.id);
+      rows.push(entry);
+    }
+  }
+  rows.sort((a, b) => a.id - b.id);
+  const header = "AttendeeId,Name,Company,Title";
+  const body = rows.map((r) =>
+    [String(r.id), r.name, r.company, r.title].map((c) => csvEscape(c)).join(","),
+  );
+  return [header, ...body].join("\n");
+}
+
 export function buildProofsKey(month: string, exportId: string): string {
   return `exports/${month}/${exportId}-proofs.zip`;
 }
@@ -347,6 +420,7 @@ export const EXPORT_DOWNLOAD_FILES = [
   "summary",
   "readme",
   "proofs",
+  "attendees",
 ] as const;
 
 export type ExportDownloadFile = (typeof EXPORT_DOWNLOAD_FILES)[number];
@@ -388,6 +462,14 @@ export function resolveExportDownload(
         r2Key: buildSummaryKey(month, exportRecord.id),
         contentType: csv,
         filename: `export-${month}-summary.csv`,
+      };
+    case "attendees":
+      // Derived key (like summary — no column on receipt_exports). Old sealed
+      // revisions predate this artifact and simply 404 from R2.
+      return {
+        r2Key: buildAttendeesKey(month, exportRecord.id),
+        contentType: csv,
+        filename: `export-${month}-attendees.csv`,
       };
     case "readme":
       return {
@@ -531,6 +613,7 @@ export function buildExportReadme(opts: {
   archiveSha256: string;
   manifestSha256?: string | null;
   summarySha256?: string | null;
+  attendeesSha256?: string | null;
   proofsSha256?: string | null;
 }): string {
   const revisionLine =
@@ -546,6 +629,7 @@ export function buildExportReadme(opts: {
     `Archive SHA-256: ${opts.archiveSha256}`,
     `Manifest SHA-256: ${opts.manifestSha256 ?? "(pending)"}`,
     `Summary SHA-256: ${opts.summarySha256 ?? "(none)"}`,
+    `Attendees CSV SHA-256: ${opts.attendeesSha256 ?? "(none)"}`,
     `Proofs ZIP SHA-256: ${opts.proofsSha256 ?? "(none)"}`,
     "",
     "── Accountant review ──────────────────────────────────────────",
@@ -558,6 +642,8 @@ export function buildExportReadme(opts: {
     "derivative, and the AMEX statement CSV included in this export.",
     "The summary CSV (<exportId>-summary.csv) provides per-category and",
     "per-PaymentPath totals for a quick reconciliation check.",
+    "The attendees CSV (<exportId>-attendees.csv) maps the AttendeeIds",
+    "column to each attendee's name, company, and title.",
     "The proofs ZIP (<exportId>-proofs.zip) bundles one proof per receipt,",
     "named No<NN>_<勘定科目>_<店舗>_¥<金額> — the No matches the receipts",
     "CSV's first column. See 目次.csv inside the ZIP for the full index.",

--- a/lib/receipts/month-closing.ts
+++ b/lib/receipts/month-closing.ts
@@ -1,8 +1,11 @@
 import { getCategoryByCode, requiresAttendees } from "@/lib/receipts/categories";
+import type { ReceiptAttendeeDirectoryEntry } from "@/lib/receipts/attendee-directory";
+import { resolveAttendeeNames } from "@/lib/receipts/attendee-directory";
 import {
   getFinalizedReconciliationForMonth,
   listAmexLineAttendeeNamesByMonth,
   listAmexLines,
+  listAttendeeDirectory,
   listAttendeeNamesByReceiptIds,
   listReceiptRecordsByIds,
 } from "@/lib/receipts/db";
@@ -60,6 +63,22 @@ export interface ExportBundle {
   /** Attendees for every receipt in `receipts`, keyed by receipt id. */
   attendeeMap: Map<string, string[]>;
   /**
+   * Attendee directory (migration 0022): the company/title lookup the receipts
+   * CSV's `AttendeeIds` column joins against and the finalize gate resolves
+   * attendee names against. Single load point — the route, the page preview,
+   * and the validator all read it from here.
+   */
+  attendeeDirectory: ReceiptAttendeeDirectoryEntry[];
+  /**
+   * Attendee names attached directly to AMEX lines for the month, keyed by
+   * line id. Moved out of `validateMonthReadyForExport` (its former private
+   * `listAmexLineAttendeeNamesByMonth` call) into the bundle so the receipts
+   * CSV builder can also see line-level attendees (the gap where line
+   * attendees satisfied the gate but vanished from the CSV). The bundle is the
+   * single row-assembly authority (audit A4).
+   */
+  amexAttendees: Record<string, string[]>;
+  /**
    * Per-row items to write into receipt_export_items at bundle-build time.
    * itemType 'receipt' covers BOTH matched-to-line and CASH/DIGITAL receipt
    * rows — the audit story is "what shipped", not "how it got there".
@@ -103,6 +122,15 @@ export async function buildExportBundle(month: string): Promise<ExportBundle> {
   const attendeeMap = allReceiptIds.length > 0
     ? await listAttendeeNamesByReceiptIds(allReceiptIds)
     : new Map<string, string[]>();
+
+  // (4b) Attendee directory (migration 0022) + line-level attendees. Both feed
+  // the CSV builder (AttendeeIds column / line-attendee fallback) and the
+  // finalize gate (name resolution). Single load point — the route, the page
+  // preview, and the validator all read them from the bundle.
+  const [attendeeDirectory, amexAttendees] = await Promise.all([
+    listAttendeeDirectory(),
+    listAmexLineAttendeeNamesByMonth(month),
+  ]);
 
   // (5) Assemble rows. AMEX-line rows first (in line order —
   // listAmexLines already sorts by transaction_date), then receipt rows.
@@ -186,7 +214,7 @@ export async function buildExportBundle(month: string): Promise<ExportBundle> {
     items.push({ itemType: "receipt", itemId: receipt.id });
   }
 
-  return { rows, receipts: allReceipts, amexLines, attendeeMap, items };
+  return { rows, receipts: allReceipts, amexLines, attendeeMap, attendeeDirectory, amexAttendees, items };
 }
 
 /**
@@ -306,7 +334,19 @@ export function validateMonthReadyForExportCore(
     }
     if (requiresAttendees(receipt.expense_category_code)) {
       const attendees = bundle.attendeeMap.get(receipt.id) ?? [];
-      if (attendees.length === 0) blockers.push(`Receipt ${label}: requires attendees`);
+      if (attendees.length === 0) {
+        blockers.push(`Receipt ${label}: requires attendees`);
+      } else {
+        // Attendees present → every name must resolve to a directory entry
+        // (company/title). Unresolved names block finalize (business-manager
+        // review: every 会議費/接待交際費 attendee must show company + title).
+        const { unresolved } = resolveAttendeeNames(attendees, bundle.attendeeDirectory);
+        for (const name of unresolved) {
+          blockers.push(
+            `Receipt ${label}: attendee "${name}" is not registered in the attendee directory (company/title required)`,
+          );
+        }
+      }
     }
   }
 
@@ -319,6 +359,7 @@ export function validateMonthReadyForExportCore(
       amexAttendees,
       bundle.attendeeMap,
       receiptMap,
+      bundle.attendeeDirectory,
     ),
   );
 
@@ -407,8 +448,11 @@ export async function validateMonthReadyForExport(
   // (pending-exclusion) to each.
   const unreviewedReceipts = [...bundle.receipts, ...unknownInScope];
 
-  // (4) AMEX-line attendees.
-  const amexAttendees = await listAmexLineAttendeeNamesByMonth(month);
+  // (4) AMEX-line attendees — sourced from the bundle (buildExportBundle loads
+  // them once). The validator input field stays; it now reflects the bundle so
+  // the route, the page preview, and the validator share one row-assembly
+  // authority (audit A4).
+  const amexAttendees = bundle.amexAttendees;
 
   // (5) Compliance — month filter UNION bundle receipt IDs (matched receipts
   // may be dated outside the statement month; Codex P1).

--- a/lib/receipts/proofs.ts
+++ b/lib/receipts/proofs.ts
@@ -311,12 +311,16 @@ function folderFor(paymentPath: ProofPaymentPath): string {
  *
  *  `summaryCsv` is the SAME bytes as the standalone summary artifact (BOM+CRLF),
  *  embedded as 集計.csv so the accountant who only opens the ZIP still gets the
- *  cost breakdown. */
+ *  cost breakdown. `attendeesCsv` is likewise the same bytes as the standalone
+ *  attendees artifact, embedded as 参加者一覧.csv next to 集計.csv so the
+ *  AttendeeIds column can be decoded into name/company/title without a second
+ *  download. */
 export function assembleProofsZip(
   month: string,
   entries: ProofZipEntry[],
   noticeInput: TransitionNoticeInput,
   summaryCsv: string,
+  attendeesCsv: string,
 ): Uint8Array {
   const root = ROOT_PREFIX(month);
   const files: Record<string, Uint8Array> = {};
@@ -368,6 +372,7 @@ export function assembleProofsZip(
 
   files[`${root}目次.csv`] = encoder.encode(buildProofsMokuziCsv(mokuziRows));
   files[`${root}集計.csv`] = encoder.encode(summaryCsv);
+  files[`${root}参加者一覧.csv`] = encoder.encode(attendeesCsv);
   files[`${root}お知らせ.txt`] = encoder.encode(buildTransitionNotice(noticeInput));
 
   return zipSync(files, { level: 0 });

--- a/lib/receipts/reconciliation-signoff.ts
+++ b/lib/receipts/reconciliation-signoff.ts
@@ -1,4 +1,6 @@
 import type { AmexStatementLine, ReceiptRecord } from "@/lib/receipts/types";
+import type { ReceiptAttendeeDirectoryEntry } from "@/lib/receipts/attendee-directory";
+import { resolveAttendeeNames } from "@/lib/receipts/attendee-directory";
 import { requiresAttendees } from "@/lib/receipts/categories";
 import { resolveLineCategory } from "@/lib/receipts/line-classification";
 import { isUncategorizedLine } from "@/lib/receipts/blockers";
@@ -99,12 +101,21 @@ export function buildReconciliationManifestCsv(
  * `receiptMap` carries the matched receipts so category can be resolved
  * from the receipt (not the line) when a match exists. Callers must build
  * it from the matched_receipt_id set of the lines being validated.
+ *
+ * `attendeeDirectory` (5th param, migration 0022): when a line's resolved
+ * category requires attendees AND attendees are present, every attendee name
+ * (the union of the linked receipt's attendees + the line's direct attendees)
+ * must resolve to a directory entry — a name with no company/title on file is
+ * a blocker (business-manager review requirement: every 会議費/接待交際費 attendee
+ * must show company + title). Directory rows enforce company/title NOT NULL, so
+ * resolution alone proves completeness.
  */
 export function validateAmexLinesForSignoff(
   amexLines: AmexStatementLine[],
   amexAttendees: Record<string, string[]>,
   receiptAttendeeMap: Map<string, string[]>,
   receiptMap: Map<string, ReceiptRecord>,
+  attendeeDirectory: ReceiptAttendeeDirectoryEntry[],
 ): string[] {
   const blockers: string[] = [];
 
@@ -140,8 +151,18 @@ export function validateAmexLinesForSignoff(
         ? receiptAttendeeMap.get(line.matched_receipt_id) ?? []
         : [];
       const directAmexAttendees = amexAttendees[line.id] ?? [];
-      if (linkedReceiptAttendees.length === 0 && directAmexAttendees.length === 0) {
+      const names = [...linkedReceiptAttendees, ...directAmexAttendees];
+      if (names.length === 0) {
         blockers.push(`AMEX ${label}: requires attendees`);
+      } else {
+        // Attendees present → every name must resolve to a directory entry
+        // (company/title). Unresolved names block finalize.
+        const { unresolved } = resolveAttendeeNames(names, attendeeDirectory);
+        for (const name of unresolved) {
+          blockers.push(
+            `AMEX ${label}: attendee "${name}" is not registered in the attendee directory (company/title required)`,
+          );
+        }
       }
     }
     if (line.business_trip_status === "candidate") {

--- a/lib/receipts/types.ts
+++ b/lib/receipts/types.ts
@@ -147,7 +147,10 @@ export type AuditAction =
   // ADR 0008 one-time policy migration (window → calendar month). Replaces the
   // ADR 0006 _window_drift action — calendar membership has no AMEX-line
   // dependency, so drift detection is retired.
-  | "receipt.export_statement_month_policy_migrated";
+  | "receipt.export_statement_month_policy_migrated"
+  // Attendee directory (migration 0022): a new entry registered from the
+  // review UI. Attended identity = directory name; company/title NOT NULL.
+  | "attendee_directory.created";
 
 // ─── Compliance: source / preservation / qualified-invoice ────────────────
 

--- a/tests/receipts/attendee-directory.test.ts
+++ b/tests/receipts/attendee-directory.test.ts
@@ -1,0 +1,104 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  ATTENDEE_DIRECTORY_SEED,
+  resolveAttendeeNames,
+  type ReceiptAttendeeDirectoryEntry,
+} from "@/lib/receipts/attendee-directory";
+import { buildAttendeesExportCsv } from "@/lib/receipts/export";
+
+const DIR: ReceiptAttendeeDirectoryEntry[] = [
+  { id: 5, company: "Acme", title: "Director", name: "Alice Nakamura" },
+  { id: 3, company: "Beta", title: "CFO", name: "Bob Smith" },
+];
+
+// ─── resolveAttendeeNames ────────────────────────────────────────────────────
+
+test("resolveAttendeeNames: exact match (case/whitespace sensitive after trim)", () => {
+  const { entries, unresolved } = resolveAttendeeNames(["Alice Nakamura", "Bob Smith"], DIR);
+  assert.equal(entries[0]?.id, 5);
+  assert.equal(entries[1]?.id, 3);
+  assert.deepEqual(unresolved, []);
+});
+
+test("resolveAttendeeNames: trims surrounding whitespace before matching", () => {
+  const { entries, unresolved } = resolveAttendeeNames(["  Alice Nakamura  "], DIR);
+  assert.equal(entries[0]?.id, 5, "trimmed name resolves");
+  assert.deepEqual(unresolved, []);
+});
+
+test("resolveAttendeeNames: unresolved name → null entry + listed in unresolved", () => {
+  const { entries, unresolved } = resolveAttendeeNames(
+    ["Alice Nakamura", "Nobody Here"],
+    DIR,
+  );
+  assert.equal(entries[0]?.id, 5);
+  assert.equal(entries[1], null, "unresolved position is null");
+  assert.deepEqual(unresolved, ["Nobody Here"]);
+});
+
+test("resolveAttendeeNames: positional alignment — entries[i] ↔ names[i]", () => {
+  // The CSV builder relies on this 1:1 alignment to keep the Attendees and
+  // AttendeeIds columns parallel (emitting "?" at unresolved positions).
+  const names = ["Nobody", "Bob Smith", "Also Missing", "Alice Nakamura"];
+  const { entries } = resolveAttendeeNames(names, DIR);
+  assert.deepEqual(
+    entries.map((e) => (e ? e.id : null)),
+    [null, 3, null, 5],
+  );
+});
+
+test("resolveAttendeeNames: empty/whitespace-only name → null, not flagged unresolved", () => {
+  const { entries, unresolved } = resolveAttendeeNames(["", "   "], DIR);
+  assert.equal(entries[0], null);
+  assert.equal(entries[1], null);
+  assert.deepEqual(unresolved, [], "blank names are not 'unresolved', just empty");
+});
+
+test("resolveAttendeeNames: dedupes unresolved names", () => {
+  const { unresolved } = resolveAttendeeNames(["Ghost", "Ghost", "Ghost"], DIR);
+  assert.deepEqual(unresolved, ["Ghost"]);
+});
+
+// ─── Seed integrity (the 66 ids are the sealed-export join key) ───────────────
+
+test("ATTENDEE_DIRECTORY_SEED: 66 entries, ids 1–66 contiguous, unique names", () => {
+  assert.equal(ATTENDEE_DIRECTORY_SEED.length, 66);
+  const ids = ATTENDEE_DIRECTORY_SEED.map((e) => e.id);
+  assert.deepEqual(ids, Array.from({ length: 66 }, (_, i) => i + 1));
+  const names = ATTENDEE_DIRECTORY_SEED.map((e) => e.name);
+  assert.equal(new Set(names).size, 66, "names must be unique (UNIQUE constraint)");
+  // company/title never empty (NOT NULL at the DB layer).
+  for (const e of ATTENDEE_DIRECTORY_SEED) {
+    assert.ok(e.company.trim().length > 0, `id ${e.id} company empty`);
+    assert.ok(e.title.trim().length > 0, `id ${e.id} title empty`);
+  }
+});
+
+// ─── buildAttendeesExportCsv ─────────────────────────────────────────────────
+
+test("buildAttendeesExportCsv: referenced-only, sorted by id, deduped, escapes commas", () => {
+  const dir: ReceiptAttendeeDirectoryEntry[] = [
+    { id: 5, company: "Acme, Inc.", title: "Director", name: "Alice Nakamura" },
+    { id: 3, company: "Beta", title: "CFO", name: "Bob Smith" },
+  ];
+  const csv = buildAttendeesExportCsv(
+    ["Bob Smith", "Alice Nakamura", "Bob Smith", "Unresolved Name"],
+    dir,
+  );
+  const lines = csv.split("\n");
+  assert.equal(lines[0], "AttendeeId,Name,Company,Title");
+  // Referenced-only + unresolved dropped + deduped + sorted by id (3 before 5).
+  assert.equal(lines[1], "3,Bob Smith,Beta,CFO");
+  assert.equal(lines[2], '5,Alice Nakamura,"Acme, Inc.",Director', "comma in company is quoted");
+  assert.equal(lines.length, 3, "header + 2 rows (deduped, unresolved dropped)");
+});
+
+test("buildAttendeesExportCsv: no referenced names → header only", () => {
+  assert.equal(buildAttendeesExportCsv([], DIR), "AttendeeId,Name,Company,Title");
+});
+
+test("buildAttendeesExportCsv: trims attendee names before resolving", () => {
+  const csv = buildAttendeesExportCsv(["  Alice Nakamura  "], DIR);
+  assert.equal(csv.split("\n")[1], "5,Alice Nakamura,Acme,Director");
+});

--- a/tests/receipts/bundle-download.test.ts
+++ b/tests/receipts/bundle-download.test.ts
@@ -223,8 +223,8 @@ test("byte-identity: text artifacts are deterministic (no draft-conditional cont
   const generatedAt = "2026-07-15T00:00:00Z";
 
   // Same inputs twice → identical bytes (and identical SHA-256).
-  const csvA = buildMonthlyExportCsv(rows, attendeeMap);
-  const csvB = buildMonthlyExportCsv(rows, attendeeMap);
+  const csvA = buildMonthlyExportCsv(rows, attendeeMap, [], {});
+  const csvB = buildMonthlyExportCsv(rows, attendeeMap, [], {});
   assert.equal(csvA, csvB);
 
   const sumA = buildExportSummaryCsv(rows, month, generatedAt);
@@ -291,7 +291,7 @@ test("byte-identity: the proofs ZIP builder takes no draft flag (draft⇄seal ca
     icAdvisories: [],
     exportRevision: 1,
   };
-  const a = assembleProofsZip(month, entries, notice, "﻿Field,Value\r\nMonth,2026-06\r\n");
+  const a = assembleProofsZip(month, entries, notice, "﻿Field,Value\r\nMonth,2026-06\r\n", "﻿AttendeeId,Name,Company,Title\r\n");
   assert.ok(a instanceof Uint8Array && a.length > 0);
   // The builder has no draft parameter to branch on — draft and finalize share
   // it. (Cross-call byte equality is not asserted because the zip's own

--- a/tests/receipts/export.test.ts
+++ b/tests/receipts/export.test.ts
@@ -3,12 +3,17 @@ import assert from "node:assert/strict";
 import {
   buildMonthlyExportCsv,
   buildExportSummaryCsv,
+  resolveRowAttendees,
   bomPrefixedCrlf,
   hashCsvContent,
   buildArchiveKey,
   buildManifestKey,
   buildSummaryKey,
+  buildAttendeesKey,
+  resolveExportDownload,
+  buildExportReadme,
 } from "@/lib/receipts/export";
+import type { ReceiptAttendeeDirectoryEntry } from "@/lib/receipts/attendee-directory";
 import {
   ExportFinalizedError,
   transactionMonthOf,
@@ -86,7 +91,7 @@ function makeAmexLineRow(overrides: Partial<ExportRow> = {}): ExportRow {
 // ─── buildMonthlyExportCsv ────────────────────────────────────────────────────
 
 test("buildMonthlyExportCsv: produces header row with RowType", () => {
-  const csv = buildMonthlyExportCsv([], new Map());
+  const csv = buildMonthlyExportCsv([], new Map(), [], {});
   const header = csv.split("\n")[0]!;
   assert.ok(header.includes("RowType"), "header must include RowType");
   assert.ok(header.includes("Merchant"), "header must include Merchant");
@@ -97,14 +102,14 @@ test("buildMonthlyExportCsv: produces header row with RowType", () => {
 
 test("buildMonthlyExportCsv: one data row per input row", () => {
   const rows = [makeReceiptRow(), makeReceiptRow({ receiptId: "r-def-456" })];
-  const csv = buildMonthlyExportCsv(rows, new Map());
+  const csv = buildMonthlyExportCsv(rows, new Map(), [], {});
   const lines = csv.split("\n").filter((l) => l.trim());
   assert.equal(lines.length, 3, "header + 2 data rows");
 });
 
 test("buildMonthlyExportCsv: No is the first column and 1-based (proofs join key)", () => {
   const rows = [makeReceiptRow(), makeReceiptRow({ receiptId: "r-2" }), makeReceiptRow({ receiptId: "r-3" })];
-  const csv = buildMonthlyExportCsv(rows, new Map());
+  const csv = buildMonthlyExportCsv(rows, new Map(), [], {});
   const lines = csv.split("\n");
   assert.equal(lines[0]!.split(",")[0], "No", "No is the header's first column");
   // 1-based row sequence, first field of each data line.
@@ -117,6 +122,8 @@ test("buildMonthlyExportCsv: JPY amounts are not divided by 100", () => {
   const csv = buildMonthlyExportCsv(
     [makeReceiptRow({ amountMinor: 1500, currency: "JPY" })],
     new Map(),
+    [],
+    {},
   );
   assert.ok(csv.includes("1500"), "JPY amount should be 1500, not 15.00");
   assert.ok(!csv.includes("15.00"), "JPY should not be divided");
@@ -126,13 +133,15 @@ test("buildMonthlyExportCsv: USD amounts are divided by 100", () => {
   const csv = buildMonthlyExportCsv(
     [makeReceiptRow({ amountMinor: 1250, currency: "USD" })],
     new Map(),
+    [],
+    {},
   );
   assert.ok(csv.includes("12.50"), "USD 1250 minor units should display as 12.50");
 });
 
 test("buildMonthlyExportCsv: null amount renders as empty string", () => {
   const row = makeReceiptRow({ amountMinor: null });
-  const csv = buildMonthlyExportCsv([row], new Map());
+  const csv = buildMonthlyExportCsv([row], new Map(), [], {});
   const dataLine = csv.split("\n")[1]!;
   const cols = dataLine.split(",");
   // Header: No(0), RowType(1), TransactionDate(2), Merchant(3), Amount(4)
@@ -142,7 +151,7 @@ test("buildMonthlyExportCsv: null amount renders as empty string", () => {
 test("buildMonthlyExportCsv: attendees are joined with semicolons and quoted", () => {
   const row = makeReceiptRow({ receiptId: "r-1" });
   const attendeeMap = new Map([["r-1", ["Alice Nakamura", "Bob Smith"]]]);
-  const csv = buildMonthlyExportCsv([row], attendeeMap);
+  const csv = buildMonthlyExportCsv([row], attendeeMap, [], {});
   assert.ok(
     csv.includes('"Alice Nakamura; Bob Smith"'),
     "attendees should be semicolon-joined and quoted",
@@ -151,18 +160,18 @@ test("buildMonthlyExportCsv: attendees are joined with semicolons and quoted", (
 
 test("buildMonthlyExportCsv: merchant with commas is properly quoted", () => {
   const row = makeReceiptRow({ merchant: "Shop, Ltd." });
-  const csv = buildMonthlyExportCsv([row], new Map());
+  const csv = buildMonthlyExportCsv([row], new Map(), [], {});
   assert.ok(csv.includes('"Shop, Ltd."'), "comma in merchant must be quoted");
 });
 
 test("buildMonthlyExportCsv: merchant with double-quotes is escaped", () => {
   const row = makeReceiptRow({ merchant: 'Shop "Best" Ltd.' });
-  const csv = buildMonthlyExportCsv([row], new Map());
+  const csv = buildMonthlyExportCsv([row], new Map(), [], {});
   assert.ok(csv.includes('"Shop ""Best"" Ltd."'), "double quotes must be escaped");
 });
 
 test("buildMonthlyExportCsv: AMEX line row carries line-only fields", () => {
-  const csv = buildMonthlyExportCsv([makeAmexLineRow()], new Map());
+  const csv = buildMonthlyExportCsv([makeAmexLineRow()], new Map(), [], {});
   assert.ok(csv.includes("amex_line"), "rowType=amex_line must appear");
   assert.ok(csv.includes("amex-line-1"), "lineId must be present");
   assert.ok(csv.includes("David Klan"), "cardholderName must be present");
@@ -181,7 +190,7 @@ test("buildMonthlyExportCsv: missing-receipt line ships with reason in CSV", () 
     merchant: "Airport Coffee",
     attendees: [],
   });
-  const csv = buildMonthlyExportCsv([row], new Map());
+  const csv = buildMonthlyExportCsv([row], new Map(), [], {});
   assert.ok(csv.includes("missing_receipt"), "receiptStatus must be present");
   assert.ok(csv.includes("Lost during travel"), "missingReceiptReason must be present");
 });
@@ -191,7 +200,7 @@ test("buildMonthlyExportCsv: formula-injection guard prefixes = + - @", () => {
   // so Excel does not evaluate it as a formula on open.
   for (const prefix of ["=", "+", "-", "@"]) {
     const row = makeReceiptRow({ merchant: `${prefix}cmd|'/c calc'!A1` });
-    const csv = buildMonthlyExportCsv([row], new Map());
+    const csv = buildMonthlyExportCsv([row], new Map(), [], {});
     assert.ok(
       csv.includes(`'${prefix}cmd`),
       `merchant starting with ${prefix} must be single-quote prefixed`,
@@ -203,7 +212,7 @@ test("buildMonthlyExportCsv: matched receipt attendees read from bundle.attendee
   // A receipt matched to a line should still surface its attendees even if
   // the caller passed an empty attendeeMap (the bundle row carries them).
   const row = makeAmexLineRow({ attendees: ["Inline Attendee"] });
-  const csv = buildMonthlyExportCsv([row], new Map());
+  const csv = buildMonthlyExportCsv([row], new Map(), [], {});
   assert.ok(csv.includes("Inline Attendee"), "row.attendees used as fallback");
 });
 
@@ -279,6 +288,8 @@ test("buildMonthlyExportCsv: compliance columns populated from receipt", () => {
       counterpartyName: "Power Lunch Sushi K.K.",
     })],
     new Map(),
+    [],
+    {},
   );
   assert.ok(csv.includes("T2810074043972"), "invoice registration number");
   assert.ok(csv.includes("valid"), "qualified invoice status");
@@ -289,7 +300,7 @@ test("buildMonthlyExportCsv: compliance columns populated from receipt", () => {
 });
 
 test("buildMonthlyExportCsv: header carries compliance column names", () => {
-  const csv = buildMonthlyExportCsv([], new Map());
+  const csv = buildMonthlyExportCsv([], new Map(), [], {});
   const header = csv.split("\n")[0]!;
   for (const col of [
     "InvoiceRegistrationNumber",
@@ -380,4 +391,85 @@ test("buildArchiveKey: uses correct path pattern", () => {
 test("buildManifestKey: uses correct path pattern", () => {
   const key = buildManifestKey("2024-01", "export-uuid");
   assert.equal(key, "exports/2024-01/export-uuid-manifest.csv");
+});
+
+// ─── AttendeeIds column + attendees CSV (migration 0022) ─────────────────────
+
+const DIR: ReceiptAttendeeDirectoryEntry[] = [
+  { id: 5, company: "Acme", title: "Director", name: "Alice Nakamura" },
+  { id: 3, company: "Beta", title: "CFO", name: "Bob Smith" },
+];
+
+test("buildMonthlyExportCsv: AttendeeIds sits right after Attendees; resolved ids + ? for unresolved", () => {
+  const row = makeReceiptRow({ receiptId: "r-1" });
+  const attendeeMap = new Map([["r-1", ["Alice Nakamura", "Bob Smith", "Nobody Here"]]]);
+  const csv = buildMonthlyExportCsv([row], attendeeMap, DIR, {});
+  const dataLine = csv.split("\n")[1]!;
+  const cols = dataLine.split(",");
+  // Header layout: …(11) BusinessPurpose, (12) Attendees, (13) AttendeeIds, (14) LineId…
+  assert.equal(cols[12], '"Alice Nakamura; Bob Smith; Nobody Here"', "Attendees column");
+  assert.equal(cols[13], '"5; 3; ?"', "AttendeeIds: resolved ids '; '-joined, ? for unresolved");
+});
+
+test("buildMonthlyExportCsv: empty attendees row → empty Attendees + empty AttendeeIds", () => {
+  const row = makeReceiptRow({ receiptId: "r-1" });
+  const csv = buildMonthlyExportCsv([row], new Map(), DIR, {});
+  const cols = csv.split("\n")[1]!.split(",");
+  assert.equal(cols[12], '""', "empty Attendees column is quoted-empty");
+  assert.equal(cols[13], '""', "empty AttendeeIds column is quoted-empty");
+});
+
+test("buildMonthlyExportCsv: amex_line with no receipt attendees falls back to line attendees", () => {
+  // Closes the gap where line-level attendees satisfied the gate but vanished
+  // from the CSV. resolveRowAttendees returns the line's direct attendees when
+  // the row is an amex_line with no receipt attendees.
+  const row = makeAmexLineRow({ receiptId: "r-x", attendees: [] });
+  const attendeeMap = new Map<string, string[]>();
+  const amexAttendees: Record<string, string[]> = { "amex-line-1": ["Alice Nakamura"] };
+  const csv = buildMonthlyExportCsv([row], attendeeMap, DIR, amexAttendees);
+  assert.ok(csv.includes('"Alice Nakamura"'), "Attendees col shows line-attendee fallback");
+  assert.ok(csv.includes('"5"'), "AttendeeIds col resolves the line attendee");
+});
+
+test("resolveRowAttendees: receipt attendees win over line attendees when present", () => {
+  const row = makeAmexLineRow({ receiptId: "r-x" });
+  const attendeeMap = new Map([["r-x", ["Bob Smith"]]]);
+  const amexAttendees: Record<string, string[]> = { "amex-line-1": ["Alice Nakamura"] };
+  const names = resolveRowAttendees(row, attendeeMap, amexAttendees);
+  assert.deepEqual(names, ["Bob Smith"], "receipt attendees take precedence; no fallback");
+});
+
+test("buildAttendeesKey: uses correct path pattern", () => {
+  assert.equal(
+    buildAttendeesKey("2024-01", "export-uuid"),
+    "exports/2024-01/export-uuid-attendees.csv",
+  );
+});
+
+test("resolveExportDownload: attendees → derived key + csv content type", () => {
+  const r = resolveExportDownload(
+    "2026-06",
+    { id: "e1", archive_r2_key: "a", manifest_r2_key: "m" },
+    "attendees",
+  );
+  assert.equal(r.r2Key, "exports/2026-06/e1-attendees.csv");
+  assert.equal(r.contentType, "text/csv; charset=utf-8");
+  assert.equal(r.filename, "export-2026-06-attendees.csv");
+});
+
+test("buildExportReadme: lists Attendees CSV SHA-256 + files-included sentence", () => {
+  const readme = buildExportReadme({
+    exportId: "e1",
+    month: "2026-06",
+    rowCount: 3,
+    generatedAt: "t",
+    exportRevision: 1,
+    archiveSha256: "a",
+    manifestSha256: "m",
+    summarySha256: "s",
+    attendeesSha256: "att",
+    proofsSha256: "p",
+  });
+  assert.match(readme, /Attendees CSV SHA-256: att/);
+  assert.match(readme, /attendees CSV.*AttendeeIds/);
 });

--- a/tests/receipts/month-closing.test.ts
+++ b/tests/receipts/month-closing.test.ts
@@ -111,6 +111,8 @@ function makeBundle(overrides: Partial<ExportBundle> = {}): ExportBundle {
     receipts: [],
     amexLines: [],
     attendeeMap: new Map(),
+    attendeeDirectory: [],
+    amexAttendees: {},
     items: [],
     ...overrides,
   };
@@ -233,6 +235,55 @@ test("gate 3: CASH receipt missing expense category blocks; AMEX is skipped here
   assert.ok(
     !amex.some((b) => b.includes("r-amex") && b.includes("missing expense category")),
     `AMEX receipt must not hit gate 3: ${JSON.stringify(amex)}`,
+  );
+});
+
+// (3b) Attendee-directory resolution (migration 0022): a receipt whose
+// category requires attendees must have every attendee name resolve to a
+// directory entry (company/title). Unresolved → blocker.
+const ATTENDEE_DIR = [
+  { id: 1, company: "Acme", title: "Director", name: "Alice" },
+];
+
+test("gate 3b: CASH receipt with an unresolved attendee name blocks", () => {
+  const receipt = makeReceipt({
+    id: "r-cash",
+    payment_path: "CASH",
+    expense_category_code: "meeting",
+  });
+  const bundle = makeBundle({
+    receipts: [receipt],
+    attendeeMap: new Map([["r-cash", ["Alice", "Ghost"]]]),
+    attendeeDirectory: ATTENDEE_DIR,
+  });
+  const blockers = validateMonthReadyForExportCore(
+    makeInput({ bundle, receiptFileCounts: new Map([["r-cash", 1]]) }),
+  );
+  assert.ok(
+    blockers.some(
+      (b) => b.includes("Ghost") && b.includes("not registered in the attendee directory"),
+    ),
+    JSON.stringify(blockers),
+  );
+});
+
+test("gate 3b: CASH receipt with all attendees resolved passes (no directory blocker)", () => {
+  const receipt = makeReceipt({
+    id: "r-cash",
+    payment_path: "CASH",
+    expense_category_code: "meeting",
+  });
+  const bundle = makeBundle({
+    receipts: [receipt],
+    attendeeMap: new Map([["r-cash", ["Alice"]]]),
+    attendeeDirectory: ATTENDEE_DIR,
+  });
+  const blockers = validateMonthReadyForExportCore(
+    makeInput({ bundle, receiptFileCounts: new Map([["r-cash", 1]]) }),
+  );
+  assert.ok(
+    !blockers.some((b) => b.includes("not registered in the attendee directory")),
+    `resolved attendees must not block: ${JSON.stringify(blockers)}`,
   );
 });
 

--- a/tests/receipts/proofs.test.ts
+++ b/tests/receipts/proofs.test.ts
@@ -247,8 +247,12 @@ function fakeEntry(over: Partial<ProofZipEntry>): ProofZipEntry {
 // breakdown too.
 const SUMMARY_CSV =
   "﻿Field,Value\r\nMonth,2026-06\r\n\r\n勘定科目,件数,合計金額\r\n研究開発費,1,108341\r\n\r\n総合計,1,108341\r\n";
+// 参加者一覧 (attendees) — same shape as the standalone attendees artifact
+// (BOM+CRLF), embedded byte-identical into the ZIP next to 集計.csv.
+const ATTENDEES_CSV =
+  "﻿AttendeeId,Name,Company,Title\r\n5,Alice Nakamura,Acme,Director\r\n";
 
-test("assembleProofsZip: UTF-8 names round-trip + 目次/集計/お知らせ present", () => {
+test("assembleProofsZip: UTF-8 names round-trip + 目次/集計/参加者一覧/お知らせ present", () => {
   const entries = [
     fakeEntry({ no: 3, ext: "pdf", paymentPath: "AMEX" }),
     fakeEntry({
@@ -266,6 +270,7 @@ test("assembleProofsZip: UTF-8 names round-trip + 目次/集計/お知らせ pre
     entries,
     { ...baseNotice, receiptCount: 2 },
     SUMMARY_CSV,
+    ATTENDEES_CSV,
   );
   const files = unzipSync(zip);
   const names = Object.keys(files);
@@ -283,9 +288,10 @@ test("assembleProofsZip: UTF-8 names round-trip + 目次/集計/お知らせ pre
     names.some((n) => n.includes("No33_旅費交通費_セブン-イレブン東中野末広橋店_¥10,000.jpg")),
     "cash proof filename (whitespace-stripped merchant) round-trips",
   );
-  // Index + summary + notice.
+  // Index + summary + attendees + notice.
   assert.ok(names.some((n) => n.endsWith("目次.csv")), "目次.csv present");
   assert.ok(names.some((n) => n.endsWith("集計.csv")), "集計.csv present");
+  assert.ok(names.some((n) => n.endsWith("参加者一覧.csv")), "参加者一覧.csv present");
   assert.ok(names.some((n) => n.endsWith("お知らせ.txt")), "お知らせ.txt present");
   // 集計.csv bytes == the standalone summary artifact (same bytes passed in).
   // Compare raw bytes — TextDecoder would strip the leading BOM and skew the
@@ -297,6 +303,15 @@ test("assembleProofsZip: UTF-8 names round-trip + 目次/集計/お知らせ pre
   assert.ok(
     shukeiBytes.every((b, i) => b === expectedShukei[i]),
     "集計.csv bytes identical to the standalone summary artifact",
+  );
+  // 参加者一覧.csv bytes == the standalone attendees artifact (same bytes in).
+  const sankashaKey = names.find((n) => n.endsWith("参加者一覧.csv"))!;
+  const sankashaBytes = files[sankashaKey];
+  const expectedSankasha = enc.encode(ATTENDEES_CSV);
+  assert.equal(sankashaBytes.length, expectedSankasha.length, "参加者一覧.csv byte length");
+  assert.ok(
+    sankashaBytes.every((b, i) => b === expectedSankasha[i]),
+    "参加者一覧.csv bytes identical to the standalone attendees artifact",
   );
 });
 
@@ -311,6 +326,7 @@ test("assembleProofsZip: 目次 No column matches entry nos (CSV⇄目次 contin
     entries,
     { ...baseNotice, receiptCount: 3 },
     SUMMARY_CSV,
+    ATTENDEES_CSV,
   );
   const files = unzipSync(zip);
   const mokuziKey = Object.keys(files).find((k) => k.endsWith("目次.csv"))!;

--- a/tests/receipts/reconciliation-signoff.test.ts
+++ b/tests/receipts/reconciliation-signoff.test.ts
@@ -2,6 +2,16 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { validateAmexLinesForSignoff } from "@/lib/receipts/reconciliation-signoff";
 import type { AmexStatementLine, ReceiptRecord } from "@/lib/receipts/types";
+import type { ReceiptAttendeeDirectoryEntry } from "@/lib/receipts/attendee-directory";
+
+// Attendee-directory fixtures (migration 0022). EMPTY_DIR = nothing resolves
+// (so attendee-present + requires-attendees lines would block on resolution,
+// unless the line has no attendees at all). ATTENDEES_DIR resolves Alice & Bob.
+const EMPTY_DIR: ReceiptAttendeeDirectoryEntry[] = [];
+const ATTENDEES_DIR: ReceiptAttendeeDirectoryEntry[] = [
+  { id: 1, company: "C", title: "T", name: "Alice" },
+  { id: 2, company: "C", title: "T", name: "Bob" },
+];
 
 function makeLine(overrides: Partial<AmexStatementLine> = {}): AmexStatementLine {
   return {
@@ -83,7 +93,7 @@ test("signoff validator: no-receipt line uses line category", () => {
     receipt_missing_reason: "lost",
     expense_category_code: "office_supplies",
   });
-  const blockers = validateAmexLinesForSignoff([line], {}, new Map(), new Map());
+  const blockers = validateAmexLinesForSignoff([line], {}, new Map(), new Map(), EMPTY_DIR);
   // Office supplies doesn't require attendees; line category is set; no blockers.
   assert.deepEqual(blockers, []);
 });
@@ -96,7 +106,7 @@ test("signoff validator: no-receipt line with null line category still blocks", 
     receipt_missing_reason: "lost",
     expense_category_code: null,
   });
-  const blockers = validateAmexLinesForSignoff([line], {}, new Map(), new Map());
+  const blockers = validateAmexLinesForSignoff([line], {}, new Map(), new Map(), EMPTY_DIR);
   assert.ok(blockers.some((b) => b.includes("missing expense category")));
 });
 
@@ -119,6 +129,7 @@ test("signoff validator: receipt-linked line with null LINE category and categor
     {},
     new Map(),
     receiptMap,
+    EMPTY_DIR,
   );
   assert.deepEqual(blockers, []);
 });
@@ -141,6 +152,7 @@ test("signoff validator: receipt-linked line with categorized RECEIPT requiring 
     {},
     receiptAttendeeMap,
     receiptMap,
+    ATTENDEES_DIR,
   );
   assert.deepEqual(blockers, []);
 });
@@ -163,8 +175,61 @@ test("signoff validator: receipt-linked line with categorized RECEIPT but no att
     {},
     new Map(),
     receiptMap,
+    EMPTY_DIR,
   );
   assert.ok(blockers.some((b) => b.includes("requires attendees")));
+});
+
+test("signoff validator: meeting line with an unresolved attendee name blocks on the directory", () => {
+  // Attendees ARE present (so "requires attendees" does not fire), but one name
+  // doesn't resolve to the directory → company/title blocker (migration 0022).
+  const line = makeLine({
+    matched_receipt_id: "r-1",
+    match_status: "confirmed",
+    receipt_status: "matched",
+    expense_category_code: null,
+  });
+  const receipt = makeReceipt({ id: "r-1", expense_category_code: "meeting" });
+  const receiptMap = new Map([[receipt.id, receipt]]);
+  const receiptAttendeeMap = new Map([["r-1", ["Alice", "Ghost"]]]);
+  const blockers = validateAmexLinesForSignoff(
+    [line],
+    {},
+    receiptAttendeeMap,
+    receiptMap,
+    ATTENDEES_DIR, // resolves Alice, NOT Ghost
+  );
+  assert.ok(
+    blockers.some(
+      (b) => b.includes("Ghost") && b.includes("not registered in the attendee directory"),
+    ),
+    JSON.stringify(blockers),
+  );
+});
+
+test("signoff validator: direct line attendees also resolve against the directory", () => {
+  // amexAttendees (line-level, no linked receipt) join the union and resolve too.
+  const line = makeLine({
+    matched_receipt_id: null,
+    match_status: "no_receipt",
+    receipt_status: "no_receipt_required",
+    receipt_missing_reason: "lost",
+    expense_category_code: "meeting",
+  });
+  const amexAttendees = { "line-1": ["Ghost"] };
+  const blockers = validateAmexLinesForSignoff(
+    [line],
+    amexAttendees,
+    new Map(),
+    new Map(),
+    ATTENDEES_DIR,
+  );
+  assert.ok(
+    blockers.some(
+      (b) => b.includes("Ghost") && b.includes("not registered in the attendee directory"),
+    ),
+    JSON.stringify(blockers),
+  );
 });
 
 test("signoff validator: dangling match (matched_receipt_id set, receipt missing) falls back to line", () => {
@@ -177,7 +242,7 @@ test("signoff validator: dangling match (matched_receipt_id set, receipt missing
     expense_category_code: "office_supplies",
   });
   // Empty receiptMap — receipt was deleted.
-  const blockers = validateAmexLinesForSignoff([line], {}, new Map(), new Map());
+  const blockers = validateAmexLinesForSignoff([line], {}, new Map(), new Map(), EMPTY_DIR);
   assert.deepEqual(blockers, []);
 });
 
@@ -209,13 +274,13 @@ function makeConsolidatedPair(receiptTotal: number) {
 
 test("signoff validator: consolidated receipt with exact group sum passes", () => {
   const { lines, receiptMap } = makeConsolidatedPair(2864 + 4185);
-  const blockers = validateAmexLinesForSignoff(lines, {}, new Map(), receiptMap);
+  const blockers = validateAmexLinesForSignoff(lines, {}, new Map(), receiptMap, EMPTY_DIR);
   assert.deepEqual(blockers, []);
 });
 
 test("signoff validator: consolidated receipt with mismatched group sum blocks", () => {
   const { lines, receiptMap } = makeConsolidatedPair(9999);
-  const blockers = validateAmexLinesForSignoff(lines, {}, new Map(), receiptMap);
+  const blockers = validateAmexLinesForSignoff(lines, {}, new Map(), receiptMap, EMPTY_DIR);
   assert.ok(
     blockers.some((b) => b.includes("Consolidated receipt") && b.includes("9999")),
     `expected consolidated-sum blocker, got: ${JSON.stringify(blockers)}`,
@@ -234,6 +299,7 @@ test("signoff validator: single-line amount mismatch is NOT a consolidated block
     {},
     new Map(),
     new Map([[receipt.id, receipt]]),
+    EMPTY_DIR,
   );
   assert.deepEqual(blockers, []);
 });
@@ -245,7 +311,7 @@ test("signoff validator: unmatched line still blocks on missing receipt confirma
     receipt_status: "missing_receipt",
     expense_category_code: "office_supplies",
   });
-  const blockers = validateAmexLinesForSignoff([line], {}, new Map(), new Map());
+  const blockers = validateAmexLinesForSignoff([line], {}, new Map(), new Map(), EMPTY_DIR);
   // Should have at least: unresolved match status, missing receipt requires reason.
   assert.ok(blockers.length >= 2, `expected at least 2 blockers, got: ${JSON.stringify(blockers)}`);
 });


### PR DESCRIPTION
Business-manager review on the first monthly settlement: every 会議費 (meeting) / 接待交際費 (entertainment) attendee must show **company + title**. This moves the attendee directory into D1, adds an `AttendeeIds` column to the receipts CSV, ships a 7th bundle artifact `参加者一覧.csv`, and extends the finalize gate.

## What changes
- **Migration 0022** — `attendee_directory` table seeded from the TS array (ids 1–66 preserved verbatim; they're the sealed-export join key). Registering an attendee is now a data op via the review UI, not a code deploy.
- **Receipts CSV** — new `AttendeeIds` column directly after `Attendees`: directory ids `"; "`-joined, `?` for unresolved, positionally aligned. AMEX-line rows with no receipt attendees now fall back to line-level attendees (closes a gap where they satisfied the gate but vanished from the CSV).
- **`参加者一覧.csv`** — 7th artifact, columns `AttendeeId,Name,Company,Title`, referenced-only + id-sorted + deduped. Standalone download **and** byte-identical inside the proofs ZIP next to `集計.csv`. README gains its SHA-256 line + files-included sentence.
- **Finalize gate** — blocks when an attendee name on an attendee-required row (receipt-level **or** AMEX-line-level) doesn't resolve to the directory (company/title required). Drafts still render `?` ids so gaps are visible.
- **Review UI** — fetches the directory live; inline Company/Title inputs + "Register attendee" button when a typed name doesn't resolve; `company — title` helper under resolved rows.

Resolution is by **exact name match** (identity = directory name) — no FK columns, no fuzzy matching.

## ⚠️ Operational impact on merge/deploy
Once deployed, the finalize gate **blocks finalizing any month whose receipts carry an unresolved attendee name**. A pre-deploy audit found **10 `receipt_attendees` names** that don't resolve (`amex_line_attendees` is clean). The operator is handling these (renames + registrations, reverting the sealed month if needed) **after** deploy — blocked finalize is the intended state until then. Notable same-person script variants in the mismatch set: `David Klan` vs id 2 `クランデイビット`, `Tazuko Murakami` vs id 1 `村上多寿子`, `Steve Kent` vs id 19 `Stephan Kent`.

## Verification
- `npm test` — 476 pass / 0 fail (new suite `attendee-directory.test.ts`; extended export/month-closing/reconciliation-signoff/proofs/bundle-download).
- `npm run build:cf` — OpenNext build complete.
- Migration 0022 already applied to live `dazbeez-receipts` D1 (count = 66); `createAttendeeDirectoryEntry` SQL contract validated live (id auto-assigned > 66, UNIQUE enforced).
- Authenticated prod e2e (Clerk blocks localhost) confirmed post-deploy by operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)