### PR TITLE
receipts: AMEX foreign-currency matching (USD receipts vs JPY-converted lines)

### DIFF
--- a/components/receipts/reconcile/reconcile-screen.tsx
+++ b/components/receipts/reconcile/reconcile-screen.tsx
@@ -854,6 +854,11 @@ function LineRow({
               re-review
             </Pill>
           ) : null}
+          {line.memo_currency_parse_status === "unparsed" ? (
+            <Pill tone="amber" size="sm">
+              currency unparsed
+            </Pill>
+          ) : null}
           {!confirmed && !noReceipt && band === "none" && (
             <Pill tone="red" size="sm" dot>
               no match
@@ -994,6 +999,11 @@ function DetailPane({
                   ? "No receipt expected"
                   : color.label}
           </Pill>
+          {line.memo_currency_parse_status === "unparsed" ? (
+            <Pill tone="amber" size="sm" dot>
+              Currency unparsed — review memo
+            </Pill>
+          ) : null}
           <span className="text-[13px] text-gray-500">
             {match?.matchReasons.join(", ") ||
               matchExplanation(
@@ -1014,7 +1024,16 @@ function DetailPane({
             <KV k="Posted" v={`${line.posting_date ?? line.transaction_date}`} />
             <KV
               k="Amount"
-              v={formatJpy(line.amount_minor, line.currency)}
+              v={
+                line.memo_currency_parse_status === "parsed" &&
+                line.foreign_currency &&
+                line.foreign_amount_minor != null
+                  ? `${formatJpy(line.amount_minor, line.currency)} · ${formatJpy(
+                      line.foreign_amount_minor,
+                      line.foreign_currency,
+                    )}`
+                  : formatJpy(line.amount_minor, line.currency)
+              }
               mono
             />
             <KV k="Card" v={line.cardholder_name ?? "AMEX"} />

--- a/db/receipts/0026_amex_foreign_currency.sql
+++ b/db/receipts/0026_amex_foreign_currency.sql
@@ -1,0 +1,43 @@
+-- 0026_amex_foreign_currency.sql
+--
+-- Foreign-currency detail for overseas-billed AMEX charges
+-- (Cloudflare / Anthropic / etc.). The Netアンサー statement reports only the
+-- JPY-converted total in amount_minor and the charge row's memo carries the
+-- original foreign amount as free text (現地通貨額:<amt> <CCY>); the row
+-- immediately after carries the FX rate used (円換算レート:M/D <rate>).
+-- reconciliation.ts previously hard-gated on line.currency === receipt.currency,
+-- so a USD receipt (receipt_records.currency = 'USD') was never even considered
+-- against a JPY statement line — a total exclusion, not a tolerance bug.
+--
+-- These columns let reconciliation match a USD/EUR/... receipt against the
+-- line's foreign amount instead of the JPY total. All four are nullable, no
+-- default, no backfill-at-migration-time: existing rows stay NULL (behave
+-- exactly as today — ordinary domestic-JPY matching) and the open-month
+-- backfill script (scripts/backfill-amex-foreign-currency.ts) populates them
+-- for already-imported lines. Finalized months are never touched (immutable
+-- per the existing guard).
+--
+--   foreign_amount_minor       — parsed foreign amount in minor units (cents
+--                                for non-JPY). Sign inherits from amount_minor
+--                                (a refund line's foreign amount is negative).
+--   foreign_currency           — ISO code, e.g. 'USD' (uppercase).
+--   foreign_exchange_rate      — the 円換算レート parsed off the trailing
+--                                continuation row. INFORMATIONAL / AUDIT ONLY:
+--                                never authoritative, never used to convert
+--                                anything. Matching compares
+--                                foreign_amount_minor directly. Stored purely
+--                                so the cross-check (rate × foreign amount ≈
+--                                JPY total) can catch a bad parse.
+--   memo_currency_parse_status — NULL = no foreign marker on the memo at all
+--                                (ordinary JPY line, behaves identically to
+--                                today); 'parsed' = extracted cleanly;
+--                                'unparsed' = marker present but extraction
+--                                failed (or the rate cross-check failed) —
+--                                surfaces an amber pill in the reconcile UI so
+--                                it is not silently lost into "unmatched".
+ALTER TABLE amex_statement_lines ADD COLUMN foreign_amount_minor INTEGER;
+ALTER TABLE amex_statement_lines ADD COLUMN foreign_currency TEXT;
+ALTER TABLE amex_statement_lines ADD COLUMN foreign_exchange_rate REAL;
+ALTER TABLE amex_statement_lines ADD COLUMN memo_currency_parse_status TEXT
+  CHECK (memo_currency_parse_status IS NULL
+         OR memo_currency_parse_status IN ('parsed', 'unparsed'));

--- a/lib/receipts/confidence.ts
+++ b/lib/receipts/confidence.ts
@@ -56,6 +56,27 @@ export function matchExplanation(
     }
     return `Consolidated receipt — ${confirmedSiblings.length} lines sum to ${sum}, receipt total is ${receipt.amount_minor}. Link the remaining charges before sign-off.`;
   }
+  // Foreign-currency match (migration 0026): a JPY statement line carrying a
+  // parsed foreign amount matched a USD (etc.) receipt on the FOREIGN amount,
+  // not the JPY total. Compare foreign_amount_minor to the receipt amount and
+  // explain it as a foreign link — otherwise a valid match reads as "Amount
+  // differs" because the JPY total ≠ the receipt's cents.
+  const foreignMatch =
+    line.memo_currency_parse_status === "parsed" &&
+    line.foreign_currency != null &&
+    line.foreign_amount_minor != null &&
+    line.foreign_currency.toUpperCase() === receipt.currency.toUpperCase();
+  if (foreignMatch) {
+    if (line.foreign_amount_minor !== (receipt.amount_minor ?? 0))
+      return "Foreign-currency amount differs — verify before confirming.";
+    if (
+      line.transaction_date &&
+      receipt.transaction_date &&
+      line.transaction_date !== receipt.transaction_date
+    )
+      return "Dates differ slightly — common for late captures.";
+    return "Linked match (foreign currency).";
+  }
   if (line.amount_minor !== (receipt.amount_minor ?? 0))
     return "Amount differs — verify before confirming.";
   if (

--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -827,14 +827,14 @@ export async function importAmexLines(
   // ── Chunked INSERT … ON CONFLICT DO UPDATE (with amex_reference) ────────
   const withRef = rows.filter((r) => !!r.amexReference);
   const withoutRef = rows.filter((r) => !r.amexReference);
-  // Each row binds 21 params (match_status is the SQL literal 'unmatched').
+  // Each row binds 25 params (match_status is the SQL literal 'unmatched').
   // receipt_status / receipt_missing_reason are set on first insert only
   // (parser-flagged no-receipt-required lines, e.g. undated annual fees) —
   // re-imports never overwrite them; see ON CONFLICT below.
-  // 21 × 4 = 84 < 100 (D1 bind-variable ceiling).
-  const CHUNK_SIZE = 4;
+  // 25 × 3 = 75 < 100 (D1 bind-variable ceiling).
+  const CHUNK_SIZE = 3;
   const rowPlaceholder =
-    "(?, ?, ?, ?, ?, ?, ?, ?, 'unmatched', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+    "(?, ?, ?, ?, ?, ?, ?, ?, 'unmatched', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
   for (let i = 0; i < withRef.length; i += CHUNK_SIZE) {
     const chunk = withRef.slice(i, i + CHUNK_SIZE);
@@ -859,6 +859,10 @@ export async function importAmexLines(
         row.paymentType ?? null,
         row.prepaymentFlag ?? null,
         row.memo ?? null,
+        row.foreignAmountMinor ?? null,
+        row.foreignCurrency ?? null,
+        row.foreignExchangeRate ?? null,
+        row.memoCurrencyParseStatus ?? null,
         row.rawCsvLineNumber ?? null,
         row.sourceFileSha256 ?? null,
         now,
@@ -871,8 +875,9 @@ export async function importAmexLines(
           (id, statement_month, transaction_date, posting_date, merchant,
            amount_minor, currency, amex_reference, match_status, receipt_status,
            receipt_missing_reason, raw_json, statement_artifact_id, cardholder_name,
-           cardholder_flag, payment_type, prepayment_flag, memo, raw_csv_line_number,
-           source_file_sha256, imported_at, created_at)
+           cardholder_flag, payment_type, prepayment_flag, memo, foreign_amount_minor,
+           foreign_currency, foreign_exchange_rate, memo_currency_parse_status,
+           raw_csv_line_number, source_file_sha256, imported_at, created_at)
          VALUES ${placeholders}
          ON CONFLICT (statement_month, amex_reference, cardholder_name) DO UPDATE SET
            transaction_date = excluded.transaction_date,
@@ -882,6 +887,10 @@ export async function importAmexLines(
            currency = excluded.currency,
            cardholder_name = excluded.cardholder_name,
            memo = excluded.memo,
+           foreign_amount_minor = excluded.foreign_amount_minor,
+           foreign_currency = excluded.foreign_currency,
+           foreign_exchange_rate = excluded.foreign_exchange_rate,
+           memo_currency_parse_status = excluded.memo_currency_parse_status,
            raw_csv_line_number = excluded.raw_csv_line_number,
            source_file_sha256 = excluded.source_file_sha256,
            statement_artifact_id = excluded.statement_artifact_id,
@@ -924,6 +933,10 @@ export async function importAmexLines(
         row.paymentType ?? null,
         row.prepaymentFlag ?? null,
         row.memo ?? null,
+        row.foreignAmountMinor ?? null,
+        row.foreignCurrency ?? null,
+        row.foreignExchangeRate ?? null,
+        row.memoCurrencyParseStatus ?? null,
         row.rawCsvLineNumber ?? null,
         row.sourceFileSha256 ?? null,
         now,
@@ -936,8 +949,9 @@ export async function importAmexLines(
           (id, statement_month, transaction_date, posting_date, merchant,
            amount_minor, currency, amex_reference, match_status, receipt_status,
            receipt_missing_reason, raw_json, statement_artifact_id, cardholder_name,
-           cardholder_flag, payment_type, prepayment_flag, memo, raw_csv_line_number,
-           source_file_sha256, imported_at, created_at)
+           cardholder_flag, payment_type, prepayment_flag, memo, foreign_amount_minor,
+           foreign_currency, foreign_exchange_rate, memo_currency_parse_status,
+           raw_csv_line_number, source_file_sha256, imported_at, created_at)
          VALUES ${placeholders}
          ON CONFLICT (statement_month, transaction_date, amount_minor, merchant, cardholder_name)
            WHERE amex_reference IS NULL
@@ -945,6 +959,10 @@ export async function importAmexLines(
            posting_date = excluded.posting_date,
            currency = excluded.currency,
            memo = excluded.memo,
+           foreign_amount_minor = excluded.foreign_amount_minor,
+           foreign_currency = excluded.foreign_currency,
+           foreign_exchange_rate = excluded.foreign_exchange_rate,
+           memo_currency_parse_status = excluded.memo_currency_parse_status,
            raw_csv_line_number = excluded.raw_csv_line_number,
            source_file_sha256 = excluded.source_file_sha256,
            statement_artifact_id = excluded.statement_artifact_id,

--- a/lib/receipts/foreign-currency.ts
+++ b/lib/receipts/foreign-currency.ts
@@ -1,0 +1,147 @@
+// Single source of truth for parsing foreign-currency detail out of AMEX
+// Netアンサー statement memos. Overseas-billed charges (Cloudflare, Anthropic,
+// …) are reported on the statement only as a JPY-converted total; the original
+// foreign amount and the FX rate used live in free-text memos:
+//   - charge-row memo:        現地通貨額:<amt> <CCY>   e.g. "現地通貨額:11.51 USD"
+//   - continuation-row memo:  円換算レート:M/D <rate>   e.g. "円換算レート:6/11 166.6377"
+// The continuation row (no date, no amount, merchant text like "(SAN
+// FRANCISCO)") is otherwise discarded by the CSV parser as an informational
+// row; validation.ts correlates it back onto the preceding foreign charge line.
+//
+// Both the import path (lib/receipts/validation.ts) and the open-month backfill
+// script (scripts/backfill-amex-foreign-currency.ts) call these functions — do
+// NOT duplicate the regex or the cross-check elsewhere.
+
+export type ForeignCurrencyParseStatus = "parsed" | "unparsed";
+
+export type ForeignCurrencyParseResult =
+  | { status: "none" }
+  | { status: "parsed"; amountMinor: number; currency: string }
+  | { status: "unparsed" };
+
+// Charge-row marker. Confirmed live against a real 2026-06/07 SAISON statement.
+const AMOUNT_MARKER = "現地通貨額";
+// Continuation-row marker.
+const RATE_MARKER = "円換算レート";
+
+/** Returns the substring after `marker`, or null when the marker is absent. */
+function tailAfterMarker(memo: string, marker: string): string | null {
+  const idx = memo.indexOf(marker);
+  if (idx === -1) return null;
+  return memo.slice(idx + marker.length);
+}
+
+// Minor-unit convention shared with receipt_records.amount_minor: 0-decimal
+// currencies keep their magnitude; everything else is ×100 (cents). Mirrors
+// lib/receipts/extraction.ts parseAmountMinor.
+const ZERO_DECIMAL_CURRENCIES = new Set([
+  "JPY",
+  "KRW",
+  "VND",
+  "IDR",
+  "CLP",
+  "PYG",
+  "UGX",
+]);
+
+function minorUnitDivisor(currency: string): number {
+  return ZERO_DECIMAL_CURRENCIES.has(currency.toUpperCase()) ? 1 : 100;
+}
+
+/** Convert a decimal major-unit amount to minor units for a currency code. */
+export function toMinorUnits(amountMajor: number, currency: string): number {
+  return Math.round(amountMajor * minorUnitDivisor(currency));
+}
+
+// Match "<amt> <CCY>" where amt may use comma-thousands grouping and a decimal
+// fraction, colon (half- or full-width) may lead, and CCY is a 3-letter ISO
+// code. Returns the amount in minor units + uppercase currency, or null when
+// both cannot be cleanly extracted.
+function parseAmountAndCurrency(
+  tail: string,
+): { amountMinor: number; currency: string } | null {
+  const m = tail.match(
+    /^\s*[:：]?\s*(-?\d[\d,]*(?:\.\d{1,4})?)\s+([A-Za-z]{3})\b/,
+  );
+  if (!m) return null;
+  const amount = Number(m[1]!.replace(/,/g, ""));
+  if (!Number.isFinite(amount) || amount === 0) return null;
+  const currency = m[2]!.toUpperCase();
+  return { amountMinor: toMinorUnits(Math.abs(amount), currency), currency };
+}
+
+/**
+ * Parse a charge-row memo for the foreign-currency amount.
+ *
+ * - No 現地通貨額 marker → `{ status: "none" }` (ordinary domestic-JPY line).
+ * - Marker present and amount + 3-letter currency cleanly extracted →
+ *   `{ status: "parsed", amountMinor, currency }` (amountMinor is a positive
+ *   magnitude in minor units; the caller inherits sign from the line's own
+ *   amount_minor so refund lines stay negative).
+ * - Marker present but extraction fails → `{ status: "unparsed" }` (surfaces an
+ *   amber pill in the reconcile UI — distinct from "no foreign data at all").
+ *
+ * Confirmed real shapes (used verbatim as test fixtures): "現地通貨額:11.51 USD",
+ * "現地通貨額:66.00 USD", "現地通貨額:3.30 USD". Half-width colon, decimal
+ * amount, single space, 3-letter code. Full-width "：" and comma-thousands are
+ * handled defensively for larger charges.
+ */
+export function parseForeignCurrencyMemo(
+  memo: string | null,
+): ForeignCurrencyParseResult {
+  if (!memo) return { status: "none" };
+  const tail = tailAfterMarker(memo, AMOUNT_MARKER);
+  if (tail === null) return { status: "none" };
+  const parsed = parseAmountAndCurrency(tail);
+  if (!parsed) return { status: "unparsed" };
+  return { status: "parsed", ...parsed };
+}
+
+/**
+ * Parse a continuation-row memo for the FX rate used (円換算レート:M/D <rate>).
+ * Returns the rate as a number, or null when the marker is absent or the rate
+ * can't be cleanly parsed. This is a SOFT signal only — never authoritative,
+ * never used to convert amounts for matching; its sole job is the cross-check
+ * below that catches a bad charge-row parse.
+ *
+ * Confirmed real shapes: "円換算レート:6/11 166.6377", "円換算レート:6/23
+ * 168.1516", "円換算レート:7/04 167.2728".
+ */
+export function parseExchangeRateMemo(memo: string | null): number | null {
+  if (!memo) return null;
+  const tail = tailAfterMarker(memo, RATE_MARKER);
+  if (tail === null) return null;
+  const m = tail.match(/[:：]?\s*(?:\d{1,2}\/\d{1,2}\s+)?(\d+(?:\.\d+)?)/);
+  if (!m) return null;
+  const rate = Number(m[1]);
+  if (!Number.isFinite(rate) || rate <= 0) return null;
+  return rate;
+}
+
+/**
+ * Cross-check a parsed foreign amount against the JPY line total using the FX
+ * rate from the continuation row. Returns true (pass) when:
+ *   - no rate is available (the rate is a BONUS check, not a requirement — a
+ *     cleanly-parsed foreign amount with no rate row stays "parsed"), or
+ *   - round(foreignMajor × rate) is within ±1 yen of the JPY line magnitude.
+ *
+ * A failure (returns false) means the charge-row parse likely grabbed the wrong
+ * row or a garbled currency code, and the caller should downgrade
+ * memo_currency_parse_status to "unparsed" — matching on a mismatched parse is
+ * worse than not matching at all.
+ */
+export function foreignAmountCrossCheckOk(args: {
+  foreignAmountMinor: number;
+  foreignCurrency: string;
+  /** abs() of the line's JPY amount_minor (the converted statement total). */
+  jpyAmountMinorAbs: number;
+  exchangeRate: number | null;
+}): boolean {
+  const { exchangeRate } = args;
+  if (exchangeRate == null || !Number.isFinite(exchangeRate) || exchangeRate <= 0) {
+    return true;
+  }
+  const foreignMajor = Math.abs(args.foreignAmountMinor) / minorUnitDivisor(args.foreignCurrency);
+  const expectedJpy = Math.round(foreignMajor * exchangeRate);
+  return Math.abs(expectedJpy - args.jpyAmountMinorAbs) <= 1;
+}

--- a/lib/receipts/reconciliation.ts
+++ b/lib/receipts/reconciliation.ts
@@ -163,12 +163,31 @@ export function matchAmexToReceipts(
       if (receipt.payment_path !== "AMEX") continue;
 
       // Amount comparison only makes sense when both sides are denominated in
-      // the same currency. amount_minor for JPY is yen units and for USD/EUR
-      // is cents — comparing across currencies silently matches e.g. ¥500
-      // (line.amount_minor 500) to $5.00 (receipt.amount_minor 500).
+      // the same currency. AMEX statement lines are JPY (amount_minor is yen);
+      // an overseas-billed charge also carries the original foreign amount in
+      // memo-derived foreign_amount_minor/foreign_currency (migration 0026) —
+      // that's the only figure comparable to a USD/EUR (cents) receipt's
+      // amount_minor. Same-currency path is today's behavior, unchanged for the
+      // common JPY↔JPY case; the foreign path compares the line's parsed foreign
+      // amount to the receipt amount. It is only eligible on a cleanly "parsed"
+      // line — an "unparsed" line is flagged for operator review and never
+      // auto-matched, and a "none" line has no foreign data at all (so ordinary
+      // domestic-JPY matching is byte-for-byte unchanged).
+      let amexMinor: number;
+      let foreignPath = false;
       if (
-        line.currency.toUpperCase() !== receipt.currency.toUpperCase()
+        line.currency.toUpperCase() === receipt.currency.toUpperCase()
       ) {
+        amexMinor = line.amount_minor;
+      } else if (
+        line.memo_currency_parse_status === "parsed" &&
+        line.foreign_currency != null &&
+        line.foreign_amount_minor != null &&
+        line.foreign_currency.toUpperCase() === receipt.currency.toUpperCase()
+      ) {
+        amexMinor = line.foreign_amount_minor;
+        foreignPath = true;
+      } else {
         continue;
       }
 
@@ -176,12 +195,11 @@ export function matchAmexToReceipts(
       let score = 0;
       let dateDelta = Infinity;
 
-      const amexMinor = line.amount_minor;
       const receiptMinor = receipt.amount_minor;
 
       if (receiptMinor !== null && amexMinor === receiptMinor) {
         score += 0.5;
-        reasons.push("exact amount");
+        reasons.push(foreignPath ? "exact amount (foreign currency)" : "exact amount");
       } else if (
         receiptMinor !== null &&
         // Use abs() on the reference value so the threshold works for refunds
@@ -190,7 +208,9 @@ export function matchAmexToReceipts(
         Math.abs(amexMinor - receiptMinor) < Math.abs(amexMinor) * 0.01
       ) {
         score += 0.2;
-        reasons.push("approximate amount");
+        reasons.push(
+          foreignPath ? "approximate amount (foreign currency)" : "approximate amount",
+        );
       } else {
         continue; // Amount mismatch too large — not a candidate
       }
@@ -314,6 +334,13 @@ export function matchAmexToReceipts(
         !assignedLines.has(line.id) &&
         line.match_status !== "confirmed" &&
         line.match_status !== "no_receipt" &&
+        // Consolidation stays JPY-only this pass (migration 0026 follow-up).
+        // line.currency is always JPY here, so a USD (etc.) receipt is naturally
+        // excluded from consolidated groups — its single foreign line is matched
+        // via the 1:1 foreign path above. Threading foreign_amount_minor through
+        // the exact-sum logic is deferred (architect-approved; the real
+        // foreign-billed charges today are single-line subscriptions, not
+        // consolidation candidates). See AGENTS backlog / worker report.
         line.currency.toUpperCase() === receipt.currency.toUpperCase() &&
         !!line.merchant &&
         (descriptionContains(line.merchant, receipt.merchant!) ||

--- a/lib/receipts/types.ts
+++ b/lib/receipts/types.ts
@@ -353,6 +353,19 @@ export interface AmexStatementLine {
   payment_type: string | null;
   prepayment_flag: string | null;
   memo: string | null;
+  // Foreign-currency detail parsed from memo (migration 0026). For an
+  // overseas-billed charge the statement reports only the JPY-converted total
+  // in amount_minor; these hold the original foreign amount / FX rate parsed
+  // off the memo so reconciliation can match a USD (etc.) receipt against
+  // foreign_amount_minor instead of the JPY total. memo_currency_parse_status:
+  // NULL/undefined = no 現地通貨額 marker (ordinary JPY line), 'parsed' =
+  // extracted, 'unparsed' = marker present but extraction failed or the
+  // FX-rate cross-check failed (amber pill in reconcile UI). Optional +
+  // nullable: rows predating 0026 (or backfill) have them NULL.
+  foreign_amount_minor?: number | null;
+  foreign_currency?: string | null;
+  foreign_exchange_rate?: number | null;
+  memo_currency_parse_status?: "parsed" | "unparsed" | null;
   raw_csv_line_number: number | null;
   source_file_sha256: string | null;
   imported_at: string | null;
@@ -664,6 +677,12 @@ export interface ImportAmexLineInput {
   paymentType?: string;
   prepaymentFlag?: string;
   memo?: string;
+  // Foreign-currency detail parsed from memo (migration 0026). See
+  // AmexStatementLine for semantics. Undefined on rows with no foreign data.
+  foreignAmountMinor?: number | null;
+  foreignCurrency?: string | null;
+  foreignExchangeRate?: number | null;
+  memoCurrencyParseStatus?: "parsed" | "unparsed" | null;
   rawCsvLineNumber?: number;
   sourceFileSha256?: string;
   // Set on rows the parser identifies as real charges with no receipt

--- a/lib/receipts/validation.ts
+++ b/lib/receipts/validation.ts
@@ -1,4 +1,10 @@
 import type { ImportAmexLineInput } from "@/lib/receipts/types";
+import {
+  parseForeignCurrencyMemo,
+  parseExchangeRateMemo,
+  foreignAmountCrossCheckOk,
+  type ForeignCurrencyParseStatus,
+} from "@/lib/receipts/foreign-currency";
 
 // Receipt file validation, accepted types, and size limits now live in the
 // client-safe upload-policy module (shared with capture components so the UI
@@ -96,6 +102,19 @@ export interface NetanswerParsedLine {
   amountCents: number;
   currency: string;
   memo: string | null;
+  // Foreign-currency detail parsed from memo (migration 0026). For an
+  // overseas-billed charge, amountCents/currency are the JPY-converted total
+  // reported on the statement; these hold the original foreign amount parsed
+  // off the 現地通貨額 memo so reconciliation can match a USD (etc.) receipt
+  // against it. memoCurrencyParseStatus: null = no 現地通貨額 marker (ordinary
+  // JPY line), "parsed" = extracted, "unparsed" = marker present but extraction
+  // failed OR the FX-rate cross-check failed (rate attached from the trailing
+  // continuation row below). foreignAmountMinor inherits the line's own sign
+  // (negative for refunds); foreignExchangeRate is informational only.
+  foreignAmountMinor: number | null;
+  foreignCurrency: string | null;
+  foreignExchangeRate: number | null;
+  memoCurrencyParseStatus: ForeignCurrencyParseStatus | null;
   rawFields: string[];
   // True when this row had no 利用日 (usage date) in the CSV — e.g. an annual
   // card fee, late fee, or interest adjustment. These are real charges that
@@ -349,6 +368,37 @@ export function parseAmexNetanswer(
       // charge (現地通貨額 is already captured in the preceding dated row's
       // memo, e.g. line 20 above). Label it as benign so the UI doesn't
       // raise it as a warning.
+      //
+      // Foreign-charge continuation-row correlation (migration 0026): this
+      // trailing row also carries the FX rate actually used
+      // (円換算レート:M/D <rate>), which would otherwise vanish into
+      // skippedLines unread. When the immediately preceding pushed line
+      // parsed a 現地通貨額 foreign amount, rescue the rate off this row's
+      // memo, attach it to that line, and run the rate × foreign-amount
+      // cross-check — a mismatch downgrades the line to "unparsed" so a bad
+      // parse can't silently drive a foreign-currency match. The row is still
+      // skipped either way (it has no monetary value of its own).
+      if (isUndatedChargeLine) {
+        const prev = lines[lines.length - 1];
+        if (prev && prev.memoCurrencyParseStatus === "parsed" && memo) {
+          const rate = parseExchangeRateMemo(memo);
+          if (rate != null) {
+            prev.foreignExchangeRate = rate;
+            if (
+              prev.foreignAmountMinor != null &&
+              prev.foreignCurrency &&
+              !foreignAmountCrossCheckOk({
+                foreignAmountMinor: prev.foreignAmountMinor,
+                foreignCurrency: prev.foreignCurrency,
+                jpyAmountMinorAbs: Math.abs(prev.amountCents),
+                exchangeRate: rate,
+              })
+            ) {
+              prev.memoCurrencyParseStatus = "unparsed";
+            }
+          }
+        }
+      }
       skippedLines.push({
         lineNumber: i + 1,
         reason: isUndatedChargeLine
@@ -376,6 +426,23 @@ export function parseAmexNetanswer(
     const effectiveDate =
       txDate ?? metadata.paymentDueDate ?? `${_statementMonth}-01`;
 
+    // Foreign-currency parse (migration 0026). 現地通貨額 memo → original
+    // foreign amount. The memo is a magnitude only, so inherit the line's own
+    // sign (a refund line's foreign amount is negative too). foreignExchangeRate
+    // starts null here and is attached from the trailing continuation row above
+    // when one follows; the cross-check there may downgrade status to "unparsed".
+    const foreign = parseForeignCurrencyMemo(memo);
+    let foreignAmountMinor: number | null = null;
+    let foreignCurrency: string | null = null;
+    let memoCurrencyParseStatus: ForeignCurrencyParseStatus | null = null;
+    if (foreign.status === "parsed") {
+      foreignAmountMinor = isNegative ? -foreign.amountMinor : foreign.amountMinor;
+      foreignCurrency = foreign.currency;
+      memoCurrencyParseStatus = "parsed";
+    } else if (foreign.status === "unparsed") {
+      memoCurrencyParseStatus = "unparsed";
+    }
+
     lines.push({
       lineNumber: i + 1,
       cardholderName: currentCardholder,
@@ -387,6 +454,10 @@ export function parseAmexNetanswer(
       amountCents,
       currency: "JPY",
       memo: memo || null,
+      foreignAmountMinor,
+      foreignCurrency,
+      foreignExchangeRate: null,
+      memoCurrencyParseStatus,
       noReceiptRequired: isUndatedChargeLine,
       noReceiptReason: isUndatedChargeLine
         ? `No 利用日 (usage date) on statement for "${merchantName}" — fixed/recurring charge, no receipt applicable.`
@@ -447,6 +518,10 @@ export function netanswerLinesToImportInputs(
     paymentType: l.paymentType ?? undefined,
     prepaymentFlag: l.prepaymentFlag ?? undefined,
     memo: l.memo ?? undefined,
+    foreignAmountMinor: l.foreignAmountMinor ?? undefined,
+    foreignCurrency: l.foreignCurrency ?? undefined,
+    foreignExchangeRate: l.foreignExchangeRate ?? undefined,
+    memoCurrencyParseStatus: l.memoCurrencyParseStatus ?? undefined,
     rawCsvLineNumber: l.lineNumber,
     sourceFileSha256: sha256,
     receiptStatus: l.noReceiptRequired ? "no_receipt_required" : undefined,

--- a/scripts/backfill-amex-foreign-currency.ts
+++ b/scripts/backfill-amex-foreign-currency.ts
@@ -1,0 +1,181 @@
+#!/usr/bin/env -S npx tsx
+// Backfill the migration-0026 foreign-currency columns on already-imported
+// amex_statement_lines rows for OPEN statement months only, so this cycle's
+// stuck Cloudflare/Anthropic USD receipts become matchable without a re-import.
+//
+// What it does: for every line in a non-finalized month whose memo is not null,
+// re-run the single parser (parseForeignCurrencyMemo from
+// lib/receipts/foreign-currency — the same one the import path uses) and write
+// foreign_amount_minor / foreign_currency / memo_currency_parse_status.
+//
+// What it does NOT do:
+//   * Touch finalized months (immutable per the existing guard; the
+//     statement_month NOT IN (finalized) filter enforces this).
+//   * Recover foreign_exchange_rate. The 円換算レート lives on the trailing
+//     continuation row, which the CSV parser discards at import time and never
+//     persists — so for already-imported rows the rate is gone. The rate is a
+//     BONUS cross-check signal only (never used to match), so its absence here
+//     leaves cleanly-parsed rows as status='parsed' (no cross-check possible),
+//     exactly as on a fresh import whose continuation row failed to parse.
+//     Fresh imports going forward DO capture the rate. (Reported below.)
+//   * Run the rate cross-check (can't — no rate). Status is 'parsed' whenever
+//     the primary 現地通貨額 regex succeeds.
+//
+// WHERE THIS RUNS: the Mac, with live Cloudflare bindings — it shells out to
+// `wrangler d1 execute RECEIPTS_DB --remote`. It imports the PURE parser from
+// lib/receipts/foreign-currency.ts (no D1 inside it).
+//
+// SAFETY:
+//   * Dry-run by default. Pass --write to persist. Pass --month YYYY-MM to scope
+//     to one open month (still must be non-finalized).
+//   * Idempotent: parseForeignCurrencyMemo is a pure function of memo, and the
+//     UPDATE only writes memo-derived columns. Re-running after --write produces
+//     identical values (no audit row is written either way).
+//
+// USAGE:
+//   npx tsx scripts/backfill-amex-foreign-currency.ts                  # dry-run summary (all open months)
+//   npx tsx scripts/backfill-amex-foreign-currency.ts --write           # persist (all open months)
+//   npx tsx scripts/backfill-amex-foreign-currency.ts --month 2026-07   # scope to one open month
+//   npx tsx scripts/backfill-amex-foreign-currency.ts --month 2026-07 --write
+
+import { execFileSync } from "node:child_process";
+import { parseForeignCurrencyMemo } from "@/lib/receipts/foreign-currency";
+
+const DB = "RECEIPTS_DB";
+const args = process.argv.slice(2);
+const WRITE = args.includes("--write");
+const MONTH_FLAG = args.includes("--month")
+  ? (args[args.indexOf("--month") + 1] ?? null)
+  : null;
+
+function d1(sql: string): Record<string, unknown>[] {
+  const raw = execFileSync(
+    "npx",
+    ["wrangler", "d1", "execute", DB, "--remote", "--json", "--command", sql],
+    { encoding: "utf8", maxBuffer: 256 * 1024 * 1024 },
+  );
+  const parsed = JSON.parse(raw);
+  return (Array.isArray(parsed) ? parsed[0] : parsed)?.results ?? [];
+}
+
+const esc = (v: string | null) => (v == null ? "NULL" : `'${v.replace(/'/g, "''")}'`);
+const intOrNullOr = (v: number | null) => (v == null ? "NULL" : String(v));
+
+const monthFilter = MONTH_FLAG ? `AND statement_month = ${esc(MONTH_FLAG)}` : "";
+
+// Open months only: exclude months with a finalized reconciliation.
+const rows = d1(
+  `SELECT id, statement_month, amount_minor, memo
+   FROM amex_statement_lines
+   WHERE memo IS NOT NULL
+     AND statement_month NOT IN (
+       SELECT statement_month FROM amex_reconciliations WHERE status = 'finalized'
+     )
+     ${monthFilter}
+   ORDER BY statement_month ASC, transaction_date ASC;`,
+);
+
+// ── Classify each row via the single parser ────────────────────────────────
+type Plan = {
+  id: string;
+  month: string;
+  amountMinor: number;
+  memo: string;
+  status: "none" | "parsed" | "unparsed";
+  foreignAmountMinor: number | null; // signed (inherits amount_minor sign)
+  foreignCurrency: string | null;
+};
+
+const plans: Plan[] = [];
+for (const r of rows) {
+  const memo = String(r.memo);
+  const amountMinor = Number(r.amount_minor);
+  const parsed = parseForeignCurrencyMemo(memo);
+  const plan: Plan = {
+    id: String(r.id),
+    month: String(r.statement_month),
+    amountMinor,
+    memo,
+    status: parsed.status,
+    foreignAmountMinor: null,
+    foreignCurrency: null,
+  };
+  if (parsed.status === "parsed") {
+    // Sign inheritance: memo is a magnitude only; a refund line (negative
+    // amount_minor) gets a negative foreign amount too.
+    plan.foreignAmountMinor = amountMinor < 0 ? -parsed.amountMinor : parsed.amountMinor;
+    plan.foreignCurrency = parsed.currency;
+  }
+  plans.push(plan);
+}
+
+// ── Counts by (month, status) ──────────────────────────────────────────────
+const byMonthStatus: Record<string, Record<string, number>> = {};
+for (const p of plans) {
+  const m = (byMonthStatus[p.month] ??= { none: 0, parsed: 0, unparsed: 0 });
+  m[p.status] += 1;
+}
+
+const totals = { none: 0, parsed: 0, unparsed: 0 };
+for (const p of plans) totals[p.status] += 1;
+
+console.log(
+  `\nBackfilling foreign-currency columns on ${rows.length} memo-bearing line(s) in open month(s)${
+    MONTH_FLAG ? ` [scoped to ${MONTH_FLAG}]` : ""
+  }${WRITE ? " [WRITE]" : " [dry-run]"}\n`,
+);
+for (const month of Object.keys(byMonthStatus).sort()) {
+  const c = byMonthStatus[month]!;
+  console.log(
+    `  ${month}: ${c.none} none · ${c.parsed} parsed · ${c.unparsed} unparsed`,
+  );
+}
+console.log(
+  `\nTotals: ${totals.none} none · ${totals.parsed} parsed · ${totals.unparsed} unparsed\n`,
+);
+
+// ── Spot-check unparsed memos (report format surprises, don't work around them) ─
+const unparsed = plans.filter((p) => p.status === "unparsed");
+if (unparsed.length > 0) {
+  console.log(`Unparsed memos (showing up to 10) — report these to the architect if the`);
+  console.log(`marker format differs from 現地通貨額:<amt> <CCY>:\n`);
+  for (const p of unparsed.slice(0, 10)) {
+    console.log(`  [${p.month}] ${p.memo.slice(0, 80)}`);
+  }
+  if (unparsed.length > 10) console.log(`  …and ${unparsed.length - 10} more`);
+  console.log("");
+}
+
+if (!WRITE) {
+  if (totals.parsed + totals.unparsed > 0) {
+    console.log("Dry run only. Re-run with --write to persist.");
+  } else {
+    console.log("Nothing to backfill — no memo carries a 現地通貨額 marker in the open month(s).");
+  }
+} else {
+  // Batch the per-row UPDATEs to keep wrangler spawns bounded. Each statement
+  // is independent and idempotent; ordering within a batch is irrelevant.
+  const BATCH = 25;
+  const toWrite = plans.filter((p) => p.status !== "none");
+  for (let i = 0; i < toWrite.length; i += BATCH) {
+    const chunk = toWrite.slice(i, i + BATCH);
+    const sql = chunk
+      .map(
+        (p) =>
+          `UPDATE amex_statement_lines
+             SET foreign_amount_minor = ${intOrNullOr(p.foreignAmountMinor)},
+                 foreign_currency = ${esc(p.foreignCurrency)},
+                 memo_currency_parse_status = ${esc(p.status === "none" ? null : p.status)}
+           WHERE id = ${esc(p.id)};`,
+      )
+      .join("\n");
+    d1(sql);
+  }
+  console.log(
+    `Wrote ${toWrite.length} row(s) (${totals.parsed} parsed, ${totals.unparsed} unparsed).`,
+  );
+  console.log(
+    `Note: foreign_exchange_rate is NOT set by this backfill (the continuation-row rate is` +
+      ` not persisted on already-imported rows). Cleanly-parsed rows are status='parsed'.`,
+  );
+}

--- a/tests/receipts/amex-parser.test.ts
+++ b/tests/receipts/amex-parser.test.ts
@@ -586,3 +586,158 @@ test("parseAmexNetanswer: handles comma thousands separators in metadata total",
   assert.equal(result.metadata.statementTotalCents, 10000);
   assert.equal(result.validationErrors.length, 0);
 });
+
+// ─── Foreign-currency detail (migration 0026) ───────────────────────────────
+// Real 2026-06/07 SAISON shape: a dated overseas charge row whose memo carries
+// 現地通貨額:<amt> <CCY>, immediately followed by a no-date/no-amount
+// continuation row whose memo carries 円換算レート:M/D <rate>. The continuation
+// row is still skipped (no monetary value) but its rate is correlated back onto
+// the charge line and cross-checked.
+
+test("parseAmexNetanswer: foreign charge + continuation rate row → parsed foreign fields on the charge line", () => {
+  // 11.51 USD × 166.6377 = 1918.06 → ¥1918 (cross-check passes)
+  const csv = [
+    "カード名称,TestCard",
+    "お支払日,2026/07/10",
+    "今回ご請求額,001918",
+    "",
+    "利用日,ご利用店名及び商品名,本人・家族区分,支払区分名称,締前入金区分,利用金額,備考",
+    ",ご利用者名:テスト 様,,,,,",
+    "2026/06/11,CLOUDFLARE,1,1回,,1918,現地通貨額:11.51 USD",
+    ",(SAN FRANCISCO),1,1回,,,円換算レート:6/11 166.6377",
+  ].join("\n");
+  const result = parseAmexNetanswer(toBuffer(csv), "2026-07");
+  assert.equal(result.lines.length, 1);
+  assert.equal(result.parsedTotalCents, 1918);
+  assert.equal(result.validationErrors.length, 0);
+
+  const line = result.lines[0]!;
+  assert.equal(line.merchantName, "CLOUDFLARE");
+  assert.equal(line.memoCurrencyParseStatus, "parsed");
+  assert.equal(line.foreignAmountMinor, 1151);
+  assert.equal(line.foreignCurrency, "USD");
+  assert.equal(line.foreignExchangeRate, 166.6377);
+
+  // The continuation row is still skipped (no monetary value of its own), benign.
+  assert.equal(result.skippedLines.length, 1);
+  assert.equal(result.skippedLines[0]!.benign, true);
+});
+
+test("parseAmexNetanswer: ANTHROPIC 66.00 USD real example also parses", () => {
+  // 66.00 × 168.1516 = 11098.0 → ¥11098
+  const csv = [
+    "カード名称,TestCard",
+    "お支払日,2026/07/10",
+    "今回ご請求額,011098",
+    "",
+    "利用日,ご利用店名及び商品名,本人・家族区分,支払区分名称,締前入金区分,利用金額,備考",
+    ",ご利用者名:テスト 様,,,,,",
+    "2026/06/23,ANTHROPIC,1,1回,,11098,現地通貨額:66.00 USD",
+    ",(SAN FRANCISCO),1,1回,,,円換算レート:6/23 168.1516",
+  ].join("\n");
+  const result = parseAmexNetanswer(toBuffer(csv), "2026-07");
+  const line = result.lines[0]!;
+  assert.equal(line.memoCurrencyParseStatus, "parsed");
+  assert.equal(line.foreignAmountMinor, 6600);
+  assert.equal(line.foreignCurrency, "USD");
+  assert.equal(line.foreignExchangeRate, 168.1516);
+});
+
+test("netanswerLinesToImportInputs: passes foreign-currency fields through", () => {
+  const csv = [
+    "カード名称,TestCard",
+    "お支払日,2026/07/10",
+    "今回ご請求額,001918",
+    "",
+    "利用日,ご利用店名及び商品名,本人・家族区分,支払区分名称,締前入金区分,利用金額,備考",
+    ",ご利用者名:テスト 様,,,,,",
+    "2026/06/11,CLOUDFLARE,1,1回,,1918,現地通貨額:11.51 USD",
+    ",(SAN FRANCISCO),1,1回,,,円換算レート:6/11 166.6377",
+  ].join("\n");
+  const { lines } = parseAmexNetanswer(toBuffer(csv), "2026-07");
+  const inputs = netanswerLinesToImportInputs(lines, "2026-07", "artifact-1", "sha256abc");
+  assert.equal(inputs[0]!.foreignAmountMinor, 1151);
+  assert.equal(inputs[0]!.foreignCurrency, "USD");
+  assert.equal(inputs[0]!.foreignExchangeRate, 166.6377);
+  assert.equal(inputs[0]!.memoCurrencyParseStatus, "parsed");
+});
+
+test("parseAmexNetanswer: rate cross-check failure downgrades to unparsed", () => {
+  // JPY total says 5000 but 11.51 × 166.6377 = 1918 — the parse grabbed the
+  // wrong row/code, so matching on it would be worse than not matching.
+  const csv = [
+    "カード名称,TestCard",
+    "お支払日,2026/07/10",
+    "今回ご請求額,005000",
+    "",
+    "利用日,ご利用店名及び商品名,本人・家族区分,支払区分名称,締前入金区分,利用金額,備考",
+    ",ご利用者名:テスト 様,,,,,",
+    "2026/06/11,CLOUDFLARE,1,1回,,5000,現地通貨額:11.51 USD",
+    ",(SAN FRANCISCO),1,1回,,,円換算レート:6/11 166.6377",
+  ].join("\n");
+  const result = parseAmexNetanswer(toBuffer(csv), "2026-07");
+  const line = result.lines[0]!;
+  assert.equal(line.memoCurrencyParseStatus, "unparsed");
+  // Values retained for operator review (status is the source of truth for
+  // match eligibility; reconciliation gates on status === "parsed").
+  assert.equal(line.foreignAmountMinor, 1151);
+  assert.equal(line.foreignExchangeRate, 166.6377);
+});
+
+test("parseAmexNetanswer: continuation row without a rate memo leaves status parsed (rate is bonus)", () => {
+  // Charge parses cleanly; the trailing annotation row has no 円換算レート
+  // memo. The rate is a bonus cross-check, not a requirement, so the line stays
+  // parsed with a null rate (matches the existing benign-skip test shape).
+  const csv = [
+    "カード名称,TestCard",
+    "お支払日,2026/07/10",
+    "今回ご請求額,001918",
+    "",
+    "利用日,ご利用店名及び商品名,本人・家族区分,支払区分名称,締前入金区分,利用金額,備考",
+    ",ご利用者名:テスト 様,,,,,",
+    "2026/06/11,CLOUDFLARE,1,1回,,1918,現地通貨額:11.51 USD",
+    ",CLOUDFLARE,1,1回,,,",
+  ].join("\n");
+  const result = parseAmexNetanswer(toBuffer(csv), "2026-07");
+  const line = result.lines[0]!;
+  assert.equal(line.memoCurrencyParseStatus, "parsed");
+  assert.equal(line.foreignAmountMinor, 1151);
+  assert.equal(line.foreignExchangeRate, null);
+});
+
+test("parseAmexNetanswer: foreign refund inherits the line's negative sign", () => {
+  // 今回ご請求額 omitted so the total-mismatch check is skipped (its parser
+  // strips the sign, which would otherwise conflict with a negative net).
+  const csv = [
+    "カード名称,TestCard",
+    "利用日,ご利用店名及び商品名,本人・家族区分,支払区分名称,締前入金区分,利用金額,備考",
+    ",ご利用者名:テスト 様,,,,,",
+    "2026/06/11,CLOUDFLARE REFUND,1,1回,,-1918,現地通貨額:11.51 USD",
+    ",(SAN FRANCISCO),1,1回,,,円換算レート:6/11 166.6377",
+  ].join("\n");
+  const result = parseAmexNetanswer(toBuffer(csv), "2026-07");
+  const line = result.lines[0]!;
+  assert.equal(line.amountCents, -1918);
+  assert.equal(line.memoCurrencyParseStatus, "parsed");
+  // Sign inherited from amountCents: the memo magnitude 11.51 becomes -1151.
+  assert.equal(line.foreignAmountMinor, -1151);
+  assert.equal(line.foreignCurrency, "USD");
+});
+
+test("parseAmexNetanswer: ordinary JPY line (no foreign marker) has null foreign fields", () => {
+  const csv = [
+    "カード名称,TestCard",
+    "お支払日,2026/05/07",
+    "今回ご請求額,001000",
+    "",
+    "利用日,ご利用店名及び商品名,本人・家族区分,支払区分名称,締前入金区分,利用金額,備考",
+    ",ご利用者名:テスト 様,,,,,",
+    "2026/05/01,コンビニ,1,1回,,1000,",
+  ].join("\n");
+  const result = parseAmexNetanswer(toBuffer(csv), "2026-05");
+  const line = result.lines[0]!;
+  assert.equal(line.memoCurrencyParseStatus, null);
+  assert.equal(line.foreignAmountMinor, null);
+  assert.equal(line.foreignCurrency, null);
+  assert.equal(line.foreignExchangeRate, null);
+});

--- a/tests/receipts/foreign-currency.test.ts
+++ b/tests/receipts/foreign-currency.test.ts
@@ -1,0 +1,170 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseForeignCurrencyMemo,
+  parseExchangeRateMemo,
+  foreignAmountCrossCheckOk,
+  toMinorUnits,
+} from "@/lib/receipts/foreign-currency";
+
+// Real operator-screenshot rows (2026-06/07 SAISON statement) are used verbatim
+// as the primary fixtures — not synthetic strings — per the worker spec §6.
+
+// ─── parseForeignCurrencyMemo: real charge-row memos (verbatim) ──────────────
+
+test("parseForeignCurrencyMemo: 2026/06/11 CLOUDFLARE 現地通貨額:11.51 USD", () => {
+  assert.deepEqual(parseForeignCurrencyMemo("現地通貨額:11.51 USD"), {
+    status: "parsed",
+    amountMinor: 1151,
+    currency: "USD",
+  });
+});
+
+test("parseForeignCurrencyMemo: 2026/06/23 ANTHROPIC 現地通貨額:66.00 USD", () => {
+  assert.deepEqual(parseForeignCurrencyMemo("現地通貨額:66.00 USD"), {
+    status: "parsed",
+    amountMinor: 6600,
+    currency: "USD",
+  });
+});
+
+test("parseForeignCurrencyMemo: 2026/07/04 CLOUDFLARE 現地通貨額:3.30 USD", () => {
+  assert.deepEqual(parseForeignCurrencyMemo("現地通貨額:3.30 USD"), {
+    status: "parsed",
+    amountMinor: 330,
+    currency: "USD",
+  });
+});
+
+// ─── Variants ───────────────────────────────────────────────────────────────
+
+test("parseForeignCurrencyMemo: full-width colon variant", () => {
+  assert.deepEqual(parseForeignCurrencyMemo("現地通貨額：12.34 EUR"), {
+    status: "parsed",
+    amountMinor: 1234,
+    currency: "EUR",
+  });
+});
+
+test("parseForeignCurrencyMemo: comma-thousands amount", () => {
+  assert.deepEqual(parseForeignCurrencyMemo("現地通貨額:1,234.56 USD"), {
+    status: "parsed",
+    amountMinor: 123456,
+    currency: "USD",
+  });
+});
+
+test("parseForeignCurrencyMemo: lowercase currency code is uppercased", () => {
+  assert.deepEqual(parseForeignCurrencyMemo("現地通貨額:11.51 usd"), {
+    status: "parsed",
+    amountMinor: 1151,
+    currency: "USD",
+  });
+});
+
+test("parseForeignCurrencyMemo: marker present but garbled → unparsed", () => {
+  // amount missing
+  assert.deepEqual(parseForeignCurrencyMemo("現地通貨額:USD"), { status: "unparsed" });
+  // currency missing
+  assert.deepEqual(parseForeignCurrencyMemo("現地通貨額:12.50"), { status: "unparsed" });
+  // currency code not 3 letters
+  assert.deepEqual(parseForeignCurrencyMemo("現地通貨額:12.50 DOLLARS"), {
+    status: "unparsed",
+  });
+  // non-numeric amount
+  assert.deepEqual(parseForeignCurrencyMemo("現地通貨額:一二三 USD"), {
+    status: "unparsed",
+  });
+});
+
+test("parseForeignCurrencyMemo: no marker → none (behaves as ordinary JPY line)", () => {
+  assert.deepEqual(parseForeignCurrencyMemo(null), { status: "none" });
+  assert.deepEqual(parseForeignCurrencyMemo(""), { status: "none" });
+  assert.deepEqual(parseForeignCurrencyMemo("some ordinary memo"), { status: "none" });
+  assert.deepEqual(parseForeignCurrencyMemo("円換算レート:6/11 166.6377"), {
+    status: "none",
+  });
+});
+
+// ─── parseExchangeRateMemo: real continuation-row memos (verbatim) ───────────
+
+test("parseExchangeRateMemo: real continuation rows", () => {
+  assert.equal(parseExchangeRateMemo("円換算レート:6/11 166.6377"), 166.6377);
+  assert.equal(parseExchangeRateMemo("円換算レート:6/23 168.1516"), 168.1516);
+  assert.equal(parseExchangeRateMemo("円換算レート:7/04 167.2728"), 167.2728);
+});
+
+test("parseExchangeRateMemo: null / no marker / unparseable → null", () => {
+  assert.equal(parseExchangeRateMemo(null), null);
+  assert.equal(parseExchangeRateMemo("(SAN FRANCISCO)"), null);
+  assert.equal(parseExchangeRateMemo("円換算レート:abc"), null);
+});
+
+// ─── Cross-check: rate × foreign amount ≈ JPY total within ±1 yen ───────────
+
+test("foreignAmountCrossCheckOk: real rows pass (within ±1 yen)", () => {
+  // 11.51 × 166.6377 = 1918.06 → ¥1918 ✓
+  assert.equal(
+    foreignAmountCrossCheckOk({
+      foreignAmountMinor: 1151,
+      foreignCurrency: "USD",
+      jpyAmountMinorAbs: 1918,
+      exchangeRate: 166.6377,
+    }),
+    true,
+  );
+  // 66.00 × 168.1516 = 11098.0 → ¥11098 ✓
+  assert.equal(
+    foreignAmountCrossCheckOk({
+      foreignAmountMinor: 6600,
+      foreignCurrency: "USD",
+      jpyAmountMinorAbs: 11098,
+      exchangeRate: 168.1516,
+    }),
+    true,
+  );
+  // 3.30 × 167.2728 = 551.99 → ¥552 ✓
+  assert.equal(
+    foreignAmountCrossCheckOk({
+      foreignAmountMinor: 330,
+      foreignCurrency: "USD",
+      jpyAmountMinorAbs: 552,
+      exchangeRate: 167.2728,
+    }),
+    true,
+  );
+});
+
+test("foreignAmountCrossCheckOk: mismatch beyond tolerance fails", () => {
+  // 11.51 × 166.6377 = 1918, but the JPY total is 5000 → grabbed the wrong row
+  assert.equal(
+    foreignAmountCrossCheckOk({
+      foreignAmountMinor: 1151,
+      foreignCurrency: "USD",
+      jpyAmountMinorAbs: 5000,
+      exchangeRate: 166.6377,
+    }),
+    false,
+  );
+});
+
+test("foreignAmountCrossCheckOk: missing rate → pass (soft signal, not a requirement)", () => {
+  assert.equal(
+    foreignAmountCrossCheckOk({
+      foreignAmountMinor: 1151,
+      foreignCurrency: "USD",
+      jpyAmountMinorAbs: 1918,
+      exchangeRate: null,
+    }),
+    true,
+  );
+});
+
+// ─── toMinorUnits convention (cents for non-JPY, magnitude for JPY) ──────────
+
+test("toMinorUnits: USD ×100, JPY ×1", () => {
+  assert.equal(toMinorUnits(11.51, "USD"), 1151);
+  assert.equal(toMinorUnits(66.0, "USD"), 6600);
+  assert.equal(toMinorUnits(1234, "JPY"), 1234);
+  assert.equal(toMinorUnits(1234, "jpy"), 1234);
+});

--- a/tests/receipts/reconciliation.test.ts
+++ b/tests/receipts/reconciliation.test.ts
@@ -418,13 +418,123 @@ test("multiple receipts — best match is selected", () => {
   assert.equal(matches[0]!.receiptId, "r-1", "exact amount match should win");
 });
 
-test("currency mismatch (USD receipt vs JPY line) is not matched", () => {
-  // ¥500 line and $5.00 receipt both have amount_minor = 500 but represent
-  // very different values; the matcher must reject this.
+test("currency mismatch (USD receipt vs JPY line, NO foreign data) is not matched", () => {
+  // Case (a): a JPY line with no parsed foreign-currency data still does NOT
+  // match a USD receipt. ¥500 line and $5.00 receipt both have amount_minor =
+  // 500 but represent very different values; today's protective behavior,
+  // unchanged by the two-path change.
   const lines = [makeAmexLine({ amount_minor: 500, currency: "JPY" })];
   const receipts = [makeReceipt({ amount_minor: 500, currency: "USD" })];
   const matches = matchAmexToReceipts(lines, receipts);
   assert.equal(matches.length, 0, "currency must match before amount comparison");
+});
+
+test("foreign-currency path: JPY line with parsed USD data matches a same-amount USD receipt", () => {
+  // Case (b): the line's JPY total (¥1918) is not comparable to a USD receipt;
+  // matching uses the parsed foreign amount (11.51 USD = 1151 minor) against
+  // the receipt's USD amount_minor, with a distinguishing reason string.
+  const lines = [
+    makeAmexLine({
+      id: "cf-line",
+      merchant: "CLOUDFLARE",
+      amount_minor: 1918,
+      currency: "JPY",
+      transaction_date: "2026-06-11",
+      memo: "現地通貨額:11.51 USD",
+      memo_currency_parse_status: "parsed",
+      foreign_currency: "USD",
+      foreign_amount_minor: 1151,
+    }),
+  ];
+  const receipts = [
+    makeReceipt({
+      id: "r-cf",
+      merchant: "CLOUDFLARE",
+      amount_minor: 1151,
+      currency: "USD",
+      transaction_date: "2026-06-11",
+    }),
+  ];
+  const matches = matchAmexToReceipts(lines, receipts);
+  assert.equal(matches.length, 1);
+  assert.equal(matches[0]!.receiptId, "r-cf");
+  // Must NOT reuse the bare JPY "exact amount" reason — a reviewer needs to see
+  // WHY a JPY-denominated line matched a USD receipt.
+  assert.ok(
+    matches[0]!.matchReasons.some((r) => /foreign currency/.test(r)),
+    `expected a foreign-currency reason, got ${JSON.stringify(matches[0]!.matchReasons)}`,
+  );
+});
+
+test("foreign-currency path: JPY line parsed as EUR does not match a USD receipt", () => {
+  // Case (c): foreign data in a currency OTHER than the receipt's still does
+  // not match.
+  const lines = [
+    makeAmexLine({
+      amount_minor: 1918,
+      currency: "JPY",
+      transaction_date: "2026-06-11",
+      memo_currency_parse_status: "parsed",
+      foreign_currency: "EUR",
+      foreign_amount_minor: 1151,
+    }),
+  ];
+  const receipts = [
+    makeReceipt({ amount_minor: 1151, currency: "USD", transaction_date: "2026-06-11" }),
+  ];
+  assert.equal(matchAmexToReceipts(lines, receipts).length, 0);
+});
+
+test("foreign-currency path: unparsed status is not match-eligible", () => {
+  // An "unparsed" line is flagged for operator review and must never auto-match
+  // via the foreign path, even though its foreign_* fields are populated.
+  const lines = [
+    makeAmexLine({
+      amount_minor: 1918,
+      currency: "JPY",
+      transaction_date: "2026-06-11",
+      memo_currency_parse_status: "unparsed",
+      foreign_currency: "USD",
+      foreign_amount_minor: 1151,
+    }),
+  ];
+  const receipts = [
+    makeReceipt({ amount_minor: 1151, currency: "USD", transaction_date: "2026-06-11" }),
+  ];
+  assert.equal(matchAmexToReceipts(lines, receipts).length, 0);
+});
+
+test("foreign-currency path: a JPY↔JPY match is unaffected when the line also carries foreign data", () => {
+  // Protects the highest-traffic domestic path: the same-currency branch wins
+  // for a JPY receipt even though the line has parsed (unrelated) USD data.
+  const lines = [
+    makeAmexLine({
+      id: "jp-line",
+      merchant: "コンビニ",
+      amount_minor: 1000,
+      currency: "JPY",
+      transaction_date: "2026-06-11",
+      memo_currency_parse_status: "parsed",
+      foreign_currency: "USD",
+      foreign_amount_minor: 9999,
+    }),
+  ];
+  const receipts = [
+    makeReceipt({
+      id: "r-jp",
+      merchant: "コンビニ",
+      amount_minor: 1000,
+      currency: "JPY",
+      transaction_date: "2026-06-11",
+    }),
+  ];
+  const matches = matchAmexToReceipts(lines, receipts);
+  assert.equal(matches.length, 1);
+  assert.equal(matches[0]!.receiptId, "r-jp");
+  assert.ok(
+    !matches[0]!.matchReasons.some((r) => /foreign currency/.test(r)),
+    `JPY match must not carry a foreign-currency reason, got ${JSON.stringify(matches[0]!.matchReasons)}`,
+  );
 });
 
 test("currency match is case-insensitive", () => {


### PR DESCRIPTION
## What

Overseas-billed charges (Cloudflare, Anthropic, OpenAI, GitHub, Hover, Bluehost, Stripe/Z.ai, Movement) are captured as **USD receipts**, but the AMEX Netアンサー statement reports only the **JPY-converted** total. `reconciliation.ts` hard-gated on `line.currency === receipt.currency`, so a USD receipt was **never even considered** against any JPY line — a total exclusion. The original foreign amount lives only in the charge-row memo (`現地通貨額:<amt> <CCY>`); the trailing continuation row carries the FX rate (`円換算レート:M/D <rate>`) and was discarded unread.

This PR implements the architect's spec verbatim: parse the memo at import + backfill, add a foreign-currency matching path, surface parse failures, and show dual amounts in the UI.

## Changes
- **migration 0026** — 4 nullable columns on `amex_statement_lines`.
- **`lib/receipts/foreign-currency.ts`** (new) — single parser + cross-check (sole source of truth).
- **`validation.ts`** — parse at import, sign-inherit, correlate continuation-row rate, downgrade to `unparsed` on cross-check failure.
- **`reconciliation.ts`** — two-path eligibility (same-currency unchanged; foreign path on `status:"parsed"`). `none`-status lines byte-identical to today. Consolidation left JPY-only this pass (architect-approved).
- **`confidence.ts`** — `matchExplanation` foreign-aware.
- **reconcile UI** — amber "currency unparsed" pill (list + detail) + dual-amount AMEX line.
- **`scripts/backfill-amex-foreign-currency.ts`** (new) — open-months-only, dry-run default, idempotent.
- **tests** — parser (3 real operator rows), amex-parser integration, reconciliation currency-mismatch split.

## Verification (live D1)
- Migration 0026 applied; 4 columns confirmed via `PRAGMA table_info`.
- Backfill: **12 lines parsed, 0 unparsed, 0 none** (2026-03:5, 2026-04:4, 2026-08:3). No finalized month touched.
- Matcher pairs the 3 target receipts to their lines at **100% [exact amount (foreign currency)]** when `payment_path=AMEX`.
- Domestic JPY path non-regressive (confirmed pairs re-match identically; 100 reconciliation tests pass).
- `tsc --noEmit` clean; `npm run build:cf` clean; `npm test` 633 tests / 0 fail / 1 pre-existing skip.

## ⚠️ Finding for the architect (out of scope, NOT fixed)
The 3 USD receipts that prompted this fix are stored with **`payment_path = 'UNKNOWN'`**, not `'AMEX'`. The matcher's eligibility filter (`reconciliation.ts:163`, `if (receipt.payment_path !== "AMEX") continue;`) excludes them **before** any currency logic runs — so the foreign-currency path is proven correct (Run 2 below) but cannot surface them until `payment_path` is set to `AMEX`. This is a pre-existing receipt-eligibility dimension the spec did not cover. **Decision needed:** set `payment_path='AMEX'` on those 3 receipts (operator action or a follow-up), or broaden eligibility.

## Not deployed
Per the two-agent workflow, the architect verifies before deploy. PR opened, **not merged**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)