### PR TITLE
receipts: PATCH integrity hotfix — undefined-valued fields no longer clear columns

### DIFF
--- a/app/api/receipts/[id]/route.ts
+++ b/app/api/receipts/[id]/route.ts
@@ -25,6 +25,10 @@ import type {
   SourceType,
 } from "@/lib/receipts/types";
 import { VALID_SOURCE_TYPES } from "@/lib/receipts/upload-policy";
+import {
+  compactUndefinedReceiptUpdate,
+  parseExportStatementMonthOverride,
+} from "@/lib/receipts/receipt-update";
 
 type RouteContext = { params: Promise<{ id: string }> };
 
@@ -267,52 +271,65 @@ export async function PATCH(request: Request, { params }: RouteContext) {
           { status: 400 },
         );
       }
-      const raw = body.exportStatementMonth;
-      if (raw === null || raw === "") {
-        exportStatementMonth = null;
-      } else if (typeof raw === "string" && /^\d{4}-\d{2}$/.test(raw)) {
-        const sealed = await loadSealedExportMonths();
-        if (sealed.has(raw)) {
-          return NextResponse.json(
-            {
-              error:
-                `${raw}'s export is finalized — cannot reassign a receipt into a sealed month. ` +
-                `Pick an open month, or use the export revision flow.`,
-            },
-            { status: 422 },
-          );
-        }
-        exportStatementMonth = raw;
-      } else {
+      const parsed = parseExportStatementMonthOverride(body.exportStatementMonth);
+      if (parsed.kind === "empty") {
+        // Stored membership is the sticky authority (ADR 0008); intentional
+        // unassignment is not supported. The UI only sends a concrete target
+        // month — null/empty here is rejected, not silently cleared.
         return NextResponse.json(
-          { error: "Invalid exportStatementMonth (expected YYYY-MM or null)." },
+          {
+            error:
+              "exportStatementMonth cannot be cleared — pick a concrete open month. " +
+              "Stored membership is the sticky authority.",
+          },
           { status: 400 },
         );
       }
+      if (parsed.kind === "invalid") {
+        return NextResponse.json(
+          { error: "Invalid exportStatementMonth (expected a concrete open YYYY-MM)." },
+          { status: 400 },
+        );
+      }
+      const sealed = await loadSealedExportMonths();
+      if (sealed.has(parsed.value)) {
+        return NextResponse.json(
+          {
+            error:
+              `${parsed.value}'s export is finalized — cannot reassign a receipt into a sealed month. ` +
+              `Pick an open month, or use the export revision flow.`,
+          },
+          { status: 422 },
+        );
+      }
+      exportStatementMonth = parsed.value;
     }
 
-    await updateReceiptRecord(
-      id,
-      {
-        paymentPath: body.paymentPath as PaymentPath | undefined,
-        expenseType: body.expenseType as ExpenseType | undefined,
-        transactionDate: body.transactionDate,
-        merchant,
-        amountMinor: body.amountMinor,
-        currency: body.currency?.toUpperCase(),
-        taxAmountMinor: body.taxAmountMinor,
-        businessPurpose,
-        expenseCategoryCode,
-        exportStatementMonth,
-        status: body.status as ReceiptStatus | undefined,
-        sourceType,
-        invoiceRegistrationNumber,
-        counterpartyName,
-        taxRate,
-        qualifiedInvoiceStatus,
-      },
-      actor,
-    );
+    // Compact away undefined-valued own properties before mutating, so an OMITTED
+    // optional field is genuinely absent (not present-as-undefined). Otherwise the
+    // `"field" in input` presence checks in updateReceiptRecord fire and bind the
+    // column to `undefined ?? null` → NULL, silently clearing sticky data (the
+    // 2026-07-20 membership-clearing root cause). The same compacted object drives
+    // the SQL mutation and the generic audit.
+    const receiptUpdate = compactUndefinedReceiptUpdate({
+      paymentPath: body.paymentPath as PaymentPath | undefined,
+      expenseType: body.expenseType as ExpenseType | undefined,
+      transactionDate: body.transactionDate,
+      merchant,
+      amountMinor: body.amountMinor,
+      currency: body.currency?.toUpperCase(),
+      taxAmountMinor: body.taxAmountMinor,
+      businessPurpose,
+      expenseCategoryCode,
+      exportStatementMonth,
+      status: body.status as ReceiptStatus | undefined,
+      sourceType,
+      invoiceRegistrationNumber,
+      counterpartyName,
+      taxRate,
+      qualifiedInvoiceStatus,
+    });
+    await updateReceiptRecord(id, receiptUpdate, actor);
 
     // ADR 0006 §D6: dedicated audit for the override (old → new month + actor),
     // separate from the generic receipt.updated entry updateReceiptRecord writes.

--- a/docs/audits/2026-07-20-membership-clearing-mystery.md
+++ b/docs/audits/2026-07-20-membership-clearing-mystery.md
@@ -1,0 +1,172 @@
+# Architect handoff — export_statement_month silently reverting to NULL
+
+**From:** Mac worker session (Claude Code CLI), 2026-07-20
+**Operator report:** "These Cash receipts from July should auto-assign to July" —
+July-dated CASH receipts are showing up unassigned (NULL `export_statement_month`)
+instead of in their calendar month (2026-07), violating the ADR 0008 calendar
+rule. This is the same membership-reliability theme David has hit repeatedly.
+**Request:** root-cause why `export_statement_month` reverts to NULL despite no
+audited clearing path, and spec a fix. The worker has hit the limit of what
+code-reading + the audit trail explain; this needs the architect.
+
+---
+
+## CONFIRMED ROOT CAUSE (architect, 2026-07-20) + hotfix
+
+**Root cause: the receipt PATCH route passed omitted optional fields as
+undefined-valued own properties.** `app/api/receipts/[id]/route.ts` built the
+update object with `exportStatementMonth` (and every other optional field)
+defaulting to `undefined`. JS's `in` operator reports an undefined-valued own
+property as present, so `updateReceiptRecord`'s `"exportStatementMonth" in input`
+check was TRUE and it bound `input.exportStatementMonth ?? null` → NULL —
+clearing the column on every PATCH, including attendees-only. The membership
+hook's `explicitOverrideInInput` was likewise TRUE (the key existed), so automatic
+assignment was suppressed.
+
+**Why the audit hid it:** `JSON.stringify` OMITS undefined-valued properties, so
+the generic `receipt.updated` audit showed no `exportStatementMonth` even though
+the SQL cleared it. The earlier "no audited clearing path" finding was correct
+about the *audit* — it genuinely didn't show the field — but the clearing was
+happening via the SQL bind, invisible to the audit.
+
+**Broader blast radius:** every optional receipt field whose update logic
+combined a `"field" in input` presence check with a `?? null` bind —
+exportStatementMonth, transactionDate, merchant, amountMinor, taxAmountMinor,
+businessPurpose, processedR2Key, extractionJson, exportedMonth,
+expenseCategoryCode, sourceType, invoiceRegistrationNumber, counterpartyName,
+taxRate, qualifiedInvoiceStatus, extractionEnqueuedAt/ProcessedAt/Processor.
+Any of these could be silently NULLed by an ordinary form PATCH that omitted it.
+The 5 July CASH receipts are the visible symptom; other optional fields on
+receipts touched by prior sparse PATCHes may have been cleared too (see the
+read-only audit below).
+
+**Earlier hypotheses RULED OUT:** the non-app writer (MLX consumer / scheduled
+worker / scripts) and the empty-SET UPDATE were NOT the cause. The empty-set
+guard (`if (sets.length === 0) return`, db.ts) never triggered for these PATCHes
+because the undefined-valued fields ADDED entries to `sets` via the `in` checks —
+so the guard saw a non-empty update and ran the clearing UPDATE.
+
+**Hotfix (branch `hotfix/receipt-patch-undefined-clearing`):**
+1. `compactUndefinedReceiptUpdate` (lib/receipts/receipt-update.ts) drops
+   undefined-valued own properties before `updateReceiptRecord`; the same sparse
+   object drives the SQL mutation and the generic audit.
+2. `updateReceiptRecord` presence checks switched from `"field" in input` to
+   `input.field !== undefined` for every optional field (defense in depth,
+   extracted into a pure, unit-tested `buildReceiptUpdateSets`). The empty-set
+   guard now genuinely no-ops attendees-only PATCHes (no UPDATE, no generic
+   audit; the attendee mutation's own audit is authoritative).
+3. Override API: `exportStatementMonth` is rejected when null/empty/invalid/not
+   an open concrete YYYY-MM (no unassignment — stored membership is the sticky
+   authority). Concrete open months remain supported.
+4. `assignMembershipForReceipt` writes the assignment audit only when the
+   conditional UPDATE actually changes a row (no false audits on a lost race /
+   already-assigned row).
+
+The sections below are the original (pre-confirmation) handoff analysis, kept for
+the reproducer + evidence trail.
+
+---
+
+## Symptom + evidence
+
+5 of 7 July-dated CASH receipts have `export_statement_month = NULL` (2 are
+correctly `2026-07`). The 5 NULL ones:
+
+| receipt (prefix) | date | source | captured | updated (today) | stmt_month |
+|---|---|---|---|---|---|
+| `a92e47fa` | 2026-07-01 | mobile_capture | 07-01 | **13:32** | NULL |
+| `b107efb2` | 2026-07-01 | mobile_capture | 07-19 | 11:54 | NULL |
+| `48e16454` | 2026-07-05 | mobile_capture | 07-19 | 11:54 | NULL |
+| `5535d1a3` | 2026-07-11 | mobile_capture | 07-19 | (NULL) | NULL |
+| `1239c951` | 2026-07-14 | mobile_capture | 07-19 | 13:02 | NULL |
+
+(The 2 correctly-assigned: `6374a255` desktop_upload 07-19, `aff37cf9`
+mobile_capture 07-20 — both `2026-07`.)
+
+**They WERE assigned, then reverted:**
+- A one-time backfill (worker, 07:04 UTC) set all 7 → `2026-07` (verified:
+  `stmt_month='2026-07': 7`).
+- The audit shows `b107efb2` and `a92e47fa` were **assigned** to `2026-07`
+  **twice** — once by the backfill (07:04, `receipt.export_statement_month_assigned`,
+  reason `natural`) and again by the broadened `updateReceiptRecord` hook
+  (10:56, post PR #143 deploy) — yet both are NULL now with `updated_at` later
+  than the assignment (11:54, 13:32).
+
+## The contradiction (why I'm escalating)
+
+`export_statement_month` has **three** write paths, all audited:
+1. `assignMembershipForReceipt` (membership.ts:187) — `SET export_statement_month
+   = ? WHERE id = ? AND export_statement_month IS NULL` → only SETS (never
+   clears), only when NULL, audited `receipt.export_statement_month_assigned`.
+2. `updateReceiptRecord` (db.ts:276) — `SET export_statement_month = ?` only when
+   `"exportStatementMonth" in input`; audited via the generic `receipt.updated`
+   (input logged) + a dedicated `receipt.export_statement_month_overridden` when
+   it's an override.
+3. (db.ts:2558 is a **read** — `month: r.export_statement_month ??
+   r.transaction_date.slice(0,7)` — a display fallback in one list function; not
+   a write. Worth noting: this IS a read-side COALESCE, contrary to the
+   "single stored authority" stance.)
+
+**Definitive checks on `a92e47fa` (the 13:32 update):**
+- Its 4 `receipt.updated` entries today (13:32:51/56 × 2) have inputs
+  `['paymentPath','transactionDate','merchant','amountMinor','currency',
+  'businessPurpose','expenseCategoryCode','status']` and `['attendees']` —
+  **none contain `exportStatementMonth`**. So `updateReceiptRecord`'s
+  db.ts:276 branch does not fire; per the code it must not touch the column.
+- **No** `receipt.export_statement_month_overridden` audit to null on any of the
+  5 (the one override audit found SET `2026-07`).
+- The form-pane PATCH bodies (form-pane.tsx:245 and :371) were read directly and
+  do **not** include `exportStatementMonth` (only the override control at :312
+  sends it, on explicit reassignment).
+
+**So: no audited app path clears `export_statement_month`, the relevant PATCHes
+don't carry the field, the hook only sets — yet the column is NULL with a fresh
+`updated_at`.** The app code, as read, cannot produce this state.
+
+## Hypotheses for the architect (not exhausted)
+
+1. **A non-app write path** is clearing it — the most likely. Candidates the
+   worker could not rule out from code alone:
+   - The Mac MLX consumer (scripts/receipts-consumer/) writing
+     `receipt_records` directly (re-extraction / re-render POSTs, or a direct
+     D1 write) that omits/zeroes `export_statement_month`.
+   - A scheduled Worker or the receipts-auto-promote-render plist
+     (scripts/receipts-consumer/com.dazbeez.receipts-auto-promote-render.plist).
+   - A migration re-run or a `scripts/migrate-membership-to-calendar-month.ts`
+     re-execution.
+   - The iOS capture client (DazbeezCapture) PATCHing with a body the route
+     funnels through a path that clears it.
+2. **A subtle app bug**: e.g., an attendees-only PATCH
+   (`input = { attendees }`) reaching `updateReceiptRecord` produces an
+   empty `sets` array → a malformed/empty `UPDATE receipt_records SET …`
+   (`db.ts:313`) — verify whether that no-ops, errors, or somehow nulls columns.
+   (The audit shows `attendees`-only `receipt.updated` entries, so this input
+   shape does reach `updateReceiptRecord`.)
+3. **Concurrency / stale `before`**: two overlapping PATCHes where the
+   `before.export_statement_month` snapshot used by the hook is stale.
+
+## Reproducer for the architect
+
+The clearest live signal: `a92e47fa` was assigned `2026-07` at 10:56 (hook) and
+is NULL at 13:32 after attendees/form PATCHes that do not carry
+`exportStatementMonth`. Re-assigning it (worker can) and watching whether/when it
+reverts — with `wrangler tail` + the audit log — should catch the clearer in the
+act. All 5 are currently NULL and available as targets.
+
+## What I need from the architect
+
+- Root-cause the clearing (trace the non-app write paths — MLX consumer,
+  scheduled workers, scripts — and/or the empty-SET UPDATE / attendees-only
+  input path) and confirm the mechanism.
+- A fix spec. Note David's standing constraint: he rejected read-time COALESCE
+  (breaks roll-forward, masks the bug) and wants a single sticky stored
+  authority — so the fix should make the stored column reliable, not paper over
+  it. (The db.ts:2558 read-fallback should probably also be reconciled with that
+  stance.)
+
+## Worker stopgap (available, not applied)
+
+Re-assigning the 5 to `2026-07` (D1 UPDATE + `receipt.export_statement_month_assigned`
+audit, as before) puts them in July immediately — but if the clearer is still
+active they will revert. Held off pending the architect's root cause so the
+NULL state stays inspectable; can apply on David's word.

--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -227,6 +227,79 @@ export async function hardDeleteReceipt(
   return true;
 }
 
+/**
+ * Build the SET clause + binds for a receipt update from a sparse input, using
+ * `!== undefined` presence (NOT `"field" in input`). Pure (no D1) so the
+ * sparse-update behavior is unit-testable: an omitted/undefined field binds
+ * nothing (no silent NULL clear of sticky data), explicit null clears a
+ * clearable field, and an attendees-only input yields no sets (→ no UPDATE, no
+ * generic audit). Exported for tests.
+ */
+export function buildReceiptUpdateSets(
+  input: UpdateReceiptInput,
+  before: ReceiptRecord,
+): { sets: string[]; binds: unknown[] } {
+  const sets: string[] = [];
+  const binds: unknown[] = [];
+
+  // Presence = value is not undefined (NOT `"field" in input`). An undefined
+  // own property — e.g. an omitted optional field a caller passed through — must
+  // NOT trigger a bind: `in` is true for an undefined-valued key and would bind
+  // the column to `undefined ?? null` → NULL, silently clearing sticky data
+  // (the 2026-07-20 membership-clearing root cause). Explicit null is honored
+  // (null !== undefined) for legitimately clearable fields. Applied to every
+  // optional field, not only exportStatementMonth.
+  if (input.paymentPath !== undefined) { sets.push("payment_path = ?"); binds.push(input.paymentPath); }
+  if (input.expenseType !== undefined) { sets.push("expense_type = ?"); binds.push(input.expenseType); }
+  if (input.transactionDate !== undefined) { sets.push("transaction_date = ?"); binds.push(input.transactionDate ?? null); }
+  if (input.merchant !== undefined) { sets.push("merchant = ?"); binds.push(input.merchant ?? null); }
+  if (input.amountMinor !== undefined) { sets.push("amount_minor = ?"); binds.push(input.amountMinor ?? null); }
+  if (input.currency !== undefined) { sets.push("currency = ?"); binds.push(input.currency); }
+  if (input.taxAmountMinor !== undefined) { sets.push("tax_amount_minor = ?"); binds.push(input.taxAmountMinor ?? null); }
+  if (input.businessPurpose !== undefined) { sets.push("business_purpose = ?"); binds.push(input.businessPurpose ?? null); }
+  if (input.alcoholPresent !== undefined) { sets.push("alcohol_present = ?"); binds.push(input.alcoholPresent ? 1 : 0); }
+  if (input.status !== undefined) { sets.push("status = ?"); binds.push(input.status); }
+  if (input.processedR2Key !== undefined) { sets.push("processed_r2_key = ?"); binds.push(input.processedR2Key ?? null); }
+  if (input.extractionJson !== undefined) { sets.push("extraction_json = ?"); binds.push(input.extractionJson ?? null); }
+  if (input.exportedMonth !== undefined) { sets.push("exported_month = ?"); binds.push(input.exportedMonth ?? null); }
+  // ADR 0006 §D6: discretionary override of the sticky export_statement_month.
+  // The route guards the target month is export-open and writes the dedicated
+  // audit entry; this just applies the column. Explicit override wins over the
+  // automatic assignment hook below.
+  if (input.exportStatementMonth !== undefined) {
+    sets.push("export_statement_month = ?");
+    binds.push(input.exportStatementMonth ?? null);
+  }
+  if (input.expenseCategoryCode !== undefined) { sets.push("expense_category_code = ?"); binds.push(input.expenseCategoryCode ?? null); }
+  if (input.sourceType !== undefined) { sets.push("source_type = ?"); binds.push(input.sourceType ?? null); }
+  if (input.invoiceRegistrationNumber !== undefined) { sets.push("invoice_registration_number = ?"); binds.push(input.invoiceRegistrationNumber ?? null); }
+  if (input.counterpartyName !== undefined) { sets.push("counterparty_name = ?"); binds.push(input.counterpartyName ?? null); }
+  if (input.taxRate !== undefined) { sets.push("tax_rate = ?"); binds.push(input.taxRate ?? null); }
+  if (input.qualifiedInvoiceStatus !== undefined) { sets.push("qualified_invoice_status = ?"); binds.push(input.qualifiedInvoiceStatus ?? "not_checked"); }
+  if (input.extractionState !== undefined) { sets.push("extraction_state = ?"); binds.push(input.extractionState); }
+  if (input.extractionEnqueuedAt !== undefined) { sets.push("extraction_enqueued_at = ?"); binds.push(input.extractionEnqueuedAt ?? null); }
+  if (input.extractionProcessedAt !== undefined) { sets.push("extraction_processed_at = ?"); binds.push(input.extractionProcessedAt ?? null); }
+  if (input.extractionAttempts !== undefined) { sets.push("extraction_attempts = ?"); binds.push(input.extractionAttempts); }
+  if (input.extractionProcessor !== undefined) { sets.push("extraction_processor = ?"); binds.push(input.extractionProcessor ?? null); }
+
+  // ADR 0001 root-cause guard: advancing a receipt past extraction (e.g. a
+  // human reviews a still-queued capture before the consumer drains it) must
+  // clear any stale pending extraction_state, or listPendingProcessingReceipts
+  // keeps the month-close gate blocked forever. Only when the caller didn't set
+  // the state itself and the row is still pending.
+  if (
+    input.status !== undefined &&
+    input.status !== "captured" &&
+    input.extractionState === undefined &&
+    before.extraction_state !== undefined &&
+    PENDING_EXTRACTION_STATES.includes(before.extraction_state)
+  ) {
+    sets.push("extraction_state = 'processed'");
+  }
+
+  return { sets, binds };
+}
+
 export async function updateReceiptRecord(
   id: string,
   input: UpdateReceiptInput,
@@ -248,62 +321,18 @@ export async function updateReceiptRecord(
   const effectivePaymentPath = input.paymentPath ?? before.payment_path;
   if (effectivePaymentPath === "CASH" || effectivePaymentPath === "DIGITAL") {
     const effectiveDate =
-      "transactionDate" in input ? input.transactionDate : before.transaction_date;
+      input.transactionDate !== undefined ? input.transactionDate : before.transaction_date;
     await assertTransactionMonthEditable(transactionMonthOf(effectiveDate));
   }
 
-  const sets: string[] = [];
-  const binds: unknown[] = [];
+  const { sets, binds } = buildReceiptUpdateSets(input, before);
 
-  if (input.paymentPath !== undefined) { sets.push("payment_path = ?"); binds.push(input.paymentPath); }
-  if (input.expenseType !== undefined) { sets.push("expense_type = ?"); binds.push(input.expenseType); }
-  if ("transactionDate" in input) { sets.push("transaction_date = ?"); binds.push(input.transactionDate ?? null); }
-  if ("merchant" in input) { sets.push("merchant = ?"); binds.push(input.merchant ?? null); }
-  if ("amountMinor" in input) { sets.push("amount_minor = ?"); binds.push(input.amountMinor ?? null); }
-  if (input.currency !== undefined) { sets.push("currency = ?"); binds.push(input.currency); }
-  if ("taxAmountMinor" in input) { sets.push("tax_amount_minor = ?"); binds.push(input.taxAmountMinor ?? null); }
-  if ("businessPurpose" in input) { sets.push("business_purpose = ?"); binds.push(input.businessPurpose ?? null); }
-  if (input.alcoholPresent !== undefined) { sets.push("alcohol_present = ?"); binds.push(input.alcoholPresent ? 1 : 0); }
-  if (input.status !== undefined) { sets.push("status = ?"); binds.push(input.status); }
-  if ("processedR2Key" in input) { sets.push("processed_r2_key = ?"); binds.push(input.processedR2Key ?? null); }
-  if ("extractionJson" in input) { sets.push("extraction_json = ?"); binds.push(input.extractionJson ?? null); }
-  if ("exportedMonth" in input) { sets.push("exported_month = ?"); binds.push(input.exportedMonth ?? null); }
-  // ADR 0006 §D6: discretionary override of the sticky export_statement_month.
-  // The route guards the target month is export-open and writes the dedicated
-  // audit entry; this just applies the column. Explicit override wins over the
-  // automatic assignment hook below.
-  if ("exportStatementMonth" in input) {
-    sets.push("export_statement_month = ?");
-    binds.push(input.exportStatementMonth ?? null);
-  }
-  if ("expenseCategoryCode" in input) { sets.push("expense_category_code = ?"); binds.push(input.expenseCategoryCode ?? null); }
-  if ("sourceType" in input) { sets.push("source_type = ?"); binds.push(input.sourceType ?? null); }
-  if ("invoiceRegistrationNumber" in input) { sets.push("invoice_registration_number = ?"); binds.push(input.invoiceRegistrationNumber ?? null); }
-  if ("counterpartyName" in input) { sets.push("counterparty_name = ?"); binds.push(input.counterpartyName ?? null); }
-  if ("taxRate" in input) { sets.push("tax_rate = ?"); binds.push(input.taxRate ?? null); }
-  if ("qualifiedInvoiceStatus" in input) { sets.push("qualified_invoice_status = ?"); binds.push(input.qualifiedInvoiceStatus ?? "not_checked"); }
-  if (input.extractionState !== undefined) { sets.push("extraction_state = ?"); binds.push(input.extractionState); }
-  if ("extractionEnqueuedAt" in input) { sets.push("extraction_enqueued_at = ?"); binds.push(input.extractionEnqueuedAt ?? null); }
-  if ("extractionProcessedAt" in input) { sets.push("extraction_processed_at = ?"); binds.push(input.extractionProcessedAt ?? null); }
-  if (input.extractionAttempts !== undefined) { sets.push("extraction_attempts = ?"); binds.push(input.extractionAttempts); }
-  if ("extractionProcessor" in input) { sets.push("extraction_processor = ?"); binds.push(input.extractionProcessor ?? null); }
-
-  // ADR 0001 root-cause guard: advancing a receipt past extraction (e.g. a
-  // human reviews a still-queued capture before the consumer drains it) must
-  // clear any stale pending extraction_state, or listPendingProcessingReceipts
-  // keeps the month-close gate blocked forever — and the consumer later acks the
-  // now-409 message without fixing it. Only when the caller didn't set the state
-  // itself and the row is still pending.
-  if (
-    input.status !== undefined &&
-    input.status !== "captured" &&
-    input.extractionState === undefined &&
-    before.extraction_state !== undefined &&
-    PENDING_EXTRACTION_STATES.includes(before.extraction_state)
-  ) {
-    sets.push("extraction_state = 'processed'");
-  }
-
+  // No receipt-field changes (e.g. an attendees-only PATCH after compaction):
+  // do NOT run a synthetic/empty UPDATE and do NOT emit a generic receipt.updated
+  // audit. The attendee mutation's own audit (written by the route via
+  // createAttendees) is authoritative; the membership hook is skipped too (no
+  // assignment on a no-op). The route still performs the attendee mutation and
+  // returns the receipt.
   if (sets.length === 0) return;
 
   sets.push("updated_at = ?");
@@ -334,9 +363,9 @@ export async function updateReceiptRecord(
   const membershipDate = postPatchMembershipDate({
     effectivePaymentPath,
     beforeExportStatementMonth: before.export_statement_month ?? null,
-    explicitOverrideInInput: "exportStatementMonth" in input,
+    explicitOverrideInInput: input.exportStatementMonth !== undefined,
     effectiveTransactionDate:
-      ("transactionDate" in input ? input.transactionDate : before.transaction_date) ?? null,
+      (input.transactionDate !== undefined ? input.transactionDate : before.transaction_date) ?? null,
   });
   if (membershipDate) {
     try {

--- a/lib/receipts/membership.ts
+++ b/lib/receipts/membership.ts
@@ -41,8 +41,9 @@ import type { PaymentPath, ReceiptRecord } from "@/lib/receipts/types";
  * shipped AND have no open draft revision (the isMonthLockedForEdits
  * condition). Roll-forward and the override both treat these as closed targets.
  */
-export async function loadSealedExportMonths(): Promise<Set<string>> {
-  const db = getReceiptsDb();
+export async function loadSealedExportMonths(
+  db: D1Database = getReceiptsDb(),
+): Promise<Set<string>> {
   const res = await db
     .prepare(
       `SELECT export_month FROM receipt_exports
@@ -175,20 +176,26 @@ export async function assignMembershipForReceipt(
   receiptId: string,
   transactionDate: string | null,
   actor: string,
+  db: D1Database = getReceiptsDb(),
 ): Promise<AssignmentResult | null> {
   if (!transactionDate || !naturalMonth(transactionDate)) return null;
-  const sealedMonths = await loadSealedExportMonths();
+  const sealedMonths = await loadSealedExportMonths(db);
   const result = assignReceiptMembership(transactionDate, sealedMonths, {
     rollForward: true,
   });
-  const db = getReceiptsDb();
-  await db
+  // Conditional UPDATE gated on export_statement_month IS NULL: a lost race or
+  // an already-assigned row changes 0 rows. Only audit (and report success) when
+  // a row actually changed — never emit a false assignment audit.
+  const updateResult = await db
     .prepare(
       `UPDATE receipt_records SET export_statement_month = ?, updated_at = ?
        WHERE id = ? AND export_statement_month IS NULL`,
     )
     .bind(result.month, nowIso(), receiptId)
     .run();
+  if ((updateResult.meta.changes ?? 0) === 0) {
+    return null;
+  }
   await createAuditEntry(db, {
     actor,
     action:

--- a/lib/receipts/receipt-update.ts
+++ b/lib/receipts/receipt-update.ts
@@ -1,0 +1,47 @@
+// Sparse receipt-update helper. Pure + client-safe (no server imports), so it
+// unit-tests without D1 mocks and is reusable client-side.
+//
+// Problem it fixes: a PATCH route that builds an update object with optional
+// fields left as `undefined` (own properties present, value undefined). JS's
+// `in` operator reports those keys as present, so a presence check like
+// `"exportStatementMonth" in input` is TRUE and the column gets bound to
+// `undefined ?? null` → NULL (clearing sticky data). Meanwhile JSON.stringify
+// OMITS undefined-valued properties, so the generic audit hid the clearing.
+//
+// compactUndefinedReceiptUpdate drops own properties whose value is undefined,
+// preserving explicit null (a legitimate "clear this field" signal) and all
+// other values. The route passes the compacted object to updateReceiptRecord so
+// the same sparse shape drives both the SQL mutation and the generic audit.
+// updateReceiptRecord additionally uses `!== undefined` presence checks as
+// defense in depth (other callers may not compact).
+
+export function compactUndefinedReceiptUpdate<T extends object>(input: T): Partial<T> {
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(input)) {
+    const value = input[key as keyof T];
+    if (value !== undefined) out[key] = value;
+  }
+  return out as Partial<T>;
+}
+
+export type ExportStatementMonthOverride =
+  | { kind: "empty" }
+  | { kind: "invalid" }
+  | { kind: "month"; value: string };
+
+/**
+ * Parse a raw exportStatementMonth override value (pure). The route rejects
+ * `empty` (stored membership is the sticky authority — no unassignment) and
+ * `invalid`; for `month` it then checks the month is export-open. The UI only
+ * ever sends a concrete target month. Extracted so the rejection policy is
+ * unit-testable without auth/D1.
+ */
+export function parseExportStatementMonthOverride(
+  raw: unknown,
+): ExportStatementMonthOverride {
+  if (raw === null || raw === "") return { kind: "empty" };
+  if (typeof raw === "string" && /^\d{4}-\d{2}$/.test(raw)) {
+    return { kind: "month", value: raw };
+  }
+  return { kind: "invalid" };
+}

--- a/tests/receipts/membership-assign.test.ts
+++ b/tests/receipts/membership-assign.test.ts
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { assignMembershipForReceipt } from "@/lib/receipts/membership";
+
+// assignMembershipForReceipt takes `db` as a 4th param (testability seam). It
+// calls loadSealedExportMonths(db) (→ empty here, so the date's calendar month
+// wins), the conditional UPDATE (gated on export_statement_month IS NULL), and —
+// only when the UPDATE changes a row — the assignment audit INSERT. The fake D1
+// answers loadSealedExportMonths's .all() with no sealed months and the UPDATE's
+// .run() with a configurable changes count; .run() calls are recorded.
+
+type Run = { sql: string; args: unknown[] };
+
+function fakeDb(changes: number) {
+  const runs: Run[] = [];
+  const bound = (sql: string, args: unknown[]) => ({
+    async all<T = unknown>(): Promise<{ results?: T[] }> {
+      return { results: [] }; // loadSealedExportMonths → no sealed months
+    },
+    async run() {
+      runs.push({ sql, args });
+      return { meta: { changes } };
+    },
+  });
+  const db = {
+    prepare(sql: string) {
+      return {
+        // loadSealedExportMonths calls .all() directly (no bind).
+        async all<T = unknown>(): Promise<{ results?: T[] }> {
+          return { results: [] };
+        },
+        bind(...args: unknown[]) {
+          return bound(sql, args); // UPDATE + audit INSERT bind then run.
+        },
+      };
+    },
+  };
+  return { db: db as unknown as D1Database, runs };
+}
+
+test("assignMembershipForReceipt: UPDATE changes a row → audit written, result returned", async () => {
+  const { db, runs } = fakeDb(1);
+  const result = await assignMembershipForReceipt("r1", "2026-07-11", "david@example.com", db);
+  assert.ok(result, "should return the assignment result when a row changed");
+  assert.equal(result!.month, "2026-07");
+  assert.equal(result!.reason, "natural");
+  assert.ok(
+    runs.some((r) => /INSERT INTO receipt_audit_log/i.test(r.sql)),
+    "the assignment audit INSERT should fire when a row changed",
+  );
+});
+
+test("assignMembershipForReceipt: UPDATE changes 0 rows (already assigned / lost race) → NO audit, returns null", async () => {
+  const { db, runs } = fakeDb(0);
+  const result = await assignMembershipForReceipt("r1", "2026-07-11", "david@example.com", db);
+  assert.equal(result, null, "should return null when no row changed");
+  assert.ok(
+    !runs.some((r) => /INSERT INTO receipt_audit_log/i.test(r.sql)),
+    "no false assignment audit when the conditional UPDATE changed 0 rows",
+  );
+});

--- a/tests/receipts/receipt-update.test.ts
+++ b/tests/receipts/receipt-update.test.ts
@@ -1,0 +1,126 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  compactUndefinedReceiptUpdate,
+  parseExportStatementMonthOverride,
+} from "@/lib/receipts/receipt-update";
+import { buildReceiptUpdateSets } from "@/lib/receipts/db";
+import type { ReceiptRecord, UpdateReceiptInput } from "@/lib/receipts/types";
+
+// buildReceiptUpdateSets only reads before.extraction_state; a minimal fixture
+// (state not pending) keeps the ADR-0001 guard from firing.
+const before = { extraction_state: "processed" } as unknown as ReceiptRecord;
+const U = (x: Partial<UpdateReceiptInput>): UpdateReceiptInput =>
+  x as UpdateReceiptInput;
+
+// ─── compactUndefinedReceiptUpdate (root-cause fix) ──────────────────────────
+
+test("compactUndefinedReceiptUpdate: drops undefined own properties", () => {
+  const out = compactUndefinedReceiptUpdate({ a: 1, b: undefined, c: "x" }) as Record<
+    string,
+    unknown
+  >;
+  assert.deepEqual(out, { a: 1, c: "x" });
+  assert.ok(!("b" in out), "undefined-valued own property must be dropped");
+});
+
+test("compactUndefinedReceiptUpdate: preserves explicit null + falsy-defined values", () => {
+  const out = compactUndefinedReceiptUpdate({
+    a: null,
+    b: undefined,
+    c: 0,
+    d: "",
+  }) as Record<string, unknown>;
+  assert.equal(out["a"], null, "explicit null preserved (legitimate clear)");
+  assert.ok(!("b" in out), "undefined dropped");
+  assert.equal(out["c"], 0, "falsy-but-defined preserved");
+  assert.equal(out["d"], "", "empty string preserved");
+});
+
+test("compactUndefinedReceiptUpdate: omitted exportStatementMonth (undefined) is dropped — does not clear membership", () => {
+  const out = compactUndefinedReceiptUpdate({
+    merchant: "X",
+    exportStatementMonth: undefined,
+  }) as Record<string, unknown>;
+  assert.ok(!("exportStatementMonth" in out));
+  assert.equal(out["merchant"], "X");
+});
+
+// ─── parseExportStatementMonthOverride ───────────────────────────────────────
+
+test("parseExportStatementMonthOverride: null/empty → empty (rejected; sticky authority)", () => {
+  assert.equal(parseExportStatementMonthOverride(null).kind, "empty");
+  assert.equal(parseExportStatementMonthOverride("").kind, "empty");
+});
+
+test("parseExportStatementMonthOverride: invalid → invalid", () => {
+  assert.equal(parseExportStatementMonthOverride("2026").kind, "invalid");
+  assert.equal(parseExportStatementMonthOverride("june").kind, "invalid");
+  assert.equal(parseExportStatementMonthOverride(7).kind, "invalid");
+});
+
+test("parseExportStatementMonthOverride: concrete YYYY-MM → month (valid explicit override)", () => {
+  const r = parseExportStatementMonthOverride("2026-07");
+  assert.equal(r.kind, "month");
+  assert.equal(r.kind === "month" ? r.value : null, "2026-07");
+});
+
+// ─── buildReceiptUpdateSets (sparse / undefined-aware presence) ───────────────
+
+test("buildReceiptUpdateSets: empty / attendees-only input → no sets (no UPDATE, no audit)", () => {
+  const { sets } = buildReceiptUpdateSets(U({}), before);
+  assert.equal(sets.length, 0, "an attendees-only PATCH must not produce any SET clauses");
+});
+
+test("buildReceiptUpdateSets: merchant-only PATCH sets only merchant — not date/category/membership/extraction", () => {
+  const { sets } = buildReceiptUpdateSets(U({ merchant: "X" }), before);
+  assert.ok(sets.some((s) => s.startsWith("merchant")), "merchant should be set");
+  for (const col of [
+    "transaction_date",
+    "expense_category_code",
+    "export_statement_month",
+    "extraction_json",
+    "business_purpose",
+    "amount_minor",
+  ]) {
+    assert.ok(
+      !sets.some((s) => s.startsWith(col)),
+      `${col} must not be touched by a merchant-only PATCH`,
+    );
+  }
+});
+
+test("buildReceiptUpdateSets: status-only PATCH sets only status", () => {
+  const { sets } = buildReceiptUpdateSets(U({ status: "reviewed" }), before);
+  assert.ok(sets.some((s) => s.startsWith("status")));
+  assert.ok(!sets.some((s) => s.startsWith("transaction_date")));
+  assert.ok(!sets.some((s) => s.startsWith("expense_category_code")));
+  assert.ok(!sets.some((s) => s.startsWith("export_statement_month")));
+});
+
+test("buildReceiptUpdateSets: undefined exportStatementMonth does NOT bind (no silent NULL clear)", () => {
+  const { sets } = buildReceiptUpdateSets(
+    U({ merchant: "X", exportStatementMonth: undefined }),
+    before,
+  );
+  assert.ok(
+    !sets.some((s) => s.startsWith("export_statement_month")),
+    "undefined exportStatementMonth must not bind",
+  );
+});
+
+test("buildReceiptUpdateSets: explicit null exportStatementMonth IS bound (mechanism honored)", () => {
+  // The route now rejects null overrides, but the column mechanism still honors
+  // explicit null — guard the mechanism (used for legitimately clearable fields).
+  const { sets, binds } = buildReceiptUpdateSets(U({ exportStatementMonth: null }), before);
+  const idx = sets.findIndex((s) => s.startsWith("export_statement_month"));
+  assert.ok(idx >= 0, "explicit null should bind export_statement_month");
+  assert.equal(binds[idx], null);
+});
+
+test("buildReceiptUpdateSets: explicit null businessPurpose binds NULL (clearing a clearable field)", () => {
+  const { sets, binds } = buildReceiptUpdateSets(U({ businessPurpose: null }), before);
+  const idx = sets.findIndex((s) => s.startsWith("business_purpose"));
+  assert.ok(idx >= 0);
+  assert.equal(binds[idx], null);
+});


### PR DESCRIPTION
## Summary — urgent data-integrity fix

**Root cause** (confirmed, docs/audits/2026-07-20-membership-clearing-mystery.md): the PATCH route built the update object with omitted optional fields as **undefined-valued own properties**. `"field" in input` is true for an undefined-valued key → `updateReceiptRecord` bound it to `undefined ?? null` → NULL, silently clearing sticky data (notably `export_statement_month` on every form/attendees PATCH). `JSON.stringify` omits undefined, so the generic audit hid it. Blast radius: every optional field combining `in` + `?? null` (2 AMEX receipts also lost `extraction_json`).

## Fix
- `compactUndefinedReceiptUpdate` (new, lib/receipts/receipt-update.ts) drops undefined own props before `updateReceiptRecord`; the same sparse object drives SQL mutation + the generic audit.
- `updateReceiptRecord`: `!== undefined` presence for every optional field, extracted into a pure, unit-tested `buildReceiptUpdateSets`. Attendees-only/empty input now genuinely no-ops (no UPDATE, no generic audit).
- Override API: `exportStatementMonth` rejected when null/empty/invalid/not an open concrete YYYY-MM (no unassignment — stored membership is sticky). Pure `parseExportStatementMonthOverride` validator.
- `assignMembershipForReceipt` audits only when the conditional UPDATE changes a row (no false audits). `db` seam on it + `loadSealedExportMonths` for testability.

## Verification
- `tsc --noEmit` clean · `npm test` 773 pass / 0 fail (14 new tests) · `build:cf` exit 0
- cf:dev PATCH smoke not run (Clerk pk_live localhost limitation); logic covered by unit tests + live-verified post-deploy

## Follow-up (post-deploy)
- Backfill the 5 July CASH receipts (`export_statement_month = 2026-07`).
- Re-extract the 2 AMEX receipts that lost `extraction_json` (580f9aba, 8d71768d).
- June: diff rebuilt rev3 draft CSVs vs sealed rev2 (R2 snapshots) — every diff attributable to intended changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)