### PR TITLE
receipts: unfinalize action + 事業目的 column on 照合CSVs

### DIFF
--- a/app/api/receipts/export/month/route.ts
+++ b/app/api/receipts/export/month/route.ts
@@ -351,6 +351,7 @@ export async function POST(request: Request) {
             row.expenseCategoryJa ??
             row.expenseCategoryCode ??
             "",
+          businessPurpose: row.businessPurpose ?? "",
           attendeeIds: ids,
           attendeeCount: count,
           receiptFileCell:

--- a/app/api/receipts/reconcile/unfinalize/route.ts
+++ b/app/api/receipts/reconcile/unfinalize/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server";
+import { requireReceiptsActor } from "@/lib/receipts/auth";
+import { unfinalizeReconciliation } from "@/lib/receipts/db";
+
+// Minimal beta-review reopen (operator decision 2026-07-20): reverse a finalized
+// AMEX reconciliation back to 'draft' so the month's receipts become editable
+// again. Not the full ADR 0009 audited-reopen machinery. Mirrors the finalize
+// route's auth + error-handling shape.
+
+export async function POST(request: Request) {
+  try {
+    const actor = await requireReceiptsActor(request.headers);
+
+    const body = (await request.json()) as { month?: string; reason?: string };
+    const month = body.month?.trim();
+    const reason = body.reason?.trim();
+
+    if (!month || !/^\d{4}-\d{2}$/.test(month)) {
+      return NextResponse.json(
+        { error: "month must be in YYYY-MM format." },
+        { status: 400 },
+      );
+    }
+    if (!reason) {
+      return NextResponse.json(
+        { error: "reason must be a non-empty string." },
+        { status: 400 },
+      );
+    }
+
+    await unfinalizeReconciliation(month, actor, reason);
+
+    return NextResponse.json({ ok: true, month }, { status: 200 });
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Unauthorized")) {
+      return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+    }
+    if (
+      error instanceof Error &&
+      error.message.includes("No finalized reconciliation found")
+    ) {
+      return NextResponse.json(
+        { error: error.message },
+        { status: 404 },
+      );
+    }
+    console.error("[api/receipts/reconcile/unfinalize] failed", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Unfinalize failed." },
+      { status: 500 },
+    );
+  }
+}

--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -3157,3 +3157,45 @@ export async function finalizeReconciliation(
     newValueJson: stringifyJson({ manifestR2Key, manifestSha256 }),
   });
 }
+
+// Reverse a finalized AMEX reconciliation back to 'draft' so receipts in the
+// statement month become editable again. Minimal beta-review reopen (operator
+// decision 2026-07-20) — not the full ADR 0009 audited-reopen machinery.
+// `createReconciliationDraft` already deletes any stale 'draft' row for the
+// month before inserting a fresh one, so the row this leaves behind is
+// harmlessly replaced whenever the operator re-runs the normal finalize flow.
+//
+// `db` is an optional testability seam (matches the email-intake /
+// crm-reply-monitor / month-lock pattern); production callers omit it and the
+// default binding resolves exactly as finalizeReconciliation does.
+export async function unfinalizeReconciliation(
+  statementMonth: string,
+  actor: string,
+  reason: string,
+  db: D1Database = getReceiptsDb(),
+): Promise<void> {
+  const row = await db
+    .prepare(
+      `SELECT id FROM amex_reconciliations WHERE statement_month = ? AND status = 'finalized' LIMIT 1`,
+    )
+    .bind(statementMonth)
+    .first<{ id: string }>();
+  if (!row) {
+    throw new Error(`No finalized reconciliation found for ${statementMonth}.`);
+  }
+  await db
+    .prepare(
+      `UPDATE amex_reconciliations
+       SET status = 'draft', finalized_by = NULL, finalized_at = NULL
+       WHERE id = ?`,
+    )
+    .bind(row.id)
+    .run();
+  await createAuditEntry(db, {
+    actor,
+    action: "amex.reconciliation_amended",
+    objectType: "amex_reconciliation",
+    objectId: row.id,
+    newValueJson: stringifyJson({ reason, statementMonth, unfinalized: true }),
+  });
+}

--- a/lib/receipts/reconciliation-files.ts
+++ b/lib/receipts/reconciliation-files.ts
@@ -111,6 +111,7 @@ export function buildEvidenceAssignments(
 
 export const AMEX_RECONCILIATION_APPEND_HEADERS = [
   "科目＆No.",
+  "事業目的",
   "会議-出席者ID",
   "人数",
   "領収書ファイル名",
@@ -120,6 +121,9 @@ export const AMEX_RECONCILIATION_APPEND_HEADERS = [
 export interface AmexLineAppend {
   /** 科目＆No label for matched lines; bare 勘定科目 for no-receipt lines. */
   kamokuNo: string;
+  /** 事業目的 (business purpose), read next to the category label; blank when
+   *  the matched receipt has no business_purpose (csvEscape("") → ""). */
+  businessPurpose: string;
   /** "; "-joined directory ids ("1; 2; 29"). "; " (not spaces) is a HARD rule:
    *  Excel date-coerces space-separated ids ("2 3 4" → 2-Mar-2004). */
   attendeeIds: string;
@@ -211,6 +215,7 @@ export function buildAmexReconciliationCsv(
         [
           ...normalized.map((f) => csvEscape(f)),
           csvEscape(append.kamokuNo),
+          csvEscape(append.businessPurpose),
           csvQuoteAlways(append.attendeeIds),
           csvEscape(append.attendeeCount),
           csvEscape(append.receiptFileCell),
@@ -266,6 +271,7 @@ export const PAYMENT_PATH_CSV_HEADERS = [
   "店舗名",
   "金額",
   "科目＆No.",
+  "事業目的",
   "会議-出席者ID",
   "人数",
   "領収書ファイル名",
@@ -301,6 +307,7 @@ export function buildPaymentPathReconciliationCsv(
               : (row.amountMinor / 100).toFixed(2),
         ),
         csvEscape(assignment?.label ?? row.expenseCategoryJa ?? ""),
+        csvEscape(row.businessPurpose ?? ""),
         csvQuoteAlways(ids),
         csvEscape(count),
         csvEscape(

--- a/tests/receipts/reconciliation-files.test.ts
+++ b/tests/receipts/reconciliation-files.test.ts
@@ -107,6 +107,7 @@ test("buildAmexReconciliationCsv: frame rows verbatim, header + charge rows appe
   const appends = new Map<number, AmexLineAppend>([
     [6, {
       kamokuNo: "会議費Jun2026①",
+      businessPurpose: "クライアント打ち合わせ",
       attendeeIds: "1; 2; 29",
       attendeeCount: "3",
       receiptFileCell: "会議費Jun2026①小田原みなと食堂¥6,490.jpg",
@@ -128,7 +129,7 @@ test("buildAmexReconciliationCsv: frame rows verbatim, header + charge rows appe
   // (¥6,490) so csvEscape wraps it.
   assert.equal(
     out[5],
-    '2026/04/17,小田原みなと食堂,,1回,,6490,,会議費Jun2026①,"1; 2; 29",3,"会議費Jun2026①小田原みなと食堂¥6,490.jpg"',
+    '2026/04/17,小田原みなと食堂,,1回,,6490,,会議費Jun2026①,クライアント打ち合わせ,"1; 2; 29",3,"会議費Jun2026①小田原みなと食堂¥6,490.jpg"',
   );
   // 小計/合計 rows verbatim.
   assert.equal(out[7], ",【小計】,,,,8195,");
@@ -139,6 +140,7 @@ test("buildAmexReconciliationCsv: comma-split amount rows normalize to 7 fields 
   const appends = new Map<number, AmexLineAppend>([
     [7, {
       kamokuNo: "旅費交通費Jun2026①",
+      businessPurpose: "",
       attendeeIds: "",
       attendeeCount: "",
       receiptFileCell: "旅費交通費Jun2026①ENEOS¥1,705.jpg",
@@ -150,7 +152,7 @@ test("buildAmexReconciliationCsv: comma-split amount rows normalize to 7 fields 
   const cells = out[6]!.split(",");
   assert.equal(cells[0], "2026/05/02");
   assert.equal(cells[5], "1705");
-  // 7 base + 4 appended = 11 cells (ids cell is quoted-empty).
+  // 7 base + 5 appended = 12 cells (ids cell is quoted-empty).
   assert.equal(out[6]!.includes("旅費交通費Jun2026①"), true);
 });
 
@@ -158,13 +160,14 @@ test("buildAmexReconciliationCsv: lines without appends and missing-receipt cell
   const appends = new Map<number, AmexLineAppend>([
     [6, {
       kamokuNo: "通信費",
+      businessPurpose: "",
       attendeeIds: "",
       attendeeCount: "",
       receiptFileCell: missingReceiptCell("Monthly expense"),
     }],
   ]);
   const out = buildAmexReconciliationCsv(STATEMENT, appends).split("\n");
-  assert.ok(out[5]!.endsWith("通信費,\"\",,領収書なし：Monthly expense"), out[5]);
+  assert.ok(out[5]!.endsWith("通信費,,\"\",,領収書なし：Monthly expense"), out[5]);
   // Charge row 7 got no append entry → passes through verbatim.
   assert.equal(out[6], "2026/05/02,ENEOS,,1回,,1,705,");
 });
@@ -245,7 +248,7 @@ test("buildPaymentPathReconciliationCsv: lean header + attendees + evidence (dra
   );
   const lines = csv.split("\n");
   assert.equal(lines[0], PAYMENT_PATH_CSV_HEADERS.join(","));
-  assert.equal(lines[0], "No,利用日,店舗名,金額,科目＆No.,会議-出席者ID,人数,領収書ファイル名");
+  assert.equal(lines[0], "No,利用日,店舗名,金額,科目＆No.,事業目的,会議-出席者ID,人数,領収書ファイル名");
   assert.ok(lines[1]!.startsWith("1,2026-06-10,セブン-イレブン,1200,"), "No restarts at 1; lean columns");
   assert.ok(lines[1]!.includes("消耗品費Jun2026①"), "科目＆No appended");
   assert.ok(
@@ -264,4 +267,44 @@ test("buildPaymentPathReconciliationCsv: receipt without assignment gets 領収�
     new Map(),
   );
   assert.ok(csv.split("\n")[1]!.endsWith(",領収書なし"), csv);
+});
+
+// ─── 事業目的 (BusinessPurpose) column ──────────────────────────────────────
+
+test("buildAmexReconciliationCsv: empty businessPurpose renders an empty cell, not 'null'/'undefined'", () => {
+  const appends = new Map<number, AmexLineAppend>([
+    [6, {
+      kamokuNo: "会議費Jun2026①",
+      businessPurpose: "",
+      attendeeIds: "1; 2",
+      attendeeCount: "2",
+      receiptFileCell: "evidence.jpg",
+    }],
+  ]);
+  const row = buildAmexReconciliationCsv(STATEMENT, appends).split("\n")[5]!;
+  assert.ok(!row.includes("null"), `must not render literal null: ${row}`);
+  assert.ok(!row.includes("undefined"), `must not render literal undefined: ${row}`);
+  // 科目＆No. immediately followed by an empty 事業目的 cell, then the quoted ids.
+  assert.ok(
+    row.includes("会議費Jun2026①,,"),
+    `expected empty 事業目的 cell after 科目＆No, got: ${row}`,
+  );
+});
+
+test("buildPaymentPathReconciliationCsv: null businessPurpose renders an empty cell, not 'null'/'undefined'", () => {
+  const csv = buildPaymentPathReconciliationCsv(
+    [receiptRow({ businessPurpose: null })],
+    new Map(),
+    DIRECTORY,
+    {},
+    new Map(),
+  );
+  const row = csv.split("\n")[1]!;
+  assert.ok(!row.includes("null"), `must not render literal null: ${row}`);
+  assert.ok(!row.includes("undefined"), `must not render literal undefined: ${row}`);
+  // 科目＆No. (消耗品費, no assignment) followed by an empty 事業目的 cell.
+  assert.ok(
+    row.includes("消耗品費,,"),
+    `expected empty 事業目的 cell after 科目＆No, got: ${row}`,
+  );
 });

--- a/tests/receipts/reconciliation-unfinalize.test.ts
+++ b/tests/receipts/reconciliation-unfinalize.test.ts
@@ -1,0 +1,98 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { unfinalizeReconciliation } from "@/lib/receipts/db";
+
+// ─── Recording fake D1 ───────────────────────────────────────────────────────
+//
+// unfinalizeReconciliation issues three statements against the binding:
+//   1. SELECT id FROM amex_reconciliations WHERE statement_month=? AND status='finalized'
+//   2. UPDATE amex_reconciliations SET status='draft', finalized_by=NULL, finalized_at=NULL WHERE id=?
+//   3. INSERT INTO receipt_audit_log ... (via createAuditEntry)
+//
+// This codebase unit-tests db functions by injecting a fake D1 — see
+// email-intake, crm-reply-monitor, and month-lock tests. unfinalizeReconciliation
+// takes `db` as an optional 4th param purely as this testability seam (production
+// callers omit it; the default resolves the live binding). Live-D1 mutation
+// semantics are additionally exercised when the operator unfinalizes 2026-06.
+
+type RunCall = { sql: string; args: unknown[] };
+
+function createRecordingDb(finalizedRow: { id: string } | null) {
+  const runs: RunCall[] = [];
+  const db = {
+    prepare(sql: string) {
+      return {
+        bind(...args: unknown[]) {
+          return {
+            async first<T = unknown>(): Promise<T | null> {
+              // Only the finalized-row SELECT reads via .first(); the UPDATE and
+              // the audit INSERT use .run(). The SELECT is identified by its
+              // status='finalized' predicate (the UPDATE sets status='draft').
+              const isFinalizedSelect =
+                /FROM amex_reconciliations/i.test(sql) &&
+                /status = 'finalized'/i.test(sql);
+              return (isFinalizedSelect ? finalizedRow : null) as T | null;
+            },
+            async run(): Promise<{ meta: { changes: number } }> {
+              runs.push({ sql, args });
+              return { meta: { changes: 1 } };
+            },
+          };
+        },
+      };
+    },
+  };
+  return { db: db as unknown as D1Database, runs };
+}
+
+// ─── Happy path ──────────────────────────────────────────────────────────────
+
+test("unfinalizeReconciliation: finalized row → status 'draft', finalized_by/at NULL, audit 'amended'", async () => {
+  const { db, runs } = createRecordingDb({ id: "rec-2026-06" });
+
+  await unfinalizeReconciliation(
+    "2026-06",
+    "david@example.com",
+    "beta review — receipt corrections before accountant delivery",
+    db,
+  );
+
+  // UPDATE targets the right row and clears the finalize fields.
+  const update = runs.find((r) => /UPDATE amex_reconciliations/i.test(r.sql));
+  assert.ok(update, "expected an UPDATE against amex_reconciliations");
+  assert.equal(update!.args[0], "rec-2026-06");
+  assert.match(update!.sql, /status = 'draft'/i);
+  assert.match(update!.sql, /finalized_by = NULL/i);
+  assert.match(update!.sql, /finalized_at = NULL/i);
+  assert.match(update!.sql, /WHERE id = \?/i);
+
+  // Audit INSERT carries the pre-declared amended action + reconciliation ref.
+  const audit = runs.find((r) => /INSERT INTO receipt_audit_log/i.test(r.sql));
+  assert.ok(audit, "expected an audit INSERT");
+  // bind order: id, actor, action, object_type, object_id, old_value_json, new_value_json, created_at
+  assert.equal(audit!.args[1], "david@example.com");
+  assert.equal(audit!.args[2], "amex.reconciliation_amended");
+  assert.equal(audit!.args[3], "amex_reconciliation");
+  assert.equal(audit!.args[4], "rec-2026-06");
+  assert.deepEqual(JSON.parse(String(audit!.args[6])), {
+    reason: "beta review — receipt corrections before accountant delivery",
+    statementMonth: "2026-06",
+    unfinalized: true,
+  });
+});
+
+// ─── Throw path: nothing to unfinalize ───────────────────────────────────────
+
+test("unfinalizeReconciliation: no finalized row → throws, writes nothing", async () => {
+  const { db, runs } = createRecordingDb(null);
+
+  await assert.rejects(
+    unfinalizeReconciliation("2026-06", "david@example.com", "noop", db),
+    /No finalized reconciliation found for 2026-06/,
+  );
+  assert.equal(
+    runs.length,
+    0,
+    "no UPDATE or audit INSERT should fire when no finalized row exists",
+  );
+});


### PR DESCRIPTION
## Summary

Two independent features for the 2026-06 beta-review cycle (worker task per `prompts/WORKER-PROMPT-unlock-2026-06.md`).

### Part 1 — Minimal unfinalize for `amex_reconciliations`
Operator decision 2026-07-20: a reusable beta-review reopen (not the full ADR 0009 audited machinery) so reopening a finalized month during beta doesn't require hand-written SQL every time.

- `unfinalizeReconciliation(statementMonth, actor, reason, db?)` in `lib/receipts/db.ts` — flips `status → 'draft'`, nulls `finalized_by`/`finalized_at`, writes an `amex.reconciliation_amended` audit entry (that action was pre-declared in the `AuditAction` union but unused). The optional `db` param defaults to `getReceiptsDb()` — a testability seam invisible to production callers, matching the `email-intake` / `crm-reply-monitor` / `month-lock` pattern. Architect-approved.
- `POST /api/receipts/reconcile/unfinalize` mirrors the finalize route (`requireReceiptsActor`, validates `month` + non-empty `reason`, 404 on "no finalized reconciliation", 401 on unauthorized).
- No migration: uses existing `amex_reconciliations` columns and `receipt_audit_log`. `createReconciliationDraft` already deletes stale drafts, so the row left behind is harmlessly replaced on re-finalize.

### Part 2 — `事業目的` (BusinessPurpose) on the 照合CSVs
The machine-layer receipts CSV already had `BusinessPurpose`; the two accountant-facing reconcile CSVs (`lib/receipts/reconciliation-files.ts`) did not.

- `事業目的` added after `科目＆No.` in both `AMEX_RECONCILIATION_APPEND_HEADERS` and `PAYMENT_PATH_CSV_HEADERS`; emitted in both builders (`row.businessPurpose ?? ""` → empty cell when null, never `"null"`/`"undefined"`).
- Wired into `appends.set` in the export month route.
- ⚠️ **Deliverable-format change** — accountant to be notified before next delivery (same category as backlog #1). Only affects future export runs; nothing already shipped changes.

## Verification
- `tsc --noEmit` clean
- `npm test` — 738 pass / 0 fail / 1 skipped (4 new tests: 2 unfinalize, 2 business-purpose empty-cell)
- `npm run build:cf` — exit 0

## Follow-ups (not in this PR)
- Use this route to unfinalize 2026-06, then apply David's receipt review edits (Part 4 of the worker task), then re-seal per his call.
- Accountant heads-up on the new 照合CSV column before the next delivery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)