### PR TITLE
receipts: tentative AMEX matches for UNKNOWN-payment receipts

### DIFF
--- a/components/receipts/reconcile/reconcile-screen.tsx
+++ b/components/receipts/reconcile/reconcile-screen.tsx
@@ -781,6 +781,12 @@ function LineRow({
   );
   const confirmed = line.match_status === "confirmed";
   const noReceipt = line.match_status === "no_receipt";
+  // Tentative UNKNOWN-payment match: a suggested receipt whose payment_path is
+  // still UNKNOWN. Confirming it classifies the receipt as AMEX (db.ts), so flag
+  // it distinctly — never silently reclassify.
+  const tentativeMatch =
+    !!match &&
+    (receiptId ? receiptMap.get(receiptId)?.payment_path : undefined) === "UNKNOWN";
 
   return (
     <button
@@ -857,6 +863,11 @@ function LineRow({
           {line.memo_currency_parse_status === "unparsed" ? (
             <Pill tone="amber" size="sm">
               currency unparsed
+            </Pill>
+          ) : null}
+          {tentativeMatch ? (
+            <Pill tone="blue" size="sm">
+              confirms as AMEX
             </Pill>
           ) : null}
           {!confirmed && !noReceipt && band === "none" && (
@@ -984,6 +995,9 @@ function DetailPane({
     line.match_status === "no_receipt" ||
     line.receipt_status === "no_receipt_required" ||
     line.receipt_status === "receipt_not_available";
+  // Tentative UNKNOWN-payment match: confirming classifies the receipt as AMEX.
+  const tentativeMatch =
+    !!match && receipt?.payment_path === "UNKNOWN";
 
   return (
     <div className="h-full overflow-auto bg-gray-50 p-6">
@@ -1002,6 +1016,11 @@ function DetailPane({
           {line.memo_currency_parse_status === "unparsed" ? (
             <Pill tone="amber" size="sm" dot>
               Currency unparsed — review memo
+            </Pill>
+          ) : null}
+          {tentativeMatch ? (
+            <Pill tone="blue" size="sm" dot>
+              Payment path not set — confirms as AMEX
             </Pill>
           ) : null}
           <span className="text-[13px] text-gray-500">

--- a/lib/receipts/confidence.ts
+++ b/lib/receipts/confidence.ts
@@ -56,6 +56,14 @@ export function matchExplanation(
     }
     return `Consolidated receipt — ${confirmedSiblings.length} lines sum to ${sum}, receipt total is ${receipt.amount_minor}. Link the remaining charges before sign-off.`;
   }
+  // Tentative UNKNOWN-payment match: the receipt hasn't been classified yet.
+  // Confirming will classify it as AMEX as part of the same action — surface
+  // that side effect so the operator isn't surprised. Composes with the
+  // foreign-currency note below when both apply.
+  const tentative = receipt.payment_path === "UNKNOWN";
+  const tentativeNote = tentative
+    ? "Payment path not set — confirming will classify this receipt as AMEX. "
+    : "";
   // Foreign-currency match (migration 0026): a JPY statement line carrying a
   // parsed foreign amount matched a USD (etc.) receipt on the FOREIGN amount,
   // not the JPY total. Compare foreign_amount_minor to the receipt amount and
@@ -68,22 +76,22 @@ export function matchExplanation(
     line.foreign_currency.toUpperCase() === receipt.currency.toUpperCase();
   if (foreignMatch) {
     if (line.foreign_amount_minor !== (receipt.amount_minor ?? 0))
-      return "Foreign-currency amount differs — verify before confirming.";
+      return `${tentativeNote}Foreign-currency amount differs — verify before confirming.`;
     if (
       line.transaction_date &&
       receipt.transaction_date &&
       line.transaction_date !== receipt.transaction_date
     )
-      return "Dates differ slightly — common for late captures.";
-    return "Linked match (foreign currency).";
+      return `${tentativeNote}Dates differ slightly — common for late captures.`;
+    return `${tentativeNote}Linked match (foreign currency).`;
   }
   if (line.amount_minor !== (receipt.amount_minor ?? 0))
-    return "Amount differs — verify before confirming.";
+    return `${tentativeNote}Amount differs — verify before confirming.`;
   if (
     line.transaction_date &&
     receipt.transaction_date &&
     line.transaction_date !== receipt.transaction_date
   )
-    return "Dates differ slightly — common for late captures.";
-  return "Linked match.";
+    return `${tentativeNote}Dates differ slightly — common for late captures.`;
+  return `${tentativeNote}Linked match.`;
 }

--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -1175,23 +1175,38 @@ export async function updateAmexReconciliation(
     newMerchant: string | null;
     filledDate: string | null;
   } | null = null;
+  // Hoisted to function scope so the amex.reconciled audit below can record it
+  // even when no merchant/date adoption happened.
+  let classifyAsAmex = false;
 
   if (receiptId && matchStatus === "confirmed") {
-    // Read the receipt's current merchant/transaction_date to decide whether
-    // the AMEX override is a no-op (and to populate the audit trail).
+    // Read the receipt's current merchant/transaction_date/payment_path to
+    // decide whether the AMEX override is a no-op (and to populate the audit
+    // trail). payment_path drives the tentative-match → AMEX classification.
     const receiptRow = await db
       .prepare(
-        `SELECT merchant, transaction_date FROM receipt_records WHERE id = ? LIMIT 1`,
+        `SELECT merchant, transaction_date, payment_path FROM receipt_records WHERE id = ? LIMIT 1`,
       )
       .bind(receiptId)
-      .first<{ merchant: string | null; transaction_date: string | null }>();
+      .first<{ merchant: string | null; transaction_date: string | null; payment_path: string }>();
 
     const receiptMerchant = receiptRow?.merchant ?? null;
     const receiptDate = receiptRow?.transaction_date ?? null;
+    const receiptPaymentPath = receiptRow?.payment_path ?? null;
 
     const merchantChanged = shouldOverwriteMerchant(amexMerchant, receiptMerchant);
 
     const dateFill = !receiptDate && !!amexTransactionDate;
+
+    // Confirming a tentative UNKNOWN-payment match classifies the receipt as
+    // AMEX in the SAME batch as the match confirmation — a receipt must never
+    // be observable as matched + still UNKNOWN, even transiently. Gated
+    // strictly on UNKNOWN; an already-declared AMEX/CASH/DIGITAL receipt is
+    // never touched here. 'AMEX' is a fixed classification, inlined as a
+    // literal (not a bind param). Appended to BOTH UPDATE branches below so the
+    // flip lands regardless of which branch runs.
+    classifyAsAmex = receiptPaymentPath === "UNKNOWN";
+    const paymentPathFragment = classifyAsAmex ? ", payment_path = 'AMEX'" : "";
 
     if (merchantChanged || dateFill) {
       receiptAdoptAudit = {
@@ -1206,7 +1221,7 @@ export async function updateAmexReconciliation(
              SET merchant = ?,
                  transaction_date = COALESCE(transaction_date, ?),
                  status = 'reconciled',
-                 updated_at = ?
+                 updated_at = ?${paymentPathFragment}
              WHERE id = ?`,
           )
           .bind(
@@ -1221,7 +1236,7 @@ export async function updateAmexReconciliation(
       statements.push(
         db
           .prepare(
-            `UPDATE receipt_records SET status = 'reconciled', updated_at = ? WHERE id = ?`,
+            `UPDATE receipt_records SET status = 'reconciled', updated_at = ?${paymentPathFragment} WHERE id = ?`,
           )
           .bind(now, receiptId),
       );
@@ -1271,7 +1286,16 @@ export async function updateAmexReconciliation(
       matchStatus: previousStatus,
       receiptStatus: previousReceiptStatus,
     }),
-    newValueJson: stringifyJson({ receiptId, matchStatus, receiptStatus: newReceiptStatus }),
+    newValueJson: stringifyJson({
+      receiptId,
+      matchStatus,
+      receiptStatus: newReceiptStatus,
+      // Traceable record that this confirm also classified an UNKNOWN receipt
+      // as AMEX (audit-everything convention — never an invisible side effect).
+      ...(classifyAsAmex
+        ? { classifiedPaymentPath: { from: "UNKNOWN", to: "AMEX" } }
+        : {}),
+    }),
   });
 
   // Second audit entry when AMEX values were adopted onto the receipt.

--- a/lib/receipts/reconciliation.ts
+++ b/lib/receipts/reconciliation.ts
@@ -49,10 +49,16 @@ const MERCHANT_ALIAS_GROUPS: RegExp[][] = [
   [/えきねっと|エキネット|EKI-?NET/i, /東日本旅客鉄道|JR\s*東日本|JR\s*EAST/i],
 ];
 
-// Consolidated-group suggestions never reach the "obvious" (auto-confirm)
-// band — 0.92 in lib/receipts/confidence.ts. A wrong grouping is the
-// costliest reconciliation mistake, so a human confirms each group line.
-const CONSOLIDATED_CONFIDENCE_CAP = 0.9;
+// Matches that must NEVER reach the "obvious" (auto-confirm) band — 0.92 in
+// lib/receipts/confidence.ts — so the bulk-confirm-obvious action can never
+// action one without an individual human look. Two categories share this cap
+// today (single source of truth — do NOT let them drift):
+//   (a) consolidated multi-line matches — a wrong grouping is the costliest
+//       reconciliation mistake;
+//   (b) tentative matches against a receipt whose payment_path is still
+//       UNKNOWN — confirming one reclassifies the receipt as AMEX, which must
+//       never happen silently via a bulk action.
+const MANUAL_REVIEW_CONFIDENCE_CAP = 0.9;
 
 function merchantAliasMatch(a: string, b: string): boolean {
   return MERCHANT_ALIAS_GROUPS.some(
@@ -160,7 +166,19 @@ export function matchAmexToReceipts(
     let best: { match: ReconciliationMatch; dateDelta: number } | null = null;
 
     for (const receipt of eligibleReceipts) {
-      if (receipt.payment_path !== "AMEX") continue;
+      // Admit declared-AMEX receipts (today's behavior) AND receipts whose
+      // payment_path is still UNKNOWN — an unclassified receipt with obvious
+      // merchant/amount/date signals should surface as a *tentative* candidate
+      // (capped below the "obvious" band) rather than stay invisible until the
+      // operator manually classifies it. CASH/DIGITAL receipts are explicit
+      // human classifications and stay excluded.
+      if (
+        receipt.payment_path !== "AMEX" &&
+        receipt.payment_path !== "UNKNOWN"
+      ) {
+        continue;
+      }
+      const tentativePaymentPath = receipt.payment_path === "UNKNOWN";
 
       // Amount comparison only makes sense when both sides are denominated in
       // the same currency. AMEX statement lines are JPY (amount_minor is yen);
@@ -192,6 +210,13 @@ export function matchAmexToReceipts(
       }
 
       const reasons: string[] = [];
+      // Compose: a tentative-payment match may also be a foreign-currency
+      // match (e.g. an unclassified USD Cloudflare receipt vs a parsed-foreign
+      // JPY line). Push the tentative reason first so both reasons read
+      // together rather than one overwriting the other.
+      if (tentativePaymentPath) {
+        reasons.push("payment path not yet set — confirming will classify as AMEX");
+      }
       let score = 0;
       let dateDelta = Infinity;
 
@@ -249,7 +274,15 @@ export function matchAmexToReceipts(
           match: {
             amexLineId: line.id,
             receiptId: receipt.id,
-            confidenceScore: Math.min(score, dateCap),
+            // Tentative UNKNOWN-payment matches are additionally capped below
+            // the "obvious" band so bulk-confirm-obvious can never silently
+            // reclassify one as AMEX — a human must confirm each individually.
+            confidenceScore: Math.min(
+              score,
+              tentativePaymentPath
+                ? Math.min(dateCap, MANUAL_REVIEW_CONFIDENCE_CAP)
+                : dateCap,
+            ),
             matchReasons: reasons,
           },
           dateDelta,
@@ -366,7 +399,7 @@ export function matchAmexToReceipts(
       const dateDelta = daysBetween(line.transaction_date!, receipt.transaction_date);
       const score = Math.min(
         0.5 + Math.max(0, 0.35 - 0.05 * dateDelta) + 0.15,
-        CONSOLIDATED_CONFIDENCE_CAP,
+        MANUAL_REVIEW_CONFIDENCE_CAP,
       );
       assignedLines.add(line.id);
       resolved.push({

--- a/tests/receipts/reconciliation.test.ts
+++ b/tests/receipts/reconciliation.test.ts
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { matchAmexToReceipts, normalizeDescription } from "@/lib/receipts/reconciliation";
+import { bandForLine } from "@/lib/receipts/confidence";
 import type { AmexStatementLine, ReceiptRecord } from "@/lib/receipts/types";
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
@@ -534,6 +535,99 @@ test("foreign-currency path: a JPY↔JPY match is unaffected when the line also 
   assert.ok(
     !matches[0]!.matchReasons.some((r) => /foreign currency/.test(r)),
     `JPY match must not carry a foreign-currency reason, got ${JSON.stringify(matches[0]!.matchReasons)}`,
+  );
+});
+
+// ─── Tentative UNKNOWN-payment matches (payment path not yet set) ─────────────
+// An unclassified receipt (payment_path UNKNOWN) with obvious signals should
+// surface as a candidate, capped below the "obvious" band so the bulk-confirm
+// action can never silently reclassify it as AMEX. CASH/DIGITAL stay excluded.
+
+test("tentative UNKNOWN-payment match: surfaces as candidate, capped below obvious, reason present", () => {
+  // Default line+receipt have matching merchant/amount/date (raw signals clear
+  // 0.92). Override only payment_path → UNKNOWN.
+  const lines = [makeAmexLine({})];
+  const receipts = [makeReceipt({ payment_path: "UNKNOWN" })];
+  const matches = matchAmexToReceipts(lines, receipts);
+  assert.equal(matches.length, 1);
+  assert.ok(
+    matches[0]!.confidenceScore < 0.92,
+    `capped below 0.92, got ${matches[0]!.confidenceScore}`,
+  );
+  assert.ok(
+    matches[0]!.matchReasons.some((r) => /payment path not yet set/.test(r)),
+    `expected tentative reason, got ${JSON.stringify(matches[0]!.matchReasons)}`,
+  );
+  // The cap is UNKNOWN-specific: the same receipt declared AMEX clears obvious.
+  const amexMatches = matchAmexToReceipts(lines, [makeReceipt({ payment_path: "AMEX" })]);
+  assert.ok(
+    amexMatches[0]!.confidenceScore >= 0.92,
+    `declared-AMEX should clear obvious, got ${amexMatches[0]!.confidenceScore}`,
+  );
+});
+
+test("§3 regression: UNKNOWN-payment perfect match is NOT 'obvious' (bulk-confirm must never touch it)", () => {
+  // Raw signals (exact amount + 0-day window + merchant match) would alone
+  // reach the 0.92 "obvious" band — the gate bulkConfirmObvious auto-confirms.
+  // The tentative cap must keep it out of that band. This is the load-bearing
+  // safety gate of the whole feature; a failure here is a blocker.
+  const lines = [makeAmexLine({})];
+  const receipts = [makeReceipt({ payment_path: "UNKNOWN" })];
+  const matches = matchAmexToReceipts(lines, receipts);
+  const band = bandForLine(lines[0]!, matches[0]);
+  assert.notEqual(
+    band,
+    "obvious",
+    `capped tentative match must not reach the obvious (bulk-confirm) band, got ${band}`,
+  );
+});
+
+test("tentative match scope: CASH receipt is NOT reconsidered as an AMEX candidate", () => {
+  const lines = [makeAmexLine({})];
+  const receipts = [makeReceipt({ payment_path: "CASH" })];
+  assert.equal(matchAmexToReceipts(lines, receipts).length, 0);
+});
+
+test("tentative match scope: DIGITAL receipt is NOT reconsidered as an AMEX candidate", () => {
+  const lines = [makeAmexLine({})];
+  const receipts = [makeReceipt({ payment_path: "DIGITAL" })];
+  assert.equal(matchAmexToReceipts(lines, receipts).length, 0);
+});
+
+test("tentative + foreign: UNKNOWN USD receipt matches parsed-foreign JPY line, capped, composed reasons", () => {
+  const lines = [
+    makeAmexLine({
+      id: "cf-line",
+      merchant: "CLOUDFLARE",
+      amount_minor: 1918,
+      currency: "JPY",
+      transaction_date: "2026-06-11",
+      memo_currency_parse_status: "parsed",
+      foreign_currency: "USD",
+      foreign_amount_minor: 1151,
+    }),
+  ];
+  const receipts = [
+    makeReceipt({
+      id: "r-cf",
+      merchant: "CLOUDFLARE",
+      amount_minor: 1151,
+      currency: "USD",
+      transaction_date: "2026-06-11",
+      payment_path: "UNKNOWN",
+    }),
+  ];
+  const matches = matchAmexToReceipts(lines, receipts);
+  assert.equal(matches.length, 1);
+  assert.ok(matches[0]!.confidenceScore < 0.92);
+  const reasons = matches[0]!.matchReasons;
+  assert.ok(
+    reasons.some((r) => /payment path not yet set/.test(r)),
+    `tentative reason missing: ${JSON.stringify(reasons)}`,
+  );
+  assert.ok(
+    reasons.some((r) => /foreign currency/.test(r)),
+    `foreign-currency reason missing: ${JSON.stringify(reasons)}`,
   );
 });
 


### PR DESCRIPTION
## What

A receipt still at `payment_path = 'UNKNOWN'` was invisible to the matcher even when merchant/amount/date obviously lined up — the operator had to classify it as AMEX in review, then come back to reconcile and confirm as a **second, separate step**. This was the out-of-scope finding from PR #135 (the 3 stuck Cloudflare/Anthropic USD receipts are `UNKNOWN`).

Now the matcher suggests these as **tentative** candidates, and **confirming the suggestion classifies the receipt as AMEX atomically** with the match — one action both classifies and reconciles.

## The load-bearing constraint
Every tentative match is capped at **`MANUAL_REVIEW_CONFIDENCE_CAP = 0.9`** (the existing consolidation cap, renamed to a shared single source of truth). 0.9 < the 0.92 "obvious" band → the **bulk-confirm-obvious action can never silently reclassify** a receipt as AMEX. A perfect exact-amount/0-day/merchant UNKNOWN match lands in `likely`, not `obvious`. This mirrors how the codebase already solved the same problem for consolidated matches.

## Changes
- **`reconciliation.ts`** — admit `UNKNOWN` (CASH/DIGITAL stay excluded); `tentativePaymentPath` → cap at 0.9; composed reasons with the foreign-currency path; Phase 1 only.
- **`db.ts`** — confirm-time `payment_path: UNKNOWN → AMEX` flip in the **same batched transaction** as the match (both UPDATE branches), gated strictly on `UNKNOWN`; recorded in the `amex.reconciled` audit.
- **`confidence.ts`** — `matchExplanation` branch (composes with foreign).
- **reconcile UI** — blue pill in LineRow + DetailPane.
- **tests** — UNKNOWN surfaces (capped), §3 band regression gate, CASH/DIGITAL excluded, UNKNOWN-USD × foreign-JPY composed reasons. **638 tests, 0 fail**; tsc + build:cf clean.

## Verification (live)
- **Step 1** — the 3 stuck USD receipts now match their foreign-currency lines at **90%**, band `likely`, reasons `["payment path not yet set — confirming will classify as AMEX", "exact amount (foreign currency)", "0-day window", "merchant match"]`. (Were 0 matches before.)
- **Step 3** — **0** tentative matches in the `obvious` band → bulk-confirm-obvious can't touch them.
- **Step 4** — declared-AMEX matching unaffected (confirmed pairs re-match identically).
- **Step 2 (confirm-time flip)** — ⚠️ **post-deploy only**: requires the new Worker code to be live, and this PR is **not deployed**. Verified by code review + tsc + structural atomicity (`db.batch`); the empirical UI confirm is the operator's on-prod step after the architect deploys.

## Not deployed
Per the two-agent workflow, the architect verifies before deploy. PR opened, **not merged**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)