### PR TITLE
contact: prefill message textarea from ?message= query param

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { ContactForm } from "@/components/contact-form";
+import { normalizeMessagePrefill } from "@/lib/contact-prefill";
 import { isServiceSlug, services } from "@/lib/services";
 
 export const metadata: Metadata = {
@@ -9,13 +10,14 @@ export const metadata: Metadata = {
   alternates: { canonical: "/contact" },
 };
 
-type SearchParams = Promise<{ service?: string | string[] }>;
+type SearchParams = Promise<{ service?: string | string[]; message?: string | string[] }>;
 
 export default async function ContactPage({ searchParams }: { searchParams: SearchParams }) {
   const sp = await searchParams;
   const raw = typeof sp.service === "string" ? sp.service : Array.isArray(sp.service) ? sp.service[0] : undefined;
   const preselected = isServiceSlug(raw) ? raw : "";
   const preselectedTitle = preselected ? services[preselected].title : "";
+  const defaultMessage = normalizeMessagePrefill(sp.message);
 
   return (
     <div className="py-16">
@@ -36,7 +38,9 @@ export default async function ContactPage({ searchParams }: { searchParams: Sear
         </div>
 
         <ContactForm
+          key={defaultMessage}
           defaultService={preselected}
+          defaultMessage={defaultMessage}
           eyebrow={preselectedTitle ? preselectedTitle : "Contact"}
           headline={
             preselectedTitle

--- a/components/contact-form.tsx
+++ b/components/contact-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { CONTACT_MESSAGE_MAX_LENGTH } from "@/lib/contact-prefill";
 import { serviceList, type ServiceSlug } from "@/lib/services";
 
 type FieldErrors = Partial<Record<"firstName" | "lastName" | "email" | "phoneNumber" | "message" | "service", string>>;
@@ -14,6 +15,7 @@ const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 type Props = {
   defaultService?: string;
+  defaultMessage?: string;
   headline?: string;
   eyebrow?: string;
   source?: string;
@@ -21,6 +23,7 @@ type Props = {
 
 export function ContactForm({
   defaultService = "",
+  defaultMessage = "",
   headline = "Tell us what you\u2019re trying to build.",
   eyebrow = "Contact",
   source,
@@ -31,7 +34,7 @@ export function ContactForm({
   const [company, setCompany] = useState("");
   const [phoneNumber, setPhoneNumber] = useState("");
   const [service, setService] = useState<string>(defaultService);
-  const [message, setMessage] = useState("");
+  const [message, setMessage] = useState(defaultMessage);
   const [website, setWebsite] = useState("");
 
   const [errors, setErrors] = useState<FieldErrors>({});
@@ -62,7 +65,7 @@ export function ContactForm({
     setCompany("");
     setPhoneNumber("");
     setService(defaultService);
-    setMessage("");
+    setMessage(defaultMessage);
     setWebsite("");
     setErrors({});
     setServerError("");
@@ -267,7 +270,7 @@ export function ContactForm({
             aria-required="true"
             aria-invalid={errors.message ? true : undefined}
             aria-describedby={errors.message ? "message-error" : undefined}
-            maxLength={4000}
+            maxLength={CONTACT_MESSAGE_MAX_LENGTH}
           />
           <div className="mt-1 flex items-start justify-between gap-3">
             {errors.message ? (
@@ -277,7 +280,7 @@ export function ContactForm({
             ) : (
               <span />
             )}
-            <p className="text-xs text-gray-400">{message.length} / 4000</p>
+            <p className="text-xs text-gray-400">{message.length} / {CONTACT_MESSAGE_MAX_LENGTH}</p>
           </div>
         </div>
 

--- a/lib/contact-prefill.ts
+++ b/lib/contact-prefill.ts
@@ -1,0 +1,31 @@
+/**
+ * Maximum number of characters the contact-form message textarea accepts.
+ * Matches the `maxLength` attribute on the `<textarea>` in
+ * components/contact-form.tsx, so a URL-prefilled value can never start out
+ * past the limit the UI already enforces.
+ */
+export const CONTACT_MESSAGE_MAX_LENGTH = 4000;
+
+/**
+ * Normalize a `message` value coming from the contact page's URL search params
+ * into a safe plain-text prefill for the message textarea.
+ *
+ * - Accepts the raw `string | string[] | undefined` shape Next.js exposes for
+ *   query params (repeated `?message=a&message=b` arrives as `["a","b"]`); when
+ *   given an array it uses the first value.
+ * - Trims surrounding whitespace and returns "" for missing/blank/invalid
+ *   input, so an absent or malformed param leaves the message blank.
+ * - Clamps to {@link CONTACT_MESSAGE_MAX_LENGTH} using UTF-16 code units, the
+ *   same unit the textarea's `maxLength` and character counter use.
+ * - Preserves Unicode (incl. Japanese) and internal line breaks.
+ *
+ * The value is treated strictly as plain textarea text — it is never rendered
+ * as HTML and never auto-submits the form.
+ */
+export function normalizeMessagePrefill(value: string | string[] | undefined): string {
+  const first = Array.isArray(value) ? value[0] : value;
+  if (typeof first !== "string") return "";
+  const trimmed = first.trim();
+  if (trimmed.length === 0) return "";
+  return trimmed.slice(0, CONTACT_MESSAGE_MAX_LENGTH);
+}

--- a/tests/contact-prefill.test.ts
+++ b/tests/contact-prefill.test.ts
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { CONTACT_MESSAGE_MAX_LENGTH, normalizeMessagePrefill } from "@/lib/contact-prefill";
+
+test("normalizeMessagePrefill returns a normal English message unchanged", () => {
+  const msg = "Hi David, I'd like a private walkthrough of Dazbeez Receipts.";
+  assert.equal(normalizeMessagePrefill(msg), msg);
+});
+
+test("normalizeMessagePrefill preserves Japanese (Unicode) text", () => {
+  const msg = "Dazbeez Receiptsの個別ウォークスルーを希望します。";
+  assert.equal(normalizeMessagePrefill(msg), msg);
+});
+
+test("normalizeMessagePrefill uses the first value for repeated params / array input", () => {
+  // Next.js surfaces ?message=a&message=b as ["a", "b"].
+  assert.equal(normalizeMessagePrefill(["first message", "second message"]), "first message");
+});
+
+test("normalizeMessagePrefill returns empty string for missing, blank, or invalid input", () => {
+  assert.equal(normalizeMessagePrefill(undefined), "");
+  assert.equal(normalizeMessagePrefill(""), "");
+  assert.equal(normalizeMessagePrefill("    "), "");
+  assert.equal(normalizeMessagePrefill("\n\t  \n"), "");
+  assert.equal(normalizeMessagePrefill([]), "");
+  assert.equal(normalizeMessagePrefill([""]), "");
+});
+
+test("normalizeMessagePrefill trims surrounding whitespace but preserves internal line breaks", () => {
+  assert.equal(normalizeMessagePrefill("  hello there  "), "hello there");
+  assert.equal(normalizeMessagePrefill("\n\nLine one\nLine two\n\n"), "Line one\nLine two");
+});
+
+test("normalizeMessagePrefill clamps to the textarea's 4000-character limit", () => {
+  const long = "a".repeat(CONTACT_MESSAGE_MAX_LENGTH + 50);
+  const result = normalizeMessagePrefill(long);
+  assert.equal(result.length, CONTACT_MESSAGE_MAX_LENGTH);
+  assert.equal(result, long.slice(0, CONTACT_MESSAGE_MAX_LENGTH));
+
+  // A value exactly at the limit is left untouched.
+  const exact = "b".repeat(CONTACT_MESSAGE_MAX_LENGTH);
+  assert.equal(normalizeMessagePrefill(exact), exact);
+});


### PR DESCRIPTION
Bio_HP now links to /contact?message=<encoded>. Add safe plain-text prefilling of the contact-form message field from that query param.

- lib/contact-prefill.ts: pure normalizeMessagePrefill() — first array value wins (repeated ?message=a&message=b), trims surrounding whitespace, returns "" for missing/blank/invalid, clamps to the textarea's 4000-char limit, preserves Unicode + internal line breaks.
- app/contact/page.tsx: read message searchParam, normalize, pass as defaultMessage with a stable key so in-route navigation re-applies the prefill without clobbering user typing. service behavior unchanged.
- components/contact-form.tsx: seed message state from defaultMessage; "Send another message" resets to defaultMessage; textarea maxLength + counter use the shared constant.
- tests/contact-prefill.test.ts: EN, JA Unicode, repeated/array param, missing/empty, whitespace, >4000 clamp (TDD: tests first).

Checks: npm test 679 pass / 0 fail, lint 0 errors, tsc clean, build:cf green. Value is plain textarea text only — never rendered as HTML, never auto-submitted; no identity/email fields prefilled.