### PR TITLE
receipts: business trips phase A — backend (ADR 0010)

### DIFF
--- a/app/api/receipts/amex/import/route.ts
+++ b/app/api/receipts/amex/import/route.ts
@@ -24,6 +24,7 @@ import {
 import { getReceiptsDb } from "@/lib/cloudflare-runtime";
 import { createReceiptFile } from "@/lib/receipts/files";
 import { createAuditEntry } from "@/lib/receipts/audit";
+import { getComplianceSettings } from "@/lib/receipts/settings";
 
 /*
  * AMEX CSV Import — Dedup Contract
@@ -263,7 +264,7 @@ export async function POST(request: Request) {
       const db = getReceiptsDb();
       const inserted = await db
         .prepare(
-          `SELECT id, cardholder_name, transaction_date, merchant
+          `SELECT id, cardholder_name, transaction_date, merchant, expense_category_code
            FROM amex_statement_lines
            WHERE statement_artifact_id = ?
            ORDER BY raw_csv_line_number ASC`,
@@ -274,6 +275,7 @@ export async function POST(request: Request) {
           cardholder_name: string | null;
           transaction_date: string;
           merchant: string;
+          expense_category_code: string | null;
         }>();
 
       const realLines = (inserted.results ?? []).map((r) => ({
@@ -281,9 +283,16 @@ export async function POST(request: Request) {
         cardholderName: r.cardholder_name,
         transactionDate: r.transaction_date,
         merchant: r.merchant,
+        expenseCategoryCode: r.expense_category_code,
       }));
 
-      const candidates = detectBusinessTripCandidates(realLines);
+      // ADR 0010 D3: homebase signals come from Settings → Compliance (was a
+      // hardcoded Tokyo list). Categories aren't set at first import, so the
+      // category-boost fires mainly on re-imports after the operator
+      // categorizes lines — which is also when the dedupe (createBusinessTripReports)
+      // matters most.
+      const homebaseSignals = (await getComplianceSettings()).homebase_signals;
+      const candidates = detectBusinessTripCandidates(realLines, homebaseSignals);
       if (candidates.length > 0) {
         await createBusinessTripReports(candidates, actor);
         businessTripCandidatesCount = candidates.length;

--- a/app/api/receipts/trips/[id]/members/route.ts
+++ b/app/api/receipts/trips/[id]/members/route.ts
@@ -1,0 +1,119 @@
+import { NextResponse } from "next/server";
+import { requireReceiptsActor } from "@/lib/receipts/auth";
+import {
+  attachTripMembers,
+  detachTripMembers,
+  findCrossTripLineConflicts,
+} from "@/lib/receipts/db";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+// Trip membership (ADR 0010 D2): attach/detach lines + receipts.
+//   - Lines get business_trip_id + status; a link-table row. A line already on
+//     a DIFFERENT trip → 409 (detach there first; no silent moves).
+//   - Receipts get a link-table row ONLY — receipt rows are NEVER written, so
+//     sealed-month receipts are legal members by construction.
+
+function parseMemberIds(body: unknown): {
+  lineIds: string[];
+  receiptIds: string[];
+  malformed: boolean;
+} {
+  if (typeof body !== "object" || body === null) {
+    return { lineIds: [], receiptIds: [], malformed: true };
+  }
+  const { lineIds, receiptIds } = body as { lineIds?: unknown; receiptIds?: unknown };
+  const ok = (v: unknown): v is string[] =>
+    Array.isArray(v) && v.every((x) => typeof x === "string");
+  if (lineIds !== undefined && !ok(lineIds)) {
+    return { lineIds: [], receiptIds: [], malformed: true };
+  }
+  if (receiptIds !== undefined && !ok(receiptIds)) {
+    return { lineIds: [], receiptIds: [], malformed: true };
+  }
+  return {
+    lineIds: (lineIds as string[] | undefined) ?? [],
+    receiptIds: (receiptIds as string[] | undefined) ?? [],
+    malformed: false,
+  };
+}
+
+export async function POST(request: Request, { params }: RouteContext) {
+  try {
+    const actor = await requireReceiptsActor(request.headers);
+    const { id } = await params;
+    const parsed = parseMemberIds(await request.json().catch(() => null));
+    if (parsed.malformed) {
+      return NextResponse.json(
+        { error: "Body must be { lineIds?: string[], receiptIds?: string[] }." },
+        { status: 400 },
+      );
+    }
+    if (parsed.lineIds.length === 0 && parsed.receiptIds.length === 0) {
+      return NextResponse.json(
+        { error: "Provide lineIds and/or receiptIds to attach." },
+        { status: 400 },
+      );
+    }
+
+    // Cross-trip line conflict → 409 (operator detaches at the owner first).
+    const conflicts = await findCrossTripLineConflicts(id, parsed.lineIds);
+    if (conflicts.length > 0) {
+      return NextResponse.json(
+        {
+          error: "Some lines already belong to another trip. Detach them there first.",
+          conflicts,
+        },
+        { status: 409 },
+      );
+    }
+
+    const result = await attachTripMembers(id, parsed, actor);
+    return NextResponse.json({ ok: true, ...result }, { status: 200 });
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Unauthorized")) {
+      return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+    }
+    const msg = error instanceof Error ? error.message : "";
+    if (msg.includes("not found")) {
+      return NextResponse.json({ error: "Trip not found." }, { status: 404 });
+    }
+    console.error("[api/receipts/trips/[id]/members] POST failed", error);
+    return NextResponse.json(
+      { error: msg || "Failed to attach members." },
+      { status: 500 },
+    );
+  }
+}
+
+export async function DELETE(request: Request, { params }: RouteContext) {
+  try {
+    const actor = await requireReceiptsActor(request.headers);
+    const { id } = await params;
+    const parsed = parseMemberIds(await request.json().catch(() => null));
+    if (parsed.malformed) {
+      return NextResponse.json(
+        { error: "Body must be { lineIds?: string[], receiptIds?: string[] }." },
+        { status: 400 },
+      );
+    }
+    if (parsed.lineIds.length === 0 && parsed.receiptIds.length === 0) {
+      return NextResponse.json(
+        { error: "Provide lineIds and/or receiptIds to detach." },
+        { status: 400 },
+      );
+    }
+
+    const result = await detachTripMembers(id, parsed, actor);
+    return NextResponse.json({ ok: true, ...result }, { status: 200 });
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Unauthorized")) {
+      return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+    }
+    console.error("[api/receipts/trips/[id]/members] DELETE failed", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to detach members." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/receipts/trips/[id]/route.ts
+++ b/app/api/receipts/trips/[id]/route.ts
@@ -1,0 +1,135 @@
+import { NextResponse } from "next/server";
+import { requireReceiptsActor } from "@/lib/receipts/auth";
+import {
+  getBusinessTripWithMembers,
+  updateBusinessTrip,
+} from "@/lib/receipts/db";
+import { validateTripDates } from "@/lib/receipts/business-trips";
+import type { BusinessTripStatus } from "@/lib/receipts/types";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+// Business trip detail + edit (ADR 0010): GET resolves member lines + receipts;
+// PATCH edits fields and/or transitions status (candidate → confirmed |
+// rejected). 'exported' is terminal (Phase C) → 409.
+
+export async function GET(request: Request, { params }: RouteContext) {
+  try {
+    await requireReceiptsActor(request.headers);
+    const { id } = await params;
+    const detail = await getBusinessTripWithMembers(id);
+    if (!detail.trip) {
+      return NextResponse.json({ error: "Trip not found." }, { status: 404 });
+    }
+    return NextResponse.json(detail, { status: 200 });
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Unauthorized")) {
+      return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+    }
+    console.error("[api/receipts/trips/[id]] GET failed", error);
+    return NextResponse.json(
+      { error: "Failed to load trip." },
+      { status: 500 },
+    );
+  }
+}
+
+export async function PATCH(request: Request, { params }: RouteContext) {
+  try {
+    const actor = await requireReceiptsActor(request.headers);
+    const { id } = await params;
+    const body = (await request.json().catch(() => ({}))) as {
+      tripName?: unknown;
+      startDate?: unknown;
+      endDate?: unknown;
+      purpose?: unknown;
+      primaryLocation?: unknown;
+      status?: unknown;
+    };
+
+    // Date edits require BOTH dates so start<=end is checkable.
+    const hasStartDate = "startDate" in body;
+    const hasEndDate = "endDate" in body;
+    if (hasStartDate || hasEndDate) {
+      if (!hasStartDate || !hasEndDate) {
+        return NextResponse.json(
+          { error: "Provide both startDate and endDate to edit trip dates." },
+          { status: 400 },
+        );
+      }
+      const startDate = typeof body.startDate === "string" ? body.startDate.trim() : "";
+      const endDate = typeof body.endDate === "string" ? body.endDate.trim() : "";
+      const dateCheck = validateTripDates(startDate, endDate);
+      if (!dateCheck.ok) {
+        return NextResponse.json({ error: dateCheck.error }, { status: 400 });
+      }
+    }
+
+    // Status value pre-check (format); the exported/transition guard runs in
+    // updateBusinessTrip and is surfaced as a 409 below.
+    let status: BusinessTripStatus | undefined;
+    if (body.status !== undefined) {
+      if (
+        typeof body.status !== "string" ||
+        (body.status !== "confirmed" && body.status !== "rejected")
+      ) {
+        return NextResponse.json(
+          { error: "status must be 'confirmed' or 'rejected'." },
+          { status: 400 },
+        );
+      }
+      status = body.status as BusinessTripStatus;
+    }
+
+    const newStatus = await updateBusinessTrip(
+      id,
+      {
+        tripName:
+          typeof body.tripName === "string"
+            ? body.tripName
+            : body.tripName === null
+              ? null
+              : undefined,
+        startDate:
+          typeof body.startDate === "string" ? body.startDate.trim() : undefined,
+        endDate:
+          typeof body.endDate === "string" ? body.endDate.trim() : undefined,
+        purpose:
+          typeof body.purpose === "string"
+            ? body.purpose
+            : body.purpose === null
+              ? null
+              : undefined,
+        primaryLocation:
+          typeof body.primaryLocation === "string"
+            ? body.primaryLocation
+            : body.primaryLocation === null
+              ? null
+              : undefined,
+        status,
+      },
+      actor,
+    );
+
+    return NextResponse.json({ ok: true, status: newStatus }, { status: 200 });
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Unauthorized")) {
+      return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+    }
+    const msg = error instanceof Error ? error.message : "";
+    if (msg.includes("not found")) {
+      return NextResponse.json({ error: "Trip not found." }, { status: 404 });
+    }
+    if (msg.includes("exported")) {
+      return NextResponse.json(
+        { error: msg || "Trip is exported and cannot be changed." },
+        { status: 409 },
+      );
+    }
+    console.error("[api/receipts/trips/[id]] PATCH failed", error);
+    return NextResponse.json(
+      { error: msg || "Failed to update trip." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/receipts/trips/route.ts
+++ b/app/api/receipts/trips/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from "next/server";
+import { requireReceiptsActor } from "@/lib/receipts/auth";
+import {
+  listBusinessTripsWithCounts,
+  createBusinessTrip,
+} from "@/lib/receipts/db";
+import { validateTripDates } from "@/lib/receipts/business-trips";
+
+// Business trips (ADR 0010): list with member counts, or create an
+// operator-managed trip (born 'confirmed'). Detection-created trips stay
+// 'candidate' and are linked to existing overlapping trips on import (dedupe).
+
+export async function GET(request: Request) {
+  try {
+    await requireReceiptsActor(request.headers);
+    const trips = await listBusinessTripsWithCounts();
+    return NextResponse.json({ trips }, { status: 200 });
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Unauthorized")) {
+      return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+    }
+    console.error("[api/receipts/trips] GET failed", error);
+    return NextResponse.json(
+      { error: "Failed to load business trips." },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const actor = await requireReceiptsActor(request.headers);
+    const body = (await request.json().catch(() => ({}))) as {
+      tripName?: unknown;
+      startDate?: unknown;
+      endDate?: unknown;
+      purpose?: unknown;
+      primaryLocation?: unknown;
+      cardholderName?: unknown;
+    };
+
+    const startDate = typeof body.startDate === "string" ? body.startDate.trim() : "";
+    const endDate = typeof body.endDate === "string" ? body.endDate.trim() : "";
+    const dateCheck = validateTripDates(startDate, endDate);
+    if (!dateCheck.ok) {
+      return NextResponse.json({ error: dateCheck.error }, { status: 400 });
+    }
+
+    const id = await createBusinessTrip(
+      {
+        tripName: typeof body.tripName === "string" ? body.tripName : null,
+        startDate,
+        endDate,
+        purpose: typeof body.purpose === "string" ? body.purpose : null,
+        primaryLocation:
+          typeof body.primaryLocation === "string" ? body.primaryLocation : null,
+        cardholderName:
+          typeof body.cardholderName === "string" ? body.cardholderName : null,
+      },
+      actor,
+    );
+    return NextResponse.json({ id }, { status: 200 });
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Unauthorized")) {
+      return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+    }
+    console.error("[api/receipts/trips] POST failed", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to create trip." },
+      { status: 500 },
+    );
+  }
+}

--- a/components/receipts/ComplianceSettingsForm.tsx
+++ b/components/receipts/ComplianceSettingsForm.tsx
@@ -17,7 +17,9 @@ type Props = {
   effectiveRecipient: EffectiveRecipient;
 };
 
-const LABELS: Record<keyof ComplianceSettings, string> = {
+// homebase_signals (ADR 0010 D3) is an array setting whose UI is Phase B, so it
+// is intentionally absent from this scalar-label map until then.
+const LABELS: Record<Exclude<keyof ComplianceSettings, "homebase_signals">, string> = {
   business_name: "Business name (事業者名)",
   taxpayer_type: "Taxpayer type",
   retention_years: "Retention years",

--- a/db/receipts/0023_business_trip_receipts.sql
+++ b/db/receipts/0023_business_trip_receipts.sql
@@ -1,0 +1,28 @@
+-- 0023_business_trip_receipts.sql
+--
+-- ADR 0010 D2: business trips become first-class, operator-managed entities
+-- whose membership is lines AND receipts, date-unconstrained, overlay-only.
+-- This adds the receipts link table, mirroring business_trip_report_lines.
+--
+-- Membership is an overlay: writes touch ONLY link tables (plus
+-- business_trip_id / business_trip_status on lines, which any sealed export
+-- already snapshotted at seal time — changing them later does not alter a
+-- sealed artifact). Receipt rows are NEVER written here, so attaching a
+-- sealed-month receipt to a trip is legal by construction (no conflict with
+-- the exported-receipt guard or ADR 0009). This is what lets June 2026 close
+-- now and gain trip linkage later.
+--
+-- No other schema change this phase: trip_name/purpose/primary_location and
+-- the status CHECK already exist (0005); the homebase setting lives in the
+-- key/value receipt_settings table (needs no DDL).
+CREATE TABLE IF NOT EXISTS business_trip_report_receipts (
+  id TEXT PRIMARY KEY,
+  business_trip_report_id TEXT NOT NULL
+    REFERENCES business_trip_reports(id) ON DELETE CASCADE,
+  receipt_id TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  UNIQUE (business_trip_report_id, receipt_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_business_trip_receipts
+  ON business_trip_report_receipts(business_trip_report_id);

--- a/lib/receipts/business-trips.ts
+++ b/lib/receipts/business-trips.ts
@@ -1,0 +1,154 @@
+// Pure helpers for business-trip management (ADR 0010). Kept D1-free so the
+// overlap decision, status-sync, and input/transition validation are unit-
+// testable without mocks — same factoring doctrine as amex-line-patch.ts.
+//
+// Phase A scope: detection dedupe, CRUD/membership validation, status sync.
+// No UI, no export artifact (Phase B/C).
+
+import type { BusinessTripStatus } from "@/lib/receipts/types";
+
+/** YYYY-MM-DD lexical comparison is a correct chronological ordering. */
+export function rangesOverlap(
+  a: { start: string; end: string },
+  b: { start: string; end: string },
+): boolean {
+  return a.start <= b.end && b.start <= a.end;
+}
+
+/** Union (min start, max end) of two date ranges. */
+export function unionRange(
+  a: { start: string; end: string },
+  b: { start: string; end: string },
+): { start: string; end: string } {
+  return {
+    start: a.start < b.start ? a.start : b.start,
+    end: a.end > b.end ? a.end : b.end,
+  };
+}
+
+export interface ExistingTrip {
+  id: string;
+  cardholder_name: string;
+  start_date: string;
+  end_date: string;
+  status: string;
+}
+
+/**
+ * Detection dedupe (ADR 0010 D1): find an existing trip for the SAME
+ * cardholder whose [start_date, end_date] overlaps the candidate's range and
+ * whose status is 'candidate' or 'confirmed' (a rejected or exported trip does
+ * not absorb new lines). Returns the first match or null.
+ */
+export function findOverlappingTrip(
+  candidate: { cardholderName: string; startDate: string; endDate: string },
+  existing: ExistingTrip[],
+): ExistingTrip | null {
+  for (const trip of existing) {
+    if (
+      trip.cardholder_name === candidate.cardholderName &&
+      (trip.status === "candidate" || trip.status === "confirmed") &&
+      rangesOverlap(
+        { start: candidate.startDate, end: candidate.endDate },
+        { start: trip.start_date, end: trip.end_date },
+      )
+    ) {
+      return trip;
+    }
+  }
+  return null;
+}
+
+/**
+ * Given an overlapping existing trip + the candidate range, decide whether the
+ * trip's stored range should be widened to the union. Widening is allowed ONLY
+ * for status='candidate' — a confirmed trip is never silently widened (the
+ * operator confirmed specific dates). Returns the action + (when widen) the
+ * new range.
+ */
+export function decideWiden(
+  trip: ExistingTrip,
+  candidate: { startDate: string; endDate: string },
+): { kind: "widen"; range: { start: string; end: string } } | { kind: "skip" } | { kind: "none" } {
+  const u = unionRange(
+    { start: trip.start_date, end: trip.end_date },
+    { start: candidate.startDate, end: candidate.endDate },
+  );
+  const wouldChange = u.start !== trip.start_date || u.end !== trip.end_date;
+  if (!wouldChange) return { kind: "none" };
+  if (trip.status === "candidate") return { kind: "widen", range: u };
+  return { kind: "skip" }; // confirmed trip — never silently widen
+}
+
+// ─── Status sync (ADR 0010 D4) ──────────────────────────────────────────────
+
+export type TripTransition = "confirmed" | "rejected";
+
+/**
+ * Pure helper: the per-line updates to apply when a trip transitions.
+ *   confirm → member lines 'confirmed' (business_trip_id stays = tripId)
+ *   reject  → member lines 'excluded' + business_trip_id = NULL
+ * Receipt members have no status and survive both (handled by the caller).
+ */
+export function computeTripStatusLineUpdates(
+  tripId: string,
+  memberLineIds: string[],
+  transition: TripTransition,
+): Array<{
+  lineId: string;
+  businessTripId: string | null;
+  businessTripStatus: "confirmed" | "excluded";
+}> {
+  if (transition === "confirmed") {
+    return memberLineIds.map((lineId) => ({
+      lineId,
+      businessTripId: tripId,
+      businessTripStatus: "confirmed",
+    }));
+  }
+  return memberLineIds.map((lineId) => ({
+    lineId,
+    businessTripId: null,
+    businessTripStatus: "excluded",
+  }));
+}
+
+// ─── Input + transition validation (route-facing) ───────────────────────────
+
+export interface ValidationResult {
+  ok: boolean;
+  error?: string;
+}
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export function validateTripDates(
+  startDate: string,
+  endDate: string,
+): ValidationResult {
+  if (!DATE_RE.test(startDate) || !DATE_RE.test(endDate)) {
+    return { ok: false, error: "startDate and endDate must be YYYY-MM-DD." };
+  }
+  if (startDate > endDate) {
+    return { ok: false, error: "startDate must be on or before endDate." };
+  }
+  return { ok: true };
+}
+
+/**
+ * ADR 0010 D4 status transitions. The trip screen owns candidate→confirmed |
+ * rejected. 'exported' is terminal (set only by Phase C export integration) —
+ * any transition FROM it is rejected (409). Same-status (idempotent) is allowed.
+ */
+export function validateTripTransition(
+  current: BusinessTripStatus,
+  next: BusinessTripStatus,
+): ValidationResult {
+  if (current === "exported") {
+    return { ok: false, error: "Trip is exported and cannot be changed." };
+  }
+  if (next !== "confirmed" && next !== "rejected") {
+    return { ok: false, error: "status must be 'confirmed' or 'rejected'." };
+  }
+  return { ok: true };
+}

--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -11,6 +11,14 @@ import { assignMembershipForReceipt } from "@/lib/receipts/membership";
 import { deleteAmexArtifact } from "@/lib/receipts/storage";
 import { PENDING_EXTRACTION_STATES } from "@/lib/receipts/types";
 import type { ReceiptAttendeeDirectoryEntry } from "@/lib/receipts/attendee-directory";
+import {
+  computeTripStatusLineUpdates,
+  findOverlappingTrip,
+  decideWiden,
+  validateTripTransition,
+  type ExistingTrip,
+  type TripTransition,
+} from "@/lib/receipts/business-trips";
 import type {
   AmexMatchStatus,
   AmexReceiptStatus,
@@ -19,6 +27,7 @@ import type {
   AmexStatementArtifact,
   BusinessTripReport,
   BusinessTripCandidate,
+  BusinessTripStatus,
   CreateAmexArtifactInput,
   CreateAttendeeInput,
   CreateReceiptInput,
@@ -1587,72 +1596,87 @@ export async function getMissingStatementAlerts(
 export async function createBusinessTripReports(
   candidates: BusinessTripCandidate[],
   actor: string,
-): Promise<string[]> {
-  if (candidates.length === 0) return [];
+): Promise<{
+  created: number;
+  linked: number;
+  widened: number;
+  widenedSkipped: number;
+}> {
+  if (candidates.length === 0) {
+    return { created: 0, linked: 0, widened: 0, widenedSkipped: 0 };
+  }
   const db = getReceiptsDb();
   const now = nowIso();
-  const ids: string[] = [];
+  let created = 0;
+  let linked = 0;
+  let widened = 0;
+  let widenedSkipped = 0;
 
   for (const candidate of candidates) {
-    const tripId = newUuid();
+    // ADR 0010 D1 dedupe: link to an existing same-cardholder overlapping trip
+    // instead of minting a fresh UUID each run (the re-import duplicate defect).
+    const existing = await db
+      .prepare(
+        `SELECT id, cardholder_name, start_date, end_date, status
+         FROM business_trip_reports
+         WHERE cardholder_name = ? AND status IN ('candidate','confirmed')`,
+      )
+      .bind(candidate.cardholderName)
+      .all<ExistingTrip>();
+    const match = findOverlappingTrip(candidate, existing.results ?? []);
 
-    // One D1 batch per candidate: trip INSERT + chunked line-links INSERTs +
-    // chunked line UPDATEs. D1's 100-bind-variable per-statement limit means
-    // we can't put all line links in one statement (4 params each = 25 lines
-    // max), so we chunk both the inserts (20 lines × 4 = 80 binds) and the
-    // updates (2 + 20 ids = 22 binds).
-    const TRIP_CHUNK = 20;
-    const stmts = [
-      db
-        .prepare(
-          `INSERT INTO business_trip_reports
-            (id, cardholder_name, start_date, end_date, primary_location,
-             status, created_at, updated_at)
-           VALUES (?, ?, ?, ?, ?, 'candidate', ?, ?)`,
-        )
-        .bind(
-          tripId,
-          candidate.cardholderName,
-          candidate.startDate,
-          candidate.endDate,
-          candidate.primaryLocation,
-          now,
-          now,
-        ),
-    ];
-
-    for (let j = 0; j < candidate.lineIds.length; j += TRIP_CHUNK) {
-      const chunkIds = candidate.lineIds.slice(j, j + TRIP_CHUNK);
-      const linkPlaceholders = chunkIds.map(() => "(?, ?, ?, ?)").join(",");
-      const linkBinds = chunkIds.flatMap((lineId) => [
-        newUuid(),
-        tripId,
-        lineId,
-        now,
-      ]);
-      stmts.push(
-        db
-          .prepare(
-            `INSERT OR IGNORE INTO business_trip_report_lines
-              (id, business_trip_report_id, amex_statement_line_id, created_at)
-             VALUES ${linkPlaceholders}`,
-          )
-          .bind(...linkBinds),
-      );
-
-      const idPlaceholders = chunkIds.map(() => "?").join(",");
-      stmts.push(
-        db
-          .prepare(
-            `UPDATE amex_statement_lines
-             SET business_trip_id = ?, business_trip_status = 'candidate', updated_at = ?
-             WHERE id IN (${idPlaceholders})`,
-          )
-          .bind(tripId, now, ...chunkIds),
-      );
+    if (match) {
+      const stmts = buildTripLineLinkStmts(db, match.id, candidate.lineIds, now);
+      const widen = decideWiden(match, candidate);
+      if (widen.kind === "widen") {
+        stmts.push(
+          db
+            .prepare(
+              `UPDATE business_trip_reports
+               SET start_date = ?, end_date = ?, updated_at = ?
+               WHERE id = ?`,
+            )
+            .bind(widen.range.start, widen.range.end, now, match.id),
+        );
+      }
+      await batchWrite(db, stmts);
+      await createAuditEntry(db, {
+        actor,
+        action: "business_trip.members_changed",
+        objectType: "business_trip",
+        objectId: match.id,
+        newValueJson: stringifyJson({
+          source: "detection_dedupe",
+          lineIds: candidate.lineIds,
+          range: widen.kind,
+        }),
+      });
+      linked += 1;
+      if (widen.kind === "widen") widened += 1;
+      else if (widen.kind === "skip") widenedSkipped += 1;
+      continue;
     }
 
-    await db.batch(stmts);
+    // No overlap → create a new candidate trip (detection suggestion).
+    const tripId = newUuid();
+    const insertStmt = db
+      .prepare(
+        `INSERT INTO business_trip_reports
+          (id, cardholder_name, start_date, end_date, primary_location,
+           status, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, 'candidate', ?, ?)`,
+      )
+      .bind(
+        tripId,
+        candidate.cardholderName,
+        candidate.startDate,
+        candidate.endDate,
+        candidate.primaryLocation,
+        now,
+        now,
+      );
+    const linkStmts = buildTripLineLinkStmts(db, tripId, candidate.lineIds, now);
+    await batchWrite(db, [insertStmt, ...linkStmts]);
 
     await createAuditEntry(db, {
       actor,
@@ -1661,11 +1685,65 @@ export async function createBusinessTripReports(
       objectId: tripId,
       newValueJson: stringifyJson(candidate),
     });
-
-    ids.push(tripId);
+    created += 1;
   }
 
-  return ids;
+  return { created, linked, widened, widenedSkipped };
+}
+
+/**
+ * Build the link-table INSERTs + line-status UPDATEs that attach `lineIds` to
+ * a trip. Detection links set line status 'candidate' only for lines not
+ * already 'confirmed'/'excluded' (never clobber an operator decision). Chunked
+ * for D1's per-statement bind ceiling (20 lines × 4 = 80 binds for inserts;
+ * 2 + 20 = 22 for updates).
+ */
+function buildTripLineLinkStmts(
+  db: D1Database,
+  tripId: string,
+  lineIds: string[],
+  now: string,
+): D1PreparedStatement[] {
+  const stmts: D1PreparedStatement[] = [];
+  const CHUNK = 20;
+  for (let j = 0; j < lineIds.length; j += CHUNK) {
+    const chunkIds = lineIds.slice(j, j + CHUNK);
+    const linkPlaceholders = chunkIds.map(() => "(?, ?, ?, ?)").join(",");
+    const linkBinds = chunkIds.flatMap((lineId) => [newUuid(), tripId, lineId, now]);
+    stmts.push(
+      db
+        .prepare(
+          `INSERT OR IGNORE INTO business_trip_report_lines
+            (id, business_trip_report_id, amex_statement_line_id, created_at)
+           VALUES ${linkPlaceholders}`,
+        )
+        .bind(...linkBinds),
+    );
+    const idPlaceholders = chunkIds.map(() => "?").join(",");
+    stmts.push(
+      db
+        .prepare(
+          `UPDATE amex_statement_lines
+           SET business_trip_id = ?, business_trip_status = 'candidate', updated_at = ?
+           WHERE id IN (${idPlaceholders})
+             AND business_trip_status NOT IN ('confirmed','excluded')`,
+        )
+        .bind(tripId, now, ...chunkIds),
+    );
+  }
+  return stmts;
+}
+
+/** Run a list of prepared statements in chunked batches (D1 caps ~30/batch). */
+async function batchWrite(
+  db: D1Database,
+  stmts: D1PreparedStatement[],
+): Promise<void> {
+  const CHUNK = 30;
+  for (let i = 0; i < stmts.length; i += CHUNK) {
+    const slice = stmts.slice(i, i + CHUNK);
+    if (slice.length > 0) await db.batch(slice);
+  }
 }
 
 export async function listBusinessTripReports(
@@ -1726,6 +1804,463 @@ export async function listAmexLinesForBusinessTripReports(
     }
   }
   return out;
+}
+
+// ─── Business trip CRUD + membership (ADR 0010) ──────────────────────────────
+
+export interface BusinessTripWithCounts extends BusinessTripReport {
+  line_count: number;
+  receipt_count: number;
+}
+
+/** All trips with member counts (lines + receipts) via correlated subqueries. */
+export async function listBusinessTripsWithCounts(): Promise<BusinessTripWithCounts[]> {
+  const db = getReceiptsDb();
+  const result = await db
+    .prepare(
+      `SELECT t.*,
+          (SELECT COUNT(*) FROM business_trip_report_lines l
+             WHERE l.business_trip_report_id = t.id) AS line_count,
+          (SELECT COUNT(*) FROM business_trip_report_receipts r
+             WHERE r.business_trip_report_id = t.id) AS receipt_count
+       FROM business_trip_reports t
+       ORDER BY t.start_date DESC, t.created_at DESC`,
+    )
+    .all<BusinessTripWithCounts>();
+  return result.results ?? [];
+}
+
+export interface CreateBusinessTripInput {
+  tripName?: string | null;
+  startDate: string;
+  endDate: string;
+  purpose?: string | null;
+  primaryLocation?: string | null;
+  cardholderName?: string | null;
+}
+
+/**
+ * Operator-created trip (POST /api/receipts/trips). Born `status='confirmed'`
+ * (explicit intent) — detection-created trips stay 'candidate'. cardholder_name
+ * is NOT NULL in the schema (0005); an absent cardholder defaults to
+ * 'OPERATOR' (the import path always supplies a cardholder).
+ */
+export async function createBusinessTrip(
+  input: CreateBusinessTripInput,
+  actor: string,
+): Promise<string> {
+  const db = getReceiptsDb();
+  const id = newUuid();
+  const now = nowIso();
+  const cardholder = input.cardholderName?.trim() || "OPERATOR";
+  await db
+    .prepare(
+      `INSERT INTO business_trip_reports
+        (id, trip_name, cardholder_name, start_date, end_date, primary_location,
+         status, purpose, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, 'confirmed', ?, ?, ?)`,
+    )
+    .bind(
+      id,
+      input.tripName?.trim() || null,
+      cardholder,
+      input.startDate,
+      input.endDate,
+      input.primaryLocation?.trim() || null,
+      input.purpose?.trim() || null,
+      now,
+      now,
+    )
+    .run();
+
+  await createAuditEntry(db, {
+    actor,
+    action: "business_trip.created",
+    objectType: "business_trip",
+    objectId: id,
+    newValueJson: stringifyJson({ ...input, cardholderName: cardholder, status: "confirmed" }),
+  });
+
+  return id;
+}
+
+export interface BusinessTripMemberLine {
+  id: string;
+  transaction_date: string;
+  merchant: string;
+  amount_minor: number;
+  statement_month: string;
+  business_trip_status: string;
+}
+
+export interface BusinessTripMemberReceipt {
+  id: string;
+  transaction_date: string | null;
+  merchant: string | null;
+  amount_minor: number | null;
+  status: string;
+  payment_path: string;
+}
+
+export interface BusinessTripDetail {
+  trip: BusinessTripReport | null;
+  lines: BusinessTripMemberLine[];
+  receipts: BusinessTripMemberReceipt[];
+}
+
+export async function getBusinessTripWithMembers(
+  id: string,
+): Promise<BusinessTripDetail> {
+  const db = getReceiptsDb();
+  const trip = await db
+    .prepare(`SELECT * FROM business_trip_reports WHERE id = ?`)
+    .bind(id)
+    .first<BusinessTripReport>();
+
+  const lines = await db
+    .prepare(
+      `SELECT asl.id, asl.transaction_date, asl.merchant, asl.amount_minor,
+              asl.statement_month, asl.business_trip_status
+       FROM business_trip_report_lines btl
+       JOIN amex_statement_lines asl ON asl.id = btl.amex_statement_line_id
+       WHERE btl.business_trip_report_id = ?
+       ORDER BY asl.transaction_date ASC`,
+    )
+    .bind(id)
+    .all<BusinessTripMemberLine>();
+
+  const receipts = await db
+    .prepare(
+      `SELECT r.id, r.transaction_date, r.merchant, r.amount_minor, r.status, r.payment_path
+       FROM business_trip_report_receipts btr
+       JOIN receipt_records r ON r.id = btr.receipt_id
+       WHERE btr.business_trip_report_id = ?
+       ORDER BY r.transaction_date ASC`,
+    )
+    .bind(id)
+    .all<BusinessTripMemberReceipt>();
+
+  return {
+    trip,
+    lines: lines.results ?? [],
+    receipts: receipts.results ?? [],
+  };
+}
+
+export interface UpdateBusinessTripInput {
+  tripName?: string | null;
+  startDate?: string;
+  endDate?: string;
+  purpose?: string | null;
+  primaryLocation?: string | null;
+  status?: BusinessTripStatus;
+}
+
+/**
+ * Edit trip fields and/or transition status (ADR 0010 D4). Status transitions
+ * are validated here (defense-in-depth; the route validates first for a clean
+ * 409). A confirm/reject transition syncs member lines via the pure
+ * computeTripStatusLineUpdates helper. 'exported' is rejected (409 at route).
+ */
+export async function updateBusinessTrip(
+  id: string,
+  input: UpdateBusinessTripInput,
+  actor: string,
+): Promise<BusinessTripStatus> {
+  const db = getReceiptsDb();
+  const now = nowIso();
+  const before = await db
+    .prepare(`SELECT * FROM business_trip_reports WHERE id = ?`)
+    .bind(id)
+    .first<BusinessTripReport>();
+  if (!before) throw new Error(`Business trip ${id} not found.`);
+
+  const sets: string[] = [];
+  const binds: unknown[] = [];
+  if ("tripName" in input) { sets.push("trip_name = ?"); binds.push(input.tripName?.trim() || null); }
+  if ("purpose" in input) { sets.push("purpose = ?"); binds.push(input.purpose?.trim() || null); }
+  if ("primaryLocation" in input) { sets.push("primary_location = ?"); binds.push(input.primaryLocation?.trim() || null); }
+  if (input.startDate !== undefined) { sets.push("start_date = ?"); binds.push(input.startDate); }
+  if (input.endDate !== undefined) { sets.push("end_date = ?"); binds.push(input.endDate); }
+
+  let newStatus: BusinessTripStatus = before.status;
+  if (input.status !== undefined && input.status !== before.status) {
+    const v = validateTripTransition(before.status, input.status);
+    if (!v.ok) throw new Error(v.error ?? "Invalid trip transition.");
+    newStatus = input.status;
+    sets.push("status = ?");
+    binds.push(newStatus);
+  }
+
+  if (sets.length > 0) {
+    sets.push("updated_at = ?");
+    binds.push(now, id);
+    await db
+      .prepare(`UPDATE business_trip_reports SET ${sets.join(", ")} WHERE id = ?`)
+      .bind(...binds)
+      .run();
+
+    const action =
+      newStatus !== before.status && newStatus === "confirmed"
+        ? "business_trip.confirmed"
+        : newStatus !== before.status && newStatus === "rejected"
+          ? "business_trip.rejected"
+          : "business_trip.updated";
+    await createAuditEntry(db, {
+      actor,
+      action,
+      objectType: "business_trip",
+      objectId: id,
+      oldValueJson: stringifyJson({ status: before.status }),
+      newValueJson: stringifyJson(input),
+    });
+  }
+
+  // Status sync (ADR D4): apply member-line updates on a real transition.
+  if (
+    newStatus !== before.status &&
+    (newStatus === "confirmed" || newStatus === "rejected")
+  ) {
+    const memberLineIds = await getMemberLineIds(db, id);
+    const updates = computeTripStatusLineUpdates(
+      id,
+      memberLineIds,
+      newStatus as TripTransition,
+    );
+    await applyLineStatusUpdates(db, updates, now);
+  }
+
+  return newStatus;
+}
+
+async function getMemberLineIds(db: D1Database, tripId: string): Promise<string[]> {
+  const result = await db
+    .prepare(
+      `SELECT amex_statement_line_id AS id
+       FROM business_trip_report_lines
+       WHERE business_trip_report_id = ?`,
+    )
+    .bind(tripId)
+    .all<{ id: string }>();
+  return (result.results ?? []).map((r) => r.id);
+}
+
+async function applyLineStatusUpdates(
+  db: D1Database,
+  updates: Array<{
+    lineId: string;
+    businessTripId: string | null;
+    businessTripStatus: string;
+  }>,
+  now: string,
+): Promise<void> {
+  // Two bulk UPDATEs split by target status: confirmed keeps business_trip_id
+  // (already = tripId from attach); rejected clears it. Chunked for D1's bind
+  // ceiling.
+  const confirmedIds = updates
+    .filter((u) => u.businessTripStatus === "confirmed")
+    .map((u) => u.lineId);
+  const excludedIds = updates
+    .filter((u) => u.businessTripStatus === "excluded")
+    .map((u) => u.lineId);
+  const stmts: D1PreparedStatement[] = [];
+  for (let i = 0; i < confirmedIds.length; i += D1_ID_CHUNK_SIZE) {
+    const chunk = confirmedIds.slice(i, i + D1_ID_CHUNK_SIZE);
+    const ph = chunk.map(() => "?").join(",");
+    stmts.push(
+      db
+        .prepare(
+          `UPDATE amex_statement_lines SET business_trip_status = 'confirmed', updated_at = ?
+           WHERE id IN (${ph})`,
+        )
+        .bind(now, ...chunk),
+    );
+  }
+  for (let i = 0; i < excludedIds.length; i += D1_ID_CHUNK_SIZE) {
+    const chunk = excludedIds.slice(i, i + D1_ID_CHUNK_SIZE);
+    const ph = chunk.map(() => "?").join(",");
+    stmts.push(
+      db
+        .prepare(
+          `UPDATE amex_statement_lines
+           SET business_trip_id = NULL, business_trip_status = 'excluded', updated_at = ?
+           WHERE id IN (${ph})`,
+        )
+        .bind(now, ...chunk),
+    );
+  }
+  await batchWrite(db, stmts);
+}
+
+export interface TripMemberIds {
+  lineIds?: string[];
+  receiptIds?: string[];
+}
+
+/**
+ * Lines in `lineIds` currently claimed by a DIFFERENT trip — the attach route
+ * refuses these with a 409 (operator detaches at the owning trip first; no
+ * silent moves). Returns [] when all are free or already on this trip.
+ */
+export async function findCrossTripLineConflicts(
+  tripId: string,
+  lineIds: string[],
+): Promise<Array<{ lineId: string; businessTripId: string }>> {
+  if (lineIds.length === 0) return [];
+  const db = getReceiptsDb();
+  const conflicts: Array<{ lineId: string; businessTripId: string }> = [];
+  for (let i = 0; i < lineIds.length; i += D1_ID_CHUNK_SIZE) {
+    const chunk = lineIds.slice(i, i + D1_ID_CHUNK_SIZE);
+    const ph = chunk.map(() => "?").join(",");
+    const result = await db
+      .prepare(
+        `SELECT id, business_trip_id
+         FROM amex_statement_lines
+         WHERE id IN (${ph}) AND business_trip_id IS NOT NULL AND business_trip_id != ?`,
+      )
+      .bind(...chunk, tripId)
+      .all<{ id: string; business_trip_id: string }>();
+    for (const row of result.results ?? []) {
+      conflicts.push({ lineId: row.id, businessTripId: row.business_trip_id });
+    }
+  }
+  return conflicts;
+}
+
+/**
+ * Attach lines + receipts to a trip. Lines get business_trip_id + status
+ * ('confirmed' if the trip is confirmed, else 'candidate') and a link-table
+ * row. Receipts get a link-table row ONLY — receipt rows are never written
+ * (ADR D2; sealed receipts are legal members by construction). Cross-trip line
+ * conflicts must be checked by the caller (findCrossTripLineConflicts) first.
+ */
+export async function attachTripMembers(
+  tripId: string,
+  members: TripMemberIds,
+  actor: string,
+): Promise<{ lines: number; receipts: number }> {
+  const db = getReceiptsDb();
+  const now = nowIso();
+  const lineIds = (members.lineIds ?? []).filter(Boolean);
+  const receiptIds = (members.receiptIds ?? []).filter(Boolean);
+
+  const trip = await db
+    .prepare(`SELECT status FROM business_trip_reports WHERE id = ?`)
+    .bind(tripId)
+    .first<{ status: BusinessTripStatus }>();
+  if (!trip) throw new Error(`Business trip ${tripId} not found.`);
+  const lineStatus = trip.status === "confirmed" ? "confirmed" : "candidate";
+
+  const stmts: D1PreparedStatement[] = [];
+  for (let i = 0; i < lineIds.length; i += 20) {
+    const chunk = lineIds.slice(i, i + 20);
+    const linkPh = chunk.map(() => "(?, ?, ?, ?)").join(",");
+    const linkBinds = chunk.flatMap((lid) => [newUuid(), tripId, lid, now]);
+    stmts.push(
+      db
+        .prepare(
+          `INSERT OR IGNORE INTO business_trip_report_lines
+            (id, business_trip_report_id, amex_statement_line_id, created_at)
+           VALUES ${linkPh}`,
+        )
+        .bind(...linkBinds),
+    );
+    const idPh = chunk.map(() => "?").join(",");
+    stmts.push(
+      db
+        .prepare(
+          `UPDATE amex_statement_lines
+           SET business_trip_id = ?, business_trip_status = ?, updated_at = ?
+           WHERE id IN (${idPh})`,
+        )
+        .bind(tripId, lineStatus, now, ...chunk),
+    );
+  }
+  for (let i = 0; i < receiptIds.length; i += 20) {
+    const chunk = receiptIds.slice(i, i + 20);
+    const ph = chunk.map(() => "(?, ?, ?, ?)").join(",");
+    const binds = chunk.flatMap((rid) => [newUuid(), tripId, rid, now]);
+    stmts.push(
+      db
+        .prepare(
+          `INSERT OR IGNORE INTO business_trip_report_receipts
+            (id, business_trip_report_id, receipt_id, created_at)
+           VALUES ${ph}`,
+        )
+        .bind(...binds),
+    );
+  }
+  await batchWrite(db, stmts);
+
+  await createAuditEntry(db, {
+    actor,
+    action: "business_trip.members_changed",
+    objectType: "business_trip",
+    objectId: tripId,
+    newValueJson: stringifyJson({ attach: { lineIds, receiptIds } }),
+  });
+  return { lines: lineIds.length, receipts: receiptIds.length };
+}
+
+/**
+ * Detach lines + receipts from a trip. Lines: business_trip_id = NULL, status
+ * 'excluded', link row deleted (only for lines claimed by this trip). Receipts:
+ * link row deleted. (Receipt rows are never written.)
+ */
+export async function detachTripMembers(
+  tripId: string,
+  members: TripMemberIds,
+  actor: string,
+): Promise<{ lines: number; receipts: number }> {
+  const db = getReceiptsDb();
+  const now = nowIso();
+  const lineIds = (members.lineIds ?? []).filter(Boolean);
+  const receiptIds = (members.receiptIds ?? []).filter(Boolean);
+
+  const stmts: D1PreparedStatement[] = [];
+  for (let i = 0; i < lineIds.length; i += D1_ID_CHUNK_SIZE) {
+    const chunk = lineIds.slice(i, i + D1_ID_CHUNK_SIZE);
+    const ph = chunk.map(() => "?").join(",");
+    stmts.push(
+      db
+        .prepare(
+          `UPDATE amex_statement_lines
+           SET business_trip_id = NULL, business_trip_status = 'excluded', updated_at = ?
+           WHERE id IN (${ph}) AND business_trip_id = ?`,
+        )
+        .bind(now, ...chunk, tripId),
+    );
+    stmts.push(
+      db
+        .prepare(
+          `DELETE FROM business_trip_report_lines
+           WHERE business_trip_report_id = ? AND amex_statement_line_id IN (${ph})`,
+        )
+        .bind(tripId, ...chunk),
+    );
+  }
+  for (let i = 0; i < receiptIds.length; i += D1_ID_CHUNK_SIZE) {
+    const chunk = receiptIds.slice(i, i + D1_ID_CHUNK_SIZE);
+    const ph = chunk.map(() => "?").join(",");
+    stmts.push(
+      db
+        .prepare(
+          `DELETE FROM business_trip_report_receipts
+           WHERE business_trip_report_id = ? AND receipt_id IN (${ph})`,
+        )
+        .bind(tripId, ...chunk),
+    );
+  }
+  await batchWrite(db, stmts);
+
+  await createAuditEntry(db, {
+    actor,
+    action: "business_trip.members_changed",
+    objectType: "business_trip",
+    objectId: tripId,
+    newValueJson: stringifyJson({ detach: { lineIds, receiptIds } }),
+  });
+  return { lines: lineIds.length, receipts: receiptIds.length };
 }
 
 // ─── Expense categories ───────────────────────────────────────────────────────

--- a/lib/receipts/settings.ts
+++ b/lib/receipts/settings.ts
@@ -1,5 +1,6 @@
 import { getReceiptsDb } from "@/lib/cloudflare-runtime";
 import { nowIso } from "@/lib/receipts/db-utils";
+import { DEFAULT_HOMEBASE_SIGNALS } from "@/lib/receipts/validation";
 import type {
   ComplianceSettings,
   InvoiceNumberRequirementMode,
@@ -18,6 +19,9 @@ export const COMPLIANCE_DEFAULTS: ComplianceSettings = {
   statement_expected_day: 18,
   track_tax_breakdown: false,
   notification_recipient: "",
+  // ADR 0010 D3: verbatim former TOKYO_SIGNALS. Behavior unchanged until the
+  // operator edits Settings → Compliance.
+  homebase_signals: DEFAULT_HOMEBASE_SIGNALS,
 };
 
 const INVOICE_MODES: ReadonlySet<InvoiceNumberRequirementMode> = new Set([
@@ -41,6 +45,27 @@ function parseInt10(v: string | undefined, fallback: number): number {
   if (v === undefined) return fallback;
   const n = Number.parseInt(v, 10);
   return Number.isFinite(n) ? n : fallback;
+}
+
+/**
+ * Parse the `homebase_signals` JSON-array string. Falls back to a copy of the
+ * default list on missing/corrupt/non-array values (ADR 0010 D3). Returns a
+ * fresh array so callers/tests can't mutate the shared default.
+ */
+function parseHomebaseSignals(v: string | undefined): string[] {
+  if (v === undefined) return [...COMPLIANCE_DEFAULTS.homebase_signals];
+  try {
+    const parsed: unknown = JSON.parse(v);
+    if (
+      Array.isArray(parsed) &&
+      parsed.every((entry) => typeof entry === "string")
+    ) {
+      return parsed as string[];
+    }
+  } catch {
+    // fall through to default
+  }
+  return [...COMPLIANCE_DEFAULTS.homebase_signals];
 }
 
 export function parseComplianceSettings(
@@ -87,6 +112,7 @@ export function parseComplianceSettings(
     notification_recipient:
       map.get("notification_recipient") ??
       COMPLIANCE_DEFAULTS.notification_recipient,
+    homebase_signals: parseHomebaseSignals(map.get("homebase_signals")),
   };
 }
 
@@ -106,8 +132,17 @@ export async function updateComplianceSettings(
   const now = nowIso();
   const entries = Object.entries(updates).filter(([, v]) => v !== undefined);
   for (const [key, value] of entries) {
+    // Arrays (homebase_signals) serialize as JSON; booleans as true/false;
+    // everything else via String(). The previous `String(value)` would have
+    // stored an array as a comma-joined string, corrupting the round-trip.
     const stringValue =
-      typeof value === "boolean" ? (value ? "true" : "false") : String(value);
+      typeof value === "boolean"
+        ? value
+          ? "true"
+          : "false"
+        : Array.isArray(value)
+          ? JSON.stringify(value)
+          : String(value);
     await db
       .prepare(
         `INSERT INTO receipt_settings (key, value, updated_at, updated_by)

--- a/lib/receipts/types.ts
+++ b/lib/receipts/types.ts
@@ -150,7 +150,14 @@ export type AuditAction =
   | "receipt.export_statement_month_policy_migrated"
   // Attendee directory (migration 0022): a new entry registered from the
   // review UI. Attended identity = directory name; company/title NOT NULL.
-  | "attendee_directory.created";
+  | "attendee_directory.created"
+  // Business trips as first-class entities (ADR 0010). The trip screen owns
+  // the lifecycle; detection only suggests ('candidate').
+  | "business_trip.created"
+  | "business_trip.updated"
+  | "business_trip.confirmed"
+  | "business_trip.rejected"
+  | "business_trip.members_changed";
 
 // ─── Compliance: source / preservation / qualified-invoice ────────────────
 
@@ -499,6 +506,14 @@ export interface ComplianceSettings {
   /** Notification recipient email (Settings → Compliance). Empty = use the
    *  ACCOUNTANT_EMAIL var fallback. */
   notification_recipient: string;
+  /**
+   * Homebase location signals (ADR 0010 D3). A merchant whose string carries
+   * one of these is treated as an at-homebase charge (not a trip anchor).
+   * Default reproduces the former hardcoded TOKYO_SIGNALS list verbatim —
+   * zero behavior change until the operator edits Settings → Compliance.
+   * Stored as a JSON array string under key `homebase_signals`.
+   */
+  homebase_signals: string[];
 }
 
 export interface AmexReconciliation {

--- a/lib/receipts/validation.ts
+++ b/lib/receipts/validation.ts
@@ -177,8 +177,10 @@ function decodeAmexBuffer(buffer: ArrayBuffer): { text: string; encoding: string
   }
 }
 
-// Known outside-Tokyo location signals
-const OUTSIDE_TOKYO_SIGNALS = [
+// Known outside-homebase region signals (ADR 0010 D3: renamed from
+// OUTSIDE_TOKYO_SIGNALS; contents unchanged). A merchant carrying one of these
+// AND no homebase signal is a trip ANCHOR.
+const REGION_SIGNALS = [
   "神奈川", "横浜", "大阪", "京都", "福岡", "札幌", "名古屋", "仙台", "広島",
   "埼玉", "千葉", "兵庫", "神戸", "奈良", "滋賀", "岡山", "北海道", "静岡",
   "愛知", "栃木", "群馬", "茨城", "宮城", "新潟", "富山", "金沢", "石川",
@@ -186,22 +188,35 @@ const OUTSIDE_TOKYO_SIGNALS = [
   "Sendai", "Fukuoka", "KANAGAWA", "OSAKA", "KYOTO", "HIROSHIMA",
 ];
 
-// Tokyo signals — presence means NOT outside Tokyo
-const TOKYO_SIGNALS = [
+// Default homebase signals — verbatim the former hardcoded TOKYO_SIGNALS list
+// (ADR 0010 D3). Presence in a merchant means the charge is at homebase (NOT a
+// trip anchor). Exported so ComplianceSettings can default to it and detection
+// tests can reproduce today's behavior; the operator can override it in
+// Settings → Compliance (stored under key `homebase_signals`).
+export const DEFAULT_HOMEBASE_SIGNALS = [
   "東京都", "東京", "新宿", "渋谷", "中野", "東中野", "港区", "東京オペラシティ",
   "Tokyo", "TOKYO",
 ];
 
-export function isOutsideTokyo(merchantName: string): boolean {
-  // If it contains a Tokyo signal, it's in Tokyo
-  for (const sig of TOKYO_SIGNALS) {
-    if (merchantName.includes(sig)) return false;
-  }
-  // If it contains an outside-Tokyo signal, it's outside Tokyo
-  for (const sig of OUTSIDE_TOKYO_SIGNALS) {
-    if (merchantName.includes(sig)) return true;
-  }
-  return false;
+/** Does `merchant` carry a homebase signal (i.e. is it an at-homebase charge)? */
+export function hasHomebaseSignal(
+  merchant: string,
+  homebaseSignals: string[],
+): boolean {
+  return homebaseSignals.some((sig) => merchant.includes(sig));
+}
+
+/**
+ * Is `merchant` outside the homebase (a trip anchor)? True only when it carries
+ * a region signal AND no homebase signal. ADR 0010 D3 renamed this from
+ * isOutsideTokyo; `homebaseSignals` replaces the hardcoded TOKYO_SIGNALS list.
+ */
+export function isOutsideHomebase(
+  merchant: string,
+  homebaseSignals: string[],
+): boolean {
+  if (hasHomebaseSignal(merchant, homebaseSignals)) return false;
+  return REGION_SIGNALS.some((sig) => merchant.includes(sig));
 }
 
 export function parseAmexNetanswer(
@@ -416,61 +431,105 @@ export function netanswerLinesToImportInputs(
   }));
 }
 
-// ─── Business trip candidate detection ────────────────────────────────────
+// ─── Business trip candidate detection (ADR 0010 D3) ───────────────────────
 
 import type { BusinessTripCandidate } from "@/lib/receipts/types";
+import { isBusinessTripEligible } from "@/lib/receipts/categories";
 
 interface TripableAmexLine {
   id: string;
   cardholderName: string | null;
   transactionDate: string;
   merchant: string;
+  /**
+   * Resolved expense category code for the category-boost rule (ADR 0010 D3).
+   * Optional so legacy callers/fixtures without a category still work — an
+   * absent/null category is simply never boost-eligible (today's behavior).
+   */
+  expenseCategoryCode?: string | null;
 }
 
+/**
+ * Detect business-trip candidate clusters from a set of AMEX lines.
+ *
+ * ANCHORS: lines with a location signal outside homebase (as before).
+ * BOOST: lines whose expense category is trip-eligible AND whose merchant
+ * carries no homebase signal (e.g. Ekinet / airline / hotel-chain charges
+ * that bill without a region string) join a cluster when within `windowDays`
+ * of a member line. A cluster ships as a candidate only if it contains ≥1
+ * anchor AND ≥2 lines total — boost lines never form a cluster alone.
+ *
+ * `homebaseSignals` replaces the former hardcoded TOKYO_SIGNALS list; default
+ * `DEFAULT_HOMEBASE_SIGNALS` reproduces today's behavior exactly on lines with
+ * no category code (the boost set is empty, so only anchors cluster, as today).
+ */
 export function detectBusinessTripCandidates(
   lines: TripableAmexLine[],
+  homebaseSignals: string[] = DEFAULT_HOMEBASE_SIGNALS,
   windowDays = 7,
 ): BusinessTripCandidate[] {
-  // Only consider lines that are outside Tokyo
-  const outsideLines = lines.filter(
-    (l) => l.cardholderName && isOutsideTokyo(l.merchant),
-  );
-
-  if (outsideLines.length < 2) return [];
-
-  // Group by cardholder
-  const byCardholder = new Map<string, typeof outsideLines>();
-  for (const line of outsideLines) {
-    const ch = line.cardholderName!;
-    if (!byCardholder.has(ch)) byCardholder.set(ch, []);
-    byCardholder.get(ch)!.push(line);
+  // Partition into anchors and boost-eligible lines (both require a cardholder).
+  type L = (typeof lines)[number];
+  const anchors: L[] = [];
+  const boosts: L[] = [];
+  for (const line of lines) {
+    if (!line.cardholderName) continue;
+    if (isOutsideHomebase(line.merchant, homebaseSignals)) {
+      anchors.push(line);
+    } else if (
+      isBusinessTripEligible(line.expenseCategoryCode) &&
+      !hasHomebaseSignal(line.merchant, homebaseSignals)
+    ) {
+      boosts.push(line);
+    }
   }
+
+  // Need at least one anchor anywhere to form any candidate.
+  if (anchors.length === 0) return [];
+
+  // Group anchors + boost lines by cardholder.
+  const byCardholder = new Map<string, L[]>();
+  const push = (ch: string, line: L) => {
+    const arr = byCardholder.get(ch);
+    if (arr) arr.push(line);
+    else byCardholder.set(ch, [line]);
+  };
+  for (const line of anchors) push(line.cardholderName!, line);
+  for (const line of boosts) push(line.cardholderName!, line);
 
   const candidates: BusinessTripCandidate[] = [];
 
   for (const [cardholder, chLines] of byCardholder) {
-    // Sort by date
+    // A cardholder with only boost lines (no anchor) can't form a candidate.
+    if (!chLines.some((l) => isOutsideHomebase(l.merchant, homebaseSignals))) {
+      continue;
+    }
     const sorted = [...chLines].sort((a, b) =>
       a.transactionDate.localeCompare(b.transactionDate),
     );
 
-    // Cluster: group lines where adjacent dates are within windowDays
+    // Cluster: group lines where adjacent dates are within windowDays.
     let cluster: typeof sorted = [sorted[0]!];
+    const flush = () => {
+      // ≥2 lines AND ≥1 anchor (boost-never-alone).
+      const hasAnchor = cluster.some((l) =>
+        isOutsideHomebase(l.merchant, homebaseSignals),
+      );
+      if (cluster.length >= 2 && hasAnchor) {
+        candidates.push(buildCandidate(cardholder, cluster));
+      }
+    };
     for (let i = 1; i < sorted.length; i++) {
       const prev = cluster[cluster.length - 1]!;
       const dayDiff = dateDiffDays(prev.transactionDate, sorted[i]!.transactionDate);
       if (dayDiff <= windowDays) {
         cluster.push(sorted[i]!);
       } else {
-        if (cluster.length >= 2) {
-          candidates.push(buildCandidate(cardholder, cluster));
-        }
+        flush();
         cluster = [sorted[i]!];
       }
     }
-    if (cluster.length >= 2) {
-      candidates.push(buildCandidate(cardholder, cluster));
-    }
+    flush();
   }
 
   return candidates;
@@ -486,8 +545,12 @@ function buildCandidate(
   cluster: Array<{ id: string; transactionDate: string; merchant: string }>,
 ): BusinessTripCandidate {
   const dates = cluster.map((l) => l.transactionDate).sort();
-  // Extract location signal from first outside-Tokyo merchant
-  const locationSignal = extractLocationSignal(cluster[0]!.merchant);
+  // Extract a location signal from the first anchor merchant in the cluster
+  // (the cluster is guaranteed ≥1 anchor by the caller).
+  const anchorMerchant =
+    cluster.find((l) => REGION_SIGNALS.some((sig) => l.merchant.includes(sig)))?.merchant ??
+    cluster[0]!.merchant;
+  const locationSignal = extractLocationSignal(anchorMerchant);
   return {
     cardholderName,
     startDate: dates[0]!,
@@ -498,7 +561,7 @@ function buildCandidate(
 }
 
 function extractLocationSignal(merchant: string): string {
-  for (const sig of OUTSIDE_TOKYO_SIGNALS) {
+  for (const sig of REGION_SIGNALS) {
     if (merchant.includes(sig)) return sig;
   }
   return merchant.slice(0, 20);

--- a/tests/receipts/amex-parser.test.ts
+++ b/tests/receipts/amex-parser.test.ts
@@ -3,8 +3,9 @@ import assert from "node:assert/strict";
 import {
   parseAmexNetanswer,
   netanswerLinesToImportInputs,
-  isOutsideTokyo,
+  isOutsideHomebase,
   detectBusinessTripCandidates,
+  DEFAULT_HOMEBASE_SIGNALS,
 } from "@/lib/receipts/validation";
 
 // ─── Helper: build ArrayBuffer from a UTF-8 string ────────────────────────────
@@ -170,25 +171,31 @@ test("netanswerLinesToImportInputs: maps all fields correctly", () => {
   assert.equal(inputs[0]!.rawCsvLineNumber, lines[0]!.lineNumber);
 });
 
-// ─── isOutsideTokyo ────────────────────────────────────────────────────────────
+// ─── isOutsideHomebase (default signals reproduce former isOutsideTokyo) ────────
 
-test("isOutsideTokyo: Tokyo merchants return false", () => {
-  assert.equal(isOutsideTokyo("HUB 東京オペラシティ店"), false);
-  assert.equal(isOutsideTokyo("スターバックス 渋谷店"), false);
-  assert.equal(isOutsideTokyo("新宿レストラン"), false);
-  assert.equal(isOutsideTokyo("東京駅近くの店"), false);
+test("isOutsideHomebase: homebase (Tokyo) merchants return false", () => {
+  assert.equal(isOutsideHomebase("HUB 東京オペラシティ店", DEFAULT_HOMEBASE_SIGNALS), false);
+  assert.equal(isOutsideHomebase("スターバックス 渋谷店", DEFAULT_HOMEBASE_SIGNALS), false);
+  assert.equal(isOutsideHomebase("新宿レストラン", DEFAULT_HOMEBASE_SIGNALS), false);
+  assert.equal(isOutsideHomebase("東京駅近くの店", DEFAULT_HOMEBASE_SIGNALS), false);
 });
 
-test("isOutsideTokyo: outside-Tokyo merchants return true", () => {
-  assert.equal(isOutsideTokyo("ピーシーデポ バリューパック -神奈川県 横浜市"), true);
-  assert.equal(isOutsideTokyo("JTB KANAGAWANISHI"), true);
-  assert.equal(isOutsideTokyo("大阪駅前ホテル"), true);
-  assert.equal(isOutsideTokyo("京都レストラン"), true);
+test("isOutsideHomebase: outside-homebase merchants return true", () => {
+  assert.equal(isOutsideHomebase("ピーシーデポ バリューパック -神奈川県 横浜市", DEFAULT_HOMEBASE_SIGNALS), true);
+  assert.equal(isOutsideHomebase("JTB KANAGAWANISHI", DEFAULT_HOMEBASE_SIGNALS), true);
+  assert.equal(isOutsideHomebase("大阪駅前ホテル", DEFAULT_HOMEBASE_SIGNALS), true);
+  assert.equal(isOutsideHomebase("京都レストラン", DEFAULT_HOMEBASE_SIGNALS), true);
 });
 
-test("isOutsideTokyo: generic merchants return false", () => {
-  assert.equal(isOutsideTokyo("コンビニ"), false);
-  assert.equal(isOutsideTokyo("Amazon.com"), false);
+test("isOutsideHomebase: generic merchants return false", () => {
+  assert.equal(isOutsideHomebase("コンビニ", DEFAULT_HOMEBASE_SIGNALS), false);
+  assert.equal(isOutsideHomebase("Amazon.com", DEFAULT_HOMEBASE_SIGNALS), false);
+});
+
+test("isOutsideHomebase: homebase is configurable (Osaka as homebase → Osaka merchant no longer anchors)", () => {
+  // ADR 0010 D3: homebase is a setting, not a hardcoded city.
+  assert.equal(isOutsideHomebase("大阪駅前ホテル", [...DEFAULT_HOMEBASE_SIGNALS, "大阪"]), false);
+  assert.equal(isOutsideHomebase("京都レストラン", [...DEFAULT_HOMEBASE_SIGNALS, "大阪"]), true);
 });
 
 // ─── detectBusinessTripCandidates ─────────────────────────────────────────────
@@ -202,7 +209,7 @@ test("detectBusinessTripCandidates: single outside-Tokyo line does not create ca
       merchant: "ピーシーデポ バリューパック -神奈川県 横浜市",
     },
   ];
-  const candidates = detectBusinessTripCandidates(lines);
+  const candidates = detectBusinessTripCandidates(lines, DEFAULT_HOMEBASE_SIGNALS);
   assert.equal(candidates.length, 0);
 });
 
@@ -221,7 +228,7 @@ test("detectBusinessTripCandidates: two outside-Tokyo lines within window create
       merchant: "JTB KANAGAWANISHI",
     },
   ];
-  const candidates = detectBusinessTripCandidates(lines);
+  const candidates = detectBusinessTripCandidates(lines, DEFAULT_HOMEBASE_SIGNALS);
   assert.equal(candidates.length, 1);
   assert.equal(candidates[0]!.cardholderName, "David");
   assert.equal(candidates[0]!.startDate, "2026-03-10");
@@ -256,7 +263,7 @@ test("detectBusinessTripCandidates: lines beyond window are separate candidates"
       merchant: "札幌ホテル",
     },
   ];
-  const candidates = detectBusinessTripCandidates(lines);
+  const candidates = detectBusinessTripCandidates(lines, DEFAULT_HOMEBASE_SIGNALS);
   assert.equal(candidates.length, 2);
 });
 
@@ -287,7 +294,7 @@ test("detectBusinessTripCandidates: different cardholders are separate candidate
       merchant: "京都レストラン",
     },
   ];
-  const candidates = detectBusinessTripCandidates(lines);
+  const candidates = detectBusinessTripCandidates(lines, DEFAULT_HOMEBASE_SIGNALS);
   assert.equal(candidates.length, 2);
   const cardholders = candidates.map((c) => c.cardholderName).sort();
   assert.deepEqual(cardholders, ["Alice", "Bob"]);
@@ -308,7 +315,7 @@ test("detectBusinessTripCandidates: Tokyo-only lines do not generate candidates"
       merchant: "新宿レストラン",
     },
   ];
-  const candidates = detectBusinessTripCandidates(lines);
+  const candidates = detectBusinessTripCandidates(lines, DEFAULT_HOMEBASE_SIGNALS);
   assert.equal(candidates.length, 0);
 });
 

--- a/tests/receipts/business-trips.test.ts
+++ b/tests/receipts/business-trips.test.ts
@@ -1,0 +1,187 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  detectBusinessTripCandidates,
+  DEFAULT_HOMEBASE_SIGNALS,
+} from "@/lib/receipts/validation";
+import {
+  rangesOverlap,
+  unionRange,
+  findOverlappingTrip,
+  decideWiden,
+  computeTripStatusLineUpdates,
+  validateTripDates,
+  validateTripTransition,
+  type ExistingTrip,
+} from "@/lib/receipts/business-trips";
+
+const H = DEFAULT_HOMEBASE_SIGNALS;
+
+interface TLine {
+  id: string;
+  cardholderName: string;
+  transactionDate: string;
+  merchant: string;
+  expenseCategoryCode: string | null;
+}
+function line(over: Partial<TLine> & { id: string }): TLine {
+  return {
+    cardholderName: "David",
+    transactionDate: "2026-03-10",
+    merchant: "",
+    expenseCategoryCode: null,
+    ...over,
+  };
+}
+
+// ─── Detection: homebase-config parity + category boost (ADR 0010 D3) ────────
+
+test("detection parity: default signals, no category codes → anchors only (today's behavior)", () => {
+  const candidates = detectBusinessTripCandidates(
+    [
+      line({ id: "a", merchant: "大阪ホテル", transactionDate: "2026-03-10" }),
+      line({ id: "b", merchant: "京都レストラン", transactionDate: "2026-03-11" }),
+    ],
+    H,
+  );
+  assert.equal(candidates.length, 1);
+  assert.deepEqual(candidates[0]!.lineIds.sort(), ["a", "b"]);
+});
+
+test("detection boost: eligible-category line with no region string joins an anchor within window", () => {
+  // Ekinet-style: travel-eligible category, no location signal, within 7d of an anchor.
+  const candidates = detectBusinessTripCandidates(
+    [
+      line({ id: "anchor", merchant: "大阪ホテル", transactionDate: "2026-03-10" }),
+      line({ id: "ekinet", merchant: "Ekinet チケット", transactionDate: "2026-03-13", expenseCategoryCode: "travel_transportation" }),
+    ],
+    H,
+  );
+  assert.equal(candidates.length, 1);
+  assert.deepEqual(candidates[0]!.lineIds.sort(), ["anchor", "ekinet"]);
+});
+
+test("detection boost: eligible lines with NO anchor form no candidate (boost never alone)", () => {
+  const candidates = detectBusinessTripCandidates(
+    [
+      line({ id: "e1", merchant: "Ekinet", transactionDate: "2026-03-10", expenseCategoryCode: "travel_transportation" }),
+      line({ id: "e2", merchant: "JR East", transactionDate: "2026-03-11", expenseCategoryCode: "travel_transportation" }),
+    ],
+    H,
+  );
+  assert.equal(candidates.length, 0);
+});
+
+test("detection boost: eligible-category line AT homebase is neither anchor nor boost", () => {
+  // "東京 Ekinet" carries a homebase signal → not a trip line. Only the anchor
+  // remains → 1 line → no candidate.
+  const candidates = detectBusinessTripCandidates(
+    [
+      line({ id: "anchor", merchant: "大阪ホテル", transactionDate: "2026-03-10" }),
+      line({ id: "home", merchant: "東京 Ekinet", transactionDate: "2026-03-11", expenseCategoryCode: "travel_transportation" }),
+    ],
+    H,
+  );
+  assert.equal(candidates.length, 0);
+});
+
+test("detection window edges: boost at 7d joins, at 8d does not", () => {
+  const within = detectBusinessTripCandidates(
+    [
+      line({ id: "a", merchant: "大阪ホテル", transactionDate: "2026-03-10" }),
+      line({ id: "b", merchant: "Ekinet", transactionDate: "2026-03-17", expenseCategoryCode: "travel_transportation" }),
+    ],
+    H,
+  );
+  assert.equal(within.length, 1);
+
+  const beyond = detectBusinessTripCandidates(
+    [
+      line({ id: "a", merchant: "大阪ホテル", transactionDate: "2026-03-10" }),
+      line({ id: "b", merchant: "Ekinet", transactionDate: "2026-03-18", expenseCategoryCode: "travel_transportation" }),
+    ],
+    H,
+  );
+  assert.equal(beyond.length, 0); // anchor alone < 2 lines
+});
+
+// ─── Dedupe overlap helper ───────────────────────────────────────────────────
+
+test("rangesOverlap: inclusive, shared boundary counts as overlap", () => {
+  assert.equal(rangesOverlap({ start: "2026-03-01", end: "2026-03-10" }, { start: "2026-03-05", end: "2026-03-15" }), true);
+  assert.equal(rangesOverlap({ start: "2026-03-01", end: "2026-03-10" }, { start: "2026-03-11", end: "2026-03-20" }), false);
+  assert.equal(rangesOverlap({ start: "2026-03-01", end: "2026-03-10" }, { start: "2026-03-10", end: "2026-03-20" }), true);
+});
+
+test("unionRange: min start, max end", () => {
+  assert.deepEqual(
+    unionRange({ start: "2026-03-05", end: "2026-03-12" }, { start: "2026-03-01", end: "2026-03-10" }),
+    { start: "2026-03-01", end: "2026-03-12" },
+  );
+});
+
+test("findOverlappingTrip: same cardholder + overlap + candidate|confirmed; ignores others", () => {
+  const existing: ExistingTrip[] = [
+    { id: "t1", cardholder_name: "David", start_date: "2026-03-01", end_date: "2026-03-10", status: "candidate" },
+    { id: "t3", cardholder_name: "Alice", start_date: "2026-03-05", end_date: "2026-03-09", status: "candidate" }, // other cardholder
+    { id: "t4", cardholder_name: "David", start_date: "2026-03-05", end_date: "2026-03-09", status: "rejected" }, // rejected
+    { id: "t5", cardholder_name: "David", start_date: "2026-03-05", end_date: "2026-03-09", status: "exported" }, // exported
+  ];
+  const m = findOverlappingTrip({ cardholderName: "David", startDate: "2026-03-05", endDate: "2026-03-07" }, existing);
+  assert.equal(m?.id, "t1");
+  assert.equal(
+    findOverlappingTrip({ cardholderName: "David", startDate: "2026-05-01", endDate: "2026-05-02" }, existing),
+    null,
+  );
+});
+
+test("decideWiden: widen candidate only; skip confirmed; none when contained", () => {
+  const cand = { startDate: "2026-03-05", endDate: "2026-03-12" };
+  assert.deepEqual(
+    decideWiden({ id: "t", cardholder_name: "D", start_date: "2026-03-01", end_date: "2026-03-10", status: "candidate" }, cand),
+    { kind: "widen", range: { start: "2026-03-01", end: "2026-03-12" } },
+  );
+  assert.deepEqual(
+    decideWiden({ id: "t", cardholder_name: "D", start_date: "2026-03-01", end_date: "2026-03-10", status: "confirmed" }, cand),
+    { kind: "skip" },
+  );
+  assert.deepEqual(
+    decideWiden({ id: "t", cardholder_name: "D", start_date: "2026-03-01", end_date: "2026-03-20", status: "candidate" }, cand),
+    { kind: "none" },
+  );
+});
+
+// ─── Status sync (ADR 0010 D4) ───────────────────────────────────────────────
+
+test("computeTripStatusLineUpdates: confirm keeps tripId; reject nulls + excluded", () => {
+  assert.deepEqual(
+    computeTripStatusLineUpdates("trip-1", ["l1", "l2"], "confirmed"),
+    [
+      { lineId: "l1", businessTripId: "trip-1", businessTripStatus: "confirmed" },
+      { lineId: "l2", businessTripId: "trip-1", businessTripStatus: "confirmed" },
+    ],
+  );
+  assert.deepEqual(
+    computeTripStatusLineUpdates("trip-1", ["l1", "l2"], "rejected"),
+    [
+      { lineId: "l1", businessTripId: null, businessTripStatus: "excluded" },
+      { lineId: "l2", businessTripId: null, businessTripStatus: "excluded" },
+    ],
+  );
+});
+
+// ─── Trip input / transition validation ──────────────────────────────────────
+
+test("validateTripDates: format + start<=end ordering", () => {
+  assert.equal(validateTripDates("2026-03-01", "2026-03-10").ok, true);
+  assert.equal(validateTripDates("2026-03-10", "2026-03-01").ok, false); // start > end
+  assert.equal(validateTripDates("2026-3-1", "2026-03-10").ok, false); // bad format
+  assert.equal(validateTripDates("", "").ok, false);
+});
+
+test("validateTripTransition: exported rejected; candidate/confirmed transitions allowed; bad value rejected", () => {
+  assert.equal(validateTripTransition("exported", "confirmed").ok, false); // 409 case
+  assert.equal(validateTripTransition("candidate", "confirmed").ok, true);
+  assert.equal(validateTripTransition("confirmed", "rejected").ok, true);
+  assert.equal(validateTripTransition("candidate", "exported").ok, false); // only confirmed/rejected
+});

--- a/tests/receipts/compliance-settings.test.ts
+++ b/tests/receipts/compliance-settings.test.ts
@@ -66,3 +66,29 @@ test("settings: bool parsing accepts true/false/1/0", () => {
   assert.equal(settings.require_attendees_for_entertainment, false);
   assert.equal(settings.export_block_on_warnings, true);
 });
+
+// ─── homebase_signals (ADR 0010 D3) ──────────────────────────────────────────
+
+test("settings: homebase_signals JSON array round-trips", () => {
+  const settings = parseComplianceSettings([
+    { key: "homebase_signals", value: JSON.stringify(["大阪", "京都"]) },
+  ]);
+  assert.deepEqual(settings.homebase_signals, ["大阪", "京都"]);
+});
+
+test("settings: homebase_signals missing → default (former TOKYO_SIGNALS)", () => {
+  const settings = parseComplianceSettings([]);
+  assert.deepEqual(settings.homebase_signals, COMPLIANCE_DEFAULTS.homebase_signals);
+});
+
+test("settings: homebase_signals corrupt/non-array value falls back to default", () => {
+  const notJson = parseComplianceSettings([
+    { key: "homebase_signals", value: "not-json" },
+  ]);
+  assert.deepEqual(notJson.homebase_signals, COMPLIANCE_DEFAULTS.homebase_signals);
+
+  const nonStringArray = parseComplianceSettings([
+    { key: "homebase_signals", value: "[1, 2, 3]" },
+  ]);
+  assert.deepEqual(nonStringArray.homebase_signals, COMPLIANCE_DEFAULTS.homebase_signals);
+});


### PR DESCRIPTION
Backend-only Phase A of ADR 0010 (architect-verified). Trips become operator-managed; import detection demotes to a suggestion that dedupes against overlapping trips.

## Changes
- **Migration 0023** — `business_trip_report_receipts` link table (overlay-only; receipt rows never written → sealed-month receipts can join a trip) + index.
- **Homebase config** — `ComplianceSettings.homebase_signals` (default = former hardcoded Tokyo list, behavior unchanged until edited). `isOutsideTokyo`→`isOutsideHomebase`; settings serializer JSON-stringifies arrays.
- **Detection** — anchor + category-boost clustering (finally uses `default_business_trip_eligible`); ≥1 anchor + ≥2 lines, boost-never-alone.
- **Detection dedupe** — links to an existing same-cardholder overlapping candidate/confirmed trip instead of minting duplicates on re-import (the latent defect — `realLines` re-runs the full month on re-import). Widens the range only for `candidate` trips; `confirmed` trips report `widened_skipped`.
- **Trip CRUD + membership APIs** (`requireReceiptsActor` + audit): list w/ counts, create (born `confirmed`), detail w/ members, PATCH fields/status (`exported`→409), attach/detach lines+receipts (cross-trip line→409). Status transitions sync member lines via a pure tested helper.

## Scope
No UI (trips screen + settings field = Phase B); finalize gate and export CSV untouched (Phase C). Migration 0023 already applied to live D1 during verification.

## Verification
- `npm test` → 492 pass / 0 fail (new `business-trips.test.ts`; detection/homebase/settings tests).
- `npm run build:cf` → OpenNext build complete.
- Migration 0023 applied to live D1; table + index confirmed.
- Live SQL-contract throwaway validated CREATE / ATTACH / UNIQUE / CONFIRM-REJECT / DETACH / ON-DELETE-CASCADE; cleaned up.
- `cf:dev` boots clean. Live API e2e is Clerk-gated (exercised SQL contracts directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)