### PR TITLE
receipts: add Research & Development expense category (研究開発費)

### DIFF
--- a/components/receipts/export/export-screen.tsx
+++ b/components/receipts/export/export-screen.tsx
@@ -19,6 +19,7 @@ import {
   type ManifestSampleRow,
 } from "@/lib/receipts/manifest-preview";
 import type { StatementWindow } from "@/lib/receipts/statement-window";
+import { EXPENSE_CATEGORIES } from "@/lib/receipts/categories";
 
 export type { Blocker } from "@/lib/receipts/blockers";
 
@@ -894,7 +895,7 @@ const SCHEMA_COLS = [
   { k: "transaction_date", t: "date", ex: "2026-04-17", n: "JST, ISO 8601" },
   { k: "amount", t: "integer", ex: "8850", n: "minor units in `currency`" },
   { k: "currency", t: "string", ex: "JPY", n: "ISO 4217" },
-  { k: "category", t: "enum", ex: "接待交際費", n: "one of 14 JP catalog" },
+  { k: "category", t: "enum", ex: "接待交際費", n: `one of ${EXPENSE_CATEGORIES.length} JP catalog` },
   { k: "expense_type", t: "enum", ex: "meeting-no-alcohol", n: "expense classification" },
   { k: "payment_path", t: "enum", ex: "AMEX", n: "AMEX / CASH / DIGITAL / UNKNOWN" },
   { k: "amex_reference", t: "string", ex: "20260417-0214", n: "links to amex_statement_lines" },

--- a/components/receipts/review/form-pane.tsx
+++ b/components/receipts/review/form-pane.tsx
@@ -636,7 +636,7 @@ export function FormPane(props: FormPaneProps) {
             />
           </Field>
           <div className="mt-3 grid grid-cols-1 gap-3 md:grid-cols-2">
-            <Field label="Category" hint="14-item JP catalog">
+            <Field label="Category" hint={`${EXPENSE_CATEGORIES.length}-item JP catalog`}>
               <select
                 ref={categoryRef}
                 value={expenseCategoryCode}

--- a/db/receipts/0031_research_development_category.sql
+++ b/db/receipts/0031_research_development_category.sql
@@ -1,0 +1,26 @@
+-- Add 研究開発費 (Research & Development) to the canonical expense category
+-- master list, ordered immediately before 雑費 (miscellaneous).
+--
+-- Idempotent upsert: re-runs keep labels/flags/order exact. Does NOT backfill
+-- or reclassify existing receipts. The legacy 'research' value continues to map
+-- to newspapers_books (LEGACY_CATEGORY_MAP in lib/receipts/categories.ts) —
+-- historical legacy values must not be silently reinterpreted as R&D; only this
+-- canonical code represents the new category.
+
+-- Research & Development (display_order 150) — upsert so labels/flags stay exact.
+INSERT INTO expense_categories
+  (code, ja_name, en_name, requires_attendees, default_business_trip_eligible, display_order, updated_at)
+VALUES
+  ('research_development', '研究開発費', 'Research & Development', 0, 0, 150, strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+ON CONFLICT(code) DO UPDATE SET
+  ja_name = excluded.ja_name,
+  en_name = excluded.en_name,
+  requires_attendees = excluded.requires_attendees,
+  default_business_trip_eligible = excluded.default_business_trip_eligible,
+  display_order = excluded.display_order,
+  updated_at = excluded.updated_at;
+
+-- Move Miscellaneous to display_order 160 (now after Research & Development).
+UPDATE expense_categories
+SET display_order = 160, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+WHERE code = 'miscellaneous';

--- a/docs/expenseCat_Requirements.md
+++ b/docs/expenseCat_Requirements.md
@@ -45,9 +45,10 @@ Seed this exact list:
 | `payment_fees` | 支払手数料 | Payment and service fees | false | false |
 | `rent_lease` | 賃借料 | Rent and lease expenses | false | false |
 | `insurance` | 保険料 | Insurance premiums | false | false |
+| `research_development` | 研究開発費 | Research & Development | false | false |
 | `miscellaneous` | 雑費 | Miscellaneous expenses | false | false |
 
-Note (2026-07): `miscellaneous` (雑費) added as the 15th canonical category (migration 0018). The code is deliberately not `misc` — legacy `misc` values continue to map to null (require review).
+Note (2026-07): `miscellaneous` (雑費) added as the 15th canonical category (migration 0018). The code is deliberately not `misc` — legacy `misc` values continue to map to null (require review). Note (2026-07-20): `research_development` (研究開発費) added as the 16th canonical category (migration 0031), ordered immediately before `miscellaneous` at display_order 150; `miscellaneous` moved to display_order 160. Legacy `research` still maps to `newspapers_books` — only this canonical code is R&D.
 
 ---
 
@@ -305,7 +306,9 @@ type ExpenseCategoryCode =
   | "membership_dues"
   | "payment_fees"
   | "rent_lease"
-  | "insurance";
+  | "insurance"
+  | "research_development"
+  | "miscellaneous";
 ```
 
 If uncertain:
@@ -424,7 +427,7 @@ Attendees: David Klan (Dazbeez), Jane Smith (Client Co.)
 
 Add `expense_categories` table if one does not already exist.
 
-Seed all 14 categories idempotently.
+Seed all 16 categories idempotently.
 
 ### Task 2: Add Category References
 
@@ -494,7 +497,7 @@ Add tests for category seed, UI rendering, attendee requirements, AI category va
 
 Add or update tests for:
 
-1. Category seed contains all 14 Japanese categories.
+1. Category seed contains all 16 Japanese categories.
 2. Each category has an English translation.
 3. Category selector renders Japanese and English labels.
 4. Receipt review saves `expense_category_code`.
@@ -518,7 +521,7 @@ npm run build:cf
 
 ## Acceptance Criteria
 
-1. All 14 Japanese categories are maintained in the system.
+1. All 16 Japanese categories are maintained in the system.
 2. Each category has a stable code and English translation.
 3. The category list is stored in the system, not duplicated in UI components.
 4. Receipt review uses this category list.

--- a/lib/receipts/categories.ts
+++ b/lib/receipts/categories.ts
@@ -16,6 +16,7 @@ export type ExpenseCategoryCode =
   | "payment_fees"
   | "rent_lease"
   | "insurance"
+  | "research_development"
   | "miscellaneous";
 
 export interface ExpenseCategory {
@@ -42,11 +43,12 @@ export const EXPENSE_CATEGORIES: ExpenseCategory[] = [
   { code: "payment_fees",          jaName: "支払手数料",   enName: "Payment and service fees",            requiresAttendees: false, defaultBusinessTripEligible: false, displayOrder: 120 },
   { code: "rent_lease",            jaName: "賃借料",       enName: "Rent and lease expenses",             requiresAttendees: false, defaultBusinessTripEligible: false, displayOrder: 130 },
   { code: "insurance",             jaName: "保険料",       enName: "Insurance premiums",                  requiresAttendees: false, defaultBusinessTripEligible: false, displayOrder: 140 },
+  { code: "research_development",  jaName: "研究開発費",   enName: "Research & Development",              requiresAttendees: false, defaultBusinessTripEligible: false, displayOrder: 150 },
   // NOTE: deliberately "miscellaneous", not "misc" — legacy free-text "misc"
   // values map to null in LEGACY_CATEGORY_MAP (require review), and
   // mapLegacyCategory() checks isCanonicalCode() first. A canonical code
   // named "misc" would silently legitimize old dumping-ground data.
-  { code: "miscellaneous",         jaName: "雑費",         enName: "Miscellaneous expenses",              requiresAttendees: false, defaultBusinessTripEligible: false, displayOrder: 150 },
+  { code: "miscellaneous",         jaName: "雑費",         enName: "Miscellaneous expenses",              requiresAttendees: false, defaultBusinessTripEligible: false, displayOrder: 160 },
 ];
 
 export const EXPENSE_CATEGORY_CODES = new Set<string>(EXPENSE_CATEGORIES.map((c) => c.code));

--- a/tests/receipts/categories.test.ts
+++ b/tests/receipts/categories.test.ts
@@ -12,9 +12,29 @@ import {
 
 // ─── Category seed ───────────────────────────────────────────────────────────
 
-test("EXPENSE_CATEGORIES has exactly 15 entries", () => {
-  // 14 original + miscellaneous (雑費), added 2026-07 per operator request.
-  assert.equal(EXPENSE_CATEGORIES.length, 15);
+test("EXPENSE_CATEGORIES has exactly 16 entries", () => {
+  // 14 original + miscellaneous (雑費, 2026-07) + research_development (研究開発費, 2026-07-20).
+  assert.equal(EXPENSE_CATEGORIES.length, 16);
+});
+
+test("research_development (研究開発費) is canonical, ordered immediately before miscellaneous", () => {
+  const rd = getCategoryByCode("research_development");
+  assert.ok(rd, "research_development should exist");
+  assert.equal(rd!.jaName, "研究開発費");
+  assert.equal(rd!.enName, "Research & Development");
+  assert.equal(rd!.requiresAttendees, false);
+  assert.equal(rd!.defaultBusinessTripEligible, false);
+  assert.equal(rd!.displayOrder, 150);
+
+  // Immediately before miscellaneous, which moved to display_order 160.
+  const rdIdx = EXPENSE_CATEGORIES.findIndex((c) => c.code === "research_development");
+  const miscIdx = EXPENSE_CATEGORIES.findIndex((c) => c.code === "miscellaneous");
+  assert.ok(rdIdx >= 0 && miscIdx >= 0);
+  assert.equal(miscIdx, rdIdx + 1, "research_development must immediately precede miscellaneous");
+  assert.equal(getCategoryByCode("miscellaneous")!.displayOrder, 160);
+
+  assert.equal(isCanonicalCode("research_development"), true);
+  assert.equal(formatCategoryLabel("research_development"), "研究開発費 — Research & Development");
 });
 
 test("all canonical codes are unique", () => {
@@ -118,7 +138,7 @@ test("isBusinessTripEligible returns false for null/undefined", () => {
 
 // ─── isCanonicalCode ─────────────────────────────────────────────────────────
 
-test("isCanonicalCode accepts all 14 canonical codes", () => {
+test("isCanonicalCode accepts all 16 canonical codes", () => {
   for (const cat of EXPENSE_CATEGORIES) {
     assert.equal(isCanonicalCode(cat.code), true, `${cat.code} should be canonical`);
   }
@@ -151,6 +171,8 @@ test("mapLegacyCategory maps known legacy values", () => {
   assert.deepEqual(mapLegacyCategory("entertainment-alcohol"), { code: "entertainment", ambiguous: false });
   assert.deepEqual(mapLegacyCategory("transportation"), { code: "travel_transportation", ambiguous: false });
   assert.deepEqual(mapLegacyCategory("books"), { code: "newspapers_books", ambiguous: false });
+  // Legacy 'research' stays newspapers_books — only the canonical research_development code is R&D.
+  assert.deepEqual(mapLegacyCategory("research"), { code: "newspapers_books", ambiguous: false });
   assert.deepEqual(mapLegacyCategory("office_supplies"), { code: "supplies", ambiguous: false });
   assert.deepEqual(mapLegacyCategory("telecom"), { code: "communications", ambiguous: false });
 });


### PR DESCRIPTION
## Summary

Adds `research_development` (研究開発費 / Research & Development) as the 16th canonical expense category, ordered immediately before `miscellaneous`. Architect-approved (`codex/research-development-category`, commits `6aa214c` + `f6339cf`).

- `research_development`: attendees=false, business-trip=false, display_order 150
- `miscellaneous` → display_order 160
- Legacy `research` → `newspapers_books` unchanged (only the canonical code is R&D)
- No backfill/reclassification of existing receipts

## Changes
- `lib/receipts/categories.ts` — code in union + array (before misc); misc → 160
- `db/receipts/0031_research_development_category.sql` — idempotent upsert + misc order 160 (already applied to prod D1; CI re-runs as no-op)
- `components/receipts/review/form-pane.tsx` — category hint derives from `EXPENSE_CATEGORIES.length`
- `components/receipts/export/export-screen.tsx` — SCHEMA_COLS category note derives from `EXPENSE_CATEGORIES.length` (renders "one of 16 JP catalog")
- `docs/expenseCat_Requirements.md` — new canonical row, ordering, 16-category total
- `tests/receipts/categories.test.ts` — 16 categories; R&D labels/flags/position/orders/canonical/format; legacy research→newspapers_books

## Verification
- `tsc --noEmit` clean · `npm test` 750 pass / 0 fail · `build:cf` exit 0
- rg sweep: no remaining live-code 14/15-category-count references
- Live D1: research_development @ 150, misc @ 160, flags 0, 16 rows; FK empirically confirmed (probe UPDATE accepted + restored)
- cf:dev UI visual blocked by Clerk pk_live localhost rejection (known); selector order covered by unit tests (Review + Reconcile derive from EXPENSE_CATEGORIES)

🤖 Generated with [Claude Code](https://claude.com/claude-code)