### PR TITLE
fix(capture): wire mobile payment-preselect chip to the upload

### DIFF
--- a/components/receipts/capture/capture-mobile.tsx
+++ b/components/receipts/capture/capture-mobile.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useRef, useState, type ChangeEvent } from "react";
+import { useRef, type ChangeEvent } from "react";
 import { Btn } from "@/components/ui/btn";
 import { Pill } from "@/components/ui/pill";
 import { CameraIcon, CheckIcon, PlusIcon } from "@/components/ui/icons";
@@ -11,7 +11,11 @@ import type { PaymentPath } from "@/lib/receipts/types";
 import type { CapturePhase } from "./use-receipt-upload";
 
 export interface CaptureMobileProps {
-  initialPayment: PaymentPath | null;
+  // paymentChip/setPaymentChip are owned by ReceiptCaptureForm (lifted state)
+  // so the toggled value actually reaches the upload call. See
+  // receipt-capture-form.tsx.
+  paymentChip: PaymentPath | null;
+  setPaymentChip: (p: PaymentPath | null) => void;
   rapidMode: boolean;
   todayCount: number | null;
   phase: CapturePhase;
@@ -22,7 +26,6 @@ export interface CaptureMobileProps {
 
 export function CaptureMobile(props: CaptureMobileProps) {
   const fileRef = useRef<HTMLInputElement>(null);
-  const [paymentChip, setPaymentChip] = useState<PaymentPath | null>(props.initialPayment);
 
   function pickFile() {
     fileRef.current?.click();
@@ -58,8 +61,8 @@ export function CaptureMobile(props: CaptureMobileProps) {
       ) : (
         <CaptureIdleMobile
           todayCount={props.todayCount}
-          paymentChip={paymentChip}
-          setPaymentChip={setPaymentChip}
+          paymentChip={props.paymentChip}
+          setPaymentChip={props.setPaymentChip}
           onTapCapture={pickFile}
           error={props.phase.kind === "error" ? props.phase.message : null}
         />

--- a/components/receipts/receipt-capture-form.tsx
+++ b/components/receipts/receipt-capture-form.tsx
@@ -99,6 +99,12 @@ export function ReceiptCaptureForm({
     () => EMPTY_QUEUE,
   );
   const [sessionUploads, setSessionUploads] = useState<SessionUpload[]>(persisted);
+  // Live "Preselect AMEX/CASH" chip state. Lifted up from CaptureMobile so
+  // onPickFile's upload() reads the value the operator actually toggled, not
+  // the one-time initialPayment prop (seeded once from the ?payment= URL).
+  // Before this, paymentChip lived in CaptureMobile and only drove the chip's
+  // own highlight — it never reached the upload call, so the chip was cosmetic.
+  const [paymentChip, setPaymentChip] = useState<PaymentChip>(initialPayment);
   // Desktop FIFO concurrency pool (limit DESKTOP_MAX_CONCURRENT_UPLOADS) and
   // the mobile single-flight gate. Both held in refs so they survive re-renders
   // without restarting in-flight work.
@@ -123,7 +129,7 @@ export function ReceiptCaptureForm({
         // phase. The normal capture -> upload -> re-arm flow is unchanged.
         if (!mobileSingleFlightRef.current.start()) return;
         try {
-          await upload(file, initialPayment, source);
+          await upload(file, paymentChip, source);
         } finally {
           mobileSingleFlightRef.current.finish();
         }
@@ -147,7 +153,7 @@ export function ReceiptCaptureForm({
 
       const slot = await desktopPoolRef.current.acquire();
       try {
-        const result = await upload(file, initialPayment, source);
+        const result = await upload(file, paymentChip, source);
         setSessionUploads((prev) =>
           prev.map((u) =>
             u.id === id
@@ -161,13 +167,14 @@ export function ReceiptCaptureForm({
         slot.release();
       }
     },
-    [isMobile, upload, initialPayment],
+    [isMobile, upload, paymentChip],
   );
 
   if (isMobile) {
     return (
       <CaptureMobile
-        initialPayment={initialPayment}
+        paymentChip={paymentChip}
+        setPaymentChip={setPaymentChip}
         rapidMode={rapidMode}
         todayCount={todayCount}
         phase={phase}


### PR DESCRIPTION
## Problem
The mobile-capture "Preselect AMEX/CASH" chip was cosmetic since the redesign (`2ca6f9c`): `paymentChip` lived as local state in `CaptureMobile` and only drove the chip's own highlight. `onPickFile` uploaded the stale `initialPayment` prop (seeded once from the `?payment=` URL) instead — so through the bottom-nav rapid-capture path (no `?payment=`), every capture landed `payment_path='UNKNOWN'` regardless of the chip tap. David reported it: *"when I capture from iPhone and preselect AMEX or CASH, it should apply to all captures in the series. I'm not sure if any of the captures properly record the payment type."*

## Fix
Lift `paymentChip` state up into `ReceiptCaptureForm` (seeded from `initialPayment` so the `?payment=` URL shortcut still preselects on first load), wire both `upload()` branches (mobile + desktop) to the live chip value, fix the `useCallback` deps, and pass `paymentChip`/`setPaymentChip` down to `CaptureMobile` (replacing its local `useState`). Desktop path unchanged — nothing there calls `setPaymentChip`, so `paymentChip` stays equal to `initialPayment`.

Touches only `components/receipts/receipt-capture-form.tsx` + `components/receipts/capture/capture-mobile.tsx`. No API/lib changes (server already records `paymentPath` correctly; proven by existing data).

## Blast radius (live D1, 2026-07-19)
71 `mobile_capture` rows: **62 AMEX + 8 CASH** (all recorded correctly via the `?payment=` URL shortcut David uses manually — *not* via the chip) + **1 UNKNOWN** (today, the lone rapid-capture without a `?payment=` URL — the capture that surfaced this). The chip has been silently ignored across all 71 since inception. Historical rows not reclassified (data-quality call, not inferable from code).

## Verification
- `npx tsc --noEmit` — clean
- `npm test` — **610 pass / 0 fail / 1 pre-existing skip**
- `npm run build:cf` — clean (OpenNext bundle)
- §2 bullets proven by code trace; server contract empirically proven by the 62 AMEX / 1 UNKNOWN rows above
- Live mobile-capture walkthrough (`payment_path` confirmed in D1 after each capture) — handed to operator for post-deploy on prod (receipts UI can't be served locally: Clerk `pk_live` rejects localhost)

🤖 Generated with [Claude Code](https://claude.com/claude-code)