### PR TITLE
receipts: unified draft carve-out for the month locks (ADR 0012)

### DIFF
--- a/app/api/receipts/[id]/route.ts
+++ b/app/api/receipts/[id]/route.ts
@@ -19,7 +19,7 @@ import { getComplianceSettings } from "@/lib/receipts/settings";
 import {
   validateInvoiceRegistrationNumber,
 } from "@/lib/receipts/invoice";
-import { ExportFinalizedError } from "@/lib/receipts/month-lock";
+import { ExportFinalizedError, isMonthLockedForEdits } from "@/lib/receipts/month-lock";
 import type {
   QualifiedInvoiceStatus,
   SourceType,
@@ -95,21 +95,30 @@ export async function PATCH(request: Request, { params }: RouteContext) {
       return NextResponse.json({ error: "Receipt not found." }, { status: 404 });
     }
 
-    if (receipt.status === "exported" || receipt.status === "archived") {
-      // Surface the revision endpoint when the receipt shipped in a
-      // finalized export — the operator can't edit it directly and must
-      // open a correction. exported_month tells us which month's revision
-      // endpoint to point at (audit A5 split-lock model).
-      const revisionHint =
-        receipt.status === "exported" && receipt.exported_month
-          ? ` POST /api/receipts/export/${receipt.exported_month}?correction=true to create a revision.`
-          : "";
+    // 'archived' is terminal — always refused. 'exported' is editable under the
+    // unified draft carve-out (ADR 0012): refuse only when the receipt has no
+    // exported_month or its month has no open correction draft.
+    if (receipt.status === "archived") {
       return NextResponse.json(
-        {
-          error: `Receipt is ${receipt.status} and cannot be edited.${revisionHint}`,
-        },
+        { error: `Receipt is ${receipt.status} and cannot be edited.` },
         { status: 409 },
       );
+    }
+    if (receipt.status === "exported") {
+      const month = receipt.exported_month;
+      const locked = !month || (await isMonthLockedForEdits(getReceiptsDb(), month));
+      if (locked) {
+        const revisionHint = month
+          ? ` POST /api/receipts/export/${month}?correction=true to create a revision.`
+          : "";
+        return NextResponse.json(
+          {
+            error: `Receipt is ${receipt.status} and cannot be edited.${revisionHint}`,
+          },
+          { status: 409 },
+        );
+      }
+      // Carve-out released (open draft) → fall through to the normal PATCH path.
     }
 
     const body = (await request.json()) as {
@@ -369,7 +378,18 @@ export async function DELETE(request: Request, { params }: RouteContext) {
     const actor = await requireReceiptsActor(request.headers);
     const { id } = await params;
 
-    await softDeleteReceipt(id, actor);
+    // Reason is optional for ordinary receipts but REQUIRED for exported ones
+    // (audit A1 loud-failure theme — softDeleteReceipt enforces it). Parse
+    // defensively: a missing/empty/non-JSON body is treated as no reason.
+    let reason: string | undefined;
+    try {
+      const body = (await request.json()) as { reason?: string };
+      reason = body.reason?.trim() || undefined;
+    } catch {
+      reason = undefined;
+    }
+
+    await softDeleteReceipt(id, actor, reason);
 
     return NextResponse.json({ ok: true }, { status: 200 });
   } catch (error) {
@@ -381,6 +401,9 @@ export async function DELETE(request: Request, { params }: RouteContext) {
     }
     if (error instanceof Error && error.message.includes("not found")) {
       return NextResponse.json({ error: "Receipt not found." }, { status: 404 });
+    }
+    if (error instanceof Error && error.message.includes("requires a non-empty reason")) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
     }
     console.error("[api/receipts/[id]] DELETE failed", error);
     return NextResponse.json(

--- a/components/receipts/review/form-pane.tsx
+++ b/components/receipts/review/form-pane.tsx
@@ -502,8 +502,8 @@ export function FormPane(props: FormPaneProps) {
           <span>
             {lockKind === "reconciliation" ? (
               <>
-                The {lockMonth} AMEX reconciliation is finalized. Reopen it to
-                edit.{" "}
+                The {lockMonth} AMEX reconciliation is finalized. Reopen it — or
+                open a correction export draft for {lockMonth} — to edit.{" "}
                 <Link
                   href="/receipts/reconcile"
                   className="font-semibold text-gray-900 underline"

--- a/docs/adr/0012-unified-draft-carveout-month-locks.md
+++ b/docs/adr/0012-unified-draft-carveout-month-locks.md
@@ -1,0 +1,76 @@
+# ADR 0012 — Unified draft carve-out for the month locks
+
+- **Status:** Accepted
+- **Date:** 2026-07-20 (proposed) · 2026-07-20 (accepted, operator)
+- **Owner:** David (PM)
+- **Supersedes:** —
+- **Superseded by:** —
+- **Related:** [ADR 0004](0004-split-lock-model-cash-receipts.md) (split-lock model — this extends its F1 carve-out to all three gates), [ADR 0009](0009-sealed-month-amendment-policy.md) (audited sealed-month amendment machinery — still future work; this unblocks beta correction without replacing it), `docs/audits/2026-07-20-monthly-seal-lock-system.md` (the handoff findings this responds to), `lib/receipts/month-lock.ts` (`isMonthLockedForEdits` — the single authority), `lib/receipts/receipt-locks.ts` (review-queue lock surface), `lib/receipts/db.ts` (`rejectIfReceiptInFinalizedReconciliation`, `softDeleteReceipt`)
+- **Affects:** `app/api/receipts/[id]/route.ts` (PATCH gate #3 carve-out; DELETE now parses+passes a reason), `lib/receipts/db.ts` (`softDeleteReceipt` allows `exported` under carve-out + requires reason; `rejectIfReceiptInFinalizedReconciliation` releases receipt edits under carve-out), `lib/receipts/receipt-locks.ts` (`loadReconciliationLockedReceiptIds` excludes draft months), `components/receipts/review/form-pane.tsx` (lock copy), module headers in `receipt-locks.ts` + `month-lock.ts`
+
+## Decision record (2026-07-20)
+
+### Context
+
+The 2026-07-20 worker handoff (`docs/audits/2026-07-20-monthly-seal-lock-system.md`)
+found that the documented two-lock split model (ADR 0004: export lock for
+non-AMEX receipts, reconciliation lock for AMEX, each draft-aware via the F1
+carve-out) was **defeated by a third, ad-hoc per-receipt status gate**. The
+PATCH handler (`app/api/receipts/[id]/route.ts`) and `softDeleteReceipt`
+(`lib/receipts/db.ts`) hard-refused `status='exported'` with **no draft
+carve-out**, and nothing in the codebase ever reverted a receipt off `exported`.
+Net effect: once a receipt shipped in a finalized export, it was permanently
+non-editable and non-deletable via any API route — even while a correction draft
+was open. This blocked the entire 2026-06 beta-review edit pass and made the
+revision flow's own error advice ("create a revision") self-defeating for data
+edits (the flow only ever supported format/regeneration — e.g. the 2026-06 rev2
+proofs/No-column transition).
+
+### Operator decisions (David, 2026-07-20 — all three confirmed explicitly)
+
+1. **Gate #3 gets the F1 draft carve-out.** `status='exported'` blocks
+   PATCH/DELETE only when the receipt's `exported_month` has no open draft
+   revision. The authority is the existing `isMonthLockedForEdits(db, month)`
+   (finalized + no draft ⇒ locked). No status reverting — `createExportRevision`
+   stays receipt-untouched; abandoning/deleting a draft auto-relocks.
+2. **Deletes stay soft.** `softDeleteReceipt` is extended to allow `exported`
+   under the same carve-out, with a **non-empty reason required** for the
+   exported branch (loud-failure / audit theme). `hardDeleteReceipt` stays
+   routeless — sealed revision manifests reference R2 originals by hash/key, and
+   those objects must survive a soft-delete (which only sets `deleted_at`).
+3. **Reconciliation lock becomes draft-aware for RECEIPT edits only.**
+   `rejectIfReceiptInFinalizedReconciliation` releases when the matched
+   statement month is not locked per `isMonthLockedForEdits`. The LINE-level
+   seal (`rejectIfFinalized` on `amex_statement_lines` writes) stays strict — a
+   format-only export revision must NOT reopen match assignments. This scoping is
+   an architect mitigation David accepted; it is not to be widened.
+
+### Mitigation: receipt-scope vs line-scope
+
+A correction export draft reopens the month for **receipt data edits**
+(business purpose, attendees, category, soft-delete) but explicitly does **not**
+reopen **match assignments** — `amex_statement_lines` writes still pass through
+`rejectIfFinalized`, which is untouched. Rationale: a format/regeneration
+revision (proofs bundle, column layout) should never silently unlock the
+statement-to-receipt match layer that the reconciliation seal protects. If match
+assignments themselves need reopening, the operator uses `unfinalizeReconciliation`
+(PR #139) — the reconciliation stays `finalized` otherwise.
+
+### Consequences
+
+- **An open export draft is the single "month open for correction" signal.**
+  One mechanism, three gates released (for receipt edits). The operator no longer
+  reasons about three independent locks to correct a sealed month.
+- **`unfinalizeReconciliation` is reserved for the match layer.** It is no longer
+  needed to make a month's receipts editable (a draft does that) — only to reopen
+  statement-line match assignments.
+- **`hardDeleteReceipt` remains unreachable from the API.** Soft-delete under the
+  carve-out is the supported removal path for shipped receipts; the R2 originals
+  are preserved by design.
+- **ADR 0009's full audited-grounds amendment machinery remains future work** —
+  this ADR unblocks beta correction cycles without replacing it. Nothing here
+  weakens the finalized-row permanence principle (finalized exports/reconciliations
+  are never mutated; only their receipts become editable while a draft exists).
+- **Review-queue lock surface mirrors the server** (`receipt-locks.ts`): the
+  reconciliation side excludes months with an open draft, so the queue never
+  over-reports a 409 the server would no longer throw.

--- a/docs/audits/2026-07-20-monthly-seal-lock-system.md
+++ b/docs/audits/2026-07-20-monthly-seal-lock-system.md
@@ -1,0 +1,173 @@
+# Architect handoff — 2026-06 monthly seal & locking system review
+
+**From:** Mac worker session (Claude Code CLI), 2026-07-20
+**Task of record:** `prompts/WORKER-PROMPT-unlock-2026-06.md`
+**Operator decision (David, 2026-07-20):** stop attempting Part-4 edits; escalate
+for a **full review and revision plan of the monthly seal and locking system**.
+Nothing below is a request to improvise — it is a snapshot + findings for the
+architect to design against.
+
+---
+
+## TL;DR
+
+The codebase has a **cleanly documented 2-lock split model** (export lock for
+non-AMEX receipts, reconciliation lock for AMEX, both intended to be
+draft-aware). It is **defeated by a third, ad-hoc per-receipt status gate** that
+has no draft carve-out and is **never reverted**. Net effect: once a receipt is
+`status='exported'` it is **permanently non-editable and non-deletable via any
+API route**, even when the two designed locks would allow the edit (e.g. while a
+correction draft is open). This blocked 100% of the Part-4 review edits and made
+the revision flow's own error advice ("create a revision") self-defeating for
+data edits. The reconciliation for 2026-06 was also never actually unfinalized.
+Requesting a unified review + revision plan (open questions at the end).
+
+---
+
+## What shipped this session (LIVE on dazbeez.com via CI)
+
+PR #139 (merge `5e0233e`, auto-deployed, CI verify+deploy+smoke green):
+
+1. **`unfinalizeReconciliation(statementMonth, actor, reason, db?)`** — `lib/receipts/db.ts` (after `finalizeReconciliation`, ~L3160). Flips `amex_reconciliations` `status→'draft'`, nulls `finalized_by/finalized_at`, writes `amex.reconciliation_amended` audit. Optional `db` param = testability seam (default `getReceiptsDb()`, invisible to callers). **Reverses the RECONCILIATION lock only — does NOT touch the export lock or receipt status** (see gap #3).
+2. **POST `/api/receipts/reconcile/unfinalize`** — mirrors the finalize route (`requireReceiptsActor`, validates month + non-empty reason, 404/401 handling).
+3. **事業目的 (BusinessPurpose) column** on the accountant-facing 照合CSVs (`lib/receipts/reconciliation-files.ts`): added after `科目＆No.` in `AMEX_RECONCILIATION_APPEND_HEADERS` + `PAYMENT_PATH_CSV_HEADERS`; emitted in both builders; wired in `app/api/receipts/export/month/route.ts`. **Deliverable-format change** — accountant to be notified before next delivery (backlog-#1 category).
+4. Tests: 4 new (2 unfinalize, 2 business-purpose); full suite 738 pass / 0 fail / 1 skipped; `tsc --noEmit` clean; `build:cf` exit 0.
+
+---
+
+## Current snapshot of 2026-06 (live D1, 2026-07-20)
+
+| Layer | State |
+|---|---|
+| `amex_reconciliations` | **`status=finalized`** (`finalized_at=2026-07-12`, by david.klan@gmail.com) — **never unfinalized**. The Part-3 unfinalize curl was not confirmed to have taken effect (see "misleading signal" below). |
+| `receipt_exports` | rev1 **finalized** (07-12); rev2 **finalized** (07-15, reason "tranche1"); **rev3 DRAFT** (07-18, reason "Draft 2 submit for review"). |
+| `receipt_records` | **33 receipts** in 2026-06 scope, **all `status=exported`**, none editable or deletable via any API route today. |
+
+**Pending Part-4 edits (NONE applied — all blocked):**
+- **a** — `business_purpose = "交通系ICカードチャージ(Klan)"` on 4 CASH IC-card top-up receipts: `0802caae-5c18-4f71-86db-364e9d9b3264` (06-02), `ca757eb0-98a6-41ea-b87b-9c2b98c55b43` (06-11), `113480df-66d9-431e-83fa-ac1c5f482748` (06-22), `e47e27a7-2152-4755-abb6-17cc994ef993` (06-27).
+- **b** — delete ¥60 CASH receipt `4af7dea8-2dba-479d-971c-e874e6895f19` (2026-06-22, セブン-イレブン 東中野末広橋店).
+- **c** — attendees on May-1/May-2 charges (AMEX lines in the June statement; 10 lines total, 9 distinct receipts; receipt-level attendees today via `receipt_attendees`, 0 line-level). David to specify which + names.
+- **d** — expense-category changes on specific receipts. David to specify.
+
+**Operator decisions on record:** leave 2026-06 open; David finalizes manually later; beta — nothing shipped to the accountant.
+
+---
+
+## The monthly seal & locking system as-built
+
+The authoritative design description is the header of `lib/receipts/receipt-locks.ts`
+(L1–23, "split-lock model, audit A5"). Two independent locks own **disjoint
+populations**:
+
+1. **EXPORT lock** — `isMonthLockedForEdits` (`lib/receipts/month-lock.ts`) +
+   `loadSealedExportMonths`. Applies to **non-AMEX** receipts' transaction month.
+   **F1 carve-out**: finalized export + open draft → **released**.
+   → 2026-06: **RELEASED** (rev3 draft exists). `month-lock.test.ts` F1 covers this.
+2. **RECONCILIATION lock** — `rejectIfReceiptInFinalizedReconciliation`
+   (`db.ts` ~L2966) + `isAmexLikeForLock` (`receipt-locks.ts:101`). Applies to
+   **AMEX/UNKNOWN** receipts matched to a finalized `amex_reconciliations` line.
+   **No carve-out** — finalize is the seal; `unfinalizeReconciliation` (new) is the
+   manual reverse.
+   → 2026-06: **ENGAGED** (reconciliation finalized) for AMEX receipts matched to June lines.
+
+…plus a **third gate that is NOT in the documented split model**:
+
+3. **Per-receipt STATUS gate** — `PATCH app/api/receipts/[id]/route.ts:98`
+   (`if (receipt.status === "exported" || "archived") → 409`) and `DELETE`
+   (`softDeleteReceipt` `db.ts:565`, refuses any status outside
+   `captured/needs_review/reviewed`). **Hard status check, no draft carve-out.**
+   → 2026-06: **ENGAGED** for all 33 exported receipts.
+
+Supporting facts:
+- `hardDeleteReceipt` (`db.ts:186`) exists — **no status gate**, cascades
+  (nulls AMEX line refs, deletes files/attendees/record, writes audit with
+  reason) — but has **no public route**. The `DELETE` route calls `softDeleteReceipt`
+  instead. So there is **no API path at all** to remove an exported receipt.
+- Receipt status lifecycle writes: →`reconciled` (`db.ts:1296/1312`), →`needs_review`
+  **only from `reconciled`** (`db.ts:1334`), →`exported` (`finalizeExport` `db.ts:2880`).
+  **Nothing anywhere reverts a receipt off `exported`.**
+- `createExportRevision` (`db.ts` ~L2925) inserts a draft `receipt_exports` row +
+  audit; it does **not** touch `receipt_records`. So opening a revision does not
+  unfreeze the receipts.
+
+---
+
+## Gaps & inconsistencies (core findings)
+
+1. **Gate #3 is an undocumented third lock with no carve-out — it overrides the
+   designed model.** While rev3 draft is open, the EXPORT lock (#1) says
+   "editable," but gate #3 says "locked"; the stricter one wins, so exported
+   receipts stay frozen. **This is the direct Part-4 blocker.**
+2. **Nothing reverts `status` off `exported`** ⇒ a shipped receipt is permanently
+   immutable via API. The revision flow's own error message ("POST
+   …/export/<month>?correction=true to create a revision") is **self-defeating for
+   data edits**: `createExportRevision` opens a draft but changes no receipt, so
+   creating the revision does not unfreeze anything. The revision flow has only
+   ever been used for **format/regeneration** (rev2 = proofs ZIP / No-column
+   transition), never for editing exported receipt data. Missing link: either
+   (a) add the F1 carve-out to gate #3, or (b) revert receipt status when a draft
+   opens.
+3. **`unfinalizeReconciliation` (shipped this session) reverses only gate #2.** It
+   does not release the export lock (#1) or receipt status (#3). "Unfinalize the
+   reconciliation" therefore never makes a month fully editable on its own — which
+   is exactly what the operator hit ("the reversal didn't clean the receipts").
+4. **DELETE vs PATCH gates diverge from each other and from the F1 model.** Both
+   key on `status='exported'`; neither is draft-aware.
+5. **`hardDeleteReceipt` is unreachable.** The one function that could delete an
+   exported receipt (no status gate) has no route; the DELETE route soft-deletes
+   instead. No API path removes an exported receipt.
+6. **Reconciliation lock has no F1-style carve-out**, unlike the export lock —
+   finalized reconciliation = AMEX receipts frozen until a *manual* unfinalize.
+   Inconsistent with the export lock's draft-aware design.
+
+---
+
+## Why the step-3 "PATCH works" signal was misleading
+
+During Part 3, one June receipt PATCH reportedly succeeded and was taken
+(incorrectly) as proof the unfinalize had worked. The DB now shows the
+reconciliation was **never unfinalized**. The edit succeeded because of the
+split-lock model, not the unfinalize: the edited receipt was non-AMEX (subject
+to the EXPORT lock #1, which rev3's draft releases) and was not `status=exported`
+(dodged gate #3). Lesson: a successful PATCH is **not** evidence the
+reconciliation lock is released — only that the specific receipt fell outside
+both engaged locks.
+
+---
+
+## Request: full review + unified revision plan
+
+Open design questions for the architect (not an exhaustive list):
+
+- **Single "reopen month for correction" action?** Today the operator must reason
+  about 3 independent locks to edit a sealed month. Should one action reverse all
+  applicable locks (unfinalize reconciliation + ensure an open export draft +
+  unfreeze receipt status / relax gate #3)?
+- **How should data edits on exported receipts work?** Candidate fixes: (a) add
+  the F1 carve-out to gate #3 (`PATCH route.ts:98` + `DELETE db.ts:565`) so an open
+  draft unfreezes exported receipts; (b) revert receipt status off `exported` when
+  a draft opens (in `createExportRevision` or the rebuild). Which — or both — and
+  how do they interact with `finalizeExport` re-stamping on re-finalize?
+- **Reconciliation lock carve-out?** Should it become draft-aware (F1-style) for
+  consistency with the export lock, so opening a revision also releases AMEX
+  receipts without a separate manual unfinalize?
+- **Expose `hardDeleteReceipt` (or relax soft-delete under a draft)?** Today there
+  is no API path to remove an exported receipt — the ¥60 delete (Part 4b) is
+  impossible as-is. Decide the intended operator model for removing a receipt
+  that already shipped.
+- **Reconcile implementation vs the documented model.** `receipt-locks.ts` L1–23
+  describes a clean 2-lock split; gate #3 and the unreachable `hardDeleteReceipt`
+  break it. Either bring the code in line or update the model + the review-queue
+  lock surface to match.
+
+## Constraints / context for the plan
+
+- Beta; nothing has been delivered to the tax accountant. 2026-06 is to remain
+  open until David finalizes manually.
+- The Part-4 edits above (a/b/c/d) are the concrete unblock targets — the plan
+  should let them land.
+- `unfinalizeReconciliation` + the `/unfinalize` route (shipped, PR #139) are
+  available building blocks; fold them into the unified model rather than
+  re-creating.
+- The 事業目的 column (PR #139) changes the 照合CSV deliverable format — separate
+  accountant-notice item, but relevant if the revision plan touches export format.

--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -3,6 +3,7 @@ import { createAuditEntry } from "@/lib/receipts/audit";
 import { D1_ID_CHUNK_SIZE, nowIso, newUuid, stringifyJson } from "@/lib/receipts/db-utils";
 import {
   assertTransactionMonthEditable,
+  isMonthLockedForEdits,
   transactionMonthOf,
 } from "@/lib/receipts/month-lock";
 import { shouldOverwriteMerchant } from "@/lib/receipts/reconciliation";
@@ -345,13 +346,13 @@ export async function updateReceiptRecord(
   }
 }
 
-async function rejectIfReceiptInFinalizedReconciliation(
+export async function rejectIfReceiptInFinalizedReconciliation(
   db: D1Database,
   receiptId: string,
 ): Promise<void> {
   const finalized = await db
     .prepare(
-      `SELECT ar.id
+      `SELECT ar.id, ar.statement_month AS statement_month
        FROM amex_statement_lines asl
        JOIN amex_reconciliations ar
          ON ar.statement_month = asl.statement_month
@@ -360,8 +361,15 @@ async function rejectIfReceiptInFinalizedReconciliation(
        LIMIT 1`,
     )
     .bind(receiptId)
-    .first<{ id: string }>();
-  if (finalized) {
+    .first<{ id: string; statement_month: string }>();
+  if (!finalized) return;
+  // Unified draft carve-out (ADR 0012): a finalized reconciliation releases
+  // RECEIPT edits when its statement month has an open export draft — the same
+  // single "month open for correction" signal the export lock uses. The
+  // LINE-level seal (rejectIfFinalized on amex_statement_lines writes) is
+  // intentionally NOT released here: a format-only export revision must not
+  // reopen match assignments.
+  if (await isMonthLockedForEdits(db, finalized.statement_month)) {
     throw new Error(`Receipt ${receiptId} is locked by a finalized reconciliation.`);
   }
 }
@@ -552,20 +560,34 @@ export async function softDeleteReceipt(
   id: string,
   actor: string,
   reason?: string,
+  db: D1Database = getReceiptsDb(),
 ): Promise<void> {
-  const db = getReceiptsDb();
-
   const record = await db
-    .prepare(`SELECT id, status FROM receipt_records WHERE id = ? LIMIT 1`)
+    .prepare(`SELECT id, status, exported_month FROM receipt_records WHERE id = ? LIMIT 1`)
     .bind(id)
-    .first<{ id: string; status: string }>();
+    .first<{ id: string; status: string; exported_month: string | null }>();
 
   if (!record) throw new Error(`Receipt ${id} not found.`);
 
-  if (!DELETABLE_STATUSES.has(record.status)) {
+  // Unified draft carve-out (ADR 0012): an exported receipt becomes deletable
+  // when its month has an open correction draft (isMonthLockedForEdits → false).
+  // Other non-deletable statuses (archived, etc.) stay refused. A non-empty
+  // reason is mandatory for the exported branch (loud-failure / audit theme).
+  const exportCarveout =
+    record.status === "exported" &&
+    record.exported_month !== null &&
+    !(await isMonthLockedForEdits(db, record.exported_month));
+  if (!DELETABLE_STATUSES.has(record.status) && !exportCarveout) {
     throw new Error(
-      `Receipt cannot be deleted because its status is "${record.status}". Only captured, needs_review, and reviewed receipts may be deleted.`,
+      `Receipt cannot be deleted because its status is "${record.status}". Only captured, needs_review, and reviewed receipts may be deleted${
+        record.status === "exported"
+          ? " (or exported, while a correction draft is open for its month)"
+          : ""
+      }.`,
     );
+  }
+  if (record.status === "exported" && (!reason || !reason.trim())) {
+    throw new Error(`Deleting an exported receipt requires a non-empty reason.`);
   }
 
   const now = nowIso();
@@ -2963,7 +2985,7 @@ export async function createExportRevision(
 
 // ─── Reconciliation signoff ────────────────────────────────────────────────
 
-async function rejectIfFinalized(db: D1Database, month: string): Promise<void> {
+export async function rejectIfFinalized(db: D1Database, month: string): Promise<void> {
   const finalized = await db
     .prepare(
       `SELECT id FROM amex_reconciliations WHERE statement_month = ? AND status = 'finalized' LIMIT 1`,

--- a/lib/receipts/month-lock.ts
+++ b/lib/receipts/month-lock.ts
@@ -75,6 +75,16 @@ export function buildMonthLock(input: {
 // attempt would re-hit the finalized row and re-throw. The predicate
 // below treats "has draft revision" as a release of the lock; finalizing
 // the revision closes the lock again (draft goes away, finalized stays).
+//
+// ADR 0012 (2026-07-20) unifies this draft carve-out as the single "month
+// open for correction" signal across ALL three edit gates: this export lock
+// (#1), the reconciliation lock (#2, for receipt edits only —
+// rejectIfReceiptInFinalizedReconciliation in db.ts), and the per-receipt
+// status gate (#3 — an `exported` receipt becomes editable/deletable while a
+// draft is open, via isMonthLockedForEdits in the PATCH/DELETE paths). The
+// line-level reconciliation seal (rejectIfFinalized on amex_statement_lines
+// writes) deliberately stays strict. See receipt-locks.ts header +
+// docs/adr/0012-unified-draft-carveout-month-locks.md.
 
 /**
  * Typed error thrown when an insert/update would land a CASH/DIGITAL

--- a/lib/receipts/receipt-locks.ts
+++ b/lib/receipts/receipt-locks.ts
@@ -1,23 +1,36 @@
-// Review-queue lock surface (split-lock model, month-lock.ts header + audit A5).
+// Review-queue lock surface (three-gate model with a unified draft carve-out,
+// ADR 0012; see also month-lock.ts header + audit A5).
 //
 // The review queue hides receipts the server would refuse to mutate, so the
 // operator never types into a locked receipt and discovers the 409 at save
-// time. Two independent locks own disjoint populations:
+// time. The server enforces THREE independent gates; this module mirrors the
+// first two for display (gate #3 is a per-receipt status check the queue
+// infers from `status`):
 //
 //   1. EXPORT lock — a non-AMEX receipt (CASH/DIGITAL/UNKNOWN) whose
 //      transaction month is export-sealed: status='finalized' export exists
-//      AND no 'draft' revision (exactly loadSealedExportMonths). AMEX is
-//      intentionally NOT export-gated — it flows through (2).
-//   2. RECONCILIATION lock — an AMEX receipt matched to an amex_statement_lines
-//      row whose statement month's amex_reconciliation.status='finalized'
-//      (same join as rejectIfReceiptInFinalizedReconciliation in db.ts).
-//      CASH/DIGITAL have no statement line to match, so they are not recon-
-//      gated. UNKNOWN matched to a finalized line IS locked here too: the
-//      server's recon predicate is path-agnostic, and the UI must never
-//      under-report a server 409.
+//      AND no 'draft' revision (loadSealedExportMonths). AMEX is intentionally
+//      NOT export-gated — it flows through (2).
+//   2. RECONCILIATION lock — an AMEX/UNKNOWN receipt matched to an
+//      amex_statement_lines row whose statement month's
+//      amex_reconciliation.status='finalized'. CASH/DIGITAL have no statement
+//      line to match, so they are not recon-gated.
+//   3. PER-RECEIPT STATUS gate (server only — PATCH app/api/receipts/[id]/
+//      route.ts + softDeleteReceipt in db.ts): status='exported'/'archived'
+//      is refused, except 'exported' is released under the carve-out below.
+//
+// Unified draft carve-out (ADR 0012): an open export draft
+// (receipt_exports.status='draft') for a month is the SINGLE "month open for
+// correction" signal. It releases gate #1 (by definition), gate #2 for RECEIPT
+// edits only (loadReconciliationLockedReceiptIds excludes draft months; the
+// server's rejectIfReceiptInFinalizedReconciliation does the same), and gate #3
+// (isMonthLockedForEdits → false). The LINE-level reconciliation seal
+// (rejectIfFinalized on amex_statement_lines writes) is deliberately NOT
+// released — a format-only export revision must not reopen match assignments.
 //
 // Undated receipts are never EXPORT-locked (transactionMonthOf → null). They
-// may still be RECONCILIATION-locked when matched to a finalized line.
+// may still be RECONCILIATION-locked when matched to a finalized line (subject
+// to the carve-out).
 //
 // This module is read-only: it computes lock info for display. It does NOT
 // enforce anything — the API-side 409 backstop stays the source of truth.
@@ -124,7 +137,12 @@ export async function loadReconciliationLockedReceiptIds(
        JOIN amex_reconciliations AS ar
          ON ar.statement_month = asl.statement_month
         AND ar.status = 'finalized'
-       WHERE asl.matched_receipt_id IN (${placeholders})`,
+       WHERE asl.matched_receipt_id IN (${placeholders})
+         AND NOT EXISTS (
+           SELECT 1 FROM receipt_exports re
+           WHERE re.export_month = ar.statement_month
+             AND re.status = 'draft'
+         )`,
     )
     .bind(...receiptIds)
     .all<{ rid: string; m: string }>();

--- a/tests/receipts/receipt-locks.test.ts
+++ b/tests/receipts/receipt-locks.test.ts
@@ -211,6 +211,46 @@ test("loadReconciliationLockedReceiptIds: empty id list → empty map, no query"
   assert.equal(prepared, false, "must short-circuit and not run a query for empty input");
 });
 
+// ─── ADR 0012: drafted months are excluded from the recon-locked set ─────────
+
+test("loadReconciliationLockedReceiptIds: query excludes months that have an open export draft", async () => {
+  // A drafted month must NOT appear in the locked set — otherwise the queue
+  // over-reports a 409 the server would no longer throw. The canned-fake style
+  // can't execute the NOT EXISTS, so assert the exclusion clause is in the
+  // emitted SQL (live behavior is covered by the server carve-out tests).
+  let capturedSql = "";
+  const recording: ReceiptLockD1 = {
+    prepare(sql: string) {
+      capturedSql = sql;
+      return {
+        bind(..._args: unknown[]) {
+          return {
+            async all<T = unknown>(): Promise<{ results?: T[] }> {
+              return { results: [] };
+            },
+          };
+        },
+      };
+    },
+  };
+  await loadReconciliationLockedReceiptIds(recording, ["a"]);
+  assert.match(capturedSql, /NOT EXISTS/i);
+  assert.match(capturedSql, /receipt_exports/i);
+  assert.match(capturedSql, /status = 'draft'/i);
+});
+
+test("computeReceiptLocks: AMEX receipt whose finalized-recon month has a draft → UNLOCKED (carve-out)", () => {
+  // End-to-end effect: a drafted month is excluded from the recon-locked map by
+  // loadReconciliationLockedReceiptIds, so the receipt the operator wants to
+  // correct surfaces unlocked (empty map here models the exclusion).
+  const locks = computeReceiptLocks(
+    [receipt({ id: "amex", payment_path: "AMEX", transaction_date: "2026-06-15" })],
+    new Set(),
+    new Map(),
+  );
+  assert.equal(locks.get("amex")?.locked, false);
+});
+
 // Static guard: keep the PaymentPath literals honest against the lock model.
 test("computeReceiptLocks: covers all four payment paths", () => {
   const paths: PaymentPath[] = ["AMEX", "CASH", "DIGITAL", "UNKNOWN"];

--- a/tests/receipts/reconciliation-lock-carveout.test.ts
+++ b/tests/receipts/reconciliation-lock-carveout.test.ts
@@ -1,0 +1,90 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  rejectIfFinalized,
+  rejectIfReceiptInFinalizedReconciliation,
+} from "@/lib/receipts/db";
+
+// ADR 0012: the reconciliation lock becomes draft-aware for RECEIPT edits only.
+// rejectIfReceiptInFinalizedReconciliation releases when the matched statement
+// month has an open export draft (isMonthLockedForEdits → false). The LINE seal
+// (rejectIfFinalized) is deliberately NOT draft-aware — a format-only export
+// revision must not reopen match assignments. This file guards both halves.
+
+function fakeDb(opts: {
+  /** Finalized-reconciliation match for the receipt (the JOIN row), or null. */
+  match: { id: string; statement_month: string } | null;
+  /** isMonthLockedForEdits result: 0 = open draft (released), 1 = no draft (locked). */
+  locked: 0 | 1;
+  /** Whether a finalized amex_reconciliations row exists for the month (rejectIfFinalized). */
+  finalizedRecon: boolean;
+}) {
+  const db = {
+    prepare(sql: string) {
+      return {
+        bind(..._args: unknown[]) {
+          return {
+            async first<T = unknown>(): Promise<T | null> {
+              // Receipt-reconciliation join (has amex_statement_lines).
+              if (/FROM amex_statement_lines/i.test(sql)) {
+                return (opts.match ?? null) as T | null;
+              }
+              // isMonthLockedForEdits (CASE over receipt_exports).
+              if (/CASE/i.test(sql) && /receipt_exports/i.test(sql)) {
+                return { locked: opts.locked } as T;
+              }
+              // rejectIfFinalized line seal (SELECT id FROM amex_reconciliations … finalized).
+              if (/FROM amex_reconciliations/i.test(sql) && /finalized/i.test(sql)) {
+                return (opts.finalizedRecon ? { id: "rec" } : null) as T | null;
+              }
+              return null as T | null;
+            },
+          };
+        },
+      };
+    },
+  };
+  return db as unknown as D1Database;
+}
+
+// ─── Receipt-scope carve-out (draft-aware) ───────────────────────────────────
+
+test("rejectIfReceiptInFinalizedReconciliation: no finalized match → returns (no throw)", async () => {
+  await rejectIfReceiptInFinalizedReconciliation(
+    fakeDb({ match: null, locked: 1, finalizedRecon: false }),
+    "r1",
+  );
+});
+
+test("rejectIfReceiptInFinalizedReconciliation: match + month locked (no draft) → throws", async () => {
+  await assert.rejects(
+    rejectIfReceiptInFinalizedReconciliation(
+      fakeDb({ match: { id: "rec", statement_month: "2026-06" }, locked: 1, finalizedRecon: true }),
+      "r1",
+    ),
+    /locked by a finalized reconciliation/i,
+  );
+});
+
+test("rejectIfReceiptInFinalizedReconciliation: match + open draft (not locked) → released (ADR 0012)", async () => {
+  // Same finalized reconciliation, but an open export draft releases the RECEIPT edit.
+  await rejectIfReceiptInFinalizedReconciliation(
+    fakeDb({ match: { id: "rec", statement_month: "2026-06" }, locked: 0, finalizedRecon: true }),
+    "r1",
+  );
+});
+
+// ─── Line-seal scoping (NOT draft-aware — the mitigation boundary) ───────────
+
+test("rejectIfFinalized (line seal): finalized → throws EVEN with an open draft (strict by design)", async () => {
+  // Contrast with the receipt carve-out above: the line-level seal is the
+  // receipt-vs-line scoping mitigation and must not be released by a draft.
+  await assert.rejects(
+    rejectIfFinalized(fakeDb({ match: null, locked: 0, finalizedRecon: true }), "2026-06"),
+    /finalized/i,
+  );
+});
+
+test("rejectIfFinalized (line seal): not finalized → returns (no throw)", async () => {
+  await rejectIfFinalized(fakeDb({ match: null, locked: 0, finalizedRecon: false }), "2026-06");
+});

--- a/tests/receipts/soft-delete-carveout.test.ts
+++ b/tests/receipts/soft-delete-carveout.test.ts
@@ -1,0 +1,79 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { softDeleteReceipt } from "@/lib/receipts/db";
+
+// ADR 0012 carve-out for softDeleteReceipt. The function takes `db` as an
+// optional 4th param (testability seam, same pattern as unfinalizeReconciliation
+// — invisible to the DELETE route, the sole production caller). It issues: a
+// SELECT id,status,exported_month; an isMonthLockedForEdits CASE query; a
+// deleted_at UPDATE; and an audit INSERT. The recording fake dispatches on SQL.
+
+type Run = { sql: string; args: unknown[] };
+
+function fakeDb(opts: {
+  status: string;
+  exportedMonth: string | null;
+  /** isMonthLockedForEdits result: 0 = open draft (released), 1 = no draft (locked). */
+  locked: 0 | 1;
+}) {
+  const runs: Run[] = [];
+  const db = {
+    prepare(sql: string) {
+      return {
+        bind(...args: unknown[]) {
+          return {
+            async first<T = unknown>(): Promise<T | null> {
+              if (/SELECT id, status, exported_month FROM receipt_records/i.test(sql)) {
+                return { id: "r1", status: opts.status, exported_month: opts.exportedMonth } as T;
+              }
+              if (/CASE/i.test(sql) && /receipt_exports/i.test(sql)) {
+                return { locked: opts.locked } as T;
+              }
+              return null as T | null;
+            },
+            async run() {
+              runs.push({ sql, args });
+              return { meta: { changes: 1 } };
+            },
+          };
+        },
+      };
+    },
+  };
+  return { db: db as unknown as D1Database, runs };
+}
+
+test("softDeleteReceipt: exported + open draft + reason → soft-deleted, audit written", async () => {
+  const { db, runs } = fakeDb({ status: "exported", exportedMonth: "2026-06", locked: 0 });
+  await softDeleteReceipt("r1", "david@example.com", "beta review — spurious charge", db);
+  const update = runs.find((r) => /UPDATE receipt_records SET deleted_at/i.test(r.sql));
+  assert.ok(update, "expected a deleted_at UPDATE");
+  const audit = runs.find((r) => /INSERT INTO receipt_audit_log/i.test(r.sql));
+  assert.ok(audit, "expected an audit INSERT");
+  assert.equal(audit!.args[2], "receipt.deleted"); // action bind position
+});
+
+test("softDeleteReceipt: exported + no draft (locked) → throws, writes nothing", async () => {
+  const { db, runs } = fakeDb({ status: "exported", exportedMonth: "2026-06", locked: 1 });
+  await assert.rejects(
+    softDeleteReceipt("r1", "david@example.com", "reason", db),
+    /cannot be deleted/i,
+  );
+  assert.equal(runs.length, 0, "no UPDATE or audit should fire when the month is locked");
+});
+
+test("softDeleteReceipt: exported + open draft + NO reason → throws (reason mandatory for exported)", async () => {
+  const { db, runs } = fakeDb({ status: "exported", exportedMonth: "2026-06", locked: 0 });
+  await assert.rejects(
+    softDeleteReceipt("r1", "david@example.com", undefined, db),
+    /requires a non-empty reason/i,
+  );
+  assert.equal(runs.length, 0, "no UPDATE or audit should fire without a reason");
+});
+
+test("softDeleteReceipt: reviewed (deletable) → deletes without a reason/draft (existing behavior preserved)", async () => {
+  const { db, runs } = fakeDb({ status: "reviewed", exportedMonth: null, locked: 1 });
+  await softDeleteReceipt("r1", "david@example.com", undefined, db);
+  const update = runs.find((r) => /UPDATE receipt_records SET deleted_at/i.test(r.sql));
+  assert.ok(update, "a reviewed receipt should soft-delete without a reason or draft");
+});


### PR DESCRIPTION
## Summary

Implements the architect's unified draft carve-out (`prompts/WORKER-PROMPT-unified-month-locks.md`) responding to the 2026-07-20 locking-system handoff (`docs/audits/2026-07-20-monthly-seal-lock-system.md`).

An open export draft (`receipt_exports.status='draft'`) is now the **single "month open for correction" signal**, releasing all three edit gates via the existing `isMonthLockedForEdits` predicate. This unblocks beta correction of sealed months — previously exported receipts were permanently non-editable/non-deletable, and the revision flow's own "create a revision" advice was self-defeating for data edits.

### Gate changes (RECEIPT-scope; the line-level reconciliation seal stays strict)
- **PATCH** `app/api/receipts/[id]/route.ts`: `archived` → 409 always; `exported` → 409 only when `exported_month` is null OR `isMonthLockedForEdits(month)` (no draft). Falls through to normal PATCH when released.
- **softDeleteReceipt** `db.ts`: `exported` becomes deletable under the same carve-out; a non-empty **reason is mandatory** for the exported branch. Optional `db` param = testability seam (default `getReceiptsDb`, invisible to the DELETE route) — same pattern as `unfinalizeReconciliation`.
- **DELETE route** now parses + passes a reason (the design assumed it already did; exported deletes require one).
- **rejectIfReceiptInFinalizedReconciliation** `db.ts`: releases receipt edits when the matched statement month has an open draft. **`rejectIfFinalized` (the line seal) is unchanged.** Both exported for direct testing.
- **receipt-locks.ts**: `loadReconciliationLockedReceiptIds` excludes drafted months (`NOT EXISTS`) so the queue mirrors the server; `form-pane.tsx` lock copy updated.

### Operator decisions on record (ADR 0012)
1. Gate #3 gets the F1 carve-out (no status reverting; `createExportRevision` stays receipt-untouched).
2. Deletes stay soft; `hardDeleteReceipt` stays routeless (sealed manifests reference R2 originals by hash/key — must survive).
3. Reconciliation lock draft-aware for receipt edits only; line seal strict.

## Verification
- `tsc --noEmit` clean
- `npm test` — **749 pass / 0 fail / 1 skipped** (11 new tests: soft-delete carve-out ×4, reconciliation-lock carve-out + line-seal scoping ×5, receipt-locks draft-exclusion ×2)
- `npm run build:cf` — exit 0

## Follow-up (Part 7 of the worker task)
After merge, apply the 2026-06 review edits (a/b/c/d) now that rev3's draft releases the gates, then Rebuild draft (¥60 absent, 事業目的 present). Do NOT finalize — David finalizes manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)