### PR TITLE
receipts: chunk review-path IN queries under D1 bind limit (crash fix)

### DIFF
--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -671,23 +671,30 @@ export async function listAttendeeNamesByReceiptIds(
   const out = new Map<string, string[]>();
   if (receiptIds.length === 0) return out;
   const db = getReceiptsDb();
-  const placeholders = receiptIds.map(() => "?").join(", ");
-  const result = await db
-    .prepare(
-      `SELECT receipt_id, attendee_name
-       FROM receipt_attendees
-       WHERE receipt_id IN (${placeholders})
-       ORDER BY created_at ASC`,
-    )
-    .bind(...receiptIds)
-    .all<{ receipt_id: string; attendee_name: string }>();
-  for (const row of result.results ?? []) {
-    let arr = out.get(row.receipt_id);
-    if (!arr) {
-      arr = [];
-      out.set(row.receipt_id, arr);
+  // Chunk over D1_ID_CHUNK_SIZE: callers (review queue, reconcile, export) pass
+  // 100+ ids for an all-months view, and D1 rejects >100 bound params/statement.
+  // Each receipt's rows land in exactly one chunk (chunking is by receipt_id), so
+  // per-receipt created_at order is preserved within a chunk.
+  for (let i = 0; i < receiptIds.length; i += D1_ID_CHUNK_SIZE) {
+    const chunk = receiptIds.slice(i, i + D1_ID_CHUNK_SIZE);
+    const placeholders = chunk.map(() => "?").join(", ");
+    const result = await db
+      .prepare(
+        `SELECT receipt_id, attendee_name
+         FROM receipt_attendees
+         WHERE receipt_id IN (${placeholders})
+         ORDER BY created_at ASC`,
+      )
+      .bind(...chunk)
+      .all<{ receipt_id: string; attendee_name: string }>();
+    for (const row of result.results ?? []) {
+      let arr = out.get(row.receipt_id);
+      if (!arr) {
+        arr = [];
+        out.set(row.receipt_id, arr);
+      }
+      arr.push(row.attendee_name);
     }
-    arr.push(row.attendee_name);
   }
   return out;
 }
@@ -1037,23 +1044,28 @@ export async function getAmexMatchFlagsByReceiptIds(
   if (receiptIds.length === 0) return flags;
 
   const db = getReceiptsDb();
-  const placeholders = receiptIds.map(() => "?").join(",");
-  const result = await db
-    .prepare(
-      `SELECT matched_receipt_id, re_review_needed
-       FROM amex_statement_lines
-       WHERE matched_receipt_id IN (${placeholders})`,
-    )
-    .bind(...receiptIds)
-    .all<{ matched_receipt_id: string; re_review_needed: 0 | 1 }>();
+  // Chunk over D1_ID_CHUNK_SIZE: the review queue passes 100+ ids for an
+  // all-months view, and D1 rejects >100 bound params per statement.
+  for (let i = 0; i < receiptIds.length; i += D1_ID_CHUNK_SIZE) {
+    const chunk = receiptIds.slice(i, i + D1_ID_CHUNK_SIZE);
+    const placeholders = chunk.map(() => "?").join(",");
+    const result = await db
+      .prepare(
+        `SELECT matched_receipt_id, re_review_needed
+         FROM amex_statement_lines
+         WHERE matched_receipt_id IN (${placeholders})`,
+      )
+      .bind(...chunk)
+      .all<{ matched_receipt_id: string; re_review_needed: 0 | 1 }>();
 
-  for (const row of result.results ?? []) {
-    const existing = flags.get(row.matched_receipt_id);
-    flags.set(row.matched_receipt_id, {
-      hasMatch: true,
-      reReviewNeeded:
-        (existing?.reReviewNeeded ?? false) || row.re_review_needed === 1,
-    });
+    for (const row of result.results ?? []) {
+      const existing = flags.get(row.matched_receipt_id);
+      flags.set(row.matched_receipt_id, {
+        hasMatch: true,
+        reReviewNeeded:
+          (existing?.reReviewNeeded ?? false) || row.re_review_needed === 1,
+      });
+    }
   }
   return flags;
 }

--- a/lib/receipts/receipt-locks.ts
+++ b/lib/receipts/receipt-locks.ts
@@ -38,6 +38,7 @@
 import { getReceiptsDb } from "@/lib/cloudflare-runtime";
 import { loadSealedExportMonths } from "@/lib/receipts/membership";
 import { transactionMonthOf } from "@/lib/receipts/month-lock";
+import { D1_ID_CHUNK_SIZE } from "@/lib/receipts/db-utils";
 import type { PaymentPath, ReceiptRecord } from "@/lib/receipts/types";
 
 export type ReceiptLockKind = "export" | "reconciliation";
@@ -129,25 +130,32 @@ export async function loadReconciliationLockedReceiptIds(
 ): Promise<Map<string, string>> {
   const out = new Map<string, string>();
   if (receiptIds.length === 0) return out;
-  const placeholders = receiptIds.map(() => "?").join(",");
-  const res = await db
-    .prepare(
-      `SELECT asl.matched_receipt_id AS rid, ar.statement_month AS m
-       FROM amex_statement_lines AS asl
-       JOIN amex_reconciliations AS ar
-         ON ar.statement_month = asl.statement_month
-        AND ar.status = 'finalized'
-       WHERE asl.matched_receipt_id IN (${placeholders})
-         AND NOT EXISTS (
-           SELECT 1 FROM receipt_exports re
-           WHERE re.export_month = ar.statement_month
-             AND re.status = 'draft'
-         )`,
-    )
-    .bind(...receiptIds)
-    .all<{ rid: string; m: string }>();
-  for (const row of res.results ?? []) {
-    if (!out.has(row.rid)) out.set(row.rid, row.m);
+  // Chunk over D1_ID_CHUNK_SIZE: the review queue passes every receipt id (100+
+  // for an all-months view), and D1 rejects more than 100 bound params per
+  // statement. First-writer-wins is preserved across chunks (a receipt matching
+  // several lines in the same finalized month yields the same month anyway).
+  for (let i = 0; i < receiptIds.length; i += D1_ID_CHUNK_SIZE) {
+    const chunk = receiptIds.slice(i, i + D1_ID_CHUNK_SIZE);
+    const placeholders = chunk.map(() => "?").join(",");
+    const res = await db
+      .prepare(
+        `SELECT asl.matched_receipt_id AS rid, ar.statement_month AS m
+         FROM amex_statement_lines AS asl
+         JOIN amex_reconciliations AS ar
+           ON ar.statement_month = asl.statement_month
+          AND ar.status = 'finalized'
+         WHERE asl.matched_receipt_id IN (${placeholders})
+           AND NOT EXISTS (
+             SELECT 1 FROM receipt_exports re
+             WHERE re.export_month = ar.statement_month
+               AND re.status = 'draft'
+           )`,
+      )
+      .bind(...chunk)
+      .all<{ rid: string; m: string }>();
+    for (const row of res.results ?? []) {
+      if (!out.has(row.rid)) out.set(row.rid, row.m);
+    }
   }
   return out;
 }

--- a/tests/receipts/receipt-locks.test.ts
+++ b/tests/receipts/receipt-locks.test.ts
@@ -6,6 +6,7 @@ import {
   type ReceiptLockD1,
 } from "@/lib/receipts/receipt-locks";
 import type { PaymentPath, ReceiptRecord } from "@/lib/receipts/types";
+import { D1_ID_CHUNK_SIZE } from "@/lib/receipts/db-utils";
 
 // computeReceiptLocks is pure: feed the two query results (sealed export months
 // + the receipt→statement-month map for finalized reconciliations) and assert
@@ -269,4 +270,34 @@ test("computeReceiptLocks: covers all four payment paths", () => {
   assert.equal(locks.get("CASH")?.kind, "export");
   assert.equal(locks.get("DIGITAL")?.kind, "export");
   assert.equal(locks.get("UNKNOWN")?.kind, "reconciliation"); // recon wins (checked first)
+});
+
+// ─── D1 bind-limit chunking (regression: all-months review crash) ───────────
+
+test("loadReconciliationLockedReceiptIds: chunks receipt ids to stay under D1's bind limit", async () => {
+  // The review queue passes 100+ ids for an all-months view; a single IN(?,…)
+  // exceeded D1's bound-param limit and crashed /receipts/review. The query must
+  // chunk over D1_ID_CHUNK_SIZE. Recording fake counts bind args per prepare.
+  const bindCounts: number[] = [];
+  const recording: ReceiptLockD1 = {
+    prepare() {
+      return {
+        bind(...args: unknown[]) {
+          bindCounts.push(args.length);
+          return {
+            async all<T = unknown>(): Promise<{ results?: T[] }> {
+              return { results: [] };
+            },
+          };
+        },
+      };
+    },
+  };
+  const ids = Array.from({ length: D1_ID_CHUNK_SIZE + 5 }, (_, i) => `r${i}`);
+  await loadReconciliationLockedReceiptIds(recording, ids);
+  assert.ok(bindCounts.length >= 2, `expected ≥2 chunked queries, got ${bindCounts.length}`);
+  assert.ok(
+    Math.max(...bindCounts) <= D1_ID_CHUNK_SIZE,
+    `largest chunk ${Math.max(...bindCounts)} exceeds D1_ID_CHUNK_SIZE (${D1_ID_CHUNK_SIZE})`,
+  );
 });


### PR DESCRIPTION
## Summary — urgent crash fix

`/receipts/review` with **"All months" + non-AMEX** crashed: `D1_ERROR: too many SQL variables`. Three review-render queries built a single `IN(?,…)` from the full receipt-id list (120+ for an all-months view), exceeding D1's 100-bind limit.

Chunked over `D1_ID_CHUNK_SIZE` (the existing pattern in `listReceiptRecordsByIds`):
- `loadReconciliationLockedReceiptIds` (receipt-locks.ts) — via `getReceiptLocks`
- `listAttendeeNamesByReceiptIds` (db.ts) — via `collectClosingAttentionReceiptIds`
- `getAmexMatchFlagsByReceiptIds` (db.ts) — `review/page.tsx`

Per-receipt ordering / first-writer-wins preserved (chunking is by receipt_id, so no receipt's rows span chunks).

## Verification
- `tsc --noEmit` clean · `npm test` 751 pass / 0 fail (new chunking regression test) · `build:cf` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)