### PR TITLE
receipts: business trips phase B — UI (ADR 0010)

### DIFF
--- a/app/(receipt-system)/receipts/trips/[id]/page.tsx
+++ b/app/(receipt-system)/receipts/trips/[id]/page.tsx
@@ -1,0 +1,25 @@
+import { notFound } from "next/navigation";
+import { getBusinessTripWithMembers } from "@/lib/receipts/db";
+import { assertReceiptsPageAccess } from "@/lib/receipts/auth-request";
+import { TripDetailScreen } from "@/components/receipts/trips/trip-detail-screen";
+
+export const dynamic = "force-dynamic";
+
+type PageProps = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function TripDetailPage({ params }: PageProps) {
+  await assertReceiptsPageAccess();
+  const { id } = await params;
+  const detail = await getBusinessTripWithMembers(id);
+  if (!detail.trip) notFound();
+
+  return (
+    <TripDetailScreen
+      trip={detail.trip}
+      lines={detail.lines}
+      receipts={detail.receipts}
+    />
+  );
+}

--- a/app/(receipt-system)/receipts/trips/page.tsx
+++ b/app/(receipt-system)/receipts/trips/page.tsx
@@ -1,0 +1,11 @@
+import { listBusinessTripsWithCounts } from "@/lib/receipts/db";
+import { assertReceiptsPageAccess } from "@/lib/receipts/auth-request";
+import { TripsScreen } from "@/components/receipts/trips/trips-screen";
+
+export const dynamic = "force-dynamic";
+
+export default async function TripsPage() {
+  await assertReceiptsPageAccess();
+  const trips = await listBusinessTripsWithCounts();
+  return <TripsScreen initialTrips={trips} />;
+}

--- a/app/api/receipts/trips/[id]/candidates/route.ts
+++ b/app/api/receipts/trips/[id]/candidates/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from "next/server";
+import { requireReceiptsActor } from "@/lib/receipts/auth";
+import {
+  getBusinessTripWithMembers,
+  listTripAttachCandidates,
+} from "@/lib/receipts/db";
+import { candidateWindow, filterAttachCandidates } from "@/lib/receipts/business-trips";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+// Trip attach-candidate picker (ADR 0010 D2). Returns charges attachable to
+// the trip: AMEX lines + receipts whose transaction_date falls within
+// [trip.start − window, trip.end + window] (cross-month by construction),
+// EXCLUDING current members of this trip. Lines owned by a different trip are
+// included but flagged (ownedByTripId) so the UI can show why attach will 409.
+// ?all=true drops the date window (the "show all" escape).
+
+export async function GET(request: Request, { params }: RouteContext) {
+  try {
+    await requireReceiptsActor(request.headers);
+    const { id } = await params;
+    const url = new URL(request.url);
+    const windowDays = Math.max(
+      0,
+      Math.min(365, Number.parseInt(url.searchParams.get("window") ?? "45", 10) || 45),
+    );
+    const all = url.searchParams.get("all") === "true";
+    const q = url.searchParams.get("q") ?? "";
+
+    // Trip row + current members in one call. 404 if the trip doesn't exist.
+    const detail = await getBusinessTripWithMembers(id);
+    if (!detail.trip) {
+      return NextResponse.json({ error: "Trip not found." }, { status: 404 });
+    }
+
+    const window =
+      all || !detail.trip.start_date || !detail.trip.end_date
+        ? null
+        : candidateWindow(
+            { startDate: detail.trip.start_date, endDate: detail.trip.end_date },
+            windowDays,
+          );
+
+    const memberLineIds = new Set(detail.lines.map((l) => l.id));
+    const memberReceiptIds = new Set(detail.receipts.map((r) => r.id));
+
+    // db narrows by window + q (SQL); the pure filter excludes current members.
+    const rows = await listTripAttachCandidates({ window, q });
+    const candidates = filterAttachCandidates(rows, {
+      memberLineIds,
+      memberReceiptIds,
+      window,
+      q,
+    });
+
+    return NextResponse.json(
+      { candidates, window, tripId: id },
+      { status: 200 },
+    );
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Unauthorized")) {
+      return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+    }
+    console.error("[api/receipts/trips/[id]/candidates] GET failed", error);
+    return NextResponse.json(
+      { error: "Failed to load trip candidates." },
+      { status: 500 },
+    );
+  }
+}

--- a/components/receipts/ComplianceSettingsForm.tsx
+++ b/components/receipts/ComplianceSettingsForm.tsx
@@ -17,9 +17,7 @@ type Props = {
   effectiveRecipient: EffectiveRecipient;
 };
 
-// homebase_signals (ADR 0010 D3) is an array setting whose UI is Phase B, so it
-// is intentionally absent from this scalar-label map until then.
-const LABELS: Record<Exclude<keyof ComplianceSettings, "homebase_signals">, string> = {
+const LABELS: Record<keyof ComplianceSettings, string> = {
   business_name: "Business name (事業者名)",
   taxpayer_type: "Taxpayer type",
   retention_years: "Retention years",
@@ -31,6 +29,7 @@ const LABELS: Record<Exclude<keyof ComplianceSettings, "homebase_signals">, stri
   statement_expected_day: "AMEX statement expected day",
   track_tax_breakdown: "Track tax rate / amount breakdown",
   notification_recipient: "通知先 (Notification recipient)",
+  homebase_signals: "Homebase signals (ADR 0010)",
 };
 
 export function ComplianceSettingsForm({
@@ -47,6 +46,12 @@ export function ComplianceSettingsForm({
   );
   const [testing, setTesting] = useState(false);
   const [testResult, setTestResult] = useState<TestResult | null>(null);
+  // homebase_signals is edited as a textarea (one signal per line). Keep the
+  // raw text for editing; mirror the parsed array into settings.homebase_signals
+  // so Save serializes it (Phase A serializer JSON-stringifies arrays).
+  const [homebaseText, setHomebaseText] = useState(
+    initial.homebase_signals.join("\n"),
+  );
 
   const recipientDirty = settings.notification_recipient !== persistedRecipient;
 
@@ -282,6 +287,29 @@ export function ComplianceSettingsForm({
             </p>
           ) : null}
         </div>
+      </Row>
+
+      <Row
+        label={LABELS.homebase_signals}
+        hint="Merchant name fragments that indicate homebase (charges here never anchor a business trip). One per line."
+      >
+        <textarea
+          value={homebaseText}
+          onChange={(e) => {
+            const text = e.target.value;
+            setHomebaseText(text);
+            update(
+              "homebase_signals",
+              text
+                .split("\n")
+                .map((s) => s.trim())
+                .filter(Boolean),
+            );
+          }}
+          rows={5}
+          className="w-full rounded-md border border-gray-300 px-3 py-2 font-mono text-sm sm:w-96"
+          placeholder={"東京\n新宿\n渋谷"}
+        />
       </Row>
 
       <div className="flex items-center justify-between border-t border-gray-100 pt-4">

--- a/components/receipts/receipt-shell.tsx
+++ b/components/receipts/receipt-shell.tsx
@@ -11,6 +11,7 @@ const NAV = [
   { href: "/receipts/review", label: "Review" },
   { href: "/receipts/amex", label: "AMEX" },
   { href: "/receipts/reconcile", label: "Reconcile" },
+  { href: "/receipts/trips", label: "Trips" },
   { href: "/receipts/export", label: "Export" },
   { href: "/receipts/settings", label: "Settings" },
 ] as const;

--- a/components/receipts/reconcile/business-trip-strip.tsx
+++ b/components/receipts/reconcile/business-trip-strip.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { Btn } from "@/components/ui/btn";
+import { formatDate } from "@/lib/receipts/format";
+
+// The amber business-trip strip in the reconcile detail pane (ADR 0010 D4).
+// When the candidate line is linked to a trip (business_trip_id set), the
+// strip DELEGATES: it shows the trip's date range + a link, and Confirm/Exclude
+// become "Confirm trip"/"Reject trip" that PATCH the WHOLE trip (Phase A status
+// sync updates all member lines). When business_trip_id is NULL (legacy/edge),
+// today's per-line PATCH behavior is preserved.
+
+interface TripSummary {
+  trip_name: string | null;
+  start_date: string;
+  end_date: string;
+  status: string;
+}
+
+interface BusinessTripStripProps {
+  tripId: string | null;
+  locked: boolean;
+  busy: boolean;
+  onLegacyConfirm: () => void;
+  onLegacyExclude: () => void;
+}
+
+export function BusinessTripStrip({
+  tripId,
+  locked,
+  busy,
+  onLegacyConfirm,
+  onLegacyExclude,
+}: BusinessTripStripProps) {
+  const router = useRouter();
+  const [trip, setTrip] = useState<TripSummary | null>(null);
+  const [acting, setActing] = useState(false);
+
+  // Lazy trip summary (one GET per strip render — fine at this scale).
+  useEffect(() => {
+    if (!tripId) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch(`/api/receipts/trips/${tripId}`);
+        if (!res.ok) return;
+        const data = (await res.json().catch(() => null)) as { trip?: TripSummary } | null;
+        if (!cancelled && data?.trip) setTrip(data.trip);
+      } catch {
+        // non-fatal: fall back to the link without the date range
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [tripId]);
+
+  async function patchTripStatus(status: "confirmed" | "rejected") {
+    if (!tripId) return;
+    if (status === "rejected") {
+      const ok = window.confirm(
+        "Reject this trip? All member AMEX lines become 'excluded'.",
+      );
+      if (!ok) return;
+    }
+    setActing(true);
+    try {
+      await fetch(`/api/receipts/trips/${tripId}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ status }),
+      });
+      router.refresh();
+    } finally {
+      setActing(false);
+    }
+  }
+
+  // Legacy / edge: no trip link → per-line PATCH (unchanged behavior).
+  if (!tripId) {
+    return (
+      <StripShell
+        title="Part of a candidate business trip"
+        subtitle="Linked to a trip cluster. Review & confirm the trip to lock the window."
+      >
+        {!locked && (
+          <div className="flex gap-2">
+            <Btn kind="primary" size="sm" disabled={busy} onClick={onLegacyConfirm}>
+              Confirm
+            </Btn>
+            <Btn kind="ghost" size="sm" disabled={busy} onClick={onLegacyExclude}>
+              Exclude
+            </Btn>
+          </div>
+        )}
+      </StripShell>
+    );
+  }
+
+  const disabled = busy || acting || locked;
+  return (
+    <StripShell
+      title={
+        <span>
+          Part of business trip{" "}
+          <Link
+            href={`/receipts/trips/${tripId}`}
+            className="font-semibold text-amber-700 hover:underline"
+          >
+            {trip?.trip_name?.trim() || "(unnamed trip)"}
+          </Link>
+        </span>
+      }
+      subtitle={
+        trip
+          ? `${formatDate(trip.start_date)} – ${formatDate(trip.end_date)} · confirming/rejecting here applies to the whole trip.`
+          : "Confirming/rejecting here applies to the whole trip."
+      }
+    >
+      {!locked && (
+        <div className="flex gap-2">
+          <Btn
+            kind="primary"
+            size="sm"
+            disabled={disabled}
+            onClick={() => patchTripStatus("confirmed")}
+          >
+            Confirm trip
+          </Btn>
+          <Btn
+            kind="ghost"
+            size="sm"
+            disabled={disabled}
+            onClick={() => patchTripStatus("rejected")}
+          >
+            Reject trip
+          </Btn>
+        </div>
+      )}
+    </StripShell>
+  );
+}
+
+function StripShell({
+  title,
+  subtitle,
+  children,
+}: {
+  title: React.ReactNode;
+  subtitle: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className="mt-4 flex items-center gap-3.5 rounded-xl border border-amber-200 px-5 py-3.5"
+      style={{ background: "linear-gradient(135deg, #FFFBEB, #FEF3C7)" }}
+    >
+      <div className="text-[22px]">🐝</div>
+      <div className="flex-1">
+        <div className="text-[13px] font-semibold text-gray-900">{title}</div>
+        <div className="mt-0.5 text-[12px] text-gray-600">{subtitle}</div>
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/components/receipts/reconcile/reconcile-screen.tsx
+++ b/components/receipts/reconcile/reconcile-screen.tsx
@@ -14,6 +14,7 @@ import Link from "next/link";
 import { Btn } from "@/components/ui/btn";
 import { Card } from "@/components/ui/card";
 import { Pill } from "@/components/ui/pill";
+import { BusinessTripStrip } from "@/components/receipts/reconcile/business-trip-strip";
 import { Field, SelectInput, TextInput } from "@/components/ui/field";
 import { Kbd } from "@/components/ui/kbd";
 import {
@@ -1270,49 +1271,19 @@ function DetailPane({
         </div>
       </Card>
 
-      {/* Business trip strip */}
+      {/* Business trip strip — delegates to the trip when linked (ADR 0010 D4) */}
       {line.business_trip_status === "candidate" && (
-        <div
-          className="mt-4 flex items-center gap-3.5 rounded-xl border border-amber-200 px-5 py-3.5"
-          style={{
-            background: "linear-gradient(135deg, #FFFBEB, #FEF3C7)",
-          }}
-        >
-          <div className="text-[22px]">🐝</div>
-          <div className="flex-1">
-            <div className="text-[13px] font-semibold text-gray-900">
-              Part of a candidate business trip
-            </div>
-              <div className="mt-0.5 text-[12px] text-gray-600">
-              Linked to a trip cluster. Review & confirm the trip to lock the
-              window.
-            </div>
-          </div>
-          {!locked && (
-            <div className="flex gap-2">
-              <Btn
-                kind="primary"
-                size="sm"
-                disabled={busy}
-                onClick={() =>
-                  onUpdateLineDetails(line.id, { businessTripStatus: "confirmed" })
-                }
-              >
-                Confirm
-              </Btn>
-              <Btn
-                kind="ghost"
-                size="sm"
-                disabled={busy}
-                onClick={() =>
-                  onUpdateLineDetails(line.id, { businessTripStatus: "excluded" })
-                }
-              >
-                Exclude
-              </Btn>
-            </div>
-          )}
-        </div>
+        <BusinessTripStrip
+          tripId={line.business_trip_id}
+          locked={locked}
+          busy={busy}
+          onLegacyConfirm={() =>
+            onUpdateLineDetails(line.id, { businessTripStatus: "confirmed" })
+          }
+          onLegacyExclude={() =>
+            onUpdateLineDetails(line.id, { businessTripStatus: "excluded" })
+          }
+        />
       )}
 
       {/* Keyboard hints */}

--- a/components/receipts/trips/trip-detail-screen.tsx
+++ b/components/receipts/trips/trip-detail-screen.tsx
@@ -1,0 +1,508 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { Btn } from "@/components/ui/btn";
+import { Pill } from "@/components/ui/pill";
+import { Card } from "@/components/ui/card";
+import { Field, TextInput } from "@/components/ui/field";
+import { formatDate, formatAmountMinor } from "@/lib/receipts/format";
+import {
+  tripStatusTone,
+  candidateDisableReason,
+  type CandidateRow,
+} from "@/lib/receipts/business-trips";
+import type { BusinessTripReport } from "@/lib/receipts/types";
+import type {
+  BusinessTripMemberLine,
+  BusinessTripMemberReceipt,
+} from "@/lib/receipts/db";
+
+interface TripDetailScreenProps {
+  trip: BusinessTripReport;
+  lines: BusinessTripMemberLine[];
+  receipts: BusinessTripMemberReceipt[];
+}
+
+interface MemberRow {
+  kind: "line" | "receipt";
+  id: string;
+  date: string | null;
+  merchant: string | null;
+  amountMinor: number | null;
+  month: string | null;
+  status: string | null;
+  sealed: boolean;
+}
+
+export function TripDetailScreen({ trip, lines, receipts }: TripDetailScreenProps) {
+  const router = useRouter();
+
+  // Editable fields (local state; Save PATCHes).
+  const [fields, setFields] = useState({
+    tripName: trip.trip_name ?? "",
+    startDate: trip.start_date,
+    endDate: trip.end_date,
+    purpose: trip.purpose ?? "",
+    primaryLocation: trip.primary_location ?? "",
+  });
+  const [saving, setSaving] = useState(false);
+  const [fieldError, setFieldError] = useState<string | null>(null);
+  const [fieldSaved, setFieldSaved] = useState(false);
+
+  const [busy, setBusy] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  // Candidates picker.
+  const [candidates, setCandidates] = useState<CandidateRow[]>([]);
+  const [candLoading, setCandLoading] = useState(false);
+  const [q, setQ] = useState("");
+  const [showAll, setShowAll] = useState(false);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [attachError, setAttachError] = useState<string | null>(null);
+  const [refreshNonce, setRefreshNonce] = useState(0);
+
+  const memberRows: MemberRow[] = [
+    ...lines.map((l) => ({
+      kind: "line" as const,
+      id: l.id,
+      date: l.transaction_date,
+      merchant: l.merchant,
+      amountMinor: l.amount_minor,
+      month: l.statement_month,
+      status: l.business_trip_status,
+      sealed: false,
+    })),
+    ...receipts.map((r) => ({
+      kind: "receipt" as const,
+      id: r.id,
+      date: r.transaction_date,
+      merchant: r.merchant,
+      amountMinor: r.amount_minor,
+      month: r.transaction_date ? r.transaction_date.slice(0, 7) : null,
+      status: r.status,
+      sealed: r.status === "exported" || r.status === "archived",
+    })),
+  ].sort((a, b) => (a.date ?? "").localeCompare(b.date ?? ""));
+
+  // Fetch candidates (debounced on q; refetch on showAll/refreshNonce).
+  useEffect(() => {
+    let cancelled = false;
+    setCandLoading(true);
+    const t = setTimeout(async () => {
+      try {
+        const url =
+          `/api/receipts/trips/${trip.id}/candidates` +
+          `?window=45&q=${encodeURIComponent(q)}&all=${showAll ? "true" : "false"}`;
+        const res = await fetch(url);
+        const data = (await res.json().catch(() => ({}))) as {
+          candidates?: CandidateRow[];
+        };
+        if (!cancelled) setCandidates(data.candidates ?? []);
+      } finally {
+        if (!cancelled) setCandLoading(false);
+      }
+    }, 300);
+    return () => {
+      cancelled = true;
+      clearTimeout(t);
+    };
+  }, [q, showAll, trip.id, refreshNonce]);
+
+  async function saveFields() {
+    setFieldError(null);
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/receipts/trips/${trip.id}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          tripName: fields.tripName.trim() || null,
+          startDate: fields.startDate,
+          endDate: fields.endDate,
+          purpose: fields.purpose.trim() || null,
+          primaryLocation: fields.primaryLocation.trim() || null,
+        }),
+      });
+      const data = (await res.json().catch(() => ({}))) as { error?: string };
+      if (!res.ok) {
+        setFieldError(data.error ?? `Save failed (${res.status}).`);
+        return;
+      }
+      setFieldSaved(true);
+      router.refresh();
+    } catch {
+      setFieldError("Network error");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function patchStatus(status: "confirmed" | "rejected") {
+    if (status === "rejected") {
+      const ok = window.confirm(
+        "Reject this trip? All member AMEX lines will be set to 'excluded' (receipt links survive).",
+      );
+      if (!ok) return;
+    }
+    setActionError(null);
+    setBusy(true);
+    try {
+      const res = await fetch(`/api/receipts/trips/${trip.id}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ status }),
+      });
+      const data = (await res.json().catch(() => ({}))) as { error?: string };
+      if (!res.ok) {
+        setActionError(data.error ?? `Action failed (${res.status}).`);
+        return;
+      }
+      router.refresh();
+    } catch {
+      setActionError("Network error");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function attach() {
+    const lineIds = candidates
+      .filter((c) => c.kind === "line" && selected.has(c.id))
+      .map((c) => c.id);
+    const receiptIds = candidates
+      .filter((c) => c.kind === "receipt" && selected.has(c.id))
+      .map((c) => c.id);
+    if (lineIds.length === 0 && receiptIds.length === 0) return;
+    setAttachError(null);
+    setBusy(true);
+    try {
+      const res = await fetch(`/api/receipts/trips/${trip.id}/members`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ lineIds, receiptIds }),
+      });
+      const data = (await res.json().catch(() => ({}))) as { error?: string };
+      if (!res.ok) {
+        setAttachError(data.error ?? `Attach failed (${res.status}).`);
+        return;
+      }
+      setSelected(new Set());
+      setRefreshNonce((n) => n + 1);
+      router.refresh();
+    } catch {
+      setAttachError("Network error");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function detach(row: MemberRow) {
+    setBusy(true);
+    try {
+      const body =
+        row.kind === "line" ? { lineIds: [row.id] } : { receiptIds: [row.id] };
+      await fetch(`/api/receipts/trips/${trip.id}/members`, {
+        method: "DELETE",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      setRefreshNonce((n) => n + 1);
+      router.refresh();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function toggleSelected(id: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  const status = trip.status;
+  const exported_ = status === "exported";
+
+  return (
+    <div className="mx-auto max-w-5xl px-6 py-8">
+      <div className="mb-4">
+        <Link
+          href="/receipts/trips"
+          className="text-[13px] font-medium text-amber-700 hover:underline"
+        >
+          ← All trips
+        </Link>
+      </div>
+
+      {/* Header: editable fields + status actions */}
+      <Card className="mb-6">
+        <div className="mb-4 flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <h1 className="text-lg font-bold text-gray-900">
+              {trip.trip_name?.trim() || "(unnamed trip)"}
+            </h1>
+            <Pill tone={tripStatusTone(status)} size="md" dot>
+              {status}
+            </Pill>
+          </div>
+          {!exported_ && (
+            <div className="flex gap-2">
+              {(status === "candidate" || status === "rejected") && (
+                <Btn
+                  kind="primary"
+                  size="sm"
+                  disabled={busy}
+                  onClick={() => patchStatus("confirmed")}
+                >
+                  Confirm trip
+                </Btn>
+              )}
+              {(status === "candidate" || status === "confirmed") && (
+                <Btn
+                  kind="ghost"
+                  size="sm"
+                  disabled={busy}
+                  onClick={() => patchStatus("rejected")}
+                >
+                  Reject trip
+                </Btn>
+              )}
+            </div>
+          )}
+        </div>
+        {exported_ && (
+          <p className="mb-3 rounded-lg bg-blue-50 px-3 py-2 text-[12px] text-blue-700">
+            This trip is sealed in an export and cannot be changed.
+          </p>
+        )}
+        {actionError && (
+          <p className="mb-3 text-[12px] text-red-600">{actionError}</p>
+        )}
+
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+          <Field label="Trip name">
+            <TextInput
+              value={fields.tripName}
+              onChange={(e) =>
+                setFields((s) => ({ ...s, tripName: e.target.value }))
+              }
+            />
+          </Field>
+          <Field label="Primary location">
+            <TextInput
+              value={fields.primaryLocation}
+              onChange={(e) =>
+                setFields((s) => ({ ...s, primaryLocation: e.target.value }))
+              }
+            />
+          </Field>
+          <Field label="Start date" required>
+            <TextInput
+              type="date"
+              value={fields.startDate}
+              onChange={(e) =>
+                setFields((s) => ({ ...s, startDate: e.target.value }))
+              }
+            />
+          </Field>
+          <Field label="End date" required>
+            <TextInput
+              type="date"
+              value={fields.endDate}
+              onChange={(e) =>
+                setFields((s) => ({ ...s, endDate: e.target.value }))
+              }
+            />
+          </Field>
+          <Field label="Purpose" className="md:col-span-2">
+            <TextInput
+              value={fields.purpose}
+              onChange={(e) =>
+                setFields((s) => ({ ...s, purpose: e.target.value }))
+              }
+            />
+          </Field>
+        </div>
+        {fieldError && (
+          <p className="mt-2 text-[12px] text-red-600">{fieldError}</p>
+        )}
+        <div className="mt-3 flex justify-end">
+          <Btn kind="primary" size="md" disabled={saving || exported_} onClick={saveFields}>
+            {saving ? "Saving…" : fieldSaved ? "Re-save" : "Save"}
+          </Btn>
+        </div>
+      </Card>
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        {/* Members */}
+        <Card>
+          <div className="mb-3 flex items-center justify-between">
+            <h2 className="text-[14px] font-semibold text-gray-900">
+              Members ({memberRows.length})
+            </h2>
+            <span className="text-[11px] text-gray-400">date · merchant · amount</span>
+          </div>
+          {memberRows.length === 0 ? (
+            <p className="text-[13px] text-gray-500">No charges attached yet.</p>
+          ) : (
+            <div className="space-y-1.5">
+              {memberRows.map((row) => (
+                <div
+                  key={`${row.kind}-${row.id}`}
+                  className="flex items-center gap-2 rounded-lg border border-gray-100 px-3 py-2"
+                >
+                  <Pill tone={row.kind === "line" ? "outline" : "purple"} size="sm">
+                    {row.kind === "line" ? "AMEX" : "receipt"}
+                  </Pill>
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate text-[13px] text-gray-900">
+                      {row.merchant ?? "(unnamed)"}
+                    </div>
+                    <div className="text-[11px] text-gray-500">
+                      {formatDate(row.date)}
+                      {row.month ? ` · ${row.month}` : ""}
+                      {row.status ? ` · ${row.status}` : ""}
+                    </div>
+                  </div>
+                  {row.sealed && (
+                    <Pill tone="gray" size="sm">
+                      sealed
+                    </Pill>
+                  )}
+                  <span className="shrink-0 text-[12px] tabular-nums text-gray-700">
+                    {row.amountMinor != null
+                      ? formatAmountMinor(row.amountMinor, "JPY")
+                      : "—"}
+                  </span>
+                  {!exported_ && (
+                    <Btn
+                      kind="ghost"
+                      size="sm"
+                      disabled={busy}
+                      onClick={() => detach(row)}
+                    >
+                      Detach
+                    </Btn>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </Card>
+
+        {/* Add charges */}
+        <Card>
+          <div className="mb-3 flex items-center justify-between">
+            <h2 className="text-[14px] font-semibold text-gray-900">Add charges</h2>
+            <span className="text-[11px] text-gray-400">
+              {showAll ? "all dates" : "±45 days around trip dates"}
+            </span>
+          </div>
+          <div className="mb-3 flex items-center gap-2">
+            <TextInput
+              value={q}
+              onChange={(e) => setQ(e.target.value)}
+              placeholder="Search merchant…"
+            />
+            <button
+              type="button"
+              onClick={() => setShowAll((v) => !v)}
+              className={[
+                "shrink-0 rounded-lg border px-3 py-1.5 text-[12px] font-medium",
+                showAll
+                  ? "border-amber-300 bg-amber-50 text-amber-800"
+                  : "border-gray-200 bg-white text-gray-600 hover:bg-gray-50",
+              ].join(" ")}
+            >
+              {showAll ? "Showing all" : "Show all"}
+            </button>
+          </div>
+
+          {candLoading ? (
+            <p className="text-[12px] text-gray-400">Loading…</p>
+          ) : candidates.length === 0 ? (
+            <p className="text-[13px] text-gray-500">
+              No charges in range. Toggle “Show all” or adjust the search.
+            </p>
+          ) : (
+            <div className="max-h-80 space-y-1.5 overflow-y-auto">
+              {candidates.map((row) => {
+                const reason = candidateDisableReason(row, trip.id);
+                const disabled = reason !== null;
+                const checked = selected.has(row.id);
+                return (
+                  <label
+                    key={`${row.kind}-${row.id}`}
+                    className={[
+                      "flex cursor-pointer items-center gap-2 rounded-lg border px-3 py-2",
+                      disabled
+                        ? "cursor-not-allowed border-gray-100 bg-gray-50 opacity-70"
+                        : "border-gray-100 hover:bg-gray-50",
+                    ].join(" ")}
+                  >
+                    <input
+                      type="checkbox"
+                      className="h-4 w-4 accent-amber-500"
+                      disabled={disabled || exported_}
+                      checked={checked}
+                      onChange={() => toggleSelected(row.id)}
+                    />
+                    <Pill
+                      tone={row.kind === "line" ? "outline" : "purple"}
+                      size="sm"
+                    >
+                      {row.kind === "line" ? "AMEX" : "receipt"}
+                    </Pill>
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-[13px] text-gray-900">
+                        {row.merchant ?? "(unnamed)"}
+                      </div>
+                      <div className="text-[11px] text-gray-500">
+                        {formatDate(row.transactionDate)}
+                        {row.month ? ` · ${row.month}` : ""}
+                      </div>
+                    </div>
+                    {disabled && row.ownedByTripId && (
+                      <Link
+                        href={`/receipts/trips/${row.ownedByTripId}`}
+                        className="shrink-0 text-[11px] font-medium text-amber-700 hover:underline"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        owned by another trip →
+                      </Link>
+                    )}
+                    <span className="shrink-0 text-[12px] tabular-nums text-gray-700">
+                      {row.amountMinor != null
+                        ? formatAmountMinor(row.amountMinor, row.currency)
+                        : "—"}
+                    </span>
+                  </label>
+                );
+              })}
+            </div>
+          )}
+          {attachError && (
+            <p className="mt-2 text-[12px] text-red-600">{attachError}</p>
+          )}
+          <div className="mt-3 flex items-center justify-between">
+            <span className="text-[11px] text-gray-400">
+              {selected.size} selected
+            </span>
+            <Btn
+              kind="primary"
+              size="sm"
+              disabled={busy || exported_ || selected.size === 0}
+              onClick={attach}
+            >
+              {busy ? "Attaching…" : "Attach selected"}
+            </Btn>
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/components/receipts/trips/trips-screen.tsx
+++ b/components/receipts/trips/trips-screen.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { Btn } from "@/components/ui/btn";
+import { Pill } from "@/components/ui/pill";
+import { Card } from "@/components/ui/card";
+import { Field, TextInput } from "@/components/ui/field";
+import { formatDate } from "@/lib/receipts/format";
+import {
+  filterTripsByTab,
+  tripStatusTone,
+  type TripTab,
+} from "@/lib/receipts/business-trips";
+import type { BusinessTripWithCounts } from "@/lib/receipts/db";
+
+interface TripsScreenProps {
+  initialTrips: BusinessTripWithCounts[];
+}
+
+export function TripsScreen({ initialTrips }: TripsScreenProps) {
+  const router = useRouter();
+  const [trips] = useState<BusinessTripWithCounts[]>(initialTrips);
+  const [tab, setTab] = useState<TripTab>("candidate");
+
+  // Register-trip form state.
+  const [reg, setReg] = useState({
+    tripName: "",
+    startDate: "",
+    endDate: "",
+    purpose: "",
+    primaryLocation: "",
+  });
+  const [registering, setRegistering] = useState(false);
+  const [regError, setRegError] = useState<string | null>(null);
+
+  const visible = filterTripsByTab(trips, tab);
+  const candidateCount = trips.filter((t) => t.status === "candidate").length;
+  const confirmedCount = trips.filter((t) => t.status === "confirmed").length;
+
+  async function registerTrip() {
+    setRegError(null);
+    if (!reg.startDate || !reg.endDate) {
+      setRegError("Start date and end date are required.");
+      return;
+    }
+    setRegistering(true);
+    try {
+      const res = await fetch("/api/receipts/trips", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          tripName: reg.tripName.trim() || null,
+          startDate: reg.startDate,
+          endDate: reg.endDate,
+          purpose: reg.purpose.trim() || null,
+          primaryLocation: reg.primaryLocation.trim() || null,
+        }),
+      });
+      const data = (await res.json().catch(() => ({}))) as { id?: string; error?: string };
+      if (!res.ok || !data.id) {
+        setRegError(data.error ?? `Create failed (HTTP ${res.status}).`);
+        return;
+      }
+      router.push(`/receipts/trips/${data.id}`);
+    } catch {
+      setRegError("Network error");
+    } finally {
+      setRegistering(false);
+    }
+  }
+
+  const tabs: Array<{ id: TripTab; label: string; n: number }> = [
+    { id: "candidate", label: "Candidates", n: candidateCount },
+    { id: "confirmed", label: "Confirmed", n: confirmedCount },
+    { id: "all", label: "All", n: trips.length },
+  ];
+
+  return (
+    <div className="mx-auto max-w-5xl px-6 py-8">
+      <div className="mb-6 flex items-end justify-between">
+        <div>
+          <h1 className="text-xl font-bold text-gray-900">Business trips</h1>
+          <p className="mt-1 text-[13px] text-gray-500">
+            Register trips and attach the related charges. Trip dates describe
+            the trip — prebooking and late charges are attachable across months.
+          </p>
+        </div>
+      </div>
+
+      {/* Register trip */}
+      <Card className="mb-6">
+        <div className="mb-3 text-[13px] font-semibold text-gray-900">
+          Register a trip
+        </div>
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+          <Field label="Start date" required>
+            <TextInput
+              type="date"
+              value={reg.startDate}
+              onChange={(e) => setReg((s) => ({ ...s, startDate: e.target.value }))}
+            />
+          </Field>
+          <Field label="End date" required>
+            <TextInput
+              type="date"
+              value={reg.endDate}
+              onChange={(e) => setReg((s) => ({ ...s, endDate: e.target.value }))}
+            />
+          </Field>
+          <Field label="Trip name">
+            <TextInput
+              value={reg.tripName}
+              onChange={(e) => setReg((s) => ({ ...s, tripName: e.target.value }))}
+              placeholder="e.g. Odawara offsite"
+            />
+          </Field>
+          <Field label="Primary location">
+            <TextInput
+              value={reg.primaryLocation}
+              onChange={(e) => setReg((s) => ({ ...s, primaryLocation: e.target.value }))}
+              placeholder="e.g. 神奈川"
+            />
+          </Field>
+          <Field label="Purpose" className="md:col-span-2">
+            <TextInput
+              value={reg.purpose}
+              onChange={(e) => setReg((s) => ({ ...s, purpose: e.target.value }))}
+              placeholder="Optional"
+            />
+          </Field>
+        </div>
+        {regError && <p className="mt-2 text-[12px] text-red-600">{regError}</p>}
+        <div className="mt-3 flex justify-end">
+          <Btn
+            kind="primary"
+            size="md"
+            disabled={registering}
+            onClick={registerTrip}
+          >
+            {registering ? "Creating…" : "Create trip"}
+          </Btn>
+        </div>
+      </Card>
+
+      {/* Tabs */}
+      <div className="mb-4 flex gap-2">
+        {tabs.map((t) => (
+          <button
+            key={t.id}
+            type="button"
+            onClick={() => setTab(t.id)}
+            className={[
+              "rounded-lg border px-3 py-1.5 text-[13px] font-medium transition-colors",
+              tab === t.id
+                ? "border-amber-200 bg-amber-50 text-gray-900"
+                : "border-transparent text-gray-500 hover:text-gray-900",
+            ].join(" ")}
+          >
+            {t.label} <span className="text-gray-400">({t.n})</span>
+          </button>
+        ))}
+      </div>
+
+      {/* Trip cards */}
+      {visible.length === 0 ? (
+        <Card>
+          <p className="text-[13px] text-gray-500">
+            No trips in this view. Register one above, or switch tabs.
+          </p>
+        </Card>
+      ) : (
+        <div className="space-y-3">
+          {visible.map((trip) => (
+            <Link
+              key={trip.id}
+              href={`/receipts/trips/${trip.id}`}
+              className="block rounded-[14px] border border-gray-200 bg-white p-4 transition-colors hover:border-amber-200 hover:bg-amber-50/30"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="truncate text-[15px] font-semibold text-gray-900">
+                      {trip.trip_name?.trim() || "(unnamed trip)"}
+                    </span>
+                    <Pill tone={tripStatusTone(trip.status)} size="sm" dot>
+                      {trip.status}
+                    </Pill>
+                  </div>
+                  <div className="mt-1 text-[13px] text-gray-600">
+                    {formatDate(trip.start_date)} – {formatDate(trip.end_date)}
+                    {trip.primary_location ? ` · ${trip.primary_location}` : ""}
+                  </div>
+                  <div className="mt-0.5 text-[12px] text-gray-500">
+                    {trip.cardholder_name} · {trip.line_count} line(s) ·{" "}
+                    {trip.receipt_count} receipt(s)
+                  </div>
+                </div>
+                <span className="shrink-0 text-[12px] font-medium text-amber-700">
+                  Open →
+                </span>
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/receipts/business-trips.ts
+++ b/lib/receipts/business-trips.ts
@@ -152,3 +152,135 @@ export function validateTripTransition(
   }
   return { ok: true };
 }
+
+// ─── Attach-candidate picker (ADR 0010 D2) ───────────────────────────────────
+// Trip dates describe the trip, not the charge window — prebooking charges
+// before and service-provider charges after are the norm, spanning months. The
+// picker defaults to trip dates ± `window` days (cross-month by construction),
+// with a "show all" escape. Window/date arithmetic lives here (pure, tested);
+// the db function narrows in SQL for efficiency.
+
+/** Parse a YYYY-MM-DD string to a UTC-midnight Date (no TZ drift). */
+function parseIsoDate(iso: string): Date {
+  const [y, m, d] = iso.split("-").map(Number);
+  return new Date(Date.UTC(y ?? 1970, (m ?? 1) - 1, d ?? 1));
+}
+
+/** YYYY-MM-DD shifted by `days` (can be negative). */
+export function shiftDate(iso: string, days: number): string {
+  const date = parseIsoDate(iso);
+  date.setUTCDate(date.getUTCDate() + days);
+  return date.toISOString().slice(0, 10);
+}
+
+/** [start_date − windowDays, end_date + windowDays] — the default charge list. */
+export function candidateWindow(
+  trip: { startDate: string; endDate: string },
+  windowDays: number,
+): { start: string; end: string } {
+  return {
+    start: shiftDate(trip.startDate, -windowDays),
+    end: shiftDate(trip.endDate, windowDays),
+  };
+}
+
+/** Inclusive window membership (YYYY-MM-DD lexical compare = chronological). */
+export function isInCandidateWindow(
+  date: string,
+  window: { start: string; end: string },
+): boolean {
+  return date >= window.start && date <= window.end;
+}
+
+export interface CandidateRow {
+  kind: "line" | "receipt";
+  id: string;
+  transactionDate: string | null;
+  merchant: string | null;
+  amountMinor: number | null;
+  currency: string;
+  /** statement_month for lines; export_statement_month or calendar month for receipts. */
+  month: string | null;
+  /** line match_status / receipt status. */
+  status: string | null;
+  /** Lines only: the trip currently owning this line (business_trip_id), if any.
+   *  A different-trip owner is INCLUDED but flagged so the UI can show why attach 409s. */
+  ownedByTripId: string | null;
+}
+
+/**
+ * Pure picker filter: drops current members of THIS trip, applies the date
+ * window (unless null = "show all"), and the merchant search `q`. Used by the
+ * candidates route after the db function narrows by window+q in SQL.
+ */
+export function filterAttachCandidates(
+  rows: CandidateRow[],
+  opts: {
+    memberLineIds: Set<string>;
+    memberReceiptIds: Set<string>;
+    window: { start: string; end: string } | null;
+    q: string;
+  },
+): CandidateRow[] {
+  const qLower = opts.q.trim().toLowerCase();
+  return rows.filter((row) => {
+    if (row.kind === "line" && opts.memberLineIds.has(row.id)) return false;
+    if (row.kind === "receipt" && opts.memberReceiptIds.has(row.id)) return false;
+    if (
+      opts.window &&
+      row.transactionDate &&
+      !isInCandidateWindow(row.transactionDate, opts.window)
+    ) {
+      return false;
+    }
+    if (qLower && !(row.merchant ?? "").toLowerCase().includes(qLower)) {
+      return false;
+    }
+    return true;
+  });
+}
+
+/**
+ * Why a candidate row is not attachable right now (for the UI's disabled-state
+ * helper text). Pure so it can be unit-tested alongside the picker.
+ */
+export function candidateDisableReason(
+  row: CandidateRow,
+  tripId: string,
+): string | null {
+  if (row.kind === "line" && row.ownedByTripId && row.ownedByTripId !== tripId) {
+    return `Owned by another trip — detach it there first.`;
+  }
+  return null;
+}
+
+// ─── Pure UI helpers (trips screen) ──────────────────────────────────────────
+
+export type TripTab = "candidate" | "confirmed" | "all";
+
+/** Candidates tab shows candidate; Confirmed shows confirmed; All shows all
+ *  (rejected trips appear only under All). */
+export function filterTripsByTab<T extends { status: string }>(
+  trips: T[],
+  tab: TripTab,
+): T[] {
+  if (tab === "all") return trips;
+  return trips.filter((t) => t.status === tab);
+}
+
+/** Pill tone for a trip status (candidate=amber, confirmed=green, rejected=gray,
+ *  exported=blue). Pure so the list + detail screens + tests share one map. */
+export function tripStatusTone(
+  status: string,
+): "amber" | "green" | "gray" | "blue" {
+  switch (status) {
+    case "candidate":
+      return "amber";
+    case "confirmed":
+      return "green";
+    case "exported":
+      return "blue";
+    default:
+      return "gray"; // rejected + unknown
+  }
+}

--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -16,6 +16,7 @@ import {
   findOverlappingTrip,
   decideWiden,
   validateTripTransition,
+  type CandidateRow,
   type ExistingTrip,
   type TripTransition,
 } from "@/lib/receipts/business-trips";
@@ -2261,6 +2262,122 @@ export async function detachTripMembers(
     newValueJson: stringifyJson({ detach: { lineIds, receiptIds } }),
   });
   return { lines: lineIds.length, receipts: receiptIds.length };
+}
+
+/** Current member line + receipt ids for a trip (for the picker's exclusion set). */
+export async function listTripMemberIds(
+  tripId: string,
+): Promise<{ lineIds: string[]; receiptIds: string[] }> {
+  const db = getReceiptsDb();
+  const lines = await db
+    .prepare(
+      `SELECT amex_statement_line_id AS id FROM business_trip_report_lines WHERE business_trip_report_id = ?`,
+    )
+    .bind(tripId)
+    .all<{ id: string }>();
+  const receipts = await db
+    .prepare(
+      `SELECT receipt_id AS id FROM business_trip_report_receipts WHERE business_trip_report_id = ?`,
+    )
+    .bind(tripId)
+    .all<{ id: string }>();
+  return {
+    lineIds: (lines.results ?? []).map((r) => r.id),
+    receiptIds: (receipts.results ?? []).map((r) => r.id),
+  };
+}
+
+/**
+ * Charges attachable to a trip (ADR 0010 D2 picker). Returns AMEX lines +
+ * receipts whose transaction_date falls in `window` (null = all), optionally
+ * filtered by merchant `q` (LIKE). Lines carry `ownedByTripId` so the UI can
+ * flag a different-trip owner (attach will 409). Does NOT exclude current
+ * members of THIS trip — the candidates route applies {@link filterAttachCandidates}
+ * for that (pure, tested). Cross-month by construction (the window spans months).
+ */
+export async function listTripAttachCandidates(
+  opts: { window: { start: string; end: string } | null; q: string },
+): Promise<CandidateRow[]> {
+  const db = getReceiptsDb();
+  const hasQ = opts.q.trim().length > 0;
+  const qPattern = `%${opts.q.trim()}%`;
+  const rows: CandidateRow[] = [];
+
+  const datePred = opts.window ? "transaction_date BETWEEN ? AND ?" : "1=1";
+
+  const lines = await db
+    .prepare(
+      `SELECT id, transaction_date, merchant, amount_minor, currency,
+              statement_month, match_status, business_trip_id
+       FROM amex_statement_lines
+       WHERE ${datePred} ${hasQ ? "AND merchant LIKE ?" : ""}
+       ORDER BY transaction_date ASC`,
+    )
+    .bind(...(opts.window ? [opts.window.start, opts.window.end] : []), ...(hasQ ? [qPattern] : []))
+    .all<{
+      id: string;
+      transaction_date: string;
+      merchant: string;
+      amount_minor: number;
+      currency: string;
+      statement_month: string;
+      match_status: string | null;
+      business_trip_id: string | null;
+    }>();
+  for (const l of lines.results ?? []) {
+    rows.push({
+      kind: "line",
+      id: l.id,
+      transactionDate: l.transaction_date,
+      merchant: l.merchant,
+      amountMinor: l.amount_minor,
+      currency: l.currency,
+      month: l.statement_month,
+      status: l.match_status,
+      ownedByTripId: l.business_trip_id,
+    });
+  }
+
+  const recs = await db
+    .prepare(
+      `SELECT id, transaction_date, merchant, amount_minor, currency,
+              export_statement_month, status
+       FROM receipt_records
+       WHERE deleted_at IS NULL
+         AND ${datePred} ${hasQ ? "AND merchant LIKE ?" : ""}
+       ORDER BY transaction_date ASC`,
+    )
+    .bind(...(opts.window ? [opts.window.start, opts.window.end] : []), ...(hasQ ? [qPattern] : []))
+    .all<{
+      id: string;
+      transaction_date: string | null;
+      merchant: string | null;
+      amount_minor: number | null;
+      currency: string;
+      export_statement_month: string | null;
+      status: string;
+    }>();
+  for (const r of recs.results ?? []) {
+    rows.push({
+      kind: "receipt",
+      id: r.id,
+      transactionDate: r.transaction_date,
+      merchant: r.merchant,
+      amountMinor: r.amount_minor,
+      currency: r.currency,
+      month:
+        r.export_statement_month ??
+        (r.transaction_date ? r.transaction_date.slice(0, 7) : null),
+      status: r.status,
+      ownedByTripId: null,
+    });
+  }
+
+  // Mixed sort by transactionDate (nulls last).
+  rows.sort((a, b) =>
+    (a.transactionDate ?? "9999-99-99").localeCompare(b.transactionDate ?? "9999-99-99"),
+  );
+  return rows;
 }
 
 // ─── Expense categories ───────────────────────────────────────────────────────

--- a/lib/receipts/format.ts
+++ b/lib/receipts/format.ts
@@ -47,3 +47,21 @@ export function formatPaymentPath(path: string | null | undefined): string {
       return path ?? "—";
   }
 }
+
+/**
+ * Format a YYYY-MM-DD date as "Oct 12, 2026". Falls back to the raw input.
+ */
+export function formatDate(iso: string | null | undefined): string {
+  if (!iso) return "—";
+  const [y, m, d] = iso.split("-").map(Number);
+  if (!y || !m || !d) return iso;
+  try {
+    return new Date(y, m - 1, d).toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+  } catch {
+    return iso;
+  }
+}

--- a/tests/receipts/business-trips.test.ts
+++ b/tests/receipts/business-trips.test.ts
@@ -12,6 +12,14 @@ import {
   computeTripStatusLineUpdates,
   validateTripDates,
   validateTripTransition,
+  shiftDate,
+  candidateWindow,
+  isInCandidateWindow,
+  filterAttachCandidates,
+  candidateDisableReason,
+  filterTripsByTab,
+  tripStatusTone,
+  type CandidateRow,
   type ExistingTrip,
 } from "@/lib/receipts/business-trips";
 
@@ -184,4 +192,135 @@ test("validateTripTransition: exported rejected; candidate/confirmed transitions
   assert.equal(validateTripTransition("candidate", "confirmed").ok, true);
   assert.equal(validateTripTransition("confirmed", "rejected").ok, true);
   assert.equal(validateTripTransition("candidate", "exported").ok, false); // only confirmed/rejected
+});
+
+// ─── Picker window/date arithmetic (ADR 0010 D2) ─────────────────────────────
+
+test("shiftDate: adds/subtracts days, crosses month/year boundaries", () => {
+  assert.equal(shiftDate("2026-03-10", 5), "2026-03-15");
+  assert.equal(shiftDate("2026-03-31", 1), "2026-04-01"); // month boundary
+  assert.equal(shiftDate("2026-01-01", -1), "2025-12-31"); // year boundary
+  assert.equal(shiftDate("2026-03-10", -45), "2026-01-24");
+});
+
+test("candidateWindow: [start − windowDays, end + windowDays]", () => {
+  assert.deepEqual(
+    candidateWindow({ startDate: "2026-06-10", endDate: "2026-06-15" }, 45),
+    { start: "2026-04-26", end: "2026-07-30" }, // spans Apr–Jul (cross-month)
+  );
+});
+
+test("isInCandidateWindow: inclusive boundaries", () => {
+  const w = { start: "2026-04-26", end: "2026-07-30" };
+  assert.equal(isInCandidateWindow("2026-04-26", w), true); // start edge
+  assert.equal(isInCandidateWindow("2026-07-30", w), true); // end edge
+  assert.equal(isInCandidateWindow("2026-06-10", w), true);
+  assert.equal(isInCandidateWindow("2026-04-25", w), false); // just before
+  assert.equal(isInCandidateWindow("2026-07-31", w), false); // just after
+});
+
+// ─── filterAttachCandidates: member exclusion + window + q + all ─────────────
+
+function cand(over: Partial<CandidateRow> & { kind: "line" | "receipt"; id: string }): CandidateRow {
+  return {
+    transactionDate: "2026-06-10",
+    merchant: "OpenAI",
+    amountMinor: 1000,
+    currency: "JPY",
+    month: "2026-06",
+    status: "confirmed",
+    ownedByTripId: null,
+    ...over,
+  };
+}
+
+test("filterAttachCandidates: excludes current members of this trip", () => {
+  const rows = [
+    cand({ kind: "line", id: "l-mem", merchant: "Member Line" }),
+    cand({ kind: "receipt", id: "r-mem", merchant: "Member Receipt" }),
+    cand({ kind: "line", id: "l-new", merchant: "New Line" }),
+  ];
+  const out = filterAttachCandidates(rows, {
+    memberLineIds: new Set(["l-mem"]),
+    memberReceiptIds: new Set(["r-mem"]),
+    window: null,
+    q: "",
+  });
+  assert.deepEqual(
+    out.map((r) => r.id),
+    ["l-new"],
+  );
+});
+
+test("filterAttachCandidates: applies window (all=true passes null window)", () => {
+  const rows = [
+    cand({ kind: "line", id: "in", transactionDate: "2026-06-10" }),
+    cand({ kind: "receipt", id: "out", transactionDate: "2025-01-01" }),
+  ];
+  const windowed = filterAttachCandidates(rows, {
+    memberLineIds: new Set(),
+    memberReceiptIds: new Set(),
+    window: { start: "2026-04-26", end: "2026-07-30" },
+    q: "",
+  });
+  assert.deepEqual(windowed.map((r) => r.id), ["in"]);
+
+  const all = filterAttachCandidates(rows, {
+    memberLineIds: new Set(),
+    memberReceiptIds: new Set(),
+    window: null, // "show all"
+    q: "",
+  });
+  assert.equal(all.length, 2);
+});
+
+test("filterAttachCandidates: q filters merchant (case-insensitive)", () => {
+  const rows = [
+    cand({ kind: "line", id: "a", merchant: "Ekinet" }),
+    cand({ kind: "receipt", id: "b", merchant: "Hotel Odawara" }),
+  ];
+  const out = filterAttachCandidates(rows, {
+    memberLineIds: new Set(),
+    memberReceiptIds: new Set(),
+    window: null,
+    q: "ekinet",
+  });
+  assert.deepEqual(out.map((r) => r.id), ["a"]);
+});
+
+// ─── candidateDisableReason (ownedByTripId flag) ─────────────────────────────
+
+test("candidateDisableReason: different-trip owner → reason; same trip / receipt → null", () => {
+  assert.equal(
+    candidateDisableReason(cand({ kind: "line", id: "l1", ownedByTripId: "other-trip" }), "this-trip"),
+    `Owned by another trip — detach it there first.`,
+  );
+  assert.equal(
+    candidateDisableReason(cand({ kind: "line", id: "l1", ownedByTripId: "this-trip" }), "this-trip"),
+    null,
+  );
+  assert.equal(
+    candidateDisableReason(cand({ kind: "receipt", id: "r1", ownedByTripId: "other" }), "this-trip"),
+    null, // receipts are never "owned" — attach is always allowed
+  );
+});
+
+// ─── Pure UI helpers (trips screen) ──────────────────────────────────────────
+
+test("filterTripsByTab: candidate/confirmed filtered; rejected only under all", () => {
+  const trips = [
+    { status: "candidate" },
+    { status: "confirmed" },
+    { status: "rejected" },
+  ];
+  assert.equal(filterTripsByTab(trips, "candidate").length, 1);
+  assert.equal(filterTripsByTab(trips, "confirmed").length, 1);
+  assert.equal(filterTripsByTab(trips, "all").length, 3);
+});
+
+test("tripStatusTone: candidate=amber, confirmed=green, rejected=gray, exported=blue", () => {
+  assert.equal(tripStatusTone("candidate"), "amber");
+  assert.equal(tripStatusTone("confirmed"), "green");
+  assert.equal(tripStatusTone("rejected"), "gray");
+  assert.equal(tripStatusTone("exported"), "blue");
 });


### PR DESCRIPTION
Phase B UI on the Phase A backend (ADR 0010).

## Changes
- **Picker endpoint** `GET /api/receipts/trips/[id]/candidates` — charges in `[start−window, end+window]` (cross-month), excluding this trip's members; lines owned by another trip flagged `ownedByTripId` (attach will 409). `?all=true` drops the window. Window/date arithmetic + filter are pure + unit-tested.
- **`/receipts/trips`** — Candidates/Confirmed/All tabs, trip cards, inline Register-trip form → POST → detail. Nav entry between Reconcile/Export.
- **`/receipts/trips/[id]`** — editable fields + Save (PATCH), status-aware Confirm/Reject, mixed members table (sealed pill on exported/archived receipts — attachable/detachable per ADR D2 overlay), Add-charges picker (search, ±45-day window, Show all, ownedByTripId rows disabled + linked to the owner).
- **Reconcile strip delegation** — when `business_trip_id` is set, the amber strip shows the trip range + link and Confirm/Exclude become Confirm-trip/Reject-trip (PATCH the whole trip; Phase A status sync updates all member lines). Legacy NULL keeps per-line PATCH.
- **Homebase settings field** — textarea (one signal per line); removes the Phase A `Exclude<>` workaround now that the field exists.

## Verification
- `npm test` → 501 pass / 0 fail (+9 picker/UI-helper tests).
- `npm run build:cf` → OpenNext build complete.
- `cf:dev` boots clean; `/receipts/trips` is Clerk-gated locally (404, like all receipts routes).
- Authenticated UI flows validated on prod by the operator (registering the real June trip — Ekinet/hotel/Odawara receipts, which are sealed; the picker + attach handle them per ADR D2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)