### PR TITLE
receipts: email receipt intake (ADR 0011)

### DIFF
--- a/app/(receipt-system)/receipts/inbox/page.tsx
+++ b/app/(receipt-system)/receipts/inbox/page.tsx
@@ -1,0 +1,45 @@
+import { assertReceiptsPageAccess } from "@/lib/receipts/auth-request";
+import { getReceiptsDb } from "@/lib/cloudflare-runtime";
+import { listPendingIntake } from "@/lib/receipts/email-intake";
+import { InboxRow } from "@/components/receipts/inbox/inbox-row";
+
+export const dynamic = "force-dynamic";
+
+// ADR 0011: human triage queue for emailed receipts (receipts@dazbeez.com).
+// Unauthenticated mail never writes to receipt_records directly — it lands in
+// email_receipt_intake at pending_triage and only an explicit Promote creates
+// a real receipt. This screen is deliberately separate from /receipts/review
+// (whose lock/month-scoping semantics don't apply to unreviewed mail).
+export default async function InboxPage() {
+  await assertReceiptsPageAccess();
+  const rows = await listPendingIntake(getReceiptsDb());
+
+  return (
+    <main className="mx-auto w-full max-w-3xl px-4 py-8 sm:px-8">
+      <header className="mb-6">
+        <h1 className="text-xl font-bold text-gray-900">Email inbox</h1>
+        <p className="mt-1 text-sm text-gray-500">
+          Mail sent to <span className="font-medium">receipts@</span> or{" "}
+          <span className="font-medium">receipt@dazbeez.com</span>. Promote
+          to create a real receipt; reject to dismiss. SPF/DKIM verdicts are
+          informational — nothing is auto-accepted or auto-rejected.
+        </p>
+      </header>
+
+      {rows.length === 0 ? (
+        <div className="rounded-2xl border border-dashed border-gray-300 bg-white px-6 py-12 text-center">
+          <p className="text-sm font-medium text-gray-600">No emails to triage.</p>
+          <p className="mt-1 text-xs text-gray-400">
+            Emails with a valid PDF/image attachment will appear here.
+          </p>
+        </div>
+      ) : (
+        <ul className="space-y-3">
+          {rows.map((intake) => (
+            <InboxRow key={intake.id} intake={intake} />
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/app/api/receipts/inbox/[id]/promote/route.ts
+++ b/app/api/receipts/inbox/[id]/promote/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from "next/server";
+import { requireReceiptsActor } from "@/lib/receipts/auth";
+import { promoteIntake } from "@/lib/receipts/email-intake";
+
+// POST /api/receipts/inbox/[id]/promote
+// Promote a triaged email_receipt_intake row into a real receipt via the
+// canonical createReceiptRecord path (ADR 0011). Clerk-gated like every other
+// /api/receipts/* route. Returns the new receipt id; the receipt then flows
+// through the normal extraction queue → Mac MLX → review pipeline.
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const actor = await requireReceiptsActor(request.headers);
+    const { id } = await params;
+    const receiptId = await promoteIntake(id, actor);
+    return NextResponse.json({ receiptId }, { status: 200 });
+  } catch (error) {
+    if (isUnauthorized(error)) return unauthorized();
+    if (isNotFound(error)) return notFound();
+    if (isIntakeStateConflict(error)) return conflict(error);
+    console.error("[api/receipts/inbox/promote] failed", error);
+    return NextResponse.json(
+      { error: errorMessage(error) },
+      { status: 500 },
+    );
+  }
+}
+
+function isUnauthorized(error: unknown): boolean {
+  return error instanceof Error && error.message.startsWith("Unauthorized");
+}
+function isNotFound(error: unknown): boolean {
+  return error instanceof Error && /not found/i.test(error.message);
+}
+function isIntakeStateConflict(error: unknown): boolean {
+  // assertPromotable / rejectIntake refuse with messages mentioning the
+  // intake's state (already promoted/rejected, no promotable attachment,
+  // missing R2 object). These are 409s, not 500s.
+  return (
+    error instanceof Error &&
+    (/already (promoted|rejected|pending_triage)/i.test(error.message) ||
+      /no promotable attachment/i.test(error.message) ||
+      /only pending_triage may be/i.test(error.message) ||
+      /is missing from r2/i.test(error.message))
+  );
+}
+function unauthorized() {
+  return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+}
+function notFound() {
+  return NextResponse.json({ error: "Intake row not found." }, { status: 404 });
+}
+function conflict(error: unknown) {
+  return NextResponse.json(
+    { error: errorMessage(error) },
+    { status: 409 },
+  );
+}
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Failed to promote intake.";
+}

--- a/app/api/receipts/inbox/[id]/reject/route.ts
+++ b/app/api/receipts/inbox/[id]/reject/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server";
+import { requireReceiptsActor } from "@/lib/receipts/auth";
+import { getReceiptsDb } from "@/lib/cloudflare-runtime";
+import { rejectIntake } from "@/lib/receipts/email-intake";
+
+// POST /api/receipts/inbox/[id]/reject  body: { reason: string }
+// Reject a pending intake row with a REQUIRED reason. Does not create a
+// receipt and does not delete the R2 object immediately (30-day cleanup does).
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const actor = await requireReceiptsActor(request.headers);
+    const { id } = await params;
+
+    let reason = "";
+    try {
+      const body = (await request.json()) as { reason?: unknown };
+      reason = typeof body.reason === "string" ? body.reason : "";
+    } catch {
+      // Empty/non-JSON body → empty reason → rejectIntake throws below.
+      reason = "";
+    }
+
+    await rejectIntake(getReceiptsDb(), id, reason, actor);
+    return NextResponse.json({ ok: true }, { status: 200 });
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Unauthorized")) {
+      return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+    }
+    if (error instanceof Error && /reject_reason is required/i.test(error.message)) {
+      return NextResponse.json(
+        { error: "A reject reason is required." },
+        { status: 400 },
+      );
+    }
+    if (error instanceof Error && /not found/i.test(error.message)) {
+      return NextResponse.json({ error: "Intake row not found." }, { status: 404 });
+    }
+    if (
+      error instanceof Error &&
+      (/already (promoted|rejected)/i.test(error.message) ||
+        /only pending_triage may be/i.test(error.message))
+    ) {
+      return NextResponse.json(
+        { error: error.message },
+        { status: 409 },
+      );
+    }
+    console.error("[api/receipts/inbox/reject] failed", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to reject intake." },
+      { status: 500 },
+    );
+  }
+}

--- a/components/receipts/inbox/inbox-row.tsx
+++ b/components/receipts/inbox/inbox-row.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import type { EmailReceiptIntake } from "@/lib/receipts/types";
+
+/**
+ * One triage row in /receipts/inbox. Promote creates a real receipt (the row
+ * then leaves pending_triage and disappears on refresh); Reject requires a
+ * reason. Promote is disabled when the row has no promotable attachment
+ * (mirrors the server assertPromotable check) and the reject_reason is shown
+ * inline so the operator sees WHY it can't be promoted.
+ */
+export function InboxRow({ intake }: { intake: EmailReceiptIntake }) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [rejectOpen, setRejectOpen] = useState(false);
+  const [reason, setReason] = useState("");
+
+  const promotable = intake.status === "pending_triage" && !!intake.attachment_r2_key;
+
+  function refresh() {
+    startTransition(() => {
+      router.refresh();
+    });
+  }
+
+  async function handlePromote() {
+    setError(null);
+    try {
+      const res = await fetch(
+        `/api/receipts/inbox/${encodeURIComponent(intake.id)}/promote`,
+        { method: "POST" },
+      );
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(body.error ?? `Promote failed (HTTP ${res.status}).`);
+      }
+      refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Promote failed.");
+    }
+  }
+
+  async function handleReject() {
+    setError(null);
+    if (!reason.trim()) {
+      setError("A reject reason is required.");
+      return;
+    }
+    try {
+      const res = await fetch(
+        `/api/receipts/inbox/${encodeURIComponent(intake.id)}/reject`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ reason }),
+        },
+      );
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(body.error ?? `Reject failed (HTTP ${res.status}).`);
+      }
+      setRejectOpen(false);
+      setReason("");
+      refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Reject failed.");
+    }
+  }
+
+  return (
+    <li className="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="truncate text-sm font-semibold text-gray-900">
+            {intake.from_address}
+          </p>
+          <p className="truncate text-sm text-gray-600">
+            {intake.subject || <span className="text-gray-400">(no subject)</span>}
+          </p>
+          <p className="mt-0.5 text-xs text-gray-400">
+            {formatReceived(intake.received_at)}
+          </p>
+          {intake.to_address && (
+            <p className="truncate text-xs text-gray-400">→ {intake.to_address}</p>
+          )}
+        </div>
+        <div className="flex flex-none items-center gap-1.5">
+          <VerdictBadge label="SPF" pass={intake.spf_pass === 1} />
+          <VerdictBadge label="DKIM" pass={intake.dkim_pass === 1} />
+        </div>
+      </div>
+
+      <div className="mt-3">
+        {intake.attachment_r2_key ? (
+          <p className="text-xs text-gray-700">
+            <span className="text-gray-400">Attachment: </span>
+            {intake.attachment_filename || "untitled"}
+            {intake.attachment_content_type
+              ? ` · ${intake.attachment_content_type}`
+              : ""}
+          </p>
+        ) : (
+          <p className="rounded-lg bg-amber-50 px-2.5 py-1.5 text-xs text-amber-800">
+            {intake.reject_reason || "No promotable attachment."}
+          </p>
+        )}
+      </div>
+
+      {error && (
+        <p className="mt-2 text-xs font-medium text-red-600">{error}</p>
+      )}
+
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          onClick={handlePromote}
+          disabled={!promotable || isPending}
+          className="rounded-lg bg-amber-500 px-3 py-1.5 text-xs font-semibold text-white hover:bg-amber-600 disabled:cursor-not-allowed disabled:opacity-50"
+          title={promotable ? "Promote to a real receipt" : "Nothing to promote"}
+        >
+          Promote
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            setRejectOpen((v) => !v);
+            setError(null);
+          }}
+          disabled={isPending}
+          className="rounded-lg border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-100 disabled:opacity-50"
+        >
+          {rejectOpen ? "Cancel" : "Reject"}
+        </button>
+      </div>
+
+      {rejectOpen && (
+        <div className="mt-3 rounded-lg border border-gray-200 bg-gray-50 p-3">
+          <label className="block text-xs font-medium text-gray-600">
+            Reason (required)
+            <textarea
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              rows={2}
+              className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-2 py-1.5 text-sm text-gray-900 focus:border-amber-500 focus:outline-none"
+              placeholder="e.g. personal expense, not a business receipt"
+            />
+          </label>
+          <button
+            type="button"
+            onClick={handleReject}
+            disabled={isPending}
+            className="mt-2 rounded-lg bg-gray-900 px-3 py-1.5 text-xs font-semibold text-white hover:bg-gray-800 disabled:opacity-50"
+          >
+            Confirm reject
+          </button>
+        </div>
+      )}
+    </li>
+  );
+}
+
+function VerdictBadge({ label, pass }: { label: string; pass: boolean }) {
+  return (
+    <span
+      title={`${label} ${pass ? "pass" : "fail"}`}
+      className={[
+        "rounded-full px-2 py-0.5 text-[10px] font-semibold",
+        pass
+          ? "bg-green-100 text-green-800"
+          : "bg-red-100 text-red-700",
+      ].join(" ")}
+    >
+      {label} {pass ? "✓" : "✗"}
+    </span>
+  );
+}
+
+function formatReceived(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString("en-US", {
+      dateStyle: "medium",
+      timeStyle: "short",
+    });
+  } catch {
+    return iso;
+  }
+}

--- a/components/receipts/receipt-shell.tsx
+++ b/components/receipts/receipt-shell.tsx
@@ -8,6 +8,7 @@ import { ToasterProvider } from "@/components/ui/toaster";
 const NAV = [
   { href: "/receipts", label: "Dashboard" },
   { href: "/receipts/capture", label: "Capture" },
+  { href: "/receipts/inbox", label: "Inbox" },
   { href: "/receipts/review", label: "Review" },
   { href: "/receipts/amex", label: "AMEX" },
   { href: "/receipts/reconcile", label: "Reconcile" },

--- a/db/receipts/0024_email_intake.sql
+++ b/db/receipts/0024_email_intake.sql
@@ -1,0 +1,47 @@
+-- 0024_email_intake.sql
+--
+-- ADR 0011: inbound email receipt intake at receipts@dazbeez.com. Mail is
+-- parsed by a Worker `email()` handler; attachments land here for human
+-- triage. Nothing in this table is a tax record until a human explicitly
+-- promotes a row (which calls the existing createReceiptRecord()).
+--
+-- Deliberate differences from receipt_records (per ADR 0011 "Decision"):
+--   - No retention_until / legal_hold columns. Unreviewed, unauthenticated
+--     mail must NOT inherit the 10-year retention / legal-hold posture that
+--     every receipt_records insert correctly assumes. Retention is short
+--     (cleanup deletes R2 after 30 days; the row is kept with a nulled
+--     attachment_r2_key for audit history). Adding these columns here would
+--     be wrong — do not.
+--   - status is a 3-state triage lifecycle (pending_triage → promoted |
+--     rejected), intentionally separate from the receipt_records status
+--     CHECK so the two lifecycles cannot accidentally entangle.
+--   - promoted_receipt_id references receipt_records(id) only AFTER a
+--     promote; it is NULL until then.
+--
+-- See docs/adr/0011-email-receipt-intake.md for the full rationale and the
+-- "why a separate table" alternative-rejected analysis.
+CREATE TABLE IF NOT EXISTS email_receipt_intake (
+  id TEXT PRIMARY KEY,
+  received_at TEXT NOT NULL,
+  from_address TEXT NOT NULL,
+  subject TEXT,
+  spf_pass INTEGER NOT NULL DEFAULT 0,
+  dkim_pass INTEGER NOT NULL DEFAULT 0,
+  attachment_r2_key TEXT,
+  attachment_sha256 TEXT,
+  attachment_content_type TEXT,
+  attachment_size_bytes INTEGER,
+  attachment_filename TEXT,
+  status TEXT NOT NULL DEFAULT 'pending_triage'
+    CHECK (status IN ('pending_triage','promoted','rejected')),
+  reject_reason TEXT,
+  promoted_receipt_id TEXT REFERENCES receipt_records(id),
+  raw_headers_json TEXT,
+  created_at TEXT NOT NULL
+);
+
+-- Triage queue is the hot read path (the /receipts/inbox screen lists
+-- pending_triage, newest first). Status-first keeps the working set small
+-- even as promoted/rejected history accumulates.
+CREATE INDEX IF NOT EXISTS idx_email_intake_status
+  ON email_receipt_intake(status, received_at);

--- a/db/receipts/0025_email_intake_to_address.sql
+++ b/db/receipts/0025_email_intake_to_address.sql
@@ -1,0 +1,8 @@
+-- 0025_email_intake_to_address.sql
+--
+-- Adds to_address to email_receipt_intake so a human triaging /receipts/inbox
+-- can see which alias (receipts@ or receipt@dazbeez.com) captured a given email.
+-- Nullable — older rows predate this column; no backfill. Intake-side metadata
+-- only; does NOT flow into receipt_records on promote (ADR 0011 follow-up,
+-- 2026-07-19 scope-change note).
+ALTER TABLE email_receipt_intake ADD COLUMN to_address TEXT;

--- a/docs/adr/0011-email-receipt-intake.md
+++ b/docs/adr/0011-email-receipt-intake.md
@@ -1,0 +1,299 @@
+# ADR 0011 — Email receipt intake (receipts@dazbeez.com)
+
+- **Status:** Accepted
+- **Date:** 2026-07-19 (proposed) · 2026-07-19 (accepted, placement resolved)
+- **Owner:** David (PM)
+- **Supersedes:** —
+- **Superseded by:** —
+- **Related:** [ADR 0001](0001-receipt-extraction-runtime.md) (store-and-forward extraction runtime, which this feeds into), `lib/receipts/upload-policy.ts` header note ("no email/HTML ingestion pipeline exists," 2026-07-16), `lib/receipts/compliance.ts` (`ELECTRONIC_SOURCE_TYPES` already includes `email_attachment`), `workers/email-reply-capture/` (the standalone-worker precedent this ADR follows)
+- **Affects:** new standalone Cloudflare Worker `workers/receipts-email-intake/` (email routing + cleanup cron — NOT the main `dazbeez` OpenNext worker), `db/receipts/0024_email_intake.sql` (new table, written), `lib/receipts/email-intake.ts` (new, written — placement-agnostic, takes injected `db`/`bucket`), `app/(receipt-system)/receipts/inbox/` (new review screen, written), `app/api/receipts/inbox/*` (new, written), `lib/receipts/db.ts` (`createReceiptRecord` — reused, not modified), `lib/receipts/audit.ts` (new `email_intake.*` actions, written)
+
+## Decision record (2026-07-19)
+
+**Worker report confirmed the predicted blocker.** The implementing agent
+investigated §3 (email handler placement) and reported, correctly, that
+`@opennextjs/cloudflare`'s `CloudflareOverrides` type has no `email` or
+`scheduled` hook, and the generated `.open-next/worker.js` exports only
+`fetch` — regenerated on every `build:cf`, so hand-editing it is not viable.
+**Verified independently** (not taken on the report's word): read
+`node_modules/@opennextjs/cloudflare/dist/api/config.d.ts` directly (confirms
+the override surface is `incrementalCache | tagCache | queue | cachePurge |
+enableCacheInterception | routePreloadingBehavior` — no email/scheduled), and
+read the generated `.open-next/worker.js` directly (confirms `export default
+{ async fetch(...) }` and nothing else).
+
+**Resolved:**
+
+1. **§3 placement — Option A, standalone worker, approved.** A new Cloudflare
+   Worker, `workers/receipts-email-intake/`, mirroring the existing
+   `workers/email-reply-capture/` precedent exactly (own `wrangler.jsonc`,
+   own `name`, own `d1_databases`/`r2_buckets` bindings). Cloudflare Email
+   Routing points `receipts@dazbeez.com` at this worker, not at `dazbeez`.
+   It parses MIME (the `email-reply-capture` precedent already vets
+   `postal-mime` for this — reuse it, do not re-evaluate MIME libraries) and
+   calls the already-written, placement-agnostic `recordIntake(db, bucket,
+   input)`.
+2. **§6 cleanup cron — lives in the same standalone worker.** It already
+   needs `RECEIPTS_DB`/`RECEIPTS_BUCKET` bindings for intake; carrying its
+   own `[triggers].crons` for the 30-day stale-row cleanup is trivial there
+   and was never viable in OpenNext regardless. Do not add scheduled-worker
+   machinery to the main `dazbeez` worker for a receipts-only concern.
+3. **30-day stale-triage window confirmed.** `INTAKE_STALE_DAYS = 30` (already
+   coded in `lib/receipts/email-intake.ts`) stands as written; no change
+   needed.
+
+**Why a third worker (not folding into `email-reply-capture`):** conflates
+two unrelated domains (CRM email replies vs. tax-record receipt intake)
+behind one deploy/secret/monitoring surface. A separate worker costs one more
+`wrangler.jsonc` and one more deploy step, and buys real isolation: a broken
+`dazbeez` (Next.js/OpenNext) deploy cannot take down receipt-email intake,
+and vice versa, and the two domains' secrets/bindings stay scoped to what
+each actually needs. Consistent with the existing two-worker split already
+in the repo, not a new pattern.
+
+**Operational impact worth flagging (PM-relevant):** this is now a **third**
+independently deployable Cloudflare Worker in the account (`dazbeez`,
+`dazbeez-email-reply-capture`, and now `dazbeez-receipts-email-intake`).
+Each is a separate thing that can be down, misconfigured, or silently
+failing without the others noticing. `docs/receipt-module.md` and the deploy
+runbook should get a line for it once built, and — per the "no
+SLA/notification in scope for v1" negative consequence already called out
+below — it's worth deciding later whether an unattended intake worker with
+no monitoring is acceptable indefinitely or just for launch.
+
+**New finding — SPF/DKIM verdicts may not be reliably available on the
+Worker-delivery path.** Researched while resolving §3 (not something the
+worker report or the original design surfaced). Per a known, currently open
+Cloudflare issue (`cloudflare/workerd#6740`), Email Routing's "Send to a
+Worker" delivery path does NOT reliably stamp an `Authentication-Results`
+header on the message the way forwarding-to-an-address does — the
+`ARC-Authentication-Results` header observed contains `arc=none` with no
+`spf=`/`dkim=`/`dmarc=` verdict. This does not block anything — the ADR's
+`spf_pass`/`dkim_pass` fields were always advisory ("not used to
+auto-reject"), and mail is still accepted and processed regardless — but the
+audit rationale of "the SPF/DKIM verdicts stay answerable" may be weaker in
+practice than written if this Worker-delivery gap is still present when
+built. The implementation prompt below directs the worker to verify this
+empirically against a live test message and default `spf_pass`/`dkim_pass`
+to `false` (not throw/guess) if the expected header is absent, rather than
+silently reporting an inaccurate pass.
+
+**§3/§6 build complete and independently verified (2026-07-19).**
+`workers/receipts-email-intake/` is scaffolded, type-checks, and bundles
+clean. Verified myself, not just from the report: `tsc --noEmit` clean in
+both the worker and the root app; `wrangler deploy --dry-run` reproduces
+the reported bundle (140.20 KiB / gzip 33.82 KiB) with the exact bindings
+(`RECEIPTS_DB`, `RECEIPTS_BUCKET`, nothing else); grepping the emitted
+bundle confirms zero occurrences of `getCloudflareContext` /
+`createReceiptRecord` / `createAuditEntry` / `promoteIntake` /
+`rejectIntake` (OpenNext/consumer-side code is correctly tree-shaken out)
+and six occurrences of `recordIntake`/`classifyAttachment` (correctly
+kept); root suite is 609 tests / 608 pass / 1 pre-existing skip (+19 new,
+zero regressions), matching the report exactly.
+
+**Fail-safe vs. fail-loud on intake failure — kept fail-safe, not a
+policy toggle.** The report flagged a real trade-off: `email()` currently
+logs-and-swallows failures rather than throwing, so a failed intake leaves
+no trace beyond Worker logs. The suggested alternative — throw so
+Cloudflare bounces the message back to the sender — does not actually
+work as described under the current structure: `email()` calls
+`ctx.waitUntil(processMessage(...))` and returns immediately, so
+`processMessage`'s internal try/catch already runs *after* the handler
+has resolved. Making failures throw there would surface as an unhandled
+background rejection, not a bounce — achieving an actual bounce would
+require awaiting `processMessage` synchronously inside `email()` instead
+of backgrounding it, a real restructure, not a one-line change. Decision:
+**do not make this change.** Two reasons beyond the structural one: a
+bounce on a transient D1/R2 blip would reject legitimate mail for a
+reason the sender can't fix, and bounce behavior is itself a small
+information-disclosure surface on an unauthenticated endpoint (repeated
+probing could fingerprint intake-worker internals from bounce timing/
+content). Fail-safe stays. The residual risk — a failed intake is
+invisible outside Worker logs — is accepted for v1, consistent with the
+"no SLA/monitoring in scope for v1" trade-off already on record below;
+revisit if real volume makes this worth a dashboard alert.
+
+**Migration 0024 — applied live (David, prior turn).** Cannot be
+independently confirmed from this sandboxed session (no live Cloudflare
+API token available here — `wrangler d1 migrations list --remote` fails
+with the expected non-interactive-auth error). Taken on David's word;
+worth a `wrangler d1 migrations list RECEIPTS_DB --remote` spot-check on
+the Mac before relying on it.
+
+**Still required before this is live (unchanged from the worker's own
+list):** first deploy of `dazbeez-receipts-email-intake`; the Cloudflare
+Email Routing dashboard rule pointing `receipts@dazbeez.com` at it (see
+the quick-instructions given separately); and a live-mail test to resolve
+the still-open §0.3 question (whether `Authentication-Results` is
+actually stamped on Worker-delivered mail) — `extractAuthVerdicts`/
+`pickRawHeadersSubset` may need adjusting once real header shapes are
+observed.
+`db/receipts/0024_email_intake.sql` is written and matches this ADR exactly
+(confirmed by direct read: no `retention_until`/`legal_hold` columns, 3-state
+`status` CHECK, `promoted_receipt_id` FK). Per `AGENTS.md`, D1 migrations run
+on the Mac against live bindings (`npx wrangler d1 migrations apply
+RECEIPTS_DB --local` then, after verifying, without `--local` for
+production) — this sandboxed session has no live Cloudflare credentials to
+do that. **Action for David:** apply the migration on the Mac before the
+`/receipts/inbox` screen or promote/reject APIs are exercised — they will
+500 (`no such table: email_receipt_intake`) until then. Low risk to apply
+early since the table has no callers yet (routes exist but nothing reachable
+without the worker + Email Routing wired).
+
+**Scope change (2026-07-19, operator action): three addresses now route to
+this worker, not one.** `receipts@`, `receipt@`, and `billing@dazbeez.com`
+are all wired in Cloudflare Email Routing to `dazbeez-receipts-email-intake`.
+This ADR and title were written and built around a single address; the
+system now needs to be evaluated against three.
+
+Nothing about the trust model changes — the worker doesn't branch on
+recipient address, so all three still land in the same undifferentiated
+`pending_triage` queue under the same accept-any-sender-then-triage posture
+already decided. But two real gaps follow directly from the address, not the
+sender:
+
+- **The intake pipeline doesn't record which address received the mail.**
+  `message.to` is only read for a size-ceiling log line
+  (`workers/receipts-email-intake/src/index.ts`); `recordIntake()` has no
+  `toAddress` field, `email_receipt_intake` has no `to_address` column, and
+  `/receipts/inbox` never surfaces it (the "to" header does end up buried in
+  `raw_headers_json`, but nothing reads it back out). A human triaging today
+  cannot tell, without opening dev tools, whether a given row arrived via
+  `receipts@`, `receipt@`, or `billing@`.
+- **`billing@` is a materially different address than `receipts@`.** A
+  dedicated `receipts@`/`receipt@` alias mostly only gets what someone
+  deliberately forwards there. `billing@` is a conventional address vendors
+  and SaaS tools auto-CC on invoices, payment-failure notices, subscription
+  changes, dunning emails, and account correspondence generally — not just
+  receipts. Expect materially higher and noisier volume on that address, most
+  of it without a promotable attachment, which dilutes the triage queue and
+  makes "reject reason" entries much more common in normal operation, not the
+  exception.
+
+**Recommendation, not yet built:** add `to_address` as a first-class column
+(`email_receipt_intake.to_address`, populated from `message.to` in the
+worker) and surface it as a small badge/filter in `/receipts/inbox`, so the
+mixed-address inbox stays triageable at volume rather than becoming an
+undifferentiated pile. Low-cost, additive migration (new column, nullable,
+no CHECK needed). Also update the now-inaccurate inbox header copy, which
+still says "Receipts emailed to receipts@dazbeez.com" — fixed directly in
+this pass (see below) since it's a one-line static string, not logic.
+
+**Resolved 2026-07-19: `billing@` removed.** David pulled it back out of
+Email Routing — it may serve other purposes and shouldn't feed this
+pipeline unreviewed. **Final address set: `receipts@` and `receipt@`
+dazbeez.com only**, both routed to `dazbeez-receipts-email-intake`. `receipt@`
+exists purely as misspelling-tolerance for `receipts@`, not a distinct
+purpose — unlike the `billing@` case, these two addresses have the same
+intent and the same expected sender population, so the "noisier/different
+mail" concern above no longer applies. The `to_address` visibility gap is
+now a smaller, lower-urgency issue (nice-to-have for audit trail — "which
+spelling did they use" — not noise triage), but it's cheap enough that it's
+still worth building; see `prompts/WORKER-PROMPT-email-intake-to-address.md`.
+
+## Context
+
+`receipts@dazbeez.com` already exists as an *outbound* address (`NOTIFY_FROM_ADDRESS`, Resend). There is no inbound pipeline. `dazbeez.com` is a Cloudflare zone, and the receipts module already runs entirely on Cloudflare primitives (D1, R2, Queues) with a deliberate architecture from ADR 0001: **capture is always-on Cloudflare, processing is Mac-only, images never leave our estate.** The compliance layer (`lib/receipts/compliance.ts`) already anticipates this feature — `SourceType` includes `email_attachment`, and it's already classified as an `ELECTRONIC_SOURCE_TYPES` member, meaning Japan's electronic-bookkeeping preservation rules (original digital file preserved as-is, not a screenshot proxy) already apply to it in the compliance engine. The upload-policy header explicitly notes email ingestion doesn't exist yet ("no email/HTML ingestion pipeline exists" — as of 2026-07-16).
+
+Three decisions were made with the operator (2026-07-19) before design:
+
+1. **Ingestion mechanism:** Cloudflare Email Routing, not a third-party inbound-email API. No new vendor; the domain is already on Cloudflare; the Worker gets a native `email()` handler.
+2. **Sender trust:** accept mail from any sender, but nothing an unauthenticated sender sends becomes a real receipt record automatically. It lands in a distinct **triage** state a human must promote.
+3. **v1 scope:** attachments only (PDF/image, same types the capture form already accepts). Body-only receipts (HTML/plain-text vendor emails with no attachment, e.g. Uber/Amazon) are out of scope for v1.
+
+This is a genuine expansion of the trust boundary. Every other write path into `receipt_records` is authenticated: Clerk session, `RECEIPTS_PROCESSOR_KEY` (Mac consumer), Queues API token, or a trusted-device bearer (`lib/receipts/trusted-devices.ts`). `receipts@dazbeez.com` becomes the first **unauthenticated, internet-facing** entry point into a system that carries 10-year legal-hold tax records.
+
+## Decision
+
+### Ingestion: Cloudflare Email Routing → Worker `email()` handler
+
+Add an inbound route for `receipts@dazbeez.com` in Cloudflare Email Routing pointing at the `dazbeez` Worker. The Worker exports an `email(message, env, ctx)` handler alongside the existing `fetch` handler. It parses the MIME message (attachments + headers only — no body rendering in v1), extracts SPF/DKIM/DMARC verdicts Cloudflare already attaches to the message, and hands attachments to the intake path below. No new vendor, no new secret, no new webhook to authenticate — the trust boundary is `dazbeez.com`'s own DNS/MX.
+
+### Intake lands in a new table, not `receipt_records`
+
+Unauthenticated mail does **not** write into `receipt_records` directly. It writes into a new `email_receipt_intake` table:
+
+```sql
+CREATE TABLE IF NOT EXISTS email_receipt_intake (
+  id TEXT PRIMARY KEY,
+  received_at TEXT NOT NULL,
+  from_address TEXT NOT NULL,
+  subject TEXT,
+  spf_pass INTEGER NOT NULL DEFAULT 0,
+  dkim_pass INTEGER NOT NULL DEFAULT 0,
+  attachment_r2_key TEXT,
+  attachment_sha256 TEXT,
+  attachment_content_type TEXT,
+  attachment_size_bytes INTEGER,
+  attachment_filename TEXT,
+  status TEXT NOT NULL DEFAULT 'pending_triage'
+    CHECK (status IN ('pending_triage','promoted','rejected')),
+  reject_reason TEXT,
+  promoted_receipt_id TEXT REFERENCES receipt_records(id),
+  raw_headers_json TEXT,
+  created_at TEXT NOT NULL
+);
+```
+
+Rationale for a separate table rather than inserting at `status='captured'` with a new "unverified" flag on `receipt_records`:
+
+- **Nothing unreviewed touches the extraction queue or month-close.** ADR 0001 already made "pending processing" a hard gate on month-close (`finalize` returns 409 while the queue holds anything for the window). If arbitrary inbound mail could land in `receipt_records` at `status='captured'`, spam or a wrong-address forward would silently become a month-close blocker or consume a Mac MLX processing slot. A separate table means the extraction queue and month-close gate are structurally untouched by anything a human hasn't looked at.
+- **Retention/legal-hold doesn't fire on unreviewed junk.** `receipt_records` inserts always carry `legal_hold=1` and a 10-year `retention_until` (`retentionUntilIso`). That posture is correct for real receipts, wrong for a misdirected spam attachment. The intake table carries no such metadata; only promotion creates a retained record.
+- **One promotion path, reusing everything.** Promoting an intake row calls the *existing* `createReceiptRecord()` with `source: "email"`, `sourceType: "email_attachment"`, `status: "captured"` — the exact same insert mobile/desktop capture already uses, which already seeds `extraction_state='captured'` and is picked up by the existing enqueue-and-Mac-MLX pipeline unchanged. `paymentPath`/`expenseType` default to `"UNKNOWN"` (already-supported values) since email intake never carries them. No parallel extraction, review, reconciliation, or export logic is written.
+
+### Review surface: `/receipts/inbox`
+
+A new lightweight screen, not the existing `/receipts/review` queue (that queue's semantics — locks, month-scoping, reconciliation status — don't apply to unreviewed mail). Lists `email_receipt_intake` rows at `status='pending_triage'`, shows sender, SPF/DKIM verdicts, subject, and an attachment preview. Two actions per row:
+
+- **Promote** → calls `createReceiptRecord` as above, sets `promoted_receipt_id`, `status='promoted'`. The resulting receipt then flows through the normal review queue exactly like a mobile capture.
+- **Reject** → `status='rejected'` with a required `reject_reason`. The R2 object is retained for a short audit window (30 days, not 10 years) then deleted by a scheduled cleanup — this is not a tax record.
+
+Every promote/reject is audit-logged (`lib/receipts/audit.ts`) with the SPF/DKIM verdicts preserved, so "who let this in" is always answerable even though the sender itself is unauthenticated.
+
+### Validation reused, not reinvented
+
+Attachments are validated against the exact same `ALLOWED_RECEIPT_MIME_TYPES` / `ALLOWED_RECEIPT_EXTENSIONS` / `MAX_RECEIPT_FILE_BYTES` (5 MiB) constants in `lib/receipts/upload-policy.ts` that already gate mobile/desktop capture. An email with no attachment, an unsupported attachment type, or an attachment over 5 MiB is still recorded in `email_receipt_intake` (so nothing silently vanishes) but flagged and cannot be promoted until resolved — it shows in the inbox as a rejected/needs-attention row with the reason, never as a phantom receipt.
+
+### Explicit non-decisions (v1)
+
+- **No body-only parsing.** An email with a receipt in the HTML/text body and no attachment is recorded (subject/sender visible in the inbox) but has nothing to promote. Revisit as a separate ADR if this shows up often enough to matter — it requires a body→PDF rendering step this ADR deliberately excludes.
+- **No allow-list enforcement at the mail layer.** SPF/DKIM verdicts are captured and surfaced for the human triaging, not used to auto-reject. If spam volume becomes a real problem, add Cloudflare Email Routing rules (or a from-address allow-list before intake) as a follow-up — cheap to add later, doesn't need to block v1.
+- **No auto-matching of duplicate receipts at intake.** `attachment_sha256` is captured on every intake row so a future pass can flag "this was already captured via mobile" before promotion, but that comparison is not built in v1.
+
+## Consequences
+
+### Positive
+
+- Reuses 100% of the existing capture → queue → Mac MLX extraction → review → reconciliation → export pipeline. The only new code is: MIME parsing in the Worker, one new table, one new review screen, one promotion call into code that already exists.
+- The trust-boundary expansion is contained to a table with no compliance weight (no legal hold, no month-close interaction, no retention) until a human explicitly promotes a row — the "accept any sender" decision doesn't mean "accept any sender into the books."
+- Matches the compliance model already encoded in `compliance.ts` (`email_attachment` as an electronic source type) — this ADR is filling in a pipeline the schema was already designed to expect.
+
+### Negative / accepted trade-offs
+
+- New unauthenticated surface, full stop. Even with everything staged in a low-weight table, `receipts@dazbeez.com` can now receive attacker-controlled files (malformed PDFs, zip bombs disguised with a spoofed content-type, etc.) that a Worker must parse. MIME parsing must be defensive: hard size ceiling before parsing (reject anything over, say, 10 MiB at the Worker before it touches R2, independent of the 5 MiB receipt limit checked after), no execution of any parsed content, R2 write only after the size/type check passes.
+- A second inbox to check. If nobody looks at `/receipts/inbox`, forwarded receipts sit unpromoted indefinitely. No SLA/notification is in scope for v1 — worth a follow-up (e.g. a daily count in the existing notify email) if this becomes the primary capture path rather than a convenience one.
+- `email_receipt_intake` is a second place receipt-shaped data can live, which is one more thing a future schema change has to remember exists. Kept deliberately thin (no business fields — payment path, expense type, attendees — all of that only exists after promotion) to minimize the surface that can drift from `receipt_records`.
+
+## Alternatives considered
+
+- **Insert directly into `receipt_records` at a new `status='unverified'`.** Rejected: entangles an untrusted write path with the month-close gate and the 10-year retention/legal-hold defaults that every other insert path correctly assumes. Would require threading "is this verified" through the extraction queue, the review queue, and every reconciliation/export query that currently just trusts `receipt_records` — a much larger and riskier change for the same outcome.
+- **Third-party inbound-email API (Postmark/SendGrid/Mailgun) instead of Cloudflare Email Routing.** Rejected per operator decision: adds a vendor, a webhook secret to manage, and a third party that sees attachment content in transit, for no capability Cloudflare Email Routing doesn't already provide given the domain is already on Cloudflare.
+- **Allow-list senders at the mail layer before intake.** Considered and set aside, not rejected — operator chose accept-any + triage for v1 to keep the address usable for ad hoc forwarding (e.g. forwarding a vendor's emailed invoice) without needing every possible sender pre-registered. Revisit if spam/junk volume makes triage noisy.
+
+## Implementation notes (non-binding)
+
+1. Cloudflare dashboard / `wrangler` — add `receipts@dazbeez.com` as an Email Routing destination pointed at the `dazbeez` Worker (out-of-band control-plane config, same posture as the Queues HTTP pull consumer in ADR 0001 — not declarative in `wrangler.jsonc`).
+2. Worker `email()` handler: parse MIME, extract SPF/DKIM verdicts Cloudflare provides on the message, extract attachments only (ignore body in v1), enforce a hard pre-parse size ceiling.
+3. New migration `db/receipts/00NN_email_intake.sql` (next free number after 0023) for `email_receipt_intake`.
+4. `lib/receipts/email-intake.ts`: insert intake rows, validate attachments against the existing `upload-policy.ts` constants, promote/reject actions (promote calls `createReceiptRecord`).
+5. `/receipts/inbox` page + `app/api/receipts/inbox/*` routes, Clerk-gated like every other `/receipts/*` route.
+6. Audit log entries for promote/reject via existing `lib/receipts/audit.ts`.
+7. Scheduled cleanup (cron trigger or piggyback on an existing scheduled job) to delete rejected/unpromoted-and-stale intake R2 objects after 30 days.
+
+## Open questions
+
+- ~~Placement of the `email()` handler.~~ **Resolved 2026-07-19:** standalone worker (see Decision record above).
+- ~~Retention window for unpromoted `pending_triage` rows.~~ **Resolved 2026-07-19:** 30 days, as coded (`INTAKE_STALE_DAYS`).
+- Whether to add a low-noise notification (e.g. folded into the existing Resend notify email) when the inbox has unpromoted items, and at what age. Still open.
+- Whether SPF/DKIM failure should downgrade an attachment to "visible but not promotable" rather than just an informational flag, once real spam volume is observed. Still open.
+- Whether an unattended third worker (no monitoring/alerting) is acceptable long-term or just for launch — flagged in the Decision record's operational-impact note.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,6 +19,7 @@ other, and the superseded ADR is preserved verbatim as decision history.
 | [0006](0006-statement-window-membership-for-non-amex-receipts.md) | Statement-window membership for non-AMEX receipts | **Superseded in part** | 2026-07-13 | Superseded by [0008](0008-calendar-month-membership-for-non-amex-receipts.md) (in part); kept as history |
 | [0008](0008-calendar-month-membership-for-non-amex-receipts.md) | Calendar-month membership for non-AMEX receipts | Accepted | 2026-07-14 | Supersedes [0006](0006-statement-window-membership-for-non-amex-receipts.md) (in part) |
 | [0009](0009-sealed-month-amendment-policy.md) | Sealed-month amendment policy | Proposed (design of record, not yet implemented) | 2026-07-14 | — |
+| [0011](0011-email-receipt-intake.md) | Email receipt intake (receipts@dazbeez.com via Cloudflare Email Routing, triage table before promotion, standalone worker) | Accepted | 2026-07-19 | — |
 
 ### Numbering
 

--- a/lib/receipts/email-intake.ts
+++ b/lib/receipts/email-intake.ts
@@ -1,0 +1,521 @@
+// ADR 0011 — email receipt intake (receipts@dazbeez.com).
+//
+// Two halves live here:
+//   1. recordIntake() — the producer side, called by the Worker `email()`
+//      handler. Validates attachments against the SAME policy that gates
+//      mobile/desktop capture (upload-policy.ts), writes valid attachments
+//      to R2 under an intake key, and inserts email_receipt_intake row(s).
+//      Takes injected `db` + `bucket` so it runs in whatever Worker the
+//      architect places the email() handler in (see ADR 0011 §3 — placement
+//      is an open decision; this function is placement-agnostic).
+//   2. listPendingIntake / promoteIntake / rejectIntake — the consumer side,
+//      called from /receipts/inbox (Clerk-gated). Promote reuses the existing
+//      createReceiptRecord() so an emailed receipt flows through the normal
+//      capture → queue → Mac MLX → review pipeline unchanged.
+//
+// Nothing in email_receipt_intake is a tax record. Only promoteIntake creates
+// a receipt_records row (legal_hold + 10-year retention), via the single
+// existing insert path. Do not add a second insert path into receipt_records.
+
+import { getReceiptsDb, getReceiptsBucket } from "@/lib/cloudflare-runtime";
+import { createReceiptRecord } from "@/lib/receipts/db";
+import { createAuditEntry } from "@/lib/receipts/audit";
+import { nowIso, newUuid, stringifyJson } from "@/lib/receipts/db-utils";
+import {
+  generateR2Key,
+  uploadOriginal,
+  sanitizeFilenameForR2,
+} from "@/lib/receipts/storage";
+import {
+  ALLOWED_RECEIPT_MIME_TYPES,
+  ALLOWED_RECEIPT_EXTENSIONS,
+  MAX_RECEIPT_FILE_BYTES,
+  formatFileSize,
+} from "@/lib/receipts/upload-policy";
+import type {
+  CreateReceiptInput,
+  EmailIntakeStatus,
+  EmailReceiptIntake,
+} from "@/lib/receipts/types";
+
+// Hard pre-parse ceiling on the raw MIME message (ADR 0011 "Negative"). This
+// is INDEPENDENT of and TIGHTER than the per-attachment MAX_RECEIPT_FILE_BYTES
+// (5 MiB) check: it rejects oversized messages before the Worker allocates or
+// parses anything. Enforced by the email() handler before recordIntake; kept
+// here as the single source of the constant.
+export const INTAKE_MAX_MESSAGE_BYTES = 10 * 1024 * 1024; // 10 MiB
+
+// Pending rows older than this are stale and cleaned up by the scheduled job
+// (ADR 0011 §6 / open question: 30-day window).
+export const INTAKE_STALE_DAYS = 30;
+
+export const INTAKE_STATUSES: readonly EmailIntakeStatus[] = [
+  "pending_triage",
+  "promoted",
+  "rejected",
+];
+
+// ─── R2 intake key ───────────────────────────────────────────────────────────
+
+/**
+ * Intake object key: `receipts-intake/{YYYY}/{MM}/{intakeId}/{uuid}-{filename}`.
+ * Distinct prefix from the promoted-receipt `receipts/...` pattern so intake
+ * objects (disposable, no retention) are visually separable in the bucket and
+ * cannot be confused with promoted tax-record originals. Sanitization is
+ * shared with generateR2Key via sanitizeFilenameForR2 (no second sanitizer).
+ */
+export function generateIntakeR2Key(
+  intakeId: string,
+  filename: string,
+  receivedAt: string,
+): string {
+  const date = receivedAt.slice(0, 10); // YYYY-MM-DD
+  const [year, month] = date.split("-") as [string, string];
+  const safe = sanitizeFilenameForR2(filename || "attachment");
+  return `receipts-intake/${year}/${month}/${intakeId}/${newUuid()}-${safe}`;
+}
+
+// ─── Pure: attachment classification ────────────────────────────────────────
+//
+// Mirrors upload-policy.ts validateReceiptFile but operates on
+// {filename, contentType, sizeBytes} (no DOM File object — the email handler
+// has raw bytes, not a File). Kept in sync with upload-policy by reusing the
+// SAME exported constants; do not re-decide accepted types here.
+
+export interface AttachmentSpec {
+  filename: string;
+  contentType: string;
+  sizeBytes: number;
+}
+
+export interface AttachmentClassification {
+  valid: boolean;
+  rejectReason: string | null;
+}
+
+export function classifyAttachment(spec: AttachmentSpec): AttachmentClassification {
+  if (spec.sizeBytes > MAX_RECEIPT_FILE_BYTES) {
+    return {
+      valid: false,
+      rejectReason: `attachment too large (${formatFileSize(spec.sizeBytes)}); limit ${formatFileSize(MAX_RECEIPT_FILE_BYTES)}`,
+    };
+  }
+
+  const ext = extOf(spec.filename);
+  const mime = spec.contentType;
+  const typeErr =
+    "attachment type not allowed; accepted: JPEG, PNG, HEIC, PDF";
+
+  // Same rule as validateReceiptFile: a specific MIME must itself be
+  // allowlisted; extension is only a fallback for absent/generic MIME.
+  if (mime === "" || mime === "application/octet-stream") {
+    return (ALLOWED_RECEIPT_EXTENSIONS as readonly string[]).includes(ext)
+      ? { valid: true, rejectReason: null }
+      : { valid: false, rejectReason: typeErr };
+  }
+  return (ALLOWED_RECEIPT_MIME_TYPES as readonly string[]).includes(mime)
+    ? { valid: true, rejectReason: null }
+    : { valid: false, rejectReason: typeErr };
+}
+
+function extOf(name: string): string {
+  const dot = name.lastIndexOf(".");
+  if (dot < 0) return "";
+  return name.slice(dot).toLowerCase();
+}
+
+// ─── Producer: recordIntake (called by the email() handler) ─────────────────
+
+export interface ParsedEmailAttachment {
+  filename: string;
+  contentType: string;
+  sizeBytes: number;
+  data: ArrayBuffer;
+}
+
+export interface RecordIntakeInput {
+  receivedAt: string; // ISO; the message's Date (or now)
+  fromAddress: string;
+  toAddress: string | null; // destination alias the message arrived on (ADR 0011 follow-up)
+  subject: string | null;
+  spfPass: boolean;
+  dkimPass: boolean;
+  rawHeadersJson: string | null;
+  attachments: ParsedEmailAttachment[];
+}
+
+/**
+ * Persist one inbound email as 1+ email_receipt_intake rows.
+ *
+ * Fan-out (ADR 0011 §3.4): one row per attachment. A valid attachment is
+ * written to R2 (intake key) and its metadata recorded; an invalid one
+ * (wrong type / too large) is STILL recorded as a row with a NULL
+ * attachment_r2_key + reject_reason, left at pending_triage so a human sees
+ * why it can't be promoted (never silently dropped, never auto-rejected).
+ * An email with zero attachments records a single row with reject_reason
+ * 'no attachment' (§3.5) — visible in the inbox, nothing to promote.
+ *
+ * Returns the created intake row ids (always ≥1).
+ */
+export async function recordIntake(
+  db: D1Database,
+  bucket: R2Bucket,
+  input: RecordIntakeInput,
+): Promise<string[]> {
+  const now = nowIso();
+  const createdIds: string[] = [];
+
+  const rowsToInsert: Array<Omit<EmailReceiptIntake, "created_at">> = [];
+
+  if (input.attachments.length === 0) {
+    // §3.5: body-only email — record it so it's visible, nothing to promote.
+    rowsToInsert.push({
+      id: newUuid(),
+      received_at: input.receivedAt,
+      from_address: input.fromAddress,
+      to_address: input.toAddress,
+      subject: input.subject,
+      spf_pass: input.spfPass ? 1 : 0,
+      dkim_pass: input.dkimPass ? 1 : 0,
+      attachment_r2_key: null,
+      attachment_sha256: null,
+      attachment_content_type: null,
+      attachment_size_bytes: null,
+      attachment_filename: null,
+      status: "pending_triage",
+      reject_reason: "no attachment",
+      promoted_receipt_id: null,
+      raw_headers_json: input.rawHeadersJson,
+    });
+  } else {
+    for (const att of input.attachments) {
+      const verdict = classifyAttachment(att);
+      const id = newUuid();
+
+      if (verdict.valid) {
+        // Valid → R2 put (intake key, NO retention metadata — this is not a
+        // tax record) + full metadata row.
+        const key = generateIntakeR2Key(id, att.filename, input.receivedAt);
+        await bucket.put(key, att.data, {
+          httpMetadata: { contentType: att.contentType },
+        });
+        rowsToInsert.push({
+          id,
+          received_at: input.receivedAt,
+          from_address: input.fromAddress,
+          to_address: input.toAddress,
+          subject: input.subject,
+          spf_pass: input.spfPass ? 1 : 0,
+          dkim_pass: input.dkimPass ? 1 : 0,
+          attachment_r2_key: key,
+          attachment_sha256: await sha256Hex(att.data),
+          attachment_content_type: att.contentType,
+          attachment_size_bytes: att.sizeBytes,
+          attachment_filename: att.filename,
+          status: "pending_triage",
+          reject_reason: null,
+          promoted_receipt_id: null,
+          raw_headers_json: input.rawHeadersJson,
+        });
+      } else {
+        // Invalid → still recorded, NULL r2_key, reason visible, stays
+        // pending_triage (NOT auto-rejected) per ADR 0011.
+        rowsToInsert.push({
+          id,
+          received_at: input.receivedAt,
+          from_address: input.fromAddress,
+          to_address: input.toAddress,
+          subject: input.subject,
+          spf_pass: input.spfPass ? 1 : 0,
+          dkim_pass: input.dkimPass ? 1 : 0,
+          attachment_r2_key: null,
+          attachment_sha256: null,
+          attachment_content_type: att.contentType,
+          attachment_size_bytes: att.sizeBytes,
+          attachment_filename: att.filename,
+          status: "pending_triage",
+          reject_reason: verdict.rejectReason,
+          promoted_receipt_id: null,
+          raw_headers_json: input.rawHeadersJson,
+        });
+      }
+    }
+  }
+
+  for (const row of rowsToInsert) {
+    await db
+      .prepare(
+        `INSERT INTO email_receipt_intake
+          (id, received_at, from_address, subject, spf_pass, dkim_pass,
+           attachment_r2_key, attachment_sha256, attachment_content_type,
+           attachment_size_bytes, attachment_filename, status, reject_reason,
+           promoted_receipt_id, raw_headers_json, created_at, to_address)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        row.id,
+        row.received_at,
+        row.from_address,
+        row.subject,
+        row.spf_pass,
+        row.dkim_pass,
+        row.attachment_r2_key,
+        row.attachment_sha256,
+        row.attachment_content_type,
+        row.attachment_size_bytes,
+        row.attachment_filename,
+        row.status,
+        row.reject_reason,
+        row.promoted_receipt_id,
+        row.raw_headers_json,
+        now,
+        row.to_address,
+      )
+      .run();
+    createdIds.push(row.id);
+  }
+
+  return createdIds;
+}
+
+async function sha256Hex(data: ArrayBuffer): Promise<string> {
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+  return Array.from(new Uint8Array(hashBuffer))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+// ─── Consumer: reads + triage actions ───────────────────────────────────────
+
+export async function getIntake(
+  db: D1Database,
+  id: string,
+): Promise<EmailReceiptIntake | null> {
+  return db
+    .prepare(`SELECT * FROM email_receipt_intake WHERE id = ? LIMIT 1`)
+    .bind(id)
+    .first<EmailReceiptIntake>();
+}
+
+export async function listPendingIntake(
+  db: D1Database,
+  limit = 200,
+): Promise<EmailReceiptIntake[]> {
+  const result = await db
+    .prepare(
+      `SELECT * FROM email_receipt_intake
+       WHERE status = 'pending_triage'
+       ORDER BY received_at DESC
+       LIMIT ?`,
+    )
+    .bind(Math.min(limit, 500))
+    .all<EmailReceiptIntake>();
+  return result.results ?? [];
+}
+
+/**
+ * Build the createReceiptRecord input for a promotable intake row. Pure —
+ * extracted so the source/sourceType/status decisions are unit-testable
+ * without D1/R2. paymentPath/expenseType are deliberately omitted so
+ * createReceiptRecord's "UNKNOWN" defaults apply (email intake never carries
+ * them). originalR2Key starts as the INTAKE key and is patched to the standard
+ * receipts/... key after the object is copied (see promoteIntake).
+ */
+export function buildPromoteReceiptInput(intake: EmailReceiptIntake): CreateReceiptInput {
+  return {
+    capturedBy: intake.from_address,
+    source: "email",
+    sourceType: "email_attachment",
+    status: "captured",
+    originalR2Key: intake.attachment_r2_key as string,
+    originalSha256: intake.attachment_sha256 as string,
+    originalContentType: (intake.attachment_content_type ?? "application/octet-stream") as string,
+    originalSizeBytes: (intake.attachment_size_bytes ?? 0) as number,
+    originalFilename: intake.attachment_filename ?? undefined,
+  };
+}
+
+/**
+ * Refuse promotion for rows that have nothing to promote or are no longer
+ * pending. Throws a plain Error whose message is safe to surface as 409 body.
+ * Mirrored as a disabled state in the inbox UI (Promote disabled when
+ * attachment_r2_key is NULL) — this is the server authority.
+ */
+export function assertPromotable(intake: EmailReceiptIntake): void {
+  if (intake.status !== "pending_triage") {
+    throw new Error(
+      `Intake ${intake.id} is already ${intake.status} (only pending_triage may be promoted).`,
+    );
+  }
+  if (!intake.attachment_r2_key) {
+    throw new Error(
+      `Intake ${intake.id} has no promotable attachment${intake.reject_reason ? ` (${intake.reject_reason})` : ""}.`,
+    );
+  }
+}
+
+/**
+ * Promote a triaged intake row into a real receipt.
+ *
+ * Reuses createReceiptRecord (the single existing insert path; ADR 0011).
+ * The promoted receipt then flows through the normal extraction queue → Mac
+ * MLX → review pipeline exactly like a mobile capture.
+ *
+ * R2 handoff (ADR 0011 §2, preferred "copy to standard key" path): the intake
+ * object is COPIED to a standard receipts/{y}/{m}/{receiptId}/{uuid}-{filename}
+ * key and receipt_records.original_r2_key is patched to point at it, so the
+ * intake key pattern never leaks into receipt_records invariants. The intake
+ * object is then deleted (move semantics) and the intake row's
+ * attachment_r2_key is nulled; the row is kept for audit history at status
+ * 'promoted'. createReceiptRecord is "reused, not modified" (ADR), so the
+ * copy happens AFTER it returns the new receipt id — the row briefly holds the
+ * intake key within this single request, then is patched.
+ *
+ * Atomicity: consistent with how createReceiptRecord itself handles its own
+ * writes (separate awaits for insert/audit, not one batch). The intake status
+ * flip carries a `WHERE status = 'pending_triage'` idempotency guard. Residual
+ * crash window between createReceiptRecord and the flip is documented in ADR
+ * 0011 — a retry in that window would create a duplicate receipt; a future
+ * hardening (unique partial index on promoted_receipt_id, or letting
+ * createReceiptRecord accept an external batch) closes it.
+ */
+export async function promoteIntake(
+  id: string,
+  actor: string,
+): Promise<string> {
+  const db = getReceiptsDb();
+  const bucket = getReceiptsBucket();
+
+  const intake = await getIntake(db, id);
+  if (!intake) throw new Error(`Intake ${id} not found.`);
+  assertPromotable(intake);
+
+  // Read the intake object so we can copy it to the standard key.
+  const originalIntakeKey = intake.attachment_r2_key as string;
+  const obj = await bucket.get(originalIntakeKey);
+  if (!obj) {
+    throw new Error(
+      `Intake ${id} attachment object is missing from R2 (key ${originalIntakeKey}).`,
+    );
+  }
+  const bytes = await obj.arrayBuffer();
+
+  // 1. Create the receipt via the canonical path. originalR2Key is the intake
+  //    key for now; patched below once we know the standard key.
+  const receiptId = await createReceiptRecord(buildPromoteReceiptInput(intake), actor);
+
+  // 2. Copy the object to the standard receipts/... key (retention metadata
+  //    IS correct here — this is now a tax record). generateR2Key embeds the
+  //    receipt id, matching the rest of the system's key convention.
+  const now = nowIso();
+  const standardKey = generateR2Key(
+    receiptId,
+    intake.attachment_filename ?? "attachment",
+    now,
+  );
+  await uploadOriginal(
+    standardKey,
+    bytes,
+    intake.attachment_content_type ?? "application/octet-stream",
+  );
+
+  // 3. Patch the receipt's original_r2_key to the standard key.
+  await db
+    .prepare(
+      `UPDATE receipt_records SET original_r2_key = ?, updated_at = ? WHERE id = ?`,
+    )
+    .bind(standardKey, now, receiptId)
+    .run();
+
+  // 4. Flip the intake row (idempotent guard on status). Null the intake key —
+  //    the object was moved to the standard key.
+  await db
+    .prepare(
+      `UPDATE email_receipt_intake
+         SET status = 'promoted',
+             promoted_receipt_id = ?,
+             attachment_r2_key = NULL
+       WHERE id = ? AND status = 'pending_triage'`,
+    )
+    .bind(receiptId, id)
+    .run();
+
+  // 5. Delete the now-moved intake object. Best-effort: a failure here leaves
+  //    a redundant intake object that the 30-day cleanup reaps; it must not
+  //    fail the promotion.
+  try {
+    await bucket.delete(originalIntakeKey);
+  } catch (err) {
+    console.error("[promoteIntake] failed to delete intake R2 object", {
+      key: originalIntakeKey,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  // 6. Audit with SPF/DKIM verdicts preserved — "who let this unauthenticated
+  //    sender in" stays answerable.
+  await createAuditEntry(db, {
+    actor,
+    action: "email_intake.promoted",
+    objectType: "email_intake",
+    objectId: id,
+    newValueJson: stringifyJson({
+      receiptId,
+      from_address: intake.from_address,
+      subject: intake.subject,
+      spf_pass: intake.spf_pass,
+      dkim_pass: intake.dkim_pass,
+    }),
+  });
+
+  return receiptId;
+}
+
+/**
+ * Reject a pending intake row with a required reason. Does NOT touch
+ * receipt_records and does NOT delete the R2 object immediately (the 30-day
+ * cleanup handles that; the row is kept for audit history at status 'rejected'
+ * with a nulled key after cleanup). Idempotency guard on status.
+ */
+export async function rejectIntake(
+  db: D1Database,
+  id: string,
+  reason: string,
+  actor: string,
+): Promise<void> {
+  const trimmed = reason.trim();
+  if (!trimmed) {
+    throw new Error("reject_reason is required and must be non-empty.");
+  }
+
+  const intake = await getIntake(db, id);
+  if (!intake) throw new Error(`Intake ${id} not found.`);
+  if (intake.status !== "pending_triage") {
+    throw new Error(
+      `Intake ${id} is already ${intake.status} (only pending_triage may be rejected).`,
+    );
+  }
+
+  await db
+    .prepare(
+      `UPDATE email_receipt_intake
+         SET status = 'rejected', reject_reason = ?
+       WHERE id = ? AND status = 'pending_triage'`,
+    )
+    .bind(trimmed, id)
+    .run();
+
+  await createAuditEntry(db, {
+    actor,
+    action: "email_intake.rejected",
+    objectType: "email_intake",
+    objectId: id,
+    newValueJson: stringifyJson({
+      reason: trimmed,
+      from_address: intake.from_address,
+      subject: intake.subject,
+      spf_pass: intake.spf_pass,
+      dkim_pass: intake.dkim_pass,
+    }),
+  });
+}

--- a/lib/receipts/email-parse.ts
+++ b/lib/receipts/email-parse.ts
@@ -1,0 +1,137 @@
+// Pure helpers for the receipts-email-intake Worker (ADR 0011 §2/§3).
+//
+// Deliberately dependency-free: no `@/` aliases, no Worker bindings, no
+// postal-mime import. That keeps this file trivially portable into the
+// standalone worker's bundle AND unit-testable from the main repo's test
+// suite (tests/receipts/email-parse.test.ts). The Worker's src/index.ts owns
+// the binding/IO glue (readRaw, PostalMime.parse, R2/D1) and calls these.
+//
+// SPF/DKIM reality (ADR 0011 §0.3): whether Cloudflare Email Routing reliably
+// stamps an Authentication-Results header on the ForwardableEmailMessage is
+// NOT verified against live mail in this pass (no Email Routing wiring exists
+// yet — operator step). extractAuthVerdicts parses that header DEFENSIVELY:
+// if present it reports the verdict, otherwise it returns {false,false}. Do
+// not treat a false here as "failed auth" — it may simply mean "header not
+// provided by the transport."
+
+// ─── Message size ceiling ───────────────────────────────────────────────────
+
+/** True when the raw MIME message is within the pre-parse byte ceiling. */
+export function withinMessageSizeCeiling(rawSize: number, ceiling: number): boolean {
+  return Number.isFinite(rawSize) && rawSize >= 0 && rawSize <= ceiling;
+}
+
+// ─── Attachment mapping (postal-mime → ParsedEmailAttachment) ───────────────
+
+export interface PostalAttachmentInput {
+  filename: string | null;
+  mimeType: string;
+  content: ArrayBuffer | Uint8Array;
+}
+
+export interface MappedAttachment {
+  filename: string;
+  contentType: string;
+  sizeBytes: number;
+  data: ArrayBuffer;
+}
+
+/**
+ * Map postal-mime's parsed attachments into the shape recordIntake expects.
+ * `content` (ArrayBuffer under attachmentEncoding:"arraybuffer") is normalized
+ * to a standalone ArrayBuffer (a Uint8Array view over a larger buffer would
+ * otherwise leak bytes outside the attachment's range).
+ */
+export function mapPostalAttachments(
+  atts: readonly PostalAttachmentInput[],
+): MappedAttachment[] {
+  return atts.map((a) => {
+    const data = toArrayBuffer(a.content);
+    return {
+      filename: (a.filename ?? "attachment").trim() || "attachment",
+      contentType: a.mimeType && a.mimeType.length > 0 ? a.mimeType : "application/octet-stream",
+      sizeBytes: data.byteLength,
+      data,
+    };
+  });
+}
+
+function toArrayBuffer(content: ArrayBuffer | Uint8Array): ArrayBuffer {
+  if (content instanceof ArrayBuffer) return content;
+  // Uint8Array: copy just this view's range into a fresh ArrayBuffer so a
+  // subarray/view over a larger backing buffer doesn't carry extra bytes.
+  const copy = new Uint8Array(content.byteLength);
+  copy.set(content);
+  return copy.buffer;
+}
+
+// ─── SPF / DKIM verdicts from Authentication-Results ────────────────────────
+
+export interface AuthVerdicts {
+  spf: boolean;
+  dkim: boolean;
+}
+
+/**
+ * Parse an Authentication-Results header (RFC 8601) for spf/dkim `pass`.
+ * Conservative: ONLY `pass` → true; fail/softfail/temperror/permerror/none/
+ * missing → false. Returns {false,false} when the header is absent (per §0.3
+ * this is the expected case until live-mail verification confirms CF stamps it).
+ *
+ * Example header value:
+ *   "mx.cloudflare.net; spf=pass smtp.mailfrom=example.com; dkim=pass header.d=example.com"
+ */
+export function extractAuthVerdicts(authResults: string | null | undefined): AuthVerdicts {
+  if (!authResults) return { spf: false, dkim: false };
+  // Lowercase, semicolon/comma/whitespace-tolerant. Match "spf=pass" / "dkim=pass"
+  // as whole token boundaries so e.g. "spf=passfail" doesn't false-positive.
+  const lower = ` ${authResults.toLowerCase()} `;
+  return {
+    spf: /[^a-z]spf=pass[^a-z]/.test(lower),
+    dkim: /[^a-z]dkim=pass[^a-z]/.test(lower),
+  };
+}
+
+// ─── Raw header subset (audit-friendly, bounded) ────────────────────────────
+
+/**
+ * Pick a bounded, audit-useful header subset rather than dumping the entire
+ * (potentially large) header set into raw_headers_json. `getHeader` is the
+ * Worker's case-insensitive `message.headers.get(name)`; values are returned
+ * verbatim (trimmed of trailing whitespace).
+ */
+export function pickRawHeadersSubset(
+  getHeader: (name: string) => string | null,
+): Record<string, string> {
+  const names = [
+    "from",
+    "to",
+    "cc",
+    "subject",
+    "date",
+    "message-id",
+    "reply-to",
+    "return-path",
+    "sender",
+    "authentication-results",
+    "received-spf",
+    "dkim-signature",
+  ];
+  const out: Record<string, string> = {};
+  for (const name of names) {
+    const v = getHeader(name);
+    if (v !== null && v.trim().length > 0) out[name] = v.trim();
+  }
+  return out;
+}
+
+// ─── Scheduled cleanup ──────────────────────────────────────────────────────
+
+/**
+ * ISO timestamp of the stale cutoff: rows with received_at older than this are
+ * eligible for R2 cleanup. Pure given `nowMs` (Worker passes Date.now()) so the
+ * boundary is unit-testable without a clock.
+ */
+export function staleCutoffIso(nowMs: number, days: number): string {
+  return new Date(nowMs - days * 24 * 60 * 60 * 1000).toISOString();
+}

--- a/lib/receipts/storage.ts
+++ b/lib/receipts/storage.ts
@@ -2,6 +2,16 @@ import { getReceiptsBucket, getReceiptsArchiveBucket } from "@/lib/cloudflare-ru
 import { newUuid } from "@/lib/receipts/db-utils";
 import { retentionMetadata } from "@/lib/receipts/retention";
 
+/**
+ * Collapse a user-supplied filename into a safe R2 path segment: strip to
+ * `[A-Za-z0-9._-]`, cap at 100 chars. Shared by the receipts key builder
+ * and the email-intake key builder (ADR 0011) so the two cannot drift on
+ * sanitization rules.
+ */
+export function sanitizeFilenameForR2(filename: string): string {
+  return filename.replace(/[^a-zA-Z0-9._-]/g, "_").slice(0, 100);
+}
+
 export function generateR2Key(
   receiptId: string,
   filename: string,
@@ -9,7 +19,7 @@ export function generateR2Key(
 ): string {
   const date = capturedAt.slice(0, 10); // YYYY-MM-DD
   const [year, month] = date.split("-") as [string, string];
-  const safe = filename.replace(/[^a-zA-Z0-9._-]/g, "_").slice(0, 100);
+  const safe = sanitizeFilenameForR2(filename);
   return `receipts/${year}/${month}/${receiptId}/${newUuid()}-${safe}`;
 }
 

--- a/lib/receipts/types.ts
+++ b/lib/receipts/types.ts
@@ -157,7 +157,12 @@ export type AuditAction =
   | "business_trip.updated"
   | "business_trip.confirmed"
   | "business_trip.rejected"
-  | "business_trip.members_changed";
+  | "business_trip.members_changed"
+  // Email receipt intake (ADR 0011). promote/reject are human actions on
+  // email_receipt_intake rows; newValueJson carries the SPF/DKIM verdicts so
+  // "who let this unauthenticated sender in" stays answerable in the trail.
+  | "email_intake.promoted"
+  | "email_intake.rejected";
 
 // ─── Compliance: source / preservation / qualified-invoice ────────────────
 
@@ -284,6 +289,37 @@ export interface ReceiptRecord {
   extraction_processor?: string | null;
   created_at: string;
   updated_at: string;
+}
+
+/**
+ * ADR 0011: an inbound email receipt awaiting human triage. Lives in
+ * `email_receipt_intake`, NOT `receipt_records` — nothing here is a tax
+ * record until a human promotes it (which calls createReceiptRecord). The
+ * attachment_* fields are all nullable: a body-only email, or one whose
+ * attachment failed validation, is still recorded (so it's visible in the
+ * inbox) but has nothing to promote. No retention_until / legal_hold on this
+ * shape by design (see migration 0024).
+ */
+export type EmailIntakeStatus = "pending_triage" | "promoted" | "rejected";
+
+export interface EmailReceiptIntake {
+  id: string;
+  received_at: string;
+  from_address: string;
+  to_address: string | null;
+  subject: string | null;
+  spf_pass: number;
+  dkim_pass: number;
+  attachment_r2_key: string | null;
+  attachment_sha256: string | null;
+  attachment_content_type: string | null;
+  attachment_size_bytes: number | null;
+  attachment_filename: string | null;
+  status: EmailIntakeStatus;
+  reject_reason: string | null;
+  promoted_receipt_id: string | null;
+  raw_headers_json: string | null;
+  created_at: string;
 }
 
 export interface ReceiptAttendee {

--- a/tests/receipts/email-intake.test.ts
+++ b/tests/receipts/email-intake.test.ts
@@ -1,0 +1,485 @@
+// Tests for ADR 0011 email receipt intake (lib/receipts/email-intake.ts).
+//
+// Coverage follows the repo convention (see month-lock.test.ts / receipt-locks):
+// pure helpers + D1-injected functions are unit-tested with a fake D1; the
+// promoteIntake orchestrator is getReceiptsDb()-coupled (it calls
+// createReceiptRecord, which resolves its own binding) and is exercised by the
+// live §8 verification, not here — same convention by which createReceiptRecord
+// itself has no unit test. Its pure pieces (buildPromoteReceiptInput,
+// assertPromotable) ARE covered below.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  INTAKE_MAX_MESSAGE_BYTES,
+  classifyAttachment,
+  generateIntakeR2Key,
+  recordIntake,
+  listPendingIntake,
+  rejectIntake,
+  buildPromoteReceiptInput,
+  assertPromotable,
+} from "@/lib/receipts/email-intake";
+import { MAX_RECEIPT_FILE_BYTES } from "@/lib/receipts/upload-policy";
+import type { EmailReceiptIntake } from "@/lib/receipts/types";
+
+// ─── Fake D1 + R2 ────────────────────────────────────────────────────────────
+//
+// A structural fake that models just the SQL shapes email-intake.ts issues
+// against email_receipt_intake (and the audit log). SELECTs read from an
+// in-memory rows array; INSERT/UPDATE mutate it. Captured statements are
+// exposed for assertions where state isn't enough (e.g. "the invalid
+// attachment was not put to R2").
+
+interface FakeDb {
+  rows: EmailReceiptIntake[];
+  auditInserts: number;
+  prepare(sql: string): {
+    bind(...args: unknown[]): {
+      first<T>(): Promise<T | null>;
+      all<T>(): Promise<{ results: T[] }>;
+      run(): Promise<unknown>;
+    };
+  };
+  // D1Database members not exercised by email-intake.ts; stubbed so the fake
+  // structurally satisfies D1Database (createAuditEntry takes a full D1Database).
+  batch(_statements: unknown[]): Promise<unknown[]>;
+  exec(_query: string): Promise<unknown>;
+  withSession(): unknown;
+  dump(): Promise<ArrayBuffer>;
+}
+
+interface FakeBucket {
+  puts: Array<{ key: string; contentType: string; bytes: number }>;
+  deleted: string[];
+  put(key: string, data: ArrayBuffer, opts: { httpMetadata?: { contentType?: string } }): Promise<void>;
+  get(key: string): Promise<{ arrayBuffer(): Promise<ArrayBuffer> } | null>;
+  delete(key: string): Promise<void>;
+}
+
+function createFakeDb(initial: EmailReceiptIntake[] = []): FakeDb {
+  const db: FakeDb = {
+    rows: initial.map((r) => ({ ...r })),
+    auditInserts: 0,
+    batch: async () => [],
+    exec: async () => ({}),
+    withSession: () => ({}),
+    dump: async () => new ArrayBuffer(0),
+    prepare(sql: string) {
+      return {
+        bind(...args: unknown[]) {
+          return {
+            async first<T>(): Promise<T | null> {
+              if (/FROM email_receipt_intake WHERE id = \?/.test(sql)) {
+                const id = String(args[0]);
+                return (db.rows.find((r) => r.id === id) ?? null) as T | null;
+              }
+              return null as T | null;
+            },
+            async all<T>(): Promise<{ results: T[] }> {
+              if (/status = 'pending_triage'/.test(sql)) {
+                const rows = db.rows
+                  .filter((r) => r.status === "pending_triage")
+                  .sort((a, b) => b.received_at.localeCompare(a.received_at));
+                return { results: rows as unknown as T[] };
+              }
+              return { results: [] };
+            },
+            async run(): Promise<unknown> {
+              if (/INSERT INTO email_receipt_intake/.test(sql)) {
+                db.rows.push(rowFromInsertBinds(args));
+              } else if (/UPDATE email_receipt_intake/.test(sql)) {
+                applyIntakeUpdate(db.rows, sql, args);
+              } else if (/INSERT INTO receipt_audit_log/.test(sql)) {
+                db.auditInserts += 1;
+              }
+              return {};
+            },
+          };
+        },
+      };
+    },
+  };
+  return db;
+}
+
+// INSERT column order in recordIntake (see the SQL in email-intake.ts).
+function rowFromInsertBinds(args: unknown[]): EmailReceiptIntake {
+  return {
+    id: String(args[0]),
+    received_at: String(args[1]),
+    from_address: String(args[2]),
+    subject: (args[3] as string | null) ?? null,
+    spf_pass: Number(args[4]),
+    dkim_pass: Number(args[5]),
+    attachment_r2_key: (args[6] as string | null) ?? null,
+    attachment_sha256: (args[7] as string | null) ?? null,
+    attachment_content_type: (args[8] as string | null) ?? null,
+    attachment_size_bytes: (args[9] as number | null) ?? null,
+    attachment_filename: (args[10] as string | null) ?? null,
+    status: (args[11] as EmailReceiptIntake["status"]) ?? "pending_triage",
+    reject_reason: (args[12] as string | null) ?? null,
+    promoted_receipt_id: (args[13] as string | null) ?? null,
+    raw_headers_json: (args[14] as string | null) ?? null,
+    created_at: String(args[15]),
+    to_address: (args[16] as string | null) ?? null,
+  };
+}
+
+function applyIntakeUpdate(rows: EmailReceiptIntake[], sql: string, args: unknown[]): void {
+  // rejectIntake: SET status='rejected', reject_reason=? WHERE id=? AND status='pending_triage'
+  if (/status = 'rejected'/.test(sql)) {
+    const reason = String(args[0]);
+    const id = String(args[1]);
+    for (const r of rows) {
+      if (r.id === id && r.status === "pending_triage") {
+        r.status = "rejected";
+        r.reject_reason = reason;
+      }
+    }
+  }
+}
+
+// email-intake.ts takes a full D1Database; the fake models only the prepare()
+// subset those functions actually issue. Cast through unknown once here instead
+// of fighting D1Database's abstract-class shape (D1PreparedStatement/D1Result)
+// at every call site. Mirrors how a rich abstract class is faked elsewhere.
+function asD1(db: FakeDb): D1Database {
+  return db as unknown as D1Database;
+}
+
+// R2Bucket is another rich abstract class (head/list/multipart/…); cast the
+// fake at the call site, keep the rich FakeBucket for assertions.
+function asR2(bucket: FakeBucket): R2Bucket {
+  return bucket as unknown as R2Bucket;
+}
+
+function createFakeBucket(): FakeBucket {
+  const store = new Map<string, ArrayBuffer>();
+  const bucket: FakeBucket = {
+    puts: [],
+    deleted: [],
+    async put(key, data, opts) {
+      bucket.puts.push({
+        key,
+        contentType: opts.httpMetadata?.contentType ?? "",
+        bytes: data.byteLength,
+      });
+      store.set(key, data);
+    },
+    async get(key) {
+      const data = store.get(key);
+      return data ? { arrayBuffer: async () => data } : null;
+    },
+    async delete(key) {
+      bucket.deleted.push(key);
+      store.delete(key);
+    },
+  };
+  return bucket;
+}
+
+function intakeRow(over: Partial<EmailReceiptIntake> = {}): EmailReceiptIntake {
+  return {
+    id: "intake-1",
+    received_at: "2026-07-19T00:00:00.000Z",
+    from_address: "vendor@example.com",
+    to_address: "receipts@dazbeez.com",
+    subject: "Receipt",
+    spf_pass: 1,
+    dkim_pass: 0,
+    attachment_r2_key: "receipts-intake/2026/07/intake-1/abc.pdf",
+    attachment_sha256: "deadbeef",
+    attachment_content_type: "application/pdf",
+    attachment_size_bytes: 1234,
+    attachment_filename: "r.pdf",
+    status: "pending_triage",
+    reject_reason: null,
+    promoted_receipt_id: null,
+    raw_headers_json: null,
+    created_at: "2026-07-19T00:00:00.000Z",
+    ...over,
+  };
+}
+
+const baseInput = {
+  receivedAt: "2026-07-19T00:00:00.000Z",
+  fromAddress: "vendor@example.com",
+  toAddress: "receipts@dazbeez.com",
+  subject: "Your receipt",
+  spfPass: true,
+  dkimPass: false,
+  rawHeadersJson: null,
+};
+
+// ─── classifyAttachment ─────────────────────────────────────────────────────
+
+test("classifyAttachment: valid PDF accepted", () => {
+  const v = classifyAttachment({ filename: "a.pdf", contentType: "application/pdf", sizeBytes: 100 });
+  assert.equal(v.valid, true);
+  assert.equal(v.rejectReason, null);
+});
+
+test("classifyAttachment: valid JPEG accepted", () => {
+  const v = classifyAttachment({ filename: "a.jpg", contentType: "image/jpeg", sizeBytes: 100 });
+  assert.equal(v.valid, true);
+});
+
+test("classifyAttachment: oversized → invalid, flagged not dropped", () => {
+  const v = classifyAttachment({
+    filename: "a.pdf",
+    contentType: "application/pdf",
+    sizeBytes: MAX_RECEIPT_FILE_BYTES + 1,
+  });
+  assert.equal(v.valid, false);
+  assert.match(v.rejectReason ?? "", /too large/i);
+});
+
+test("classifyAttachment: disallowed MIME → invalid (even with .pdf name)", () => {
+  const v = classifyAttachment({ filename: "a.pdf", contentType: "text/html", sizeBytes: 100 });
+  assert.equal(v.valid, false);
+  assert.match(v.rejectReason ?? "", /not allowed/i);
+});
+
+test("classifyAttachment: generic MIME falls back to extension (.pdf ok)", () => {
+  const v = classifyAttachment({
+    filename: "a.pdf",
+    contentType: "application/octet-stream",
+    sizeBytes: 100,
+  });
+  assert.equal(v.valid, true);
+});
+
+test("classifyAttachment: generic MIME + disallowed extension → invalid", () => {
+  const v = classifyAttachment({
+    filename: "a.exe",
+    contentType: "application/octet-stream",
+    sizeBytes: 100,
+  });
+  assert.equal(v.valid, false);
+});
+
+// ─── generateIntakeR2Key ─────────────────────────────────────────────────────
+
+test("generateIntakeR2Key: receipts-intake prefix, embeds intake id + month, sanitizes filename", () => {
+  const key = generateIntakeR2Key("intake-9", "Re ceipt (1).PDF", "2026-07-19T00:00:00Z");
+  // spaces and parens all collapse to '_': "Re ceipt (1).PDF" → "Re_ceipt__1_.PDF"
+  assert.match(key, /^receipts-intake\/2026\/07\/intake-9\/[0-9a-f-]+-Re_ceipt__1_\.PDF$/);
+});
+
+test("generateIntakeR2Key: never collides with the promoted receipts/ prefix", () => {
+  const key = generateIntakeR2Key("i", "x.pdf", "2026-01-01T00:00:00Z");
+  assert.ok(!key.startsWith("receipts/"), "intake key must not use the promoted receipts/ prefix");
+});
+
+// ─── recordIntake ────────────────────────────────────────────────────────────
+
+test("recordIntake: zero attachments → one row, 'no attachment', NULL key, pending_triage", async () => {
+  const db = createFakeDb();
+  const bucket = createFakeBucket();
+  const ids = await recordIntake(asD1(db), asR2(bucket), { ...baseInput, attachments: [] });
+  assert.equal(ids.length, 1);
+  assert.equal(db.rows.length, 1);
+  const row = db.rows[0];
+  assert.equal(row.status, "pending_triage", "body-only stays pending_triage, not auto-rejected");
+  assert.equal(row.attachment_r2_key, null);
+  assert.equal(row.reject_reason, "no attachment");
+  assert.equal(bucket.puts.length, 0, "nothing written to R2");
+});
+
+test("recordIntake: one valid attachment → row with R2 key + sha256, put to R2", async () => {
+  const db = createFakeDb();
+  const bucket = createFakeBucket();
+  const data = new TextEncoder().encode("%PDF-1.4 hello").buffer;
+  const ids = await recordIntake(asD1(db), asR2(bucket), {
+    ...baseInput,
+    attachments: [{ filename: "inv.pdf", contentType: "application/pdf", sizeBytes: data.byteLength, data }],
+  });
+  assert.equal(ids.length, 1);
+  const row = db.rows[0];
+  assert.equal(row.status, "pending_triage");
+  assert.ok(row.attachment_r2_key, "valid attachment gets an R2 key");
+  assert.ok(row.attachment_sha256 && row.attachment_sha256.length === 64, "sha256 hex recorded");
+  assert.equal(row.attachment_filename, "inv.pdf");
+  assert.equal(bucket.puts.length, 1, "valid attachment written to R2 exactly once");
+  assert.equal(bucket.puts[0].contentType, "application/pdf");
+});
+
+test("recordIntake: oversized attachment → row recorded with NULL key + reason, NOT put to R2", async () => {
+  const db = createFakeDb();
+  const bucket = createFakeBucket();
+  const big = new Uint8Array(MAX_RECEIPT_FILE_BYTES + 1);
+  const ids = await recordIntake(asD1(db), asR2(bucket), {
+    ...baseInput,
+    attachments: [{ filename: "big.pdf", contentType: "application/pdf", sizeBytes: big.byteLength, data: big.buffer }],
+  });
+  assert.equal(ids.length, 1);
+  const row = db.rows[0];
+  assert.equal(row.status, "pending_triage", "invalid attachment stays pending_triage (not auto-rejected)");
+  assert.equal(row.attachment_r2_key, null, "no R2 object for an invalid attachment");
+  assert.match(row.reject_reason ?? "", /too large/i);
+  assert.equal(bucket.puts.length, 0, "oversized attachment must not be written to R2");
+});
+
+test("recordIntake: to_address round-trips through all three row-insert branches", async () => {
+  const valid = new TextEncoder().encode("%PDF-1.4").buffer;
+  const big = new Uint8Array(MAX_RECEIPT_FILE_BYTES + 1);
+  type Att = { filename: string; contentType: string; sizeBytes: number; data: ArrayBuffer };
+  const input = (attachments: Att[]) => ({
+    ...baseInput,
+    toAddress: "receipt@dazbeez.com",
+    attachments,
+  });
+
+  // zero-attachment branch
+  let db = createFakeDb();
+  await recordIntake(asD1(db), asR2(createFakeBucket()), input([]));
+  assert.equal(db.rows[0].to_address, "receipt@dazbeez.com", "zero-attachment branch");
+
+  // valid-attachment branch
+  db = createFakeDb();
+  await recordIntake(asD1(db), asR2(createFakeBucket()), input([
+    { filename: "a.pdf", contentType: "application/pdf", sizeBytes: valid.byteLength, data: valid },
+  ]));
+  assert.equal(db.rows[0].to_address, "receipt@dazbeez.com", "valid-attachment branch");
+
+  // invalid-attachment branch
+  db = createFakeDb();
+  await recordIntake(asD1(db), asR2(createFakeBucket()), input([
+    { filename: "big.pdf", contentType: "application/pdf", sizeBytes: big.byteLength, data: big.buffer },
+  ]));
+  assert.equal(db.rows[0].to_address, "receipt@dazbeez.com", "invalid-attachment branch");
+});
+
+test("recordIntake: null to_address is accepted (defensive — message.to absent)", async () => {
+  const db = createFakeDb();
+  await recordIntake(asD1(db), asR2(createFakeBucket()), { ...baseInput, toAddress: null, attachments: [] });
+  assert.equal(db.rows[0].to_address, null);
+});
+
+test("recordIntake: multiple attachments → one row per attachment (fan-out)", async () => {
+  const db = createFakeDb();
+  const bucket = createFakeBucket();
+  const a = new TextEncoder().encode("pdf-A").buffer;
+  const b = new TextEncoder().encode("png-B").buffer;
+  const ids = await recordIntake(asD1(db), asR2(bucket), {
+    ...baseInput,
+    attachments: [
+      { filename: "a.pdf", contentType: "application/pdf", sizeBytes: a.byteLength, data: a },
+      { filename: "b.png", contentType: "image/png", sizeBytes: b.byteLength, data: b },
+    ],
+  });
+  assert.equal(ids.length, 2, "one intake row per attachment");
+  assert.equal(db.rows.length, 2);
+  assert.equal(bucket.puts.length, 2, "each valid attachment put to R2");
+});
+
+test("recordIntake: SPF/DKIM verdicts captured onto each row", async () => {
+  const db = createFakeDb();
+  const bucket = createFakeBucket();
+  const data = new TextEncoder().encode("x").buffer;
+  await recordIntake(asD1(db), asR2(bucket), {
+    ...baseInput,
+    spfPass: false,
+    dkimPass: true,
+    attachments: [{ filename: "a.pdf", contentType: "application/pdf", sizeBytes: 1, data }],
+  });
+  assert.equal(db.rows[0].spf_pass, 0);
+  assert.equal(db.rows[0].dkim_pass, 1);
+});
+
+test("INTAKE_MAX_MESSAGE_BYTES is 10 MiB and tighter than the 5 MiB receipt limit", () => {
+  assert.equal(INTAKE_MAX_MESSAGE_BYTES, 10 * 1024 * 1024);
+  assert.ok(INTAKE_MAX_MESSAGE_BYTES > MAX_RECEIPT_FILE_BYTES);
+});
+
+// ─── listPendingIntake ───────────────────────────────────────────────────────
+
+test("listPendingIntake: returns only pending_triage, newest first", async () => {
+  const db = createFakeDb([
+    intakeRow({ id: "old", received_at: "2026-07-01T00:00:00Z", status: "pending_triage" }),
+    intakeRow({ id: "new", received_at: "2026-07-18T00:00:00Z", status: "pending_triage" }),
+    intakeRow({ id: "prom", status: "promoted" }),
+    intakeRow({ id: "rej", status: "rejected" }),
+  ]);
+  const rows = await listPendingIntake(asD1(db));
+  assert.deepEqual(
+    rows.map((r) => r.id),
+    ["new", "old"],
+    "only pending_triage, newest first; promoted/rejected excluded",
+  );
+});
+
+// ─── rejectIntake ─────────────────────────────────────────────────────────────
+
+test("rejectIntake: requires a non-empty reason", async () => {
+  const db = createFakeDb([intakeRow()]);
+  await assert.rejects(() => rejectIntake(asD1(db), "intake-1", "   ", "actor"), /reject_reason is required/i);
+  await assert.rejects(() => rejectIntake(asD1(db), "intake-1", "", "actor"), /reject_reason is required/i);
+});
+
+test("rejectIntake: flips pending → rejected with reason, audits, leaves receipt_records untouched", async () => {
+  const db = createFakeDb([intakeRow()]);
+  await rejectIntake(asD1(db), "intake-1", "personal expense", "david");
+  assert.equal(db.rows[0].status, "rejected");
+  assert.equal(db.rows[0].reject_reason, "personal expense");
+  assert.equal(db.auditInserts, 1, "one audit entry written");
+});
+
+test("rejectIntake: refuses on a non-pending row", async () => {
+  const db = createFakeDb([intakeRow({ status: "promoted" })]);
+  await assert.rejects(() => rejectIntake(asD1(db), "intake-1", "x", "a"), /only pending_triage may be rejected/i);
+});
+
+test("rejectIntake: not-found row throws", async () => {
+  const db = createFakeDb([]);
+  await assert.rejects(() => rejectIntake(asD1(db), "nope", "x", "a"), /not found/i);
+});
+
+// ─── buildPromoteReceiptInput (pure half of promote) ────────────────────────
+
+test("buildPromoteReceiptInput: source=email, sourceType=email_attachment, status=captured, capturedBy=from", () => {
+  const input = buildPromoteReceiptInput(intakeRow({ from_address: "v@x.com" }));
+  assert.equal(input.source, "email");
+  assert.equal(input.sourceType, "email_attachment");
+  assert.equal(input.status, "captured");
+  assert.equal(input.capturedBy, "v@x.com");
+});
+
+test("buildPromoteReceiptInput: omits paymentPath/expenseType so UNKNOWN defaults apply", () => {
+  const input = buildPromoteReceiptInput(intakeRow());
+  assert.ok(!("paymentPath" in input && input.paymentPath !== undefined), "no explicit paymentPath");
+  assert.ok(!("expenseType" in input && input.expenseType !== undefined), "no explicit expenseType");
+});
+
+test("buildPromoteReceiptInput: copies R2 metadata from the intake row", () => {
+  const input = buildPromoteReceiptInput(
+    intakeRow({
+      attachment_r2_key: "k",
+      attachment_sha256: "h",
+      attachment_content_type: "application/pdf",
+      attachment_size_bytes: 99,
+      attachment_filename: "f.pdf",
+    }),
+  );
+  assert.equal(input.originalR2Key, "k");
+  assert.equal(input.originalSha256, "h");
+  assert.equal(input.originalContentType, "application/pdf");
+  assert.equal(input.originalSizeBytes, 99);
+  assert.equal(input.originalFilename, "f.pdf");
+});
+
+// ─── assertPromotable (pure half of promote) ────────────────────────────────
+
+test("assertPromotable: refuses when attachment_r2_key is NULL", () => {
+  assert.throws(() => assertPromotable(intakeRow({ attachment_r2_key: null })), /no promotable attachment/i);
+});
+
+test("assertPromotable: refuses when status is not pending_triage", () => {
+  assert.throws(() => assertPromotable(intakeRow({ status: "promoted" })), /already promoted/i);
+  assert.throws(() => assertPromotable(intakeRow({ status: "rejected" })), /already rejected/i);
+});
+
+test("assertPromotable: passes for a pending row with an attachment", () => {
+  assert.doesNotThrow(() => assertPromotable(intakeRow()));
+});

--- a/tests/receipts/email-parse.test.ts
+++ b/tests/receipts/email-parse.test.ts
@@ -1,0 +1,159 @@
+// Tests for the pure helpers the receipts-email-intake Worker uses
+// (lib/receipts/email-parse.ts). These are dependency-free and Worker-agnostic,
+// so they live in the main suite like the rest of the receipts logic tests.
+// The Worker's src/index.ts binding/IO glue (readRaw, PostalMime.parse, R2/D1)
+// is covered by the live §8 mail test, not here.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  withinMessageSizeCeiling,
+  mapPostalAttachments,
+  extractAuthVerdicts,
+  pickRawHeadersSubset,
+  staleCutoffIso,
+} from "@/lib/receipts/email-parse";
+
+// ─── withinMessageSizeCeiling ───────────────────────────────────────────────
+
+test("withinMessageSizeCeiling: under ceiling → true", () => {
+  assert.equal(withinMessageSizeCeiling(0, 100), true);
+  assert.equal(withinMessageSizeCeiling(99, 100), true);
+});
+
+test("withinMessageSizeCeiling: exactly at ceiling → true (boundary, <=)", () => {
+  assert.equal(withinMessageSizeCeiling(100, 100), true);
+});
+
+test("withinMessageSizeCeiling: over ceiling → false", () => {
+  assert.equal(withinMessageSizeCeiling(101, 100), false);
+});
+
+test("withinMessageSizeCeiling: negative / NaN / non-finite → false", () => {
+  assert.equal(withinMessageSizeCeiling(-1, 100), false);
+  assert.equal(withinMessageSizeCeiling(NaN, 100), false);
+  assert.equal(withinMessageSizeCeiling(Infinity, 100), false);
+});
+
+// ─── mapPostalAttachments ───────────────────────────────────────────────────
+
+test("mapPostalAttachments: maps filename/mimeType and computes sizeBytes from content", () => {
+  const data = new Uint8Array([1, 2, 3, 4]).buffer;
+  const [m] = mapPostalAttachments([
+    { filename: "inv.pdf", mimeType: "application/pdf", content: data },
+  ]);
+  assert.equal(m.filename, "inv.pdf");
+  assert.equal(m.contentType, "application/pdf");
+  assert.equal(m.sizeBytes, 4);
+  assert.ok(m.data instanceof ArrayBuffer);
+  assert.equal(m.data.byteLength, 4);
+});
+
+test("mapPostalAttachments: null/empty filename → 'attachment'", () => {
+  const data = new Uint8Array([1]).buffer;
+  const a = mapPostalAttachments([{ filename: null, mimeType: "x", content: data }]);
+  const b = mapPostalAttachments([{ filename: "   ", mimeType: "x", content: data }]);
+  assert.equal(a[0].filename, "attachment");
+  assert.equal(b[0].filename, "attachment");
+});
+
+test("mapPostalAttachments: empty/missing mimeType → application/octet-stream", () => {
+  const data = new Uint8Array([1]).buffer;
+  const m = mapPostalAttachments([{ filename: "a", mimeType: "", content: data }]);
+  assert.equal(m[0].contentType, "application/octet-stream");
+});
+
+test("mapPostalAttachments: Uint8Array VIEW over a larger buffer copies only the view range", () => {
+  // The correctness point: a postal-mime attachment content can be a Uint8Array
+  // view over a larger backing buffer. Naively using .buffer would leak bytes
+  // outside the attachment's range. The mapper must copy just [byteOffset,
+  // byteOffset+byteLength).
+  const backing = new Uint8Array([0, 0, 10, 20, 30, 0, 0]); // view will be [10,20,30]
+  const view = backing.subarray(2, 5);
+  assert.equal(view.byteLength, 3);
+  const [m] = mapPostalAttachments([
+    { filename: "a", mimeType: "application/pdf", content: view },
+  ]);
+  assert.equal(m.sizeBytes, 3, "sizeBytes reflects the VIEW, not the backing buffer");
+  assert.equal(m.data.byteLength, 3);
+  assert.deepEqual(Array.from(new Uint8Array(m.data)), [10, 20, 30]);
+  assert.notEqual(m.data, backing.buffer, "must be a copy, not the backing buffer");
+});
+
+// ─── extractAuthVerdicts ────────────────────────────────────────────────────
+
+test("extractAuthVerdicts: absent header → {false,false} (not a 'fail', just unavailable)", () => {
+  assert.deepEqual(extractAuthVerdicts(null), { spf: false, dkim: false });
+  assert.deepEqual(extractAuthVerdicts(undefined), { spf: false, dkim: false });
+  assert.deepEqual(extractAuthVerdicts(""), { spf: false, dkim: false });
+});
+
+test("extractAuthVerdicts: both pass", () => {
+  const h = "mx.cloudflare.net; spf=pass smtp.mailfrom=example.com; dkim=pass header.d=example.com";
+  assert.deepEqual(extractAuthVerdicts(h), { spf: true, dkim: true });
+});
+
+test("extractAuthVerdicts: spf=fail, dkim=pass", () => {
+  const h = "spf=fail; dkim=pass";
+  assert.deepEqual(extractAuthVerdicts(h), { spf: false, dkim: true });
+});
+
+test("extractAuthVerdicts: softfail/temperror/none → not pass", () => {
+  assert.deepEqual(extractAuthVerdicts("spf=softfail; dkim=temperror"), { spf: false, dkim: false });
+  assert.deepEqual(extractAuthVerdicts("spf=none; dkim=none"), { spf: false, dkim: false });
+});
+
+test("extractAuthVerdicts: boundary — does not match 'passfail' as 'pass'", () => {
+  // "spf=passfail" must NOT register as spf pass (token-boundary check).
+  assert.deepEqual(extractAuthVerdicts("spf=passfail; dkim=passignored"), { spf: false, dkim: false });
+});
+
+test("extractAuthVerdicts: case-insensitive", () => {
+  assert.deepEqual(extractAuthVerdicts("SPF=PASS; DKIM=Pass"), { spf: true, dkim: true });
+});
+
+// ─── pickRawHeadersSubset ───────────────────────────────────────────────────
+
+test("pickRawHeadersSubset: returns present headers, trimmed; skips absent/empty", () => {
+  const headers = new Map<string, string>([
+    ["from", "  sender@example.com  "],
+    ["subject", "Hello"],
+    ["date", "Wed, 1 Jan 2026 00:00:00 +0000"],
+    ["empty", "   "],
+  ]);
+  const out = pickRawHeadersSubset((n) => headers.get(n.toLowerCase()) ?? null);
+  assert.equal(out.from, "sender@example.com");
+  assert.equal(out.subject, "Hello");
+  assert.equal(out.date, "Wed, 1 Jan 2026 00:00:00 +0000");
+  assert.ok(!("empty" in out), "whitespace-only header omitted");
+  assert.ok(!("authentication-results" in out), "absent header omitted");
+});
+
+test("pickRawHeadersSubset: includes authentication-results when present", () => {
+  const out = pickRawHeadersSubset((n) =>
+    n === "authentication-results" ? "mx.cf.net; spf=pass" : null,
+  );
+  assert.equal(out["authentication-results"], "mx.cf.net; spf=pass");
+});
+
+// ─── staleCutoffIso ─────────────────────────────────────────────────────────
+
+test("staleCutoffIso: 30 days before the given instant", () => {
+  // 2026-07-19T00:00:00Z minus 30 days → 2026-06-19T00:00:00Z
+  const now = Date.UTC(2026, 6, 19); // month is 0-indexed (6 = July)
+  const cutoff = staleCutoffIso(now, 30);
+  assert.equal(cutoff, "2026-06-19T00:00:00.000Z");
+});
+
+test("staleCutoffIso: respects the days parameter", () => {
+  const now = Date.UTC(2026, 6, 19);
+  assert.equal(staleCutoffIso(now, 1), "2026-07-18T00:00:00.000Z");
+  assert.equal(staleCutoffIso(now, 90), "2026-04-20T00:00:00.000Z");
+});
+
+test("staleCutoffIso: crosses month/year boundaries correctly", () => {
+  // 2026-03-01 minus 30 days → 2026-01-30 (crosses Feb)
+  const now = Date.UTC(2026, 2, 1); // March 1
+  const cutoff = staleCutoffIso(now, 30);
+  assert.equal(cutoff, "2026-01-30T00:00:00.000Z");
+});

--- a/workers/receipts-email-intake/package-lock.json
+++ b/workers/receipts-email-intake/package-lock.json
@@ -1,0 +1,1584 @@
+{
+  "name": "dazbeez-receipts-email-intake",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dazbeez-receipts-email-intake",
+      "version": "0.1.0",
+      "dependencies": {
+        "postal-mime": "^2.4.3"
+      },
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20260418.1",
+        "typescript": "^5",
+        "wrangler": "4.83.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
+      "integrity": "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.0.tgz",
+      "integrity": "sha512-8ovsRpwzPoEqPUzoErAYVv8l3FMZNeBVQfJTvtzP4AgLSRGZISRfuChFxHWUQd3n6cnrwkuTGxT+2cGo8EsyYg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260301.1 || ~1.20260302.1 || ~1.20260303.1 || ~1.20260304.1 || >1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260415.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260415.1.tgz",
+      "integrity": "sha512-dsxaKsQm3LnPGNPEdsRv09QN3Y4DqCw7kX5j6noKqbAtro2jTr95sVlYM1jUxZ5FkOl1f7SXgaKKB9t5H5Nkbg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260415.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260415.1.tgz",
+      "integrity": "sha512-+JgSgVA49KyKteHRA1SnonE4Zn5Ei5zdAp5FQMxFmXI8qulZw4Hl7safXxRyK4i9sTO8gl7TFOKO5Q64VPvSDQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260415.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260415.1.tgz",
+      "integrity": "sha512-tU+9pwsqCy8afOVlGtiWrWQc/fedQK4SRm4KPIAt+zOiQWDxWASm6YGBUJis5c648WN80yz47qnmdDi8DQNOcA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260415.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260415.1.tgz",
+      "integrity": "sha512-bR9uITnV19r5NQ14xnypi2xHXu2iQvfYV8cVgx0JouFUmWwTEEAwFVojDdssGq93VHX9hr/pi2IRUZeegbYBog==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260415.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260415.1.tgz",
+      "integrity": "sha512-4NuMLlerI0Ijua3Ir8HXQ+qyNvCUDEG5gDco5Om+sAiK6rnWiz+aGoSlbB8W16yW9QAgzCstbmXLiVknUBflfQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260702.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260702.1.tgz",
+      "integrity": "sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.17",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.17.tgz",
+      "integrity": "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "4.20260415.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260415.0.tgz",
+      "integrity": "sha512-JoExRWN4YBI2luA5BoSMFEgi8rQWXUGzo3mtE+58VXCLV3jj/Xnk5Yeqs/IXWz8Es5GJIaq6BtsixDvAxXSIng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "^0.34.5",
+        "undici": "7.24.8",
+        "workerd": "1.20260415.1",
+        "ws": "8.18.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/postal-mime": {
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.5.tgz",
+      "integrity": "sha512-GNEXKvWFQnbgO5NlrGzVa0FmWzBZ24PersAWErttSg1Hjpf0ATxTwS5DOMGaOpTG6bUh5cTr7xi0jAD942wCJA==",
+      "license": "MIT-0"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
+      "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260415.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260415.1.tgz",
+      "integrity": "sha512-phyPjRnx+mQDfkhN9ENPioL1L0SdhYs4S0YmJK/xF9Oga+ykNfdSy1MHnsOj8yqnOV96zcVQMx32dJ0r3pq0jQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260415.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260415.1",
+        "@cloudflare/workerd-linux-64": "1.20260415.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260415.1",
+        "@cloudflare/workerd-windows-64": "1.20260415.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.83.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.83.0.tgz",
+      "integrity": "sha512-gw5g3LCiuAqVWxaoKY6+quE0HzAUEFb/FV3oAlNkE1ttd4XP3FiV91XDkkzUCcdqxS4WjhQvPhIDBNdhEi8P0A==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.4.2",
+        "@cloudflare/unenv-preset": "2.16.0",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.27.3",
+        "miniflare": "4.20260415.0",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260415.1"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=20.3.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20260415.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    }
+  }
+}

--- a/workers/receipts-email-intake/package.json
+++ b/workers/receipts-email-intake/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "dazbeez-receipts-email-intake",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "deploy": "wrangler deploy",
+    "dev": "wrangler dev"
+  },
+  "dependencies": {
+    "postal-mime": "^2.4.3"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260418.1",
+    "typescript": "^5",
+    "wrangler": "4.83.0"
+  }
+}

--- a/workers/receipts-email-intake/src/cloudflare-env.d.ts
+++ b/workers/receipts-email-intake/src/cloudflare-env.d.ts
@@ -1,0 +1,36 @@
+// Worker-local CloudflareEnv stub (ADR 0011 intake worker).
+//
+// Why this exists: lib/receipts/email-intake.ts (shared with the OpenNext app)
+// transitively imports lib/cloudflare-runtime.ts, whose getReceiptsDb() etc.
+// cast the env to `CloudflareEnv`. This worker calls only recordIntake(), which
+// does NOT touch cloudflare-runtime — and the bundler proves it: `getCloudflareContext`
+// and every cloudflare-runtime symbol are tree-shaken out of the published bundle
+// (0 occurrences, verified via `wrangler deploy --dry-run`). But tsc --noEmit
+// type-checks the whole transitive import graph, so it still visits cloudflare-runtime.ts
+// and needs `CloudflareEnv` to carry these members.
+//
+// We cannot include the main app's cloudflare-env.d.ts here: `wrangler types`
+// regenerated it with the ENTIRE workerd runtime global surface inlined (472 KB /
+// 13k lines), which would redeclare Workers globals and collide with
+// `@cloudflare/workers-types`. Instead this file declares just the env binding
+// members (interface declaration merging adds them). Source of truth for the
+// real bindings is the main app's cloudflare-env.d.ts; this stub mirrors it.
+interface CloudflareEnv {
+  CRM_IMAGES: R2Bucket;
+  RECEIPTS_BUCKET: R2Bucket;
+  RECEIPTS_ARCHIVE_BUCKET: R2Bucket;
+  DB: D1Database;
+  CRM_DB: D1Database;
+  RECEIPTS_DB: D1Database;
+  AI: Ai;
+  ASSETS: Fetcher;
+  NEXTJS_ENV: string;
+  ACCOUNTANT_EMAIL: string;
+  NOTIFY_FROM_ADDRESS: string;
+  // Wrangler secrets (set via `wrangler secret put`) — not emitted by `wrangler
+  // types`, augmented in the app via receipts-env.d.ts. Mirrored here so
+  // cloudflare-runtime.ts's getResendApiKey() type-checks under this worker.
+  RESEND_API_KEY: string;
+  RECEIPTS_QUEUE?: Queue<unknown>;
+  RECEIPTS_PROCESSOR_KEY?: string;
+}

--- a/workers/receipts-email-intake/src/index.ts
+++ b/workers/receipts-email-intake/src/index.ts
@@ -1,0 +1,261 @@
+// dazbeez-receipts-email-intake — standalone Cloudflare Worker for inbound
+// receipt email at receipts@dazbeez.com (ADR 0011 §2 + §6).
+//
+// Why a separate worker (not the main dazbeez OpenNext worker): OpenNext's
+// generated worker exports only `fetch`, and @opennextjs/cloudflare's override
+// surface has no `email`/`scheduled` hook. This worker mirrors the existing
+// workers/email-reply-capture pattern (own wrangler/package/tsconfig, postal-mime,
+// readRaw + ctx.waitUntil) but, unlike reply-capture, it KEEPS the message
+// (intake, not a forward passthrough) and also runs the daily cleanup cron.
+//
+// All intake/cleanup LOGIC lives in lib/receipts/{email-intake,email-parse}.ts;
+// this file is the thin binding/IO glue.
+
+import PostalMime from "postal-mime";
+import {
+  recordIntake,
+  INTAKE_MAX_MESSAGE_BYTES,
+  INTAKE_STALE_DAYS,
+} from "../../../lib/receipts/email-intake";
+import {
+  withinMessageSizeCeiling,
+  mapPostalAttachments,
+  extractAuthVerdicts,
+  pickRawHeadersSubset,
+  staleCutoffIso,
+} from "../../../lib/receipts/email-parse";
+
+interface Env {
+  RECEIPTS_DB: D1Database;
+  RECEIPTS_BUCKET: R2Bucket;
+}
+
+const CLEANUP_BATCH_LIMIT = 200;
+
+const worker = {
+  // ─── Inbound mail → email_receipt_intake ──────────────────────────────────
+  async email(
+    message: ForwardableEmailMessage,
+    env: Env,
+    ctx: ExecutionContext,
+  ): Promise<void> {
+    // Hard pre-parse size ceiling (ADR 0011 "Negative"). Check the declared
+    // rawSize BEFORE reading/parsing anything. If it exceeds the ceiling, drop
+    // (do not process) and log. We deliberately do NOT call message.setReject:
+    // its bounce semantics aren't specified in the ADR and guessing wrong could
+    // bounce legitimate mail to a real sender.
+    if (!withinMessageSizeCeiling(message.rawSize, INTAKE_MAX_MESSAGE_BYTES)) {
+      console.warn("[receipts-email-intake] message exceeds size ceiling, dropping", {
+        from: message.from,
+        to: message.to,
+        rawSize: message.rawSize,
+        ceiling: INTAKE_MAX_MESSAGE_BYTES,
+      });
+      return;
+    }
+
+    let rawBytes: Uint8Array | null = null;
+    try {
+      rawBytes = await readRaw(message.raw, message.rawSize);
+    } catch (err) {
+      console.error("[receipts-email-intake] failed to read raw message", {
+        from: message.from,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return;
+    }
+    if (!rawBytes) return;
+
+    // Defense against a rawSize that understated the real stream length.
+    if (!withinMessageSizeCeiling(rawBytes.byteLength, INTAKE_MAX_MESSAGE_BYTES)) {
+      console.warn("[receipts-email-intake] read bytes exceed ceiling, dropping", {
+        from: message.from,
+        bytes: rawBytes.byteLength,
+      });
+      return;
+    }
+
+    // Process out-of-band so email() resolves promptly. IMPORTANT control-flow
+    // fact for the error posture below: the intake work is BACKGROUNDED —
+    // email() has already returned by the time processMessage runs, so a thrown
+    // error there is an INVISIBLE BACKGROUND REJECTION, not a bounce to the
+    // sender. (A real bounce would require awaiting processMessage synchronously
+    // before returning — a bigger restructure, deliberately not taken: a bounce
+    // on a transient D1/R2 hiccup would reject a legitimate sender for something
+    // they can't fix, and bounce behavior leaks a little info to an unauthenticated
+    // endpoint.)
+    //
+    // So processMessage fails safe (log + swallow): a failed intake is visible
+    // ONLY in Worker logs — no row lands in /receipts/inbox. Logged-only failure
+    // is the accepted v1 gap, same posture as the "no monitoring in v1" call in
+    // ADR 0011. If intake reliability later matters more than sender UX, revisit
+    // by awaiting synchronously AND adding a dead-letter signal (not by throwing
+    // inside this backgrounded task, which buys nothing).
+    ctx.waitUntil(processMessage(env, message, rawBytes));
+  },
+
+  // ─── Daily cleanup cron (03:00 UTC) ───────────────────────────────────────
+  async scheduled(
+    _controller: ScheduledController,
+    env: Env,
+    ctx: ExecutionContext,
+  ): Promise<void> {
+    ctx.waitUntil(cleanupStaleIntake(env));
+  },
+};
+
+export default worker;
+
+// ─── email() helpers ────────────────────────────────────────────────────────
+
+async function processMessage(
+  env: Env,
+  message: ForwardableEmailMessage,
+  rawBytes: Uint8Array,
+): Promise<void> {
+  try {
+    // arraybuffer encoding → attachment.content is an ArrayBuffer (no base64).
+    const parsed = await PostalMime.parse(rawBytes, {
+      attachmentEncoding: "arraybuffer",
+    });
+
+    const fromAddress = parsed.from?.address ?? message.from ?? "";
+    const subject = parsed.subject ?? null;
+    const receivedAt = parsed.date
+      ? new Date(parsed.date).toISOString()
+      : new Date().toISOString();
+
+    const getHeader = (name: string): string | null =>
+      message.headers.get(name) ?? null;
+
+    // SPF/DKIM (ADR 0011 §0.3): parsed DEFENSIVELY from Authentication-Results.
+    // If Cloudflare's transport doesn't stamp it, this yields {false,false} —
+    // not a "fail", just "unavailable". The verdicts are surfaced in the inbox
+    // and audit log; they never gate intake.
+    const { spf, dkim } = extractAuthVerdicts(getHeader("authentication-results"));
+    const rawHeadersJson = JSON.stringify(pickRawHeadersSubset(getHeader));
+
+    const attachments = mapPostalAttachments(
+      (parsed.attachments ?? []).map((a) => ({
+        filename: a.filename,
+        mimeType: a.mimeType,
+        content: a.content as ArrayBuffer | Uint8Array,
+      })),
+    );
+
+    const ids = await recordIntake(env.RECEIPTS_DB, env.RECEIPTS_BUCKET, {
+      receivedAt,
+      fromAddress,
+      toAddress: message.to ?? null,
+      subject,
+      spfPass: spf,
+      dkimPass: dkim,
+      rawHeadersJson,
+      attachments,
+    });
+
+    console.log("[receipts-email-intake] recorded", {
+      from: fromAddress,
+      subject,
+      attachments: attachments.length,
+      rows: ids.length,
+    });
+  } catch (err) {
+    console.error("[receipts-email-intake] intake failed", {
+      from: message.from,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+// Read a ReadableStream<Uint8Array> into a single Uint8Array. Same pattern as
+// workers/email-reply-capture (kept consistent so behavior is identical).
+async function readRaw(
+  stream: ReadableStream<Uint8Array>,
+  expectedSize: number,
+): Promise<Uint8Array> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    if (value) {
+      chunks.push(value);
+      total += value.byteLength;
+    }
+  }
+  const out = new Uint8Array(expectedSize || total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return offset === out.byteLength ? out : out.subarray(0, offset);
+}
+
+// ─── scheduled() cleanup ────────────────────────────────────────────────────
+//
+// ADR 0011 §6: delete the R2 object (the disposable part) for intake rows that
+// are rejected OR stale pending_triage (> INTAKE_STALE_DAYS old). The ROW is
+// kept for audit history with attachment_r2_key nulled. We do NOT auto-flip
+// stale pending_triage → rejected: the ADR only deletes the object, and a stale
+// row with a null key is already functionally unpromotable (assertPromotable
+// refuses it), so a status change would be redundant. Batched to keep the query
+// bounded (cron runs daily; a backlog drains over a few days).
+
+async function cleanupStaleIntake(env: Env): Promise<void> {
+  const db = env.RECEIPTS_DB;
+  const bucket = env.RECEIPTS_BUCKET;
+  const cutoff = staleCutoffIso(Date.now(), INTAKE_STALE_DAYS);
+
+  const result = await db
+    .prepare(
+      `SELECT id, attachment_r2_key
+         FROM email_receipt_intake
+        WHERE attachment_r2_key IS NOT NULL
+          AND (
+            status = 'rejected'
+            OR (status = 'pending_triage' AND received_at < ?)
+          )
+        ORDER BY received_at ASC
+        LIMIT ?`,
+    )
+    .bind(cutoff, CLEANUP_BATCH_LIMIT)
+    .all<{ id: string; attachment_r2_key: string }>();
+
+  const rows = result.results ?? [];
+  let deleted = 0;
+  for (const row of rows) {
+    // Best-effort R2 delete: a failure here must not block nulling the key
+    // (otherwise the cron retries the same object forever). Log and continue.
+    try {
+      await bucket.delete(row.attachment_r2_key);
+      deleted += 1;
+    } catch (err) {
+      console.error("[receipts-email-intake] R2 delete failed", {
+        key: row.attachment_r2_key,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+    try {
+      await db
+        .prepare(
+          `UPDATE email_receipt_intake SET attachment_r2_key = NULL WHERE id = ?`,
+        )
+        .bind(row.id)
+        .run();
+    } catch (err) {
+      console.error("[receipts-email-intake] intake row update failed", {
+        id: row.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  console.log("[receipts-email-intake] cleanup done", {
+    cutoff,
+    candidates: rows.length,
+    r2Deleted: deleted,
+  });
+}

--- a/workers/receipts-email-intake/tsconfig.json
+++ b/workers/receipts-email-intake/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["@cloudflare/workers-types"],
+    "lib": ["ES2022", "WebWorker"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["../../*"]
+    }
+  },
+  "include": [
+    "src/**/*.ts",
+    "../../lib/receipts/email-intake.ts",
+    "../../lib/receipts/email-parse.ts",
+    "../../lib/receipts/storage.ts",
+    "../../lib/receipts/upload-policy.ts",
+    "../../lib/receipts/db-utils.ts",
+    "../../lib/receipts/types.ts",
+    "../../lib/receipts/categories.ts",
+    "../../lib/receipts/retention.ts"
+  ]
+}

--- a/workers/receipts-email-intake/wrangler.jsonc
+++ b/workers/receipts-email-intake/wrangler.jsonc
@@ -1,0 +1,28 @@
+{
+  "$schema": "../../node_modules/wrangler/config-schema.json",
+  "name": "dazbeez-receipts-email-intake",
+  "main": "src/index.ts",
+  "compatibility_date": "2025-08-01",
+  "compatibility_flags": [
+    "nodejs_compat"
+  ],
+  // ADR 0011: bindings copied verbatim from the main wrangler.jsonc — same D1
+  // database and R2 bucket the receipts app uses, so intake rows and attachment
+  // objects land where /receipts/inbox and promoteIntake expect them.
+  "d1_databases": [
+    {
+      "binding": "RECEIPTS_DB",
+      "database_name": "dazbeez-receipts",
+      "database_id": "8dffd78f-b9aa-490d-822d-4f413e52aeba"
+    }
+  ],
+  "r2_buckets": [
+    { "binding": "RECEIPTS_BUCKET", "bucket_name": "dazbeez-receipts" }
+  ],
+  // Daily cleanup at 03:00 UTC. Not user-facing; 03:00 UTC (~12:00 JST) avoids
+  // the receipts module's statement-finalization window and is quiet hours for
+  // inbound mail. See ADR 0011 §6.
+  "triggers": {
+    "crons": ["0 3 * * *"]
+  }
+}


### PR DESCRIPTION
Standalone Cloudflare Worker (`dazbeez-receipts-email-intake`) captures inbound mail at `receipts@` / `receipt@dazbeez.com` into a new `email_receipt_intake` triage table. Nothing unauthenticated touches `receipt_records` until a human promotes a row via `/receipts/inbox`, which reuses the existing `createReceiptRecord` — so an emailed receipt flows through the normal extraction queue → Mac MLX → review pipeline unchanged. A daily 03:00 UTC cron deletes R2 for rejected / stale-pending rows (row kept for audit).

**What's in this PR**
- `db/receipts/0024_email_intake.sql` (table) + `0025_email_intake_to_address.sql` (`to_address`)
- `lib/receipts/email-intake.ts` (`recordIntake` / `promoteIntake` / `rejectIntake`) + `email-parse.ts` (pure, dep-free Worker helpers)
- `/receipts/inbox` screen + `POST /api/receipts/inbox/[id]/{promote,reject}` (Clerk-gated)
- `workers/receipts-email-intake/` — postal-mime; bundles at ~140 KiB with the OpenNext-coupled consumer code tree-shaken out; fail-safe `email()` handler
- ADR 0011 (design of record) + README index

**Notes**
- Both migrations are already applied to live D1; the intake worker is already deployed (`dazbeez-receipts-email-intake`). This PR puts the main-app UI (`/receipts/inbox`) + lib on master so it auto-deploys on merge.
- Live-mail end-to-end verification (SPF/DKIM header shape from Cloudflare Email Routing) is pending operator test — `extractAuthVerdicts` parses `Authentication-Results` defensively and returns `{false,false}` when absent.
- Pre-existing dirty files unrelated to ADR 0011 (`amex-import-form.tsx`, `validation.ts`, `fix-2016-date-anomaly.ts`, `amex-parser.test.ts`) are intentionally NOT included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)