### PR TITLE
receipts: trips picker is charge-centric (dedupe line/receipt)

### DIFF
--- a/app/api/receipts/trips/[id]/candidates/route.ts
+++ b/app/api/receipts/trips/[id]/candidates/route.ts
@@ -4,7 +4,7 @@ import {
   getBusinessTripWithMembers,
   listTripAttachCandidates,
 } from "@/lib/receipts/db";
-import { candidateWindow, filterAttachCandidates } from "@/lib/receipts/business-trips";
+import { candidateWindow, filterAttachCandidates, dedupeChargeCandidates } from "@/lib/receipts/business-trips";
 
 type RouteContext = { params: Promise<{ id: string }> };
 
@@ -44,14 +44,18 @@ export async function GET(request: Request, { params }: RouteContext) {
     const memberLineIds = new Set(detail.lines.map((l) => l.id));
     const memberReceiptIds = new Set(detail.receipts.map((r) => r.id));
 
-    // db narrows by window + q (SQL); the pure filter excludes current members.
+    // db narrows by window + q (SQL); pure helpers exclude current members and
+    // dedupe (a receipt matched to a line is the same charge — fold it into the
+    // line row, never a separate candidate).
     const rows = await listTripAttachCandidates({ window, q });
-    const candidates = filterAttachCandidates(rows, {
-      memberLineIds,
-      memberReceiptIds,
-      window,
-      q,
-    });
+    const candidates = dedupeChargeCandidates(
+      filterAttachCandidates(rows, {
+        memberLineIds,
+        memberReceiptIds,
+        window,
+        q,
+      }),
+    );
 
     return NextResponse.json(
       { candidates, window, tripId: id },

--- a/components/receipts/trips/trip-detail-screen.tsx
+++ b/components/receipts/trips/trip-detail-screen.tsx
@@ -7,7 +7,7 @@ import { Btn } from "@/components/ui/btn";
 import { Pill } from "@/components/ui/pill";
 import { Card } from "@/components/ui/card";
 import { Field, TextInput } from "@/components/ui/field";
-import { formatDate, formatAmountMinor } from "@/lib/receipts/format";
+import { formatDate, formatAmountMinor, formatPaymentPath } from "@/lib/receipts/format";
 import {
   tripStatusTone,
   candidateDisableReason,
@@ -34,6 +34,7 @@ interface MemberRow {
   month: string | null;
   status: string | null;
   sealed: boolean;
+  paymentPath: string | null;
 }
 
 export function TripDetailScreen({ trip, lines, receipts }: TripDetailScreenProps) {
@@ -73,6 +74,7 @@ export function TripDetailScreen({ trip, lines, receipts }: TripDetailScreenProp
       month: l.statement_month,
       status: l.business_trip_status,
       sealed: false,
+      paymentPath: null,
     })),
     ...receipts.map((r) => ({
       kind: "receipt" as const,
@@ -83,6 +85,7 @@ export function TripDetailScreen({ trip, lines, receipts }: TripDetailScreenProp
       month: r.transaction_date ? r.transaction_date.slice(0, 7) : null,
       status: r.status,
       sealed: r.status === "exported" || r.status === "archived",
+      paymentPath: r.payment_path,
     })),
   ].sort((a, b) => (a.date ?? "").localeCompare(b.date ?? ""));
 
@@ -227,6 +230,70 @@ export function TripDetailScreen({ trip, lines, receipts }: TripDetailScreenProp
   const status = trip.status;
   const exported_ = status === "exported";
 
+  // Charge-centric picker: card charges (AMEX lines) vs cash/digital receipts.
+  // The candidates endpoint already dedupes (a receipt matched to a line is
+  // folded into that line row), so each expense appears once.
+  const chargeLines = candidates.filter((c) => c.kind === "line");
+  const cashReceipts = candidates.filter((c) => c.kind === "receipt");
+
+  function renderCandidateRow(row: CandidateRow) {
+    const reason = candidateDisableReason(row, trip.id);
+    const disabled = reason !== null;
+    const checked = selected.has(row.id);
+    return (
+      <label
+        key={`${row.kind}-${row.id}`}
+        className={[
+          "flex items-center gap-2 rounded-lg border px-3 py-2",
+          disabled
+            ? "cursor-not-allowed border-gray-100 bg-gray-50 opacity-70"
+            : "cursor-pointer border-gray-100 hover:bg-gray-50",
+        ].join(" ")}
+      >
+        <input
+          type="checkbox"
+          className="h-4 w-4 accent-amber-500"
+          disabled={disabled || exported_}
+          checked={checked}
+          onChange={() => toggleSelected(row.id)}
+        />
+        <Pill tone={row.kind === "line" ? "outline" : "purple"} size="sm">
+          {row.kind === "line"
+            ? "Card charge"
+            : formatPaymentPath(row.paymentPath)}
+        </Pill>
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-[13px] text-gray-900">
+            {row.merchant ?? "(unnamed)"}
+          </div>
+          <div className="text-[11px] text-gray-500">
+            {formatDate(row.transactionDate)}
+            {row.month ? ` · ${row.month}` : ""}
+            {row.kind === "line"
+              ? row.matchedReceiptId
+                ? " · receipt ✓"
+                : " · no receipt"
+              : ""}
+          </div>
+        </div>
+        {disabled && row.ownedByTripId && (
+          <Link
+            href={`/receipts/trips/${row.ownedByTripId}`}
+            className="shrink-0 text-[11px] font-medium text-amber-700 hover:underline"
+            onClick={(e) => e.stopPropagation()}
+          >
+            owned by another trip →
+          </Link>
+        )}
+        <span className="shrink-0 text-[12px] tabular-nums text-gray-700">
+          {row.amountMinor != null
+            ? formatAmountMinor(row.amountMinor, row.currency)
+            : "—"}
+        </span>
+      </label>
+    );
+  }
+
   return (
     <div className="mx-auto max-w-5xl px-6 py-8">
       <div className="mb-4">
@@ -356,7 +423,9 @@ export function TripDetailScreen({ trip, lines, receipts }: TripDetailScreenProp
                   className="flex items-center gap-2 rounded-lg border border-gray-100 px-3 py-2"
                 >
                   <Pill tone={row.kind === "line" ? "outline" : "purple"} size="sm">
-                    {row.kind === "line" ? "AMEX" : "receipt"}
+                    {row.kind === "line"
+                      ? "Card charge"
+                      : formatPaymentPath(row.paymentPath)}
                   </Pill>
                   <div className="min-w-0 flex-1">
                     <div className="truncate text-[13px] text-gray-900">
@@ -429,60 +498,27 @@ export function TripDetailScreen({ trip, lines, receipts }: TripDetailScreenProp
               No charges in range. Toggle “Show all” or adjust the search.
             </p>
           ) : (
-            <div className="max-h-80 space-y-1.5 overflow-y-auto">
-              {candidates.map((row) => {
-                const reason = candidateDisableReason(row, trip.id);
-                const disabled = reason !== null;
-                const checked = selected.has(row.id);
-                return (
-                  <label
-                    key={`${row.kind}-${row.id}`}
-                    className={[
-                      "flex cursor-pointer items-center gap-2 rounded-lg border px-3 py-2",
-                      disabled
-                        ? "cursor-not-allowed border-gray-100 bg-gray-50 opacity-70"
-                        : "border-gray-100 hover:bg-gray-50",
-                    ].join(" ")}
-                  >
-                    <input
-                      type="checkbox"
-                      className="h-4 w-4 accent-amber-500"
-                      disabled={disabled || exported_}
-                      checked={checked}
-                      onChange={() => toggleSelected(row.id)}
-                    />
-                    <Pill
-                      tone={row.kind === "line" ? "outline" : "purple"}
-                      size="sm"
-                    >
-                      {row.kind === "line" ? "AMEX" : "receipt"}
-                    </Pill>
-                    <div className="min-w-0 flex-1">
-                      <div className="truncate text-[13px] text-gray-900">
-                        {row.merchant ?? "(unnamed)"}
-                      </div>
-                      <div className="text-[11px] text-gray-500">
-                        {formatDate(row.transactionDate)}
-                        {row.month ? ` · ${row.month}` : ""}
-                      </div>
-                    </div>
-                    {disabled && row.ownedByTripId && (
-                      <Link
-                        href={`/receipts/trips/${row.ownedByTripId}`}
-                        className="shrink-0 text-[11px] font-medium text-amber-700 hover:underline"
-                        onClick={(e) => e.stopPropagation()}
-                      >
-                        owned by another trip →
-                      </Link>
-                    )}
-                    <span className="shrink-0 text-[12px] tabular-nums text-gray-700">
-                      {row.amountMinor != null
-                        ? formatAmountMinor(row.amountMinor, row.currency)
-                        : "—"}
-                    </span>
-                  </label>
-                );
-              })}
+            <div className="max-h-80 space-y-3 overflow-y-auto">
+              {chargeLines.length > 0 && (
+                <div>
+                  <div className="mb-1 text-[11px] font-semibold uppercase tracking-[0.04em] text-gray-500">
+                    Card charges ({chargeLines.length})
+                  </div>
+                  <div className="space-y-1.5">
+                    {chargeLines.map(renderCandidateRow)}
+                  </div>
+                </div>
+              )}
+              {cashReceipts.length > 0 && (
+                <div>
+                  <div className="mb-1 text-[11px] font-semibold uppercase tracking-[0.04em] text-gray-500">
+                    Cash & digital receipts ({cashReceipts.length})
+                  </div>
+                  <div className="space-y-1.5">
+                    {cashReceipts.map(renderCandidateRow)}
+                  </div>
+                </div>
+              )}
             </div>
           )}
           {attachError && (

--- a/lib/receipts/business-trips.ts
+++ b/lib/receipts/business-trips.ts
@@ -206,6 +206,11 @@ export interface CandidateRow {
   /** Lines only: the trip currently owning this line (business_trip_id), if any.
    *  A different-trip owner is INCLUDED but flagged so the UI can show why attach 409s. */
   ownedByTripId: string | null;
+  /** Lines only: the matched receipt id, if any. Lets the UI show "receipt ✓" on a
+   *  card-charge row instead of listing that receipt as a separate candidate. */
+  matchedReceiptId: string | null;
+  /** Receipts only: payment_path (CASH/DIGITAL). Null for lines. */
+  paymentPath: string | null;
 }
 
 /**
@@ -238,6 +243,25 @@ export function filterAttachCandidates(
     }
     return true;
   });
+}
+
+/**
+ * Charge-centric dedup (ADR 0010 D2). A receipt matched to an AMEX line is the
+ * SAME expense as that line — drop it as a standalone candidate so the same
+ * charge never appears as two selectable rows. The line row carries
+ * `matchedReceiptId` so the UI can show "receipt ✓". Only receipts with no
+ * matching line (cash/digital, or genuinely unmatched) survive as receipt
+ * candidates. Pure so it can be unit-tested alongside the picker.
+ */
+export function dedupeChargeCandidates(rows: CandidateRow[]): CandidateRow[] {
+  const matchedReceiptIds = new Set(
+    rows
+      .filter((r) => r.kind === "line" && r.matchedReceiptId)
+      .map((r) => r.matchedReceiptId),
+  );
+  return rows.filter(
+    (r) => !(r.kind === "receipt" && matchedReceiptIds.has(r.id)),
+  );
 }
 
 /**

--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -2308,7 +2308,7 @@ export async function listTripAttachCandidates(
   const lines = await db
     .prepare(
       `SELECT id, transaction_date, merchant, amount_minor, currency,
-              statement_month, match_status, business_trip_id
+              statement_month, match_status, business_trip_id, matched_receipt_id
        FROM amex_statement_lines
        WHERE ${datePred} ${hasQ ? "AND merchant LIKE ?" : ""}
        ORDER BY transaction_date ASC`,
@@ -2323,6 +2323,7 @@ export async function listTripAttachCandidates(
       statement_month: string;
       match_status: string | null;
       business_trip_id: string | null;
+      matched_receipt_id: string | null;
     }>();
   for (const l of lines.results ?? []) {
     rows.push({
@@ -2335,13 +2336,15 @@ export async function listTripAttachCandidates(
       month: l.statement_month,
       status: l.match_status,
       ownedByTripId: l.business_trip_id,
+      matchedReceiptId: l.matched_receipt_id,
+      paymentPath: null,
     });
   }
 
   const recs = await db
     .prepare(
       `SELECT id, transaction_date, merchant, amount_minor, currency,
-              export_statement_month, status
+              export_statement_month, status, payment_path
        FROM receipt_records
        WHERE deleted_at IS NULL
          AND ${datePred} ${hasQ ? "AND merchant LIKE ?" : ""}
@@ -2356,6 +2359,7 @@ export async function listTripAttachCandidates(
       currency: string;
       export_statement_month: string | null;
       status: string;
+      payment_path: string;
     }>();
   for (const r of recs.results ?? []) {
     rows.push({
@@ -2370,6 +2374,8 @@ export async function listTripAttachCandidates(
         (r.transaction_date ? r.transaction_date.slice(0, 7) : null),
       status: r.status,
       ownedByTripId: null,
+      matchedReceiptId: null,
+      paymentPath: r.payment_path,
     });
   }
 

--- a/tests/receipts/business-trips.test.ts
+++ b/tests/receipts/business-trips.test.ts
@@ -16,6 +16,7 @@ import {
   candidateWindow,
   isInCandidateWindow,
   filterAttachCandidates,
+  dedupeChargeCandidates,
   candidateDisableReason,
   filterTripsByTab,
   tripStatusTone,
@@ -230,6 +231,8 @@ function cand(over: Partial<CandidateRow> & { kind: "line" | "receipt"; id: stri
     month: "2026-06",
     status: "confirmed",
     ownedByTripId: null,
+    matchedReceiptId: null,
+    paymentPath: null,
     ...over,
   };
 }
@@ -286,6 +289,36 @@ test("filterAttachCandidates: q filters merchant (case-insensitive)", () => {
     q: "ekinet",
   });
   assert.deepEqual(out.map((r) => r.id), ["a"]);
+});
+
+// ─── dedupeChargeCandidates: fold a matched receipt into its line ────────────
+
+test("dedupeChargeCandidates: a receipt matched to a line is dropped (same expense, one row)", () => {
+  const rows = [
+    cand({ kind: "line", id: "line-1", merchant: "Ekinet", matchedReceiptId: "rec-1" }),
+    cand({ kind: "receipt", id: "rec-1", merchant: "Ekinet" }), // duplicate of line-1
+    cand({ kind: "receipt", id: "rec-2", merchant: "駅弁", paymentPath: "CASH" }), // standalone cash
+  ];
+  const out = dedupeChargeCandidates(rows);
+  assert.deepEqual(
+    out.map((r) => r.id).sort(),
+    ["line-1", "rec-2"],
+  );
+  // the surviving line row still carries the matched-receipt hint
+  assert.equal(out.find((r) => r.id === "line-1")?.matchedReceiptId, "rec-1");
+});
+
+test("dedupeChargeCandidates: receipts with no matching line survive", () => {
+  const rows = [
+    cand({ kind: "line", id: "line-1", matchedReceiptId: "rec-1" }),
+    cand({ kind: "receipt", id: "rec-2", paymentPath: "DIGITAL" }),
+    cand({ kind: "receipt", id: "rec-3", paymentPath: "CASH" }),
+  ];
+  const out = dedupeChargeCandidates(rows);
+  assert.deepEqual(
+    out.map((r) => r.id).sort(),
+    ["line-1", "rec-2", "rec-3"],
+  );
 });
 
 // ─── candidateDisableReason (ownedByTripId flag) ─────────────────────────────


### PR DESCRIPTION
Fixes the line/receipt duplicate-selection confusion in the trips Add-charges picker. Each expense is now one row: receipts matched to an in-window line are folded into the line row (pure `dedupeChargeCandidates`, unit-tested); the picker splits into Card charges vs Cash & digital receipts; members table relabeled to match. Attaching a card charge links the line (matched receipt rides along via `matched_receipt_id`, no double-link per ADR D2); cash/digital rows link the receipt. `npm test` 503 pass (+2), `build:cf` clean.