### PR TITLE
receipts: close UNKNOWN→CASH membership gap + surface unassigned residue

### DIFF
--- a/components/receipts/export/export-screen.tsx
+++ b/components/receipts/export/export-screen.tsx
@@ -57,10 +57,10 @@ export interface ExportScreenProps {
   unassignableReceipts: ReceiptRecord[];
 }
 
-/** ADR 0008: receipts not yet in any export-month bundle — undated cash/digital
- * only. The ADR 0006 "awaiting statement" bucket is retired: under the calendar
- * rule every dated cash/digital receipt is immediately assignable to its
- * transaction_date's calendar month. */
+/** ADR 0008: cash/digital receipts not yet in any export-month bundle — both
+ * undated (unassignable until a date is set) and dated-but-unassigned (assignment
+ * slipped past the capture/classification hook). Deep-linked to the review view
+ * so the residue is visible on the screen where it gets fixed. */
 function UnassignedReceiptsSection({
   unassignable,
 }: {
@@ -71,18 +71,21 @@ function UnassignedReceiptsSection({
     <Card>
       <div className="flex items-baseline justify-between">
         <div className="text-[13px] font-semibold text-red-700">
-          Unassignable — missing transaction date
+          Unassigned — not in any export month
         </div>
         <Pill tone="red" size="sm">{unassignable.length}</Pill>
       </div>
       <p className="mt-1 text-[12px] text-gray-500">
-        These cash/digital receipts have no date and can never be assigned to an export month. Set a transaction date to assign them.
+        Cash/digital receipts with no statement-month assignment. Open each to set a transaction date (if missing) or assign it to an export month.
       </p>
       <ul className="mt-2 space-y-0.5 text-[12.5px]">
         {unassignable.map((r) => (
           <li key={r.id}>
             <Link href={`/receipts/review/${r.id}`} className="text-amber-700 hover:underline">
-              {r.merchant ?? `R-${r.id.slice(0, 8)}`} · captured {r.captured_at.slice(0, 10)}
+              {r.merchant ?? `R-${r.id.slice(0, 8)}`} ·{" "}
+              {r.transaction_date
+                ? `${r.transaction_date} — assign a month`
+                : `no date — captured ${r.captured_at.slice(0, 10)}`}
             </Link>
           </li>
         ))}

--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -8,7 +8,7 @@ import {
 } from "@/lib/receipts/month-lock";
 import { shouldOverwriteMerchant } from "@/lib/receipts/reconciliation";
 import { retentionUntilIso } from "@/lib/receipts/retention";
-import { assignMembershipForReceipt } from "@/lib/receipts/membership";
+import { assignMembershipForReceipt, postPatchMembershipDate } from "@/lib/receipts/membership";
 import { deleteAmexArtifact } from "@/lib/receipts/storage";
 import { PENDING_EXTRACTION_STATES } from "@/lib/receipts/types";
 import type { ReceiptAttendeeDirectoryEntry } from "@/lib/receipts/attendee-directory";
@@ -324,22 +324,23 @@ export async function updateReceiptRecord(
     newValueJson: stringifyJson(input),
   });
 
-  // ADR 0008 (was ADR 0006 PR #2): if a date is being set on a CASH/DIGITAL
-  // receipt that has no membership yet, assign it now (sticky — only when
-  // currently NULL; an already-assigned receipt is never re-derived here,
-  // matching the freeze rule). A date CHANGE on an already-assigned receipt is
-  // ignored (sticky); the operator can override explicitly if the new date
-  // should land in a different month. (ADR 0006's drift detection is retired —
-  // calendar month has no AMEX-line dependency to drift.)
-  if (
-    "transactionDate" in input &&
-    input.transactionDate &&
-    (effectivePaymentPath === "CASH" || effectivePaymentPath === "DIGITAL") &&
-    !before.export_statement_month &&
-    !("exportStatementMonth" in input)
-  ) {
+  // ADR 0008: assign membership whenever a CASH/DIGITAL receipt with a date has
+  // NULL export_statement_month after a PATCH — regardless of which field the
+  // PATCH touched (see postPatchMembershipDate). This closes the UNKNOWN→CASH
+  // classification path: extraction sets the date while payment_path=UNKNOWN,
+  // then the operator classifies UNKNOWN→CASH in a PATCH that does NOT touch the
+  // date — the previous condition (required "transactionDate" in input) never
+  // fired for that flow. Sticky + override-safe (explicit override wins).
+  const membershipDate = postPatchMembershipDate({
+    effectivePaymentPath,
+    beforeExportStatementMonth: before.export_statement_month ?? null,
+    explicitOverrideInInput: "exportStatementMonth" in input,
+    effectiveTransactionDate:
+      ("transactionDate" in input ? input.transactionDate : before.transaction_date) ?? null,
+  });
+  if (membershipDate) {
     try {
-      await assignMembershipForReceipt(id, input.transactionDate, actor);
+      await assignMembershipForReceipt(id, membershipDate, actor);
     } catch (assignErr) {
       console.error("[updateReceiptRecord] membership assignment failed", assignErr);
     }

--- a/lib/receipts/membership.ts
+++ b/lib/receipts/membership.ts
@@ -98,15 +98,23 @@ export async function listReceiptsByExportStatementMonth(
   return res.results ?? [];
 }
 
-// ─── Unassigned-receipt surface (unassignable only) ────────────────────────
+// ─── Unassigned-receipt surface (needs-attention residue) ──────────────────
 
 /**
- * CASH/DIGITAL receipts that can NEVER be assigned — no transaction_date. These
- * need operator action (set a date), will never auto-resolve, and are invisible
- * to every membership query. Style as needs-attention; deep-link to the
- * receipt's edit view. (ADR 0006's separate "awaiting statement" bucket is
- * retired by ADR 0008: a dated receipt is always immediately assignable to its
- * calendar month, so there is no awaiting state.)
+ * CASH/DIGITAL receipts with no export_statement_month assignment — the residue
+ * the export page surfaces as needs-attention, deep-linked to each receipt's
+ * review view. Two kinds land here:
+ *   - undated (transaction_date IS NULL): can NEVER be assigned until a date is
+ *     set; will never auto-resolve.
+ *   - dated-but-unassigned: assignment slipped past the capture/classification
+ *     hook (e.g. the UNKNOWN→CASH path before updateReceiptRecord's hook was
+ *     broadened to fire on the effective post-PATCH state). A dated receipt is
+ *     assignable to its calendar month — surfacing it keeps a future slip
+ *     visible on the screen where it matters instead of silently shrinking the
+ *     draft (error-surfacing doctrine, theme #12). The caller distinguishes the
+ *     two by `transaction_date` (null ⇒ undated).
+ * All are invisible to every membership query, which keys on
+ * export_statement_month.
  */
 export async function listUnassignableReceipts(): Promise<ReceiptRecord[]> {
   const db = getReceiptsDb();
@@ -116,8 +124,7 @@ export async function listUnassignableReceipts(): Promise<ReceiptRecord[]> {
        WHERE export_statement_month IS NULL
          AND payment_path IN ('CASH', 'DIGITAL')
          AND deleted_at IS NULL
-         AND transaction_date IS NULL
-       ORDER BY captured_at DESC`,
+       ORDER BY (transaction_date IS NULL) ASC, captured_at DESC`,
     )
     .all<ReceiptRecord>();
   return res.results ?? [];
@@ -198,4 +205,33 @@ export async function assignMembershipForReceipt(
     }),
   });
   return result;
+}
+
+/**
+ * Decide whether the updateReceiptRecord membership hook should assign
+ * export_statement_month after a PATCH, and with what date. Returns the date to
+ * assign with, or null to skip. Pure (unit-tested); updateReceiptRecord applies
+ * the side effect via {@link assignMembershipForReceipt}.
+ *
+ * Fires whenever the receipt is CASH/DIGITAL with a date and no existing
+ * assignment — UNLESS the PATCH carries an explicit exportStatementMonth
+ * override (explicit wins) or the receipt is already assigned (sticky). It does
+ * NOT require the PATCH to touch the date, so the UNKNOWN→CASH classification
+ * flow (date set while UNKNOWN, then classified CASH without re-touching the
+ * date) assigns instead of leaving membership NULL and silently falling out of
+ * the draft.
+ */
+export function postPatchMembershipDate(args: {
+  effectivePaymentPath: PaymentPath;
+  beforeExportStatementMonth: string | null;
+  explicitOverrideInInput: boolean;
+  effectiveTransactionDate: string | null;
+}): string | null {
+  if (args.effectivePaymentPath !== "CASH" && args.effectivePaymentPath !== "DIGITAL") {
+    return null;
+  }
+  if (args.beforeExportStatementMonth) return null; // sticky — already assigned
+  if (args.explicitOverrideInInput) return null; // explicit override wins
+  if (!args.effectiveTransactionDate) return null; // nothing to assign from
+  return args.effectiveTransactionDate;
 }

--- a/tests/receipts/membership-hook.test.ts
+++ b/tests/receipts/membership-hook.test.ts
@@ -1,0 +1,106 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { postPatchMembershipDate } from "@/lib/receipts/membership";
+
+// postPatchMembershipDate is the pure decision the updateReceiptRecord hook
+// applies (the side effect — assignMembershipForReceipt — is db-coupled and
+// integration-tested). The headline case is the UNKNOWN→CASH classification
+// path that was the reproducing bug: the date was set while payment_path=
+// UNKNOWN (no assignment — UNKNOWN isn't a membership path), then the operator
+// classifies UNKNOWN→CASH in a PATCH that does NOT touch the date. The hook
+// must fire on the effective post-PATCH state and assign from the existing date.
+
+test("postPatchMembershipDate: UNKNOWN→CASH classification (date not in PATCH) → assigns from the existing date", () => {
+  // Reproducer: extraction set the date while UNKNOWN; this PATCH sets paymentPath=CASH only.
+  const date = postPatchMembershipDate({
+    effectivePaymentPath: "CASH",
+    beforeExportStatementMonth: null,
+    explicitOverrideInInput: false,
+    effectiveTransactionDate: "2026-06-11", // before.transaction_date (PATCH didn't touch it)
+  });
+  assert.equal(date, "2026-06-11");
+});
+
+test("postPatchMembershipDate: CASH + date in PATCH + NULL membership → assigns from the PATCH date", () => {
+  assert.equal(
+    postPatchMembershipDate({
+      effectivePaymentPath: "CASH",
+      beforeExportStatementMonth: null,
+      explicitOverrideInInput: false,
+      effectiveTransactionDate: "2026-06-11", // input.transactionDate
+    }),
+    "2026-06-11",
+  );
+});
+
+test("postPatchMembershipDate: already assigned (sticky) → skip", () => {
+  assert.equal(
+    postPatchMembershipDate({
+      effectivePaymentPath: "CASH",
+      beforeExportStatementMonth: "2026-06",
+      explicitOverrideInInput: false,
+      effectiveTransactionDate: "2026-06-11",
+    }),
+    null,
+  );
+});
+
+test("postPatchMembershipDate: explicit exportStatementMonth override in PATCH → skip (explicit wins)", () => {
+  assert.equal(
+    postPatchMembershipDate({
+      effectivePaymentPath: "CASH",
+      beforeExportStatementMonth: null,
+      explicitOverrideInInput: true,
+      effectiveTransactionDate: "2026-06-11",
+    }),
+    null,
+  );
+});
+
+test("postPatchMembershipDate: no date (undated receipt) → skip", () => {
+  assert.equal(
+    postPatchMembershipDate({
+      effectivePaymentPath: "CASH",
+      beforeExportStatementMonth: null,
+      explicitOverrideInInput: false,
+      effectiveTransactionDate: null,
+    }),
+    null,
+  );
+});
+
+test("postPatchMembershipDate: AMEX effective → skip (not a membership path)", () => {
+  assert.equal(
+    postPatchMembershipDate({
+      effectivePaymentPath: "AMEX",
+      beforeExportStatementMonth: null,
+      explicitOverrideInInput: false,
+      effectiveTransactionDate: "2026-06-11",
+    }),
+    null,
+  );
+});
+
+test("postPatchMembershipDate: UNKNOWN effective → skip (waits for CASH/DIGITAL classification)", () => {
+  assert.equal(
+    postPatchMembershipDate({
+      effectivePaymentPath: "UNKNOWN",
+      beforeExportStatementMonth: null,
+      explicitOverrideInInput: false,
+      effectiveTransactionDate: "2026-06-11",
+    }),
+    null,
+  );
+});
+
+test("postPatchMembershipDate: DIGITAL behaves like CASH → assigns", () => {
+  assert.equal(
+    postPatchMembershipDate({
+      effectivePaymentPath: "DIGITAL",
+      beforeExportStatementMonth: null,
+      explicitOverrideInInput: false,
+      effectiveTransactionDate: "2026-07-01",
+    }),
+    "2026-07-01",
+  );
+});


### PR DESCRIPTION
## Summary

Two-part fix for the export_statement_month NULL gap that silently dropped dated CASH/DIGITAL receipts from their calendar month's draft (14 had slipped to NULL; backfilled separately). Merged with current master (includes the D1 chunking hotfix). Architect-approved.

**Part A — broaden the assignment hook (the reproducing case):**
`updateReceiptRecord` fired only when a PATCH contained `transactionDate`, so the common flow — extraction sets the date while `payment_path=UNKNOWN`, operator later classifies UNKNOWN→CASH in a PATCH that doesn't touch the date — never assigned, leaving `export_statement_month` NULL. The hook now fires on the effective post-PATCH state (sticky; explicit override still wins). Decision extracted to a pure, unit-tested `postPatchMembershipDate`.

**Part B — surface the residue (error-surfacing doctrine, theme #12):**
`listUnassignableReceipts` returns all CASH/DIGITAL with NULL stmt_month (undated + dated-but-unassigned), so a future slip shows on the export screen where it gets fixed. `UnassignedReceiptsSection` relabeled for both kinds + deep-linked.

## Verification
- `tsc --noEmit` clean · `npm test` 759 pass / 0 fail (8 new postPatchMembershipDate tests incl. the UNKNOWN→CASH reproducer) · `build:cf` exit 0
- Clean merge with master (no conflicts; db.ts hook vs chunking touch different functions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)