### PR TITLE
receipts: recon v2 draft-round feedback — lean CASH/DIGITAL csv, 目次 retired, per-path folders

### DIFF
--- a/app/api/receipts/export/month/route.ts
+++ b/app/api/receipts/export/month/route.ts
@@ -301,7 +301,6 @@ export async function POST(request: Request) {
           : row.paymentPath === "CASH"
             ? "CASH"
             : "AMEX") as ProofPaymentPath,
-        kamokuNo: assignment?.label,
         filename: assignment?.filename,
       });
     }

--- a/lib/receipts/export.ts
+++ b/lib/receipts/export.ts
@@ -154,7 +154,8 @@ export function serializeExportRowCells(
   return [
     // No: 1-based row sequence. The join key between this CSV and the proofs
     // ZIP filenames — the accountant matches a statement line to its proof
-    // via this number (see 目次.csv, which maps No → evidence filename).
+    // via this number (kept for the machine layer; the 照合CSVs'
+    // 領収書ファイル名 column is the accountant-facing evidence index).
     csvEscape(String(no)),
     csvEscape(row.rowType),
     csvEscape(row.transactionDate),
@@ -757,7 +758,8 @@ export function buildExportReadme(opts: {
     "reconciliation CSVs with the same evidence columns appended.",
     "The proofs ZIP (<exportId>-proofs.zip) bundles one proof per receipt,",
     "named <勘定科目><MonYYYY><①…><店舗><¥金額> — the 科目＆No. matches the",
-    "reconciliation CSVs' 科目＆No. column. See 目次.csv inside the ZIP for",
-    "the full index (including the receipts CSV's No join column).",
+    "reconciliation CSVs' 科目＆No. column; their 領収書ファイル名 column is",
+    "the evidence index. Proofs are foldered per payment path (AMEX明細分/",
+    "現金分/デジタル分).",
   ].join("\n");
 }

--- a/lib/receipts/proofs.ts
+++ b/lib/receipts/proofs.ts
@@ -7,14 +7,15 @@
 // CSV — see buildMonthlyExportCsv). The route does the R2 fetches and passes the
 // bytes here; these helpers are unit-testable without R2/D1.
 //
-// Folder contract (matches the manual delivery the accountant already receives):
+// Folder contract (review #2 + draft-round feedback 2026-07-18):
 //   領収書等証憑_<month>/
-//     AMEX明細分/            ← receipts matched to AMEX statement lines
-//       No03_研究開発費_OpenAI_¥108,341.pdf
-//     追加経費_現金デジタル分/ ← CASH/DIGITAL receipts (calendar-month membership)
-//       No33_旅費交通費_セブン-イレブン東中野末広橋店_¥10,000.jpg
-//     目次.csv               ← index
-//     お知らせ.txt           ← transition notice (what changed vs manual delivery)
+//     AMEX明細分/  ← receipts matched to AMEX statement lines
+//       会議費Jun2026③小田原みなと食堂¥6,490.jpg   (科目＆No naming)
+//     現金分/      ← CASH receipts (calendar-month membership)
+//     デジタル分/  ← DIGITAL receipts
+//     AMEX/CASH/DIGITAL{month}_Reconciliation.csv ← byte-copies of the 照合CSVs
+//     集計.csv / 参加者一覧.csv / お知らせ.txt
+//   (目次.csv retired — the 照合CSVs' 領収書ファイル名 column is the index.)
 
 import { zipSync } from "fflate";
 import { computeSha256Hex } from "@/lib/receipts/storage";
@@ -33,7 +34,7 @@ export function sanitizeZipNameSegment(s: string, maxLen = 30): string {
   return capped.length > 0 ? capped : "unknown";
 }
 
-/** ¥-prefixed comma-grouped yen amount for filenames / 目次. JPY only (proofs
+/** ¥-prefixed comma-grouped yen amount for filenames. JPY only (proofs
  *  are yen receipts); non-JPY falls back to the raw minor value. */
 export function formatYenAmount(amountMinor: number, currency: string): string {
   if (currency !== "JPY") return String(amountMinor);
@@ -65,84 +66,30 @@ export function buildProofFilename(p: ProofFilenameParts): string {
   return `No${no}_${cat}_${merchant}_${amount}${suffix}.${p.ext}`;
 }
 
-// ─── 目次.csv (index) ────────────────────────────────────────────────────────
-
-export interface ProofMokuziRow {
-  no: number;
-  /** 科目＆No. label (`会議費Jun2026③`) — the join key to the reconciliation
-   *  CSVs. Empty string for legacy No-named entries. */
-  kamokuNo: string;
-  filename: string;
-  transactionDate: string | null;
-  merchant: string;
-  amountMinor: number;
-  currency: string;
-  categoryJa: string;
-  /** 出席者: "; "-joined attendees for 会議費/接待交際費 entries (caller-resolved
-   *  from the same attendeeMap the receipts CSV uses); blank for other rows. */
-  attendees: string;
-}
-
-function csvQuote(value: string | null | undefined): string {
-  if (value === null || value === undefined) return "";
-  const s = String(value);
-  if (s.includes(",") || s.includes('"') || s.includes("\n") || s.includes("\r")) {
-    return `"${s.replace(/"/g, '""')}"`;
-  }
-  return s;
-}
-
-/** 目次.csv — the accountant's human table of contents (one row per proof),
- *  Excel-safe (BOM + CRLF + quoted comma fields). Columns:
- *    No, ファイル名, 取引日, 店舗, 金額, 勘定科目, 出席者
- *  `No` is the join key to the receipts CSV. 出席者 lists attendees for 会議費 /
- *  接待交際費 entries (caller-resolved from the receipts CSV's attendee source),
- *  blank for other categories.
- *
- *  Machine fields (statement_line_id, receipt_id, sha256, source) are
- *  intentionally NOT here — they have no value to a human reader and already
- *  live in the manifest (per-file SHAs, IDs). 目次 = human layer, manifest =
- *  machine layer. */
-export function buildProofsMokuziCsv(rows: ProofMokuziRow[]): string {
-  const header = [
-    "科目＆No.",
-    "No",
-    "ファイル名",
-    "取引日",
-    "店舗",
-    "金額",
-    "勘定科目",
-    "出席者",
-  ].join(",");
-  const body = rows
-    .slice()
-    .sort((a, b) => a.no - b.no)
-    .map((r) =>
-      [
-        csvQuote(r.kamokuNo),
-        String(r.no),
-        csvQuote(r.filename),
-        csvQuote(r.transactionDate),
-        csvQuote(r.merchant),
-        csvQuote(formatYenAmount(r.amountMinor, r.currency)),
-        csvQuote(r.categoryJa),
-        csvQuote(r.attendees),
-      ].join(","),
-    );
-  // BOM (Excel on Windows detects UTF-8 → Japanese renders) + CRLF.
-  return `\uFEFF${[header, ...body].join("\r\n")}\r\n`;
-}
-
 // ─── お知らせ.txt (transition notice) ────────────────────────────────────────
 
 export interface TransitionNoticeInput {
   monthLabel: string; // e.g. "2026年6月"
   rowCount: number; // receipts CSV rows (AMEX lines + cash/digital)
   receiptCount: number; // distinct receipts with a proof in the zip
-  /** AMEX statement lines shipped with no receipt, with the recorded reason. */
-  missingReceiptLines: { lineId: string; reason: string }[];
-  /** IC-card top-up advisories (non-blocking) among the proofs, if any. */
-  icAdvisories: { no: number; merchant: string; amountMinor: number }[];
+  /** AMEX statement lines shipped with no receipt, with the recorded reason.
+   *  date/merchant/amount identify the line for the accountant — internal
+   *  lineId UUIDs are NOT surfaced (draft-round feedback). */
+  missingReceiptLines: {
+    transactionDate: string | null;
+    merchant: string;
+    amountMinor: number;
+    reason: string;
+  }[];
+  /** IC-card top-up advisories (non-blocking) among the proofs, if any.
+   *  Identified by date/merchant/amount (目次 retired, so No means nothing
+   *  to the accountant anymore). */
+  icAdvisories: {
+    no: number;
+    transactionDate: string | null;
+    merchant: string;
+    amountMinor: number;
+  }[];
   exportRevision: number;
   supersedesExportId?: string | null;
   correctionReason?: string | null;
@@ -158,10 +105,13 @@ export function buildTransitionNotice(input: TransitionNoticeInput): string {
   lines.push("");
   lines.push("【お知りいただきたい変更点（従来の手作業納品との違い）】");
   lines.push(
-    "・各証憑のファイル名先頭にある NoXX は、明細CSVの No 列と対応しています（従来の①②等の丸数字に代わる整理番号です）。",
+    "・カード明細の照合表（AMEX＜年月＞_Reconciliation.csv）は、カード会社の明細CSVをそのまま再現し、右側に「科目＆No.」「会議-出席者ID」「人数」「領収書ファイル名」の列を追記したものです。現金・デジタル決済分は CASH／DIGITAL の照合CSVに分けて同封しています。",
   );
   lines.push(
-    "・接待・会議の出席者は別紙PDFではなく、明細CSVの 出席者 列に記載しています。",
+    "・各証憑のファイル名は「科目＆No.」（例：会議費Jun2026③）で始まり、従来の手作業納品と同じ丸数字方式です。照合CSVの「科目＆No.」「領収書ファイル名」列と対応しています。",
+  );
+  lines.push(
+    "・接待・会議の出席者は別紙PDFではなく、照合CSVの出席者ID列に記載しています。IDと氏名・会社・役職の対応は 参加者一覧.csv をご参照ください。",
   );
   lines.push(
     "・紙の領収書は一つにまとめたPDFではなく、1件ずつの画像ファイルとして同封しています。",
@@ -183,7 +133,10 @@ export function buildTransitionNotice(input: TransitionNoticeInput): string {
     lines.push("");
     lines.push("【領収書なしの明細（記録された理由）】");
     for (const m of input.missingReceiptLines) {
-      lines.push(`・No/明細 ${m.lineId}: ${m.reason || "（理由記録なし）"}`);
+      const date = m.transactionDate ?? "日付不明";
+      lines.push(
+        `・${date} ${m.merchant} ¥${m.amountMinor.toLocaleString("ja-JP")}: ${m.reason || "（理由記録なし）"}`,
+      );
     }
   }
   if (input.icAdvisories.length > 0) {
@@ -193,14 +146,14 @@ export function buildTransitionNotice(input: TransitionNoticeInput): string {
     );
     for (const ic of input.icAdvisories) {
       lines.push(
-        `・No${String(ic.no).padStart(2, "0")} ${ic.merchant} ¥${ic.amountMinor.toLocaleString("ja-JP")} — 交通系ICカードのチャージの可能性があります。業務利用の確定・精算方法は会計判断をお願いします。`,
+        `・${ic.transactionDate ?? "日付不明"} ${ic.merchant} ¥${ic.amountMinor.toLocaleString("ja-JP")} — 交通系ICカードのチャージの可能性があります。業務利用の確定・精算方法は会計判断をお願いします。`,
       );
     }
   }
   if (input.exportRevision > 1) {
     lines.push("");
     lines.push("【改訂情報】");
-    lines.push(`・改訹: ${input.exportRevision}（差替元: ${input.supersedesExportId ?? "不明"}）`);
+    lines.push(`・改訂: ${input.exportRevision}（差替元: ${input.supersedesExportId ?? "不明"}）`);
     lines.push(`・改訂理由: ${input.correctionReason ?? "（記録なし）"}`);
   }
   lines.push("");
@@ -255,7 +208,12 @@ export function deriveTransitionNoticeInput(
 ): TransitionNoticeInput {
   const missingReceiptLines = rows
     .filter((r) => r.rowType === "amex_line" && r.missingReceiptReason)
-    .map((r) => ({ lineId: r.lineId ?? "?", reason: r.missingReceiptReason ?? "" }));
+    .map((r) => ({
+      transactionDate: r.transactionDate,
+      merchant: r.merchant ?? "店舗不明",
+      amountMinor: r.amountMinor ?? 0,
+      reason: r.missingReceiptReason ?? "",
+    }));
   const icAdvisories: TransitionNoticeInput["icAdvisories"] = [];
   const icSeen = new Set<string>();
   const receiptById = new Map(receipts.map((r) => [r.id, r]));
@@ -266,6 +224,7 @@ export function deriveTransitionNoticeInput(
       icSeen.add(row.receiptId);
       icAdvisories.push({
         no: i + 1,
+        transactionDate: row.transactionDate,
         merchant: row.merchant ?? "",
         amountMinor: row.amountMinor ?? 0,
       });
@@ -298,9 +257,6 @@ export interface ProofZipEntry {
   /** 出席者 for the 目次 (会議費/接待交際費 only); blank otherwise. */
   attendees: string;
   paymentPath: ProofPaymentPath;
-  /** 科目＆No. label (`会議費Jun2026③`) — the join key shown in 目次 and the
-   *  reconciliation CSVs. */
-  kamokuNo?: string;
   /** Pre-assigned evidence filename (reconciliation-files.ts
    *  buildEvidenceAssignments). When present it names the ZIP entry —
    *  collisions still get a -2/-3 suffix before the extension. When absent
@@ -308,12 +264,17 @@ export interface ProofZipEntry {
   filename?: string;
 }
 
-const ROOT_PREFIX = (month: string) => `領収書等証憓_${month}/`;
+const ROOT_PREFIX = (month: string) => `領収書等証憑_${month}/`;
 const AMEX_FOLDER = "AMEX明細分/";
-const CASH_FOLDER = "追加経費_現金デジタル分/";
+// Draft-round feedback 2026-07-18: one folder per payment path, mirroring the
+// per-path 照合CSVs (the shared 追加経費_現金デジタル分 folder made the CASH
+// receipts hard to find).
+const CASH_FOLDER = "現金分/";
+const DIGITAL_FOLDER = "デジタル分/";
 
 function folderFor(paymentPath: ProofPaymentPath): string {
-  return paymentPath === "AMEX" ? AMEX_FOLDER : CASH_FOLDER;
+  if (paymentPath === "AMEX") return AMEX_FOLDER;
+  return paymentPath === "DIGITAL" ? DIGITAL_FOLDER : CASH_FOLDER;
 }
 
 /** Build the sealed proofs ZIP. fflate uses a single compression level; we use
@@ -343,7 +304,6 @@ export function assembleProofsZip(
 ): Uint8Array {
   const root = ROOT_PREFIX(month);
   const files: Record<string, Uint8Array> = {};
-  const mokuziRows: ProofMokuziRow[] = [];
   // Per-folder dedupe so a (rare) filename collision gets a -2/-3 suffix.
   const seenPerFolder = new Map<string, Set<string>>();
 
@@ -391,20 +351,10 @@ export function assembleProofsZip(
     seen.add(filename);
     seenPerFolder.set(folder, seen);
     files[`${root}${folder}${filename}`] = entry.bytes;
-    mokuziRows.push({
-      no: entry.no,
-      kamokuNo: entry.kamokuNo ?? "",
-      filename,
-      transactionDate: entry.transactionDate,
-      merchant: entry.merchant,
-      amountMinor: entry.amountMinor,
-      currency: entry.currency,
-      categoryJa: entry.categoryJa,
-      attendees: entry.attendees,
-    });
   }
 
-  files[`${root}目次.csv`] = encoder.encode(buildProofsMokuziCsv(mokuziRows));
+  // 目次.csv retired (draft-round feedback 2026-07-18): the AMEX/CASH/DIGITAL
+  // 照合CSVs' 領収書ファイル名 column IS the index now.
   files[`${root}集計.csv`] = encoder.encode(summaryCsv);
   files[`${root}参加者一覧.csv`] = encoder.encode(attendeesCsv);
   files[`${root}お知らせ.txt`] = encoder.encode(buildTransitionNotice(noticeInput));

--- a/lib/receipts/reconciliation-files.ts
+++ b/lib/receipts/reconciliation-files.ts
@@ -26,8 +26,6 @@ import {
   csvEscape,
   csvQuoteAlways,
   resolveRowAttendees,
-  serializeExportRowCells,
-  EXPORT_CSV_HEADERS,
 } from "@/lib/receipts/export";
 import { sanitizeZipNameSegment, formatYenAmount } from "@/lib/receipts/proofs";
 
@@ -257,13 +255,26 @@ export function attendeeIdCells(
 
 // ─── CASH / DIGITAL reconciliation CSVs ─────────────────────────────────────
 
-export const PAYMENT_PATH_APPEND_HEADERS = ["科目＆No.", "領収書ファイル名"] as const;
+/** Lean accountant-facing columns (draft-round feedback 2026-07-18: the full
+ *  receipts-CSV column set is "too many columns" — the machine layer already
+ *  ships those). Mirrors the AMEX file's appended block so both 照合CSVs read
+ *  the same way; attendees carried as IDs + count, resolvable via
+ *  参加者一覧.csv. */
+export const PAYMENT_PATH_CSV_HEADERS = [
+  "No",
+  "利用日",
+  "店舗名",
+  "金額",
+  "科目＆No.",
+  "会議-出席者ID",
+  "人数",
+  "領収書ファイル名",
+] as const;
 
 /**
- * CASH/DIGITAL reconciliation CSV — the existing receipts-CSV row format
- * (same columns, No restarts at 1 within the file) plus 科目＆No. and
- * 領収書ファイル名 appended, filtered to one payment path. Attendees/AttendeeIds
- * columns are already part of the existing format.
+ * CASH/DIGITAL reconciliation CSV — lean rows (No restarts at 1 within the
+ * file), one file per payment path. 会議-出席者ID keeps the "; " separator
+ * (Excel date-coerces space-separated ids).
  */
 export function buildPaymentPathReconciliationCsv(
   rows: ExportRow[],
@@ -272,22 +283,31 @@ export function buildPaymentPathReconciliationCsv(
   amexAttendees: Record<string, string[]>,
   assignments: Map<string, EvidenceAssignment>,
 ): string {
-  const header = [...EXPORT_CSV_HEADERS, ...PAYMENT_PATH_APPEND_HEADERS].join(",");
-  const lines: string[] = [header];
+  const lines: string[] = [PAYMENT_PATH_CSV_HEADERS.join(",")];
   rows.forEach((row, index) => {
     const attendees = resolveRowAttendees(row, attendeeMap, amexAttendees);
-    const cells = serializeExportRowCells(
-      row,
-      index + 1,
-      attendees,
-      attendeeDirectory,
-    );
+    const { ids, count } = attendeeIdCells(attendees, attendeeDirectory);
     const assignment = row.receiptId ? assignments.get(row.receiptId) : undefined;
-    cells.push(
-      csvEscape(assignment?.label ?? ""),
-      csvEscape(assignment?.filename ?? missingReceiptCell(row.missingReceiptReason)),
+    lines.push(
+      [
+        csvEscape(String(index + 1)),
+        csvEscape(row.transactionDate),
+        csvEscape(row.merchant),
+        csvEscape(
+          row.amountMinor === null
+            ? ""
+            : row.currency === "JPY"
+              ? String(row.amountMinor)
+              : (row.amountMinor / 100).toFixed(2),
+        ),
+        csvEscape(assignment?.label ?? row.expenseCategoryJa ?? ""),
+        csvQuoteAlways(ids),
+        csvEscape(count),
+        csvEscape(
+          assignment?.filename ?? missingReceiptCell(row.missingReceiptReason),
+        ),
+      ].join(","),
     );
-    lines.push(cells.join(","));
   });
   return lines.join("\n");
 }

--- a/tests/receipts/proofs.test.ts
+++ b/tests/receipts/proofs.test.ts
@@ -4,7 +4,6 @@ import { unzipSync } from "fflate";
 import {
   assembleProofsZip,
   buildProofFilename,
-  buildProofsMokuziCsv,
   buildTransitionNotice,
   formatYenAmount,
   sanitizeZipNameSegment,
@@ -108,75 +107,6 @@ test("buildProofFilename: No zero-pads to 2, 3 digits naturally", () => {
   assert.ok(f(120).startsWith("No120_"));
 });
 
-// ─── buildProofsMokuziCsv (目次) ────────────────────────────────────────────
-
-test("buildProofsMokuziCsv: human TOC columns — no machine fields", () => {
-  const csv = buildProofsMokuziCsv([
-    {
-      no: 3,
-      kamokuNo: "研究開発費Mar2026②",
-      filename: "No03_研究開発費_OpenAI_¥108,341.pdf",
-      transactionDate: "2026-03-04",
-      merchant: "OpenAI",
-      amountMinor: 108341,
-      currency: "JPY",
-      categoryJa: "研究開発費",
-      attendees: "",
-    },
-    {
-      no: 7,
-      kamokuNo: "接待交際費Mar2026⑷",
-      filename: "No07_接待交際費_屋形舟_¥69,000.jpg",
-      transactionDate: "2026-03-10",
-      merchant: "屋形舟",
-      amountMinor: 69000,
-      currency: "JPY",
-      categoryJa: "接待交際費",
-      attendees: "山田太郎; 鈴木花子",
-    },
-  ]);
-  assert.ok(csv.startsWith("﻿"), "目次 must be BOM-prefixed for Excel");
-  assert.ok(csv.includes("\r\n"), "目次 must use CRLF for Windows Excel");
-  // Exact header — the accountant's table of contents only.
-  assert.ok(
-    csv.includes("科目＆No.,No,ファイル名,取引日,店舗,金額,勘定科目,出席者"),
-    "目次 header is the human TOC",
-  );
-  // Machine fields removed (they live in the manifest).
-  assert.ok(!csv.includes("statement_line_id"), "no statement_line_id column");
-  assert.ok(!csv.includes("receipt_id"), "no receipt_id column");
-  assert.ok(!csv.includes("出典"), "no 出典 column");
-  // 出席者 populated for 接待交際費.
-  assert.ok(csv.includes("山田太郎; 鈴木花子"), "attendees listed for 接待交際費");
-  // Quoted filename field (contains a comma in the amount).
-  assert.ok(csv.includes('"No03_研究開発費_OpenAI_¥108,341.pdf"'));
-});
-
-test("buildProofsMokuziCsv: 出席者 populated for 会議費/接待交際費, empty otherwise", () => {
-  const row = (categoryJa: string, attendees: string) => ({
-    no: 1,
-    kamokuNo: "",
-    filename: "f.jpg",
-    transactionDate: "2026-06-01",
-    merchant: "M",
-    amountMinor: 1000,
-    currency: "JPY",
-    categoryJa,
-    attendees,
-  });
-  assert.ok(
-    buildProofsMokuziCsv([row("会議費", "Alice; Bob")]).includes(",会議費,Alice; Bob"),
-    "会議費 attendees populated",
-  );
-  assert.ok(
-    buildProofsMokuziCsv([row("接待交際費", "Carol")]).includes(",接待交際費,Carol"),
-    "接待交際費 attendees populated",
-  );
-  // Non-meeting/entertainment category → empty 出席者 (trailing empty field).
-  const other = buildProofsMokuziCsv([row("旅費交通費", "")]);
-  assert.match(other, /旅費交通費,\r\n/, "non-meeting category has empty 出席者");
-});
-
 // ─── buildTransitionNotice (お知らせ) ───────────────────────────────────────
 
 const baseNotice: TransitionNoticeInput = {
@@ -191,7 +121,10 @@ const baseNotice: TransitionNoticeInput = {
 test("buildTransitionNotice: static + dynamic sections, honest about gaps", () => {
   const txt = buildTransitionNotice(baseNotice);
   assert.ok(txt.includes("2026年6月"), "month label");
-  assert.ok(txt.includes("NoXX"), "explains the No join key");
+  assert.ok(txt.includes("科目＆No."), "explains the 科目＆No join key");
+  assert.ok(txt.includes("Reconciliation.csv"), "explains the AMEX passthrough file");
+  assert.ok(!txt.includes("NoXX"), "retired NoXX naming no longer described");
+  assert.ok(txt.includes("参加者一覧.csv"), "attendee IDs resolve via 参加者一覧");
   assert.ok(txt.includes("出席者"), "attendees now a CSV column");
   assert.ok(txt.includes("SHA-256"), "integrity hashing mentioned");
   assert.ok(txt.includes("再圧縮"), "honest about recompression");
@@ -203,13 +136,20 @@ test("buildTransitionNotice: static + dynamic sections, honest about gaps", () =
 test("buildTransitionNotice: missing-receipt reasons + IC advisories surface", () => {
   const txt = buildTransitionNotice({
     ...baseNotice,
-    missingReceiptLines: [{ lineId: "amex-line-9", reason: "紛失" }],
-    icAdvisories: [{ no: 33, merchant: "セブン-イレブン", amountMinor: 10000 }],
+    missingReceiptLines: [
+      { transactionDate: "2026-04-30", merchant: "ソフトバンクM", amountMinor: 14975, reason: "紛失" },
+    ],
+    icAdvisories: [
+      { no: 33, transactionDate: "2026-06-02", merchant: "セブン-イレブン", amountMinor: 10000 },
+    ],
   });
   assert.ok(txt.includes("領収書なしの明細"), "missing-receipt section header");
   assert.ok(txt.includes("紛失"), "recorded reason");
+  assert.ok(txt.includes("2026-04-30 ソフトバンクM ¥14,975"), "line identified by date/merchant/amount");
+  assert.ok(!/[0-9a-f]{8}-[0-9a-f]{4}/.test(txt), "no UUIDs surfaced to the accountant");
   assert.ok(txt.includes("ICカードチャージ"), "IC advisory section");
-  assert.ok(txt.includes("No33"), "IC advisory No");
+  assert.ok(txt.includes("2026-06-02 セブン-イレブン ¥10,000"), "IC advisory identified by date, not No");
+  assert.ok(!txt.includes("No33"), "internal No not surfaced");
 });
 
 test("buildTransitionNotice: revision context only when revision > 1", () => {
@@ -255,7 +195,7 @@ const SUMMARY_CSV =
 const ATTENDEES_CSV =
   "﻿AttendeeId,Name,Company,Title\r\n5,Alice Nakamura,Acme,Director\r\n";
 
-test("assembleProofsZip: UTF-8 names round-trip + 目次/集計/参加者一覧/お知らせ present", () => {
+test("assembleProofsZip: UTF-8 names round-trip + 集計/参加者一覧/お知らせ present, 目次 retired", () => {
   const entries = [
     fakeEntry({ no: 3, ext: "pdf", paymentPath: "AMEX" }),
     fakeEntry({
@@ -279,9 +219,9 @@ test("assembleProofsZip: UTF-8 names round-trip + 目次/集計/参加者一覧/
   const names = Object.keys(files);
 
   // Root + two folders with Japanese names.
-  assert.ok(names.some((n) => n.startsWith("領収書等証憓_2026-06/")), "Japanese root folder");
+  assert.ok(names.some((n) => n.startsWith("領収書等証憑_2026-06/")), "Japanese root folder");
   assert.ok(names.some((n) => n.includes("AMEX明細分/")), "AMEX folder");
-  assert.ok(names.some((n) => n.includes("追加経費_現金デジタル分/")), "cash/digital folder");
+  assert.ok(names.some((n) => n.includes("現金分/")), "cash folder (per payment path)");
   // The two proof files, with their No-prefixed Japanese names intact.
   assert.ok(
     names.some((n) => n.includes("No03_研究開発費_OpenAI_¥108,341.pdf")),
@@ -292,7 +232,7 @@ test("assembleProofsZip: UTF-8 names round-trip + 目次/集計/参加者一覧/
     "cash proof filename (whitespace-stripped merchant) round-trips",
   );
   // Index + summary + attendees + notice.
-  assert.ok(names.some((n) => n.endsWith("目次.csv")), "目次.csv present");
+  assert.ok(!names.some((n) => n.endsWith("目次.csv")), "目次.csv retired (照合CSVs are the index)");
   assert.ok(names.some((n) => n.endsWith("集計.csv")), "集計.csv present");
   assert.ok(names.some((n) => n.endsWith("参加者一覧.csv")), "参加者一覧.csv present");
   assert.ok(names.some((n) => n.endsWith("お知らせ.txt")), "お知らせ.txt present");
@@ -316,32 +256,6 @@ test("assembleProofsZip: UTF-8 names round-trip + 目次/集計/参加者一覧/
     sankashaBytes.every((b, i) => b === expectedSankasha[i]),
     "参加者一覧.csv bytes identical to the standalone attendees artifact",
   );
-});
-
-test("assembleProofsZip: 目次 No column matches entry nos (CSV⇄目次 continuity)", () => {
-  const entries = [
-    fakeEntry({ no: 3 }),
-    fakeEntry({ no: 7, merchant: "屋形舟", amountMinor: 69000 }),
-    fakeEntry({ no: 33, merchant: "セブン", amountMinor: 10000 }),
-  ];
-  const zip = assembleProofsZip(
-    "2026-06",
-    entries,
-    { ...baseNotice, receiptCount: 3 },
-    SUMMARY_CSV,
-    ATTENDEES_CSV,
-  );
-  const files = unzipSync(zip);
-  const mokuziKey = Object.keys(files).find((k) => k.endsWith("目次.csv"))!;
-  const mokuzi = new TextDecoder().decode(files[mokuziKey]);
-  // The entry nos (3, 7, 33) must each appear in the No column — the SECOND
-  // column since review #2 added 科目＆No. as the leading join key.
-  for (const no of [3, 7, 33]) {
-    assert.ok(
-      new RegExp(`^[^,]*,${no},`, "m").test(mokuzi.replace(/﻿/, "")),
-      `目次 must list No=${no}`,
-    );
-  }
 });
 
 test("assembleProofsZip: reconciliation CSVs embedded at root when provided (review #2)", () => {
@@ -369,6 +283,6 @@ test("assembleProofsZip: reconciliation CSVs embedded at root when provided (rev
     !keys.some((k) => k.includes("DIGITAL2026-06_Reconciliation")),
     "no DIGITAL entry when null",
   );
-  // Root placement (directly under the 領収書等証憓_<month>/ prefix).
+  // Root placement (directly under the 領収書等証憑_<month>/ prefix).
   assert.equal(amexKey!.split("/").length, 2, "embedded at ZIP root");
 });

--- a/tests/receipts/reconciliation-files.test.ts
+++ b/tests/receipts/reconciliation-files.test.ts
@@ -9,11 +9,10 @@ import {
   attendeeIdCells,
   missingReceiptCell,
   AMEX_RECONCILIATION_APPEND_HEADERS,
-  PAYMENT_PATH_APPEND_HEADERS,
+  PAYMENT_PATH_CSV_HEADERS,
   type EvidenceUnit,
   type AmexLineAppend,
 } from "@/lib/receipts/reconciliation-files";
-import { EXPORT_CSV_HEADERS } from "@/lib/receipts/export";
 import type { ExportRow } from "@/lib/receipts/types";
 import type { ReceiptAttendeeDirectoryEntry } from "@/lib/receipts/attendee-directory";
 
@@ -233,7 +232,7 @@ const receiptRow = (over: Partial<ExportRow>): ExportRow => ({
   ...over,
 } as ExportRow);
 
-test("buildPaymentPathReconciliationCsv: existing header + 科目＆No./領収書ファイル名", () => {
+test("buildPaymentPathReconciliationCsv: lean header + attendees + evidence (draft-round feedback)", () => {
   const assignments = buildEvidenceAssignments("2026-06", [
     unit({ receiptId: "r-cash-1", categoryJa: "消耗品費", merchant: "セブン-イレブン", amountMinor: 1200 }),
   ]);
@@ -245,11 +244,9 @@ test("buildPaymentPathReconciliationCsv: existing header + 科目＆No./領収�
     assignments,
   );
   const lines = csv.split("\n");
-  assert.equal(
-    lines[0],
-    [...EXPORT_CSV_HEADERS, ...PAYMENT_PATH_APPEND_HEADERS].join(","),
-  );
-  assert.ok(lines[1]!.startsWith("1,receipt,2026-06-10,"), "No restarts at 1 per file");
+  assert.equal(lines[0], PAYMENT_PATH_CSV_HEADERS.join(","));
+  assert.equal(lines[0], "No,利用日,店舗名,金額,科目＆No.,会議-出席者ID,人数,領収書ファイル名");
+  assert.ok(lines[1]!.startsWith("1,2026-06-10,セブン-イレブン,1200,"), "No restarts at 1; lean columns");
   assert.ok(lines[1]!.includes("消耗品費Jun2026①"), "科目＆No appended");
   assert.ok(
     lines[1]!.includes("消耗品費Jun2026①セブン-イレブン¥1,200.jpg") ||


### PR DESCRIPTION
David's rev-3 draft review (2026-07-18) of the reconciliation v2 export/proof package.

## What changed
- **CASH/DIGITAL 照合CSVs slimmed** to accountant columns only (`No`, `利用日`, `店舗名`, `金額`, `科目＆No.`, `会議-出席者ID`, `人数`, `領収書ファイル名`) — the full receipts-CSV column set stays machine-layer only. Attendees kept as `'; '`-separated directory IDs + count.
- **`目次.csv` retired** from the proofs ZIP — the 照合CSVs' `領収書ファイル名` column is the index (builder + tests removed; `ProofZipEntry.kamokuNo` dropped with it).
- **Proof folders split per payment path**: `AMEX明細分/` `現金分/` `デジタル分/` (was a shared `追加経費_現金デジタル分/`).
- **Root folder typo fixed**: 領収書等証憓 → 領收書等証憑.
- **お知らせ v2 text** folded in from superseded branch `receipts/recon-v2-oshirase` (`09a2a03` — do not merge that branch): passthrough/科目＆No bullets, missing-receipt lines by date/merchant/amount instead of UUID, IC advisories by date instead of internal No, 改訂 typo. Final accountant-facing fresh copy still TBC at sign-off.

## Scope
Touches export/proofs/reconciliation-files + their tests only. **No DB schema changes → no migrations.**

## Verification
Per the operator's pre-commit certification: 562 tests pass; `tsc`/lint clean.

## Note
Uncommitted WIP in the working tree (amex-import-form, validation.ts benign-skip, amex-parser tests) is a **separate in-flight feature and intentionally excluded** from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)