### PR TITLE
receipts: recon v2 fix — draft download surface + CSVs embedded in proofs ZIP

### DIFF
--- a/app/(receipt-system)/receipts/export/page.tsx
+++ b/app/(receipt-system)/receipts/export/page.tsx
@@ -33,7 +33,7 @@ import {
   ACCOUNTANT_DISCLAIMER_JA,
 } from "@/lib/receipts/settings";
 import { buildExportBundle } from "@/lib/receipts/month-closing";
-import { buildMonthlyExportCsv } from "@/lib/receipts/export";
+import { buildMonthlyExportCsv, BUNDLE_DOWNLOAD_LINK_DEFS } from "@/lib/receipts/export";
 import { deriveStatementWindow } from "@/lib/receipts/statement-window";
 import { CreateRevisionButton } from "@/components/receipts/export/create-revision-button";
 
@@ -42,14 +42,9 @@ export const dynamic = "force-dynamic";
 // The four artifacts finalize seals in RECEIPTS_ARCHIVE_BUCKET, served by
 // GET /api/receipts/export/[month]/download (Content-Disposition: attachment,
 // so plain anchors download without any client-side code).
-const BUNDLE_DOWNLOAD_LINKS = [
-  { file: "receipts", label: "Receipts CSV" },
-  { file: "manifest", label: "Manifest" },
-  { file: "summary", label: "Summary" },
-  { file: "readme", label: "README" },
-  { file: "proofs", label: "領収書ZIP" },
-  { file: "attendees", label: "参加者一覧" },
-] as const;
+// Shared definition (lib/receipts/export.ts) — the review-#2 rollout missed
+// this page because it had a local copy of the list. Do not re-inline.
+const BUNDLE_DOWNLOAD_LINKS = BUNDLE_DOWNLOAD_LINK_DEFS;
 
 export default async function ExportPage({
   searchParams,

--- a/app/api/receipts/export/month/route.ts
+++ b/app/api/receipts/export/month/route.ts
@@ -306,30 +306,6 @@ export async function POST(request: Request) {
       });
     }
 
-    // Transition notice (shared builder — also used by the finalize email, so
-    // the notice text cannot drift between the ZIP and the notification).
-    const proofsNoticeInput = deriveTransitionNoticeInput(
-      month,
-      bundle.rows,
-      bundle.receipts,
-      { rowCount: bundle.rows.length, receiptCount: proofsEntries.length },
-      { exportRevision, supersedesExportId, correctionReason },
-    );
-
-    const proofsKey = buildProofsKey(month, exportId);
-    const proofsZipBytes = assembleProofsZip(
-      month,
-      proofsEntries,
-      proofsNoticeInput,
-      summaryShipped,
-      attendeesShipped,
-    );
-    const proofsSha256 = await computeSha256Hex(proofsZipBytes);
-    await getReceiptsArchiveBucket().put(proofsKey, proofsZipBytes, {
-      httpMetadata: { contentType: "application/zip" },
-      customMetadata: retentionMetadata(),
-    });
-
     // ── Reconciliation CSVs (review #2) ───────────────────────────────────
     // AMEX: the ORIGINAL statement CSV (sealed artifact, SHA in manifest),
     // decoded and passed through line-for-line with 科目＆No./会議-出席者ID/
@@ -438,6 +414,39 @@ export async function POST(request: Request) {
         },
       );
     }
+
+    // ── Proofs ZIP assembly ───────────────────────────────────────────────
+    // Assembled AFTER the reconciliation CSVs so their shipped bytes can be
+    // embedded at ZIP root (AMEX{month}_Reconciliation.csv etc.) — the ZIP
+    // alone is the complete accountant package. Transition notice via the
+    // shared builder (also used by the finalize email, so the notice text
+    // cannot drift between the ZIP and the notification).
+    const proofsNoticeInput = deriveTransitionNoticeInput(
+      month,
+      bundle.rows,
+      bundle.receipts,
+      { rowCount: bundle.rows.length, receiptCount: proofsEntries.length },
+      { exportRevision, supersedesExportId, correctionReason },
+    );
+
+    const proofsKey = buildProofsKey(month, exportId);
+    const proofsZipBytes = assembleProofsZip(
+      month,
+      proofsEntries,
+      proofsNoticeInput,
+      summaryShipped,
+      attendeesShipped,
+      {
+        amex: amexReconShipped,
+        cash: cashReconShipped,
+        digital: digitalReconShipped,
+      },
+    );
+    const proofsSha256 = await computeSha256Hex(proofsZipBytes);
+    await getReceiptsArchiveBucket().put(proofsKey, proofsZipBytes, {
+      httpMetadata: { contentType: "application/zip" },
+      customMetadata: retentionMetadata(),
+    });
 
     // Gather all file-manifest entries for receipts included in this export
     // plus the AMEX statement artifact. This builds the per-file SHA-256

--- a/components/receipts/export/finalize-card.tsx
+++ b/components/receipts/export/finalize-card.tsx
@@ -5,22 +5,15 @@ import { useState, type ReactNode } from "react";
 import { Btn } from "@/components/ui/btn";
 import { Card } from "@/components/ui/card";
 import { LockIcon } from "@/components/ui/icons";
+import { BUNDLE_DOWNLOAD_LINK_DEFS } from "@/lib/receipts/export";
 
 // The artifacts sealed in RECEIPTS_ARCHIVE_BUCKET, served by
 // GET /api/receipts/export/[month]/download (Content-Disposition: attachment).
 // AMEX/CASH/DIGITAL reconciliation files (review #2) 404 for revisions sealed
 // before they shipped, and CASH/DIGITAL 404 when the month has no such rows —
 // the link stays visible (matching summary/attendees behavior for old seals).
-const BUNDLE_DOWNLOAD_LINKS = [
-  { file: "amex", label: "AMEX照合CSV" },
-  { file: "cash", label: "現金照合CSV" },
-  { file: "digital", label: "デジタル照合CSV" },
-  { file: "receipts", label: "Receipts CSV" },
-  { file: "manifest", label: "Manifest" },
-  { file: "summary", label: "Summary" },
-  { file: "readme", label: "README" },
-  { file: "proofs", label: "領収書ZIP" },
-] as const;
+// Shared definition (lib/receipts/export.ts) — do not re-inline a local copy.
+const BUNDLE_DOWNLOAD_LINKS = BUNDLE_DOWNLOAD_LINK_DEFS;
 
 /**
  * Finalize action + panel. Extracted from export-screen.tsx so it can render at

--- a/lib/receipts/export.ts
+++ b/lib/receipts/export.ts
@@ -483,6 +483,27 @@ export const EXPORT_DOWNLOAD_FILES = [
 
 export type ExportDownloadFile = (typeof EXPORT_DOWNLOAD_FILES)[number];
 
+/**
+ * Download-link definitions shared by EVERY download surface (export page
+ * draft + finalized sections, finalize card). Single source of truth — the
+ * review-#2 rollout missed the export page because it had its own copy of
+ * this list; never duplicate it again.
+ */
+export const BUNDLE_DOWNLOAD_LINK_DEFS: ReadonlyArray<{
+  file: ExportDownloadFile;
+  label: string;
+}> = [
+  { file: "amex", label: "AMEX照合CSV" },
+  { file: "cash", label: "現金照合CSV" },
+  { file: "digital", label: "デジタル照合CSV" },
+  { file: "receipts", label: "Receipts CSV" },
+  { file: "manifest", label: "Manifest" },
+  { file: "summary", label: "Summary" },
+  { file: "attendees", label: "参加者一覧" },
+  { file: "readme", label: "README" },
+  { file: "proofs", label: "領収書ZIP" },
+];
+
 export function isExportDownloadFile(
   value: string,
 ): value is ExportDownloadFile {

--- a/lib/receipts/proofs.ts
+++ b/lib/receipts/proofs.ts
@@ -334,6 +334,12 @@ export function assembleProofsZip(
   noticeInput: TransitionNoticeInput,
   summaryCsv: string,
   attendeesCsv: string,
+  /** Reconciliation CSVs (review #2) — byte-identical copies of the standalone
+   *  artifacts, embedded at ZIP root as AMEX{month}_Reconciliation.csv etc. so
+   *  the ZIP alone is the complete accountant package (same doctrine as
+   *  集計.csv / 参加者一覧.csv). Absent entries are skipped (e.g. no DIGITAL
+   *  rows this month). */
+  reconciliationCsvs?: { amex?: string | null; cash?: string | null; digital?: string | null },
 ): Uint8Array {
   const root = ROOT_PREFIX(month);
   const files: Record<string, Uint8Array> = {};
@@ -402,6 +408,15 @@ export function assembleProofsZip(
   files[`${root}集計.csv`] = encoder.encode(summaryCsv);
   files[`${root}参加者一覧.csv`] = encoder.encode(attendeesCsv);
   files[`${root}お知らせ.txt`] = encoder.encode(buildTransitionNotice(noticeInput));
+  if (reconciliationCsvs?.amex) {
+    files[`${root}AMEX${month}_Reconciliation.csv`] = encoder.encode(reconciliationCsvs.amex);
+  }
+  if (reconciliationCsvs?.cash) {
+    files[`${root}CASH${month}_Reconciliation.csv`] = encoder.encode(reconciliationCsvs.cash);
+  }
+  if (reconciliationCsvs?.digital) {
+    files[`${root}DIGITAL${month}_Reconciliation.csv`] = encoder.encode(reconciliationCsvs.digital);
+  }
 
   return zipSync(files, { level: 0 });
 }

--- a/tests/receipts/proofs.test.ts
+++ b/tests/receipts/proofs.test.ts
@@ -343,3 +343,32 @@ test("assembleProofsZip: 目次 No column matches entry nos (CSV⇄目次 contin
     );
   }
 });
+
+test("assembleProofsZip: reconciliation CSVs embedded at root when provided (review #2)", () => {
+  const zip = assembleProofsZip(
+    "2026-06",
+    [fakeEntry({ no: 1 })],
+    baseNotice,
+    SUMMARY_CSV,
+    ATTENDEES_CSV,
+    { amex: "﻿amex-bytes", cash: "﻿cash-bytes", digital: null },
+  );
+  const files = unzipSync(zip);
+  const keys = Object.keys(files);
+  const amexKey = keys.find((k) => k.endsWith("AMEX2026-06_Reconciliation.csv"));
+  const cashKey = keys.find((k) => k.endsWith("CASH2026-06_Reconciliation.csv"));
+  assert.ok(amexKey, "AMEX reconciliation embedded");
+  assert.ok(cashKey, "CASH reconciliation embedded");
+  // Byte-identity with the standalone artifact (same doctrine as 集計.csv).
+  assert.equal(
+    new TextDecoder("utf-8", { ignoreBOM: true }).decode(files[amexKey!]),
+    "﻿amex-bytes",
+  );
+  // Absent path → no entry.
+  assert.ok(
+    !keys.some((k) => k.includes("DIGITAL2026-06_Reconciliation")),
+    "no DIGITAL entry when null",
+  );
+  // Root placement (directly under the 領収書等証憓_<month>/ prefix).
+  assert.equal(amexKey!.split("/").length, 2, "embedded at ZIP root");
+});


### PR DESCRIPTION
The review-#2 rollout missed the export page's draft/finalized download
sections: page.tsx had its OWN copy of the download-link list, so the
rebuilt draft showed only the six legacy files and none of the new
reconciliation CSVs (they were built and uploaded, just never offered).
Consolidated into BUNDLE_DOWNLOAD_LINK_DEFS (lib/receipts/export.ts) used
by every download surface — do not re-inline.

Also embeds the AMEX/CASH/DIGITAL reconciliation CSVs byte-identically at
proofs-ZIP root (AMEX{month}_Reconciliation.csv …) so the ZIP alone is the
complete accountant package, same doctrine as 集計.csv/参加者一覧.csv. ZIP
assembly moved after the reconciliation builds to allow embedding; bytes
of each standalone artifact unchanged.

563 tests pass; tsc/lint clean.