### PR TITLE
receipts: orphan-remediation Phase 1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,15 +194,49 @@ starts. Design consequences:
    finalized-reconciliation guard also locks receipt edits. Resolution
    path: unfinalize 2026-05 → set receipt category → re-finalize. Verify
    an unfinalize flow exists before attempting.
-8. **Orphan classification: "upcoming" vs. true orphan.** The current 16
-   orphan receipts are all dated after the 2026-07 AMEX statement period —
-   they aren't errors, just receipts awaiting the next statement. Classify
-   orphans by date: receipt date after the latest statement period →
-   "upcoming" (expected to match when the next statement arrives); receipt
-   date within an existing statement's period → true orphan (needs
-   investigation). Derive at query time (no stored flag) so classification
-   flips automatically when a new statement lands. Surface the distinction
-   in reconcile/queue views so upcoming receipts don't read as problems.
+8. **Orphan classification: "upcoming" vs. true orphan.** Classify orphans by
+   date: receipt date after the latest statement period → "upcoming" (expected
+   to match when the next statement arrives); receipt date within an existing
+   statement's period → true orphan (needs investigation). Derive at query time
+   (no stored flag) so classification flips automatically when a new statement
+   lands. Surface the distinction in reconcile/queue views so upcoming receipts
+   don't read as problems.
+   HISTORY (2026-07-05): at that time the 16 orphan receipts observed were all
+   dated after the 2026-07 AMEX statement period — they weren't errors, just
+   receipts awaiting the next statement. That "all upcoming" framing was true
+   for that one snapshot.
+   AUDIT (2026-07-21, read-only): no longer true. The default reconcile month is
+   now 2026-08 (12 orphans). The 2026-08 orphan population is dominated by
+   **possible AMEX re-captures** (same canonical merchant + currency + amount +
+   date, distinct files — e.g. a HOLIDAY SKY LOUNGE ¥10680 triple, a 岡芳商店
+   ¥3862 triple) and **cross-month leakage** (a receipt confirmed in 2026-07
+   whose status drifted to "reviewed" appeared as a 2026-08 orphan because the
+   page built its linked-set from the displayed month only). Other live
+   duplicates: ロトンド / ブラチェリアロトンド and PERFECT / PBK四ッ谷
+   descriptor-vs-legal-name pairs, a NFCTAGS mobile-photo + desktop-PDF
+   cross-channel pair, and a MIURA re-capture of an already-exported receipt.
+   NOTE: the audit did **not** complete visual comparison of the receipt images
+   (the local viewer did not render and images were not sent to a third-party
+   vision service), so these are metadata-strong **possible** duplicates, not
+   pixel-confirmed. A legitimate JR round-trip (two ¥4280 えきねっと charges,
+   one day apart, reconciled to two distinct lines) must not be mislabeled.
+   PHASE 1 IMPLEMENTED ON BRANCH — NOT YET MERGED OR DEPLOYED: (a)
+   status-downgrade prevention — the public review PATCH owns only
+   captured/needs_review→reviewed, and ordinary autosaves omit status
+   (lib/receipts/receipt-status-policy.ts); (b)
+   cross-month false-orphan removal — receipts claimed by a matched/confirmed
+   line in another statement month are excluded from candidates and orphans,
+   keyed on the AMEX line relationship not receipt.status
+   (lib/receipts/cross-month-claims.ts); (c) honest classification — only true
+   in-period unmatched receipts count as "Orphan receipts"; leading-slack,
+   upcoming, and undated are separate labeled sections
+   (lib/receipts/orphan-classification.ts); (d) the global newest-200 AMEX
+   query is replaced by an exhaustive windowed read with a hard cap that throws
+   loudly (listAmexReceiptsForReconcile in db.ts); (e) non-blocking AMEX
+   possible-duplicate badges in Reconcile (lib/receipts/amex-duplicates.ts) —
+   never auto-matches/deletes. Open data-cleanup (operator action, NOT in this
+   code-only phase): the stray duplicate receipts identified by the audit still
+   need manual delete-after-review; no production data was mutated.
 9. **Consumer poison-pill handling + DLQ.** Undecodable files (pre-PDF-fix:
    PIL UnidentifiedImageError) fall into the generic retry path and redeliver
    until max-deliveries silently drops them — receipt stuck at

--- a/app/(receipt-system)/receipts/reconcile/page.tsx
+++ b/app/(receipt-system)/receipts/reconcile/page.tsx
@@ -1,23 +1,32 @@
 import {
   listAmexLines,
-  listReceiptRecords,
   getReconciliationForMonth,
   listAmexLineCountsByMonth,
   listReconciliationStatusByMonth,
   listAttendeeNamesByReceiptIds,
+  listReceiptRecordsByIds,
+  listAmexLinesByMatchedReceiptIds,
+  listAmexReceiptsForReconcile,
 } from "@/lib/receipts/db";
-import { RECEIPT_VIEW_LIMIT } from "@/lib/receipts/list-policy";
 import { matchAmexToReceipts } from "@/lib/receipts/reconciliation";
+import { deriveStatementWindow } from "@/lib/receipts/statement-window";
 import {
-  deriveStatementWindow,
-  isReceiptInWindow,
-} from "@/lib/receipts/statement-window";
+  partitionUnmatchedReceipts,
+  statementLineDateRange,
+} from "@/lib/receipts/orphan-classification";
+import {
+  crossMonthClaimedReceiptIds,
+  allClaimedReceiptIds,
+} from "@/lib/receipts/cross-month-claims";
+import { findAmexDuplicateCandidates } from "@/lib/receipts/amex-duplicates";
+import type { AmexDuplicateCandidate } from "@/lib/receipts/amex-duplicates";
 import { ReconcileScreen } from "@/components/receipts/reconcile/reconcile-screen";
 import { assertReceiptsPageAccess } from "@/lib/receipts/auth-request";
 import type { MonthOption } from "@/components/receipts/month-switcher";
 import { formatMonth } from "@/lib/receipts/format";
 import { listCategoryRules } from "@/lib/receipts/category-rules";
 import { getReceiptsDb } from "@/lib/cloudflare-runtime";
+import type { ReceiptRecord } from "@/lib/receipts/types";
 
 export const dynamic = "force-dynamic";
 
@@ -52,29 +61,63 @@ export default async function ReconcilePage({
       ? availableMonths[availableMonths.length - 1]!.month
       : new Date().toISOString().slice(0, 7));
 
-  const [amexLines, receipts, reconciliation] = await Promise.all([
+  const [amexLines, reconciliation] = await Promise.all([
     listAmexLines(month),
-    listReceiptRecords({ paymentPath: "AMEX", limit: RECEIPT_VIEW_LIMIT }),
     getReconciliationForMonth(month),
   ]);
 
-  const window = amexLines.length > 0 ? deriveStatementWindow(amexLines, month) : null;
-  const receiptsInWindow = window
-    ? receipts.filter((r) => isReceiptInWindow(r, window))
-    : receipts;
-
   const finalized = reconciliation?.status === "finalized";
+  const window =
+    amexLines.length > 0 ? deriveStatementWindow(amexLines, month) : null;
+
+  // Part D — exhaustive windowed AMEX candidate read (dated in-window + undated,
+  // separate). Replaces the old global newest-200 query; no silent truncation
+  // (a hard cap inside listAmexReceiptsForReconcile throws loudly).
+  const windowedReceipts: ReceiptRecord[] = window
+    ? await listAmexReceiptsForReconcile(window)
+    : [];
+
+  // Receipts matched to THIS month's lines, fetched by id so the detail pane's
+  // receipt map still resolves a line matched to a receipt dated outside the
+  // window (a cross-month-dated confirmed match). Also feeds the duplicate pool.
+  const matchedIdsThisMonth = amexLines
+    .map((l) => l.matched_receipt_id)
+    .filter((id): id is string => Boolean(id));
+  const matchedReceiptsById = matchedIdsThisMonth.length
+    ? await listReceiptRecordsByIds(matchedIdsThisMonth)
+    : [];
+
+  // Part B — cross-month claims. Load EVERY amex_statement_lines claim (all
+  // statement months) against the windowed receipts. A receipt confirmed in
+  // another month must NOT be offered as an automatic match or shown as an
+  // orphan in THIS month, even if its receipt status has drifted. The AMEX line
+  // relationship is authoritative here — never receipt.status.
+  const windowedIds = windowedReceipts.map((r) => r.id);
+  const crossMonthClaims = windowedIds.length
+    ? await listAmexLinesByMatchedReceiptIds(windowedIds)
+    : [];
+  const crossMonthClaimedIds = crossMonthClaimedReceiptIds(
+    crossMonthClaims,
+    month,
+  );
+
+  // Matcher candidates: windowed receipts MINUS cross-month-claimed. Same-month
+  // matches are intentionally kept so consolidated-receipt grouping still works.
+  const matcherCandidates = windowedReceipts.filter(
+    (r) => !crossMonthClaimedIds.has(r.id),
+  );
+
   const autoMatches = finalized
     ? []
-    : matchAmexToReceipts(amexLines, receiptsInWindow);
+    : matchAmexToReceipts(amexLines, matcherCandidates);
 
-  const linkedReceiptIds = new Set(
-    amexLines
-      .map((l) => l.matched_receipt_id)
-      .filter((id): id is string => Boolean(id)),
-  );
+  const linkedReceiptIds = new Set(matchedIdsThisMonth);
   const suggestedReceiptIds = new Set(autoMatches.map((m) => m.receiptId));
-  const orphanReceipts = receiptsInWindow.filter(
+
+  // Unmatched in-window AMEX receipts (active, not deleted, not linked here, not
+  // suggested, not claimed in another month). Then classify honestly (Part C):
+  // only true in-period receipts become "orphan receipts".
+  const unmatchedInWindow = windowedReceipts.filter(
     (r) =>
       r.payment_path === "AMEX" &&
       r.status !== "archived" &&
@@ -82,12 +125,44 @@ export default async function ReconcilePage({
       r.status !== "reconciled" &&
       !r.deleted_at &&
       !linkedReceiptIds.has(r.id) &&
-      !suggestedReceiptIds.has(r.id),
+      !suggestedReceiptIds.has(r.id) &&
+      !crossMonthClaimedIds.has(r.id),
   );
 
-  // Bulk-fetch attendee names once for every receipt that could be shown in
-  // the detail pane (matched on a line, suggested by the matcher, or visible
-  // as an orphan). Single query — keeps the detail pane N+1-free.
+  const dateRange = statementLineDateRange(
+    amexLines.map((l) => l.transaction_date),
+  );
+  const partition = partitionUnmatchedReceipts(unmatchedInWindow, dateRange);
+  const orphanReceipts = partition.true_in_period;
+
+  // Part E — non-destructive AMEX duplicate candidates. The pool is the windowed
+  // set ∪ this month's matched-by-id receipts (so an orphan can be compared
+  // against an already-matched partner). matchedReceiptIds is the authoritative
+  // "claimed by an AMEX line" set (this month's links ∪ every cross-month claim).
+  const poolMap = new Map<string, ReceiptRecord>();
+  for (const r of windowedReceipts) poolMap.set(r.id, r);
+  for (const r of matchedReceiptsById) poolMap.set(r.id, r);
+  const poolReceipts = [...poolMap.values()];
+
+  const claimedReceiptIds = new Set<string>(linkedReceiptIds);
+  for (const id of allClaimedReceiptIds(crossMonthClaims)) {
+    claimedReceiptIds.add(id);
+  }
+  // Duplicate candidates span every DATED unmatched display population (true
+  // in-period, leading-slack, upcoming) — not only true orphans. The 2026-07-21
+  // audit found re-captures in the leading-slack population too (HOLIDAY,
+  // NFCTAGS). Undated receipts can't form the (merchant+amount+date) fingerprint
+  // and stay excluded. Non-blocking surfacing only.
+  const datedUnmatched: ReceiptRecord[] = [
+    ...partition.true_in_period,
+    ...partition.leading_slack,
+    ...partition.upcoming,
+  ];
+  const duplicateCandidates: Map<string, AmexDuplicateCandidate[]> =
+    findAmexDuplicateCandidates(datedUnmatched, poolReceipts, claimedReceiptIds);
+
+  // Bulk-fetch attendee names once for every receipt that could be shown in the
+  // detail pane or orphan list. Single query — keeps the detail pane N+1-free.
   const attendeeReceiptIds = Array.from(
     new Set([
       ...linkedReceiptIds,
@@ -110,19 +185,22 @@ export default async function ReconcilePage({
   return (
     <ReconcileScreen
       amexLines={amexLines}
-      receipts={receipts}
+      receipts={poolReceipts}
       autoMatches={autoMatches}
       orphanReceipts={orphanReceipts}
+      leadingSlackReceipts={partition.leading_slack}
+      upcomingReceipts={partition.upcoming}
+      undatedReceipts={partition.undated}
+      duplicateCandidates={duplicateCandidates}
       month={month}
       monthLabel={formatMonth(month)}
       monthsAvailable={availableMonths}
       finalized={finalized}
       finalizedAt={reconciliation?.finalized_at ?? null}
       window={window}
-      receiptsInWindow={receiptsInWindow}
+      receiptsInWindow={windowedReceipts}
       attendeesByReceiptId={attendeesByReceiptId}
       categoryRules={categoryRules}
     />
   );
 }
-

--- a/app/api/receipts/[id]/route.ts
+++ b/app/api/receipts/[id]/route.ts
@@ -29,6 +29,7 @@ import {
   compactUndefinedReceiptUpdate,
   parseExportStatementMonthOverride,
 } from "@/lib/receipts/receipt-update";
+import { planReviewStatusTransition } from "@/lib/receipts/receipt-status-policy";
 
 type RouteContext = { params: Promise<{ id: string }> };
 
@@ -47,14 +48,6 @@ const VALID_EXPENSE_TYPES: ExpenseType[] = [
   "business_trip",
   "misc",
   "UNKNOWN",
-];
-const VALID_RECEIPT_STATUSES: ReceiptStatus[] = [
-  "captured",
-  "needs_review",
-  "reviewed",
-  "reconciled",
-  "exported",
-  "archived",
 ];
 
 function normalizeOptionalText(
@@ -157,12 +150,24 @@ export async function PATCH(request: Request, { params }: RouteContext) {
     ) {
       return NextResponse.json({ error: "Invalid expenseType." }, { status: 400 });
     }
-    if (
-      body.status !== undefined &&
-      !VALID_RECEIPT_STATUSES.includes(body.status as ReceiptStatus)
-    ) {
-      return NextResponse.json({ error: "Invalid status." }, { status: 400 });
+    // Status authority (audit 2026-07-21, Phase 1): the public review PATCH
+    // owns only captured/needs_review → reviewed. Any other status value — and
+    // any attempt to demote a reconciled/exported/archived receipt — is rejected
+    // here. Ordinary autosaves omit status entirely (plan → noop, status left
+    // untouched). Internal reconciliation/export flows keep their own status
+    // write paths and never route through this planner.
+    const statusPlan = planReviewStatusTransition({
+      currentStatus: receipt.status,
+      requestedStatus: body.status,
+    });
+    if (statusPlan.outcome === "reject") {
+      return NextResponse.json(
+        { error: statusPlan.reason },
+        { status: statusPlan.httpStatus },
+      );
     }
+    const statusForUpdate: ReceiptStatus | undefined =
+      statusPlan.outcome === "apply" ? statusPlan.status : undefined;
     if (
       body.transactionDate !== undefined &&
       body.transactionDate !== null &&
@@ -311,6 +316,13 @@ export async function PATCH(request: Request, { params }: RouteContext) {
     // column to `undefined ?? null` → NULL, silently clearing sticky data (the
     // 2026-07-20 membership-clearing root cause). The same compacted object drives
     // the SQL mutation and the generic audit.
+    //
+    // Status authority (audit 2026-07-21 Phase 1): status is taken from
+    // planReviewStatusTransition (statusForUpdate) — undefined for ordinary
+    // autosaves, so no status change — NOT the raw body.status. compactUndefined-
+    // ReceiptUpdate then drops the undefined key entirely, so an autosave can
+    // never reach updateReceiptRecord with a status that would downgrade a
+    // reconciled/exported/archived receipt.
     const receiptUpdate = compactUndefinedReceiptUpdate({
       paymentPath: body.paymentPath as PaymentPath | undefined,
       expenseType: body.expenseType as ExpenseType | undefined,
@@ -322,7 +334,7 @@ export async function PATCH(request: Request, { params }: RouteContext) {
       businessPurpose,
       expenseCategoryCode,
       exportStatementMonth,
-      status: body.status as ReceiptStatus | undefined,
+      status: statusForUpdate,
       sourceType,
       invoiceRegistrationNumber,
       counterpartyName,

--- a/components/receipts/reconcile/reconcile-screen.tsx
+++ b/components/receipts/reconcile/reconcile-screen.tsx
@@ -44,6 +44,7 @@ import type {
   ReconciliationMatch,
 } from "@/lib/receipts/types";
 import type { StatementWindow } from "@/lib/receipts/statement-window";
+import type { AmexDuplicateCandidate } from "@/lib/receipts/amex-duplicates";
 import type { MonthOption } from "@/components/receipts/month-switcher";
 import {
   BAND_DISPLAY,
@@ -56,7 +57,19 @@ export interface ReconcileScreenProps {
   amexLines: AmexStatementLine[];
   receipts: ReceiptRecord[];
   autoMatches: ReconciliationMatch[];
+  /** Honest orphan population: ONLY true in-period unmatched receipts
+   *  (audit 2026-07-21 Phase 1, Part C). The other unmatched sub-populations
+   *  are passed separately and labeled, not counted as orphans. */
   orphanReceipts: ReceiptRecord[];
+  /** Date before the statement cycle (inside the leading ±5d pad) — prior-cycle,
+   *  not orphans of this month. */
+  leadingSlackReceipts: ReceiptRecord[];
+  /** Date after the statement cycle — "Awaiting next statement". */
+  upcomingReceipts: ReceiptRecord[];
+  /** No transaction_date — "Needs date"; must not repeat as an orphan monthly. */
+  undatedReceipts: ReceiptRecord[];
+  /** Non-blocking AMEX possible-re-capture candidates per orphan receipt id. */
+  duplicateCandidates: Map<string, AmexDuplicateCandidate[]>;
   month: string;
   monthLabel: string;
   monthsAvailable: MonthOption[];
@@ -513,6 +526,10 @@ export function ReconcileScreen(props: ReconcileScreenProps) {
           setTab={setTab}
           counts={counts}
           orphanReceipts={props.orphanReceipts}
+          leadingSlackReceipts={props.leadingSlackReceipts}
+          upcomingReceipts={props.upcomingReceipts}
+          undatedReceipts={props.undatedReceipts}
+          duplicateCandidates={props.duplicateCandidates}
         />
         <DetailPane
           active={active}
@@ -574,6 +591,10 @@ function LinesPane({
   setTab,
   counts,
   orphanReceipts,
+  leadingSlackReceipts,
+  upcomingReceipts,
+  undatedReceipts,
+  duplicateCandidates,
 }: {
   linesWithBand: Array<{
     line: AmexStatementLine;
@@ -595,6 +616,10 @@ function LinesPane({
     orphan: number;
   };
   orphanReceipts: ReceiptRecord[];
+  leadingSlackReceipts: ReceiptRecord[];
+  upcomingReceipts: ReceiptRecord[];
+  undatedReceipts: ReceiptRecord[];
+  duplicateCandidates: Map<string, AmexDuplicateCandidate[]>;
 }) {
   const groupReview = linesWithBand.filter(
     (l) =>
@@ -723,7 +748,15 @@ function LinesPane({
             )}
           </>
         )}
-        {tab === "orphans" && <OrphansList receipts={orphanReceipts} />}
+        {tab === "orphans" && (
+          <OrphansList
+            orphans={orphanReceipts}
+            leadingSlack={leadingSlackReceipts}
+            upcoming={upcomingReceipts}
+            undated={undatedReceipts}
+            duplicateCandidates={duplicateCandidates}
+          />
+        )}
         {tab === "trips" && (
           <div className="px-6 py-10 text-center text-sm text-gray-400">
             Business trip detection runs at import time. No candidates for this
@@ -896,47 +929,128 @@ function LineRow({
 }
 
 function OrphansList({
-  receipts,
+  orphans,
+  leadingSlack,
+  upcoming,
+  undated,
+  duplicateCandidates,
 }: {
-  receipts: ReceiptRecord[];
+  orphans: ReceiptRecord[];
+  leadingSlack: ReceiptRecord[];
+  upcoming: ReceiptRecord[];
+  undated: ReceiptRecord[];
+  duplicateCandidates: Map<string, AmexDuplicateCandidate[]>;
 }) {
-  if (receipts.length === 0) {
+  // Part C — only true in-period unmatched receipts are "Orphan receipts".
+  // Leading-slack / upcoming / undated are shown in separate, honestly-labeled
+  // sections so they don't read as problems (audit 2026-07-21 Phase 1).
+  const total =
+    orphans.length + leadingSlack.length + upcoming.length + undated.length;
+  if (total === 0) {
     return (
       <div className="px-6 py-10 text-center text-sm text-gray-400">
-        No orphan receipts for this window.
+        No unmatched AMEX receipts for this window.
       </div>
     );
   }
   return (
     <div>
-      <SectionHeader label="Receipts with no matching AMEX line" count={receipts.length} dot="bg-gray-400" />
-      {receipts.map((r) => (
-        <div
-          key={r.id}
-          className="flex items-center gap-3 border-b border-gray-100 px-4 py-3"
-        >
-          <ReceiptThumb
-            size={28}
-            merchant={(r.merchant ?? "RECEIPT").slice(0, 8)}
-            amount={formatJpy(r.amount_minor ?? 0, r.currency)}
-          />
-          <div className="min-w-0 flex-1">
-            <div className="truncate text-[13px] font-semibold text-gray-900">
-              {r.merchant ?? "Unnamed receipt"}
-            </div>
-            <div className="text-[11px] text-gray-500">
-              {r.transaction_date ?? "(no date)"}
-            </div>
-          </div>
-          <Link
-            href={`/receipts/review/${r.id}`}
-            className="text-[12px] font-semibold text-amber-700 hover:text-amber-800"
-          >
-            Open ↗
-          </Link>
-        </div>
+      {orphans.length > 0 && (
+        <>
+          <SectionHeader label="Orphan receipts" count={orphans.length} dot="bg-red-400" />
+          {orphans.map((r) => (
+            <OrphanRow key={r.id} r={r} duplicateCandidates={duplicateCandidates} />
+          ))}
+        </>
+      )}
+      {upcoming.length > 0 && (
+        <SectionHeader label="Awaiting next statement" count={upcoming.length} dot="bg-gray-300" />
+      )}
+      {upcoming.map((r) => (
+        <OrphanRow key={r.id} r={r} duplicateCandidates={duplicateCandidates} />
+      ))}
+      {leadingSlack.length > 0 && (
+        <SectionHeader label="Before statement range" count={leadingSlack.length} dot="bg-gray-300" />
+      )}
+      {leadingSlack.map((r) => (
+        <OrphanRow key={r.id} r={r} duplicateCandidates={duplicateCandidates} />
+      ))}
+      {undated.length > 0 && (
+        <SectionHeader label="Needs date" count={undated.length} dot="bg-amber-400" />
+      )}
+      {undated.map((r) => (
+        <OrphanRow key={r.id} r={r} />
       ))}
     </div>
+  );
+}
+
+function OrphanRow({
+  r,
+  duplicateCandidates,
+}: {
+  r: ReceiptRecord;
+  duplicateCandidates?: Map<string, AmexDuplicateCandidate[]>;
+}) {
+  const dups = duplicateCandidates?.get(r.id);
+  return (
+    <div className="flex items-center gap-3 border-b border-gray-100 px-4 py-3">
+      <ReceiptThumb
+        size={28}
+        merchant={(r.merchant ?? "RECEIPT").slice(0, 8)}
+        amount={formatJpy(r.amount_minor ?? 0, r.currency)}
+      />
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-[13px] font-semibold text-gray-900">
+          {r.merchant ?? "Unnamed receipt"}
+        </div>
+        <div className="text-[11px] text-gray-500">
+          {r.transaction_date ?? "(no date)"}
+        </div>
+        {dups && dups.length > 0 && <DuplicateBadge candidates={dups} />}
+      </div>
+      <Link
+        href={`/receipts/review/${r.id}`}
+        className="text-[12px] font-semibold text-amber-700 hover:text-amber-800"
+      >
+        Open ↗
+      </Link>
+    </div>
+  );
+}
+
+// Part E — non-blocking, link-only duplicate badge. Never auto-matches or
+// suppresses; it just points the operator at a receipt to compare against.
+// Wording is deliberately cautious: only a STRONG candidate (canonical merchant
+// + currency + amount + date) is called a "re-capture"; a NEAR candidate
+// (amount/date match but merchant text differs — possible OCR/descriptor drift)
+// is "related receipt", never conclusively a re-capture (architect review).
+function DuplicateBadge({ candidates }: { candidates: AmexDuplicateCandidate[] }) {
+  // Representative target: prefer a matched strong candidate, then any strong,
+  // then the first near. The label follows the representative's strength.
+  const matchedStrong = candidates.find((c) => c.strength === "strong" && c.otherMatched);
+  const anyStrong = candidates.find((c) => c.strength === "strong");
+  const target = matchedStrong ?? anyStrong ?? candidates[0]!;
+  const href = `/receipts/review/${target.otherReceiptId}`;
+  const baseLabel =
+    target.strength === "strong"
+      ? target.otherMatched
+        ? "Possible re-capture — compare with matched receipt"
+        : "Possible re-capture"
+      : "Possible related receipt — same amount/date";
+  const label =
+    candidates.length > 1 ? `${baseLabel} · ${candidates.length}` : baseLabel;
+  return (
+    <Link
+      href={href}
+      className="mt-1 inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-[10.5px] font-medium text-amber-800 hover:bg-amber-200"
+      title={candidates
+        .map((c) => `${c.strength}: ${c.reasons.join(", ")}`)
+        .join(" | ")}
+    >
+      <WarningIcon size={11} className="text-amber-600" />
+      <span>{label}</span>
+    </Link>
   );
 }
 

--- a/components/receipts/review/form-pane.tsx
+++ b/components/receipts/review/form-pane.tsx
@@ -26,6 +26,10 @@ import {
   formatCategoryLabel,
 } from "@/lib/receipts/categories";
 import { findCategorySuggestion, type CategoryRule } from "@/lib/receipts/category-rules";
+import {
+  canMarkReviewed,
+  canPromoteToReviewed,
+} from "@/lib/receipts/receipt-status-policy";
 import type {
   PaymentPath,
   ReceiptAttendee,
@@ -251,9 +255,14 @@ export function FormPane(props: FormPaneProps) {
               currency,
               businessPurpose: businessPurpose.trim() || null,
               attendees: attendees.map((a) => a.trim()).filter(Boolean),
-              status: (markReviewed
-                ? "reviewed"
-                : receipt.status) as ReceiptStatus,
+              // Audit 2026-07-21 Phase 1: ordinary autosaves NEVER send status —
+              // a stale client value must not be able to overwrite a lifecycle
+              // status an internal flow (reconcile/export) has since advanced.
+              // "reviewed" is sent only by the explicit Mark-reviewed path below,
+              // and only when the receipt is still in a pre-review state.
+              ...(markReviewed && canPromoteToReviewed(receipt.status)
+                ? { status: "reviewed" as ReceiptStatus }
+                : {}),
             }),
             signal: ctrl.signal,
           });
@@ -377,7 +386,13 @@ export function FormPane(props: FormPaneProps) {
             currency,
             businessPurpose: businessPurpose.trim() || null,
             attendees: attendees.map((a) => a.trim()).filter(Boolean),
-            status: "reviewed" as ReceiptStatus,
+            // Promote to reviewed only when still in a pre-review state. For an
+            // already-reviewed/reconciled/exported/archived receipt the server
+            // would reject the downgrade; we simply don't send it. Fields still
+            // save and the operator advances to the next queue item.
+            ...(canPromoteToReviewed(receipt.status)
+              ? { status: "reviewed" as ReceiptStatus }
+              : {}),
           }),
         });
         if (!res.ok) {
@@ -403,6 +418,7 @@ export function FormPane(props: FormPaneProps) {
     })();
   }, [
     receipt.id,
+    receipt.status,
     paymentPath,
     expenseCategoryCode,
     transactionDate,
@@ -418,7 +434,10 @@ export function FormPane(props: FormPaneProps) {
 
   useKeyboardShortcuts({
     s: (e) => {
-      if (isLocked) return; // sealed — `s` does nothing, no PATCH fires
+      // Same shared gate as the button (canMarkReviewed): a reconciled/reviewed/
+      // exported/archived receipt must not save-and-advance through a shortcut
+      // presented as "Mark reviewed" (architect review 2026-07-21).
+      if (!canMarkReviewed(receipt.status, isLocked)) return;
       e.preventDefault();
       onMarkReviewed();
     },
@@ -762,7 +781,7 @@ export function FormPane(props: FormPaneProps) {
             kind="primary"
             size="md"
             onClick={onMarkReviewed}
-            disabled={isLocked}
+            disabled={!canMarkReviewed(receipt.status, isLocked)}
             rightIcon={<ArrowRightIcon size={14} className="text-white" />}
           >
             Mark reviewed → next

--- a/lib/receipts/amex-duplicates.ts
+++ b/lib/receipts/amex-duplicates.ts
@@ -1,0 +1,152 @@
+// Non-destructive AMEX possible-duplicate detection for the Reconcile screen.
+//
+// The existing CASH/DIGITAL duplicate warning (lib/receipts/blockers.ts
+// computeDuplicateReceiptWarnings) is intentionally UNCHANGED — it gates on
+// CASH/DIGITAL and drives the month-close warning card. This module is a
+// SEPARATE AMEX helper that surfaces re-capture candidates among AMEX receipts
+// as a non-blocking badge/link in Reconcile. It never auto-deletes,
+// auto-matches, or suppresses a candidate — the operator decides.
+//
+// Why AMEX needs its own surface: every duplicate cluster found in the
+// 2026-07-21 audit was AMEX, and the AMEX path had no duplicate detection at
+// all, so re-captures showed up as plain "orphan" receipts instead of being
+// flagged. See AGENTS.md backlog #8.
+//
+// Candidate strength:
+//   • strong — canonical merchant + currency + amount + transaction date.
+//              (canonicalizeMerchant folds OCR-garbled conbini-chain variants.)
+//   • near   — same currency + amount, transaction date within ±1 day (default),
+//              AND normalized merchant text DIFFERS (descriptor vs legal name,
+//              OCR drift). Same-merchant ±1-day pairs are deliberately NOT
+//              flagged: a legitimate round-trip (two tickets at one venue, one
+//              day apart) shares merchant text and must not be mislabeled.
+//
+// Pure + client-safe. The caller (reconcile page) supplies the pool
+// (orphans + matched/other in-window receipts) and the set of receipt ids
+// already claimed by an AMEX line — the authoritative "is this matched" signal,
+// never receipt.status (which can drift).
+
+import { canonicalizeMerchant } from "@/lib/receipts/merchant";
+import type { ReceiptRecord, ReceiptStatus } from "@/lib/receipts/types";
+
+export type AmexDuplicateStrength = "strong" | "near";
+
+export interface AmexDuplicateCandidate {
+  otherReceiptId: string;
+  strength: AmexDuplicateStrength;
+  /** True when the partner is already claimed by an AMEX line — drives the
+   *  "compare with matched receipt" badge wording. Authoritative source is the
+   *  AMEX line relationship (matchedReceiptIds), not receipt.status. */
+  otherMatched: boolean;
+  otherStatus: ReceiptStatus;
+  reasons: string[];
+}
+
+export interface FindAmexDuplicatesOptions {
+  /** Maximum transaction-date delta (days) for a "near" candidate. Default 1. */
+  nearDayWindow?: number;
+}
+
+const DAY_MS = 86_400_000;
+
+function daysBetween(a: string, b: string): number {
+  return Math.abs(Date.parse(a) - Date.parse(b)) / DAY_MS;
+}
+
+/** Normalize merchant text for the near-candidate "merchant differs" test. */
+function normMerchant(m: string | null | undefined): string {
+  return (m ?? "").normalize("NFKC").toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+/**
+ * For each orphan receipt, find possible re-capture candidates in the pool.
+ *
+ * @param orphanReceipts receipts currently shown as orphans (the subjects).
+ * @param poolReceipts   receipts to compare against — orphans AND already
+ *   matched/other in-window receipts. A matched receipt is a valid PARTNER
+ *   (the "compare with matched receipt" case).
+ * @param matchedReceiptIds receipt ids already claimed by an AMEX line
+ *   (any month). Authoritative "is matched" signal; receipt.status is not used.
+ * @returns map from orphan receipt id → its candidate list (only orphans that
+ *   have ≥1 candidate appear as keys). Never mutates input.
+ */
+export function findAmexDuplicateCandidates(
+  orphanReceipts: ReceiptRecord[],
+  poolReceipts: ReceiptRecord[],
+  matchedReceiptIds: Set<string>,
+  opts: FindAmexDuplicatesOptions = {},
+): Map<string, AmexDuplicateCandidate[]> {
+  const nearWindow = opts.nearDayWindow ?? 1;
+  const out = new Map<string, AmexDuplicateCandidate[]>();
+
+  // Index dated, non-deleted pool receipts by currency|amount for O(n) lookup.
+  type IndexEntry = {
+    r: ReceiptRecord;
+    canon: string;
+    norm: string;
+    date: string;
+  };
+  const byAmount = new Map<string, IndexEntry[]>();
+  for (const r of poolReceipts) {
+    if (r.deleted_at) continue;
+    if (r.amount_minor == null || !r.currency || !r.transaction_date || !r.merchant) continue;
+    const key = `${r.currency.toUpperCase()}|${r.amount_minor}`;
+    const arr = byAmount.get(key) ?? [];
+    arr.push({
+      r,
+      canon: canonicalizeMerchant(r.merchant),
+      norm: normMerchant(r.merchant),
+      date: r.transaction_date,
+    });
+    byAmount.set(key, arr);
+  }
+
+  for (const orphan of orphanReceipts) {
+    if (orphan.deleted_at) continue;
+    if (
+      orphan.amount_minor == null ||
+      !orphan.currency ||
+      !orphan.transaction_date ||
+      !orphan.merchant
+    ) {
+      continue;
+    }
+    const key = `${orphan.currency.toUpperCase()}|${orphan.amount_minor}`;
+    const candidates = byAmount.get(key) ?? [];
+    const oCanon = canonicalizeMerchant(orphan.merchant);
+    const oNorm = normMerchant(orphan.merchant);
+    const found: AmexDuplicateCandidate[] = [];
+
+    for (const c of candidates) {
+      if (c.r.id === orphan.id) continue;
+      const sameCanon = c.canon === oCanon;
+      const sameDate = c.date === orphan.transaction_date;
+      const merchantDiffers = c.norm !== oNorm;
+      const deltaDays = daysBetween(c.date, orphan.transaction_date!);
+
+      if (sameCanon && sameDate) {
+        found.push({
+          otherReceiptId: c.r.id,
+          strength: "strong",
+          otherMatched: matchedReceiptIds.has(c.r.id),
+          otherStatus: c.r.status,
+          reasons: ["same merchant + amount + date"],
+        });
+      } else if (merchantDiffers && deltaDays <= nearWindow) {
+        // Near: differing merchant text within the date window. Same-merchant
+        // ±1-day pairs (round-trips) are excluded — merchantDiffers is false.
+        found.push({
+          otherReceiptId: c.r.id,
+          strength: "near",
+          otherMatched: matchedReceiptIds.has(c.r.id),
+          otherStatus: c.r.status,
+          reasons: [`same amount, ${deltaDays}d apart, merchant text differs`],
+        });
+      }
+    }
+
+    if (found.length > 0) out.set(orphan.id, found);
+  }
+
+  return out;
+}

--- a/lib/receipts/cross-month-claims.ts
+++ b/lib/receipts/cross-month-claims.ts
@@ -1,0 +1,65 @@
+// Cross-month AMEX-claim policy for the Reconcile screen (audit 2026-07-21
+// Phase 1, Part B).
+//
+// Problem: the reconcile page used to build its "linked receipt" set from the
+// DISPLAYED month's lines only. A receipt confirmed in a DIFFERENT statement
+// month — but whose transaction_date falls inside the displayed month's padded
+// window, and whose receipt.status has drifted off "reconciled" — leaked in as
+// an orphan or a match candidate. The 2026-07-21 audit found exactly this
+// (NFCTAGS receipt confirmed in 2026-07, status stuck at "reviewed", appearing
+// as a 2026-08 orphan).
+//
+// Fix: the AMEX line relationship is authoritative — never receipt.status. A
+// receipt claimed by a matched/confirmed line in another statement month is
+// excluded from the displayed month's match candidates AND its orphan set.
+//
+// Pure + client-safe (type-only import) so the NFCTAGS shape is unit-tested
+// without D1.
+
+import type { AmexStatementLine } from "@/lib/receipts/types";
+
+/**
+ * Receipt ids claimed by a matched/confirmed AMEX line in a statement month
+ * OTHER than `displayedMonth`. These receipts are reconciled elsewhere and must
+ * not be offered as an automatic match or shown as an orphan in the displayed
+ * month.
+ *
+ * Only real claims count: match_status "matched" (tentative) or "confirmed".
+ * A stale "unmatched"/"no_receipt" line still carrying a matched_receipt_id
+ * does not exclude the receipt.
+ */
+export function crossMonthClaimedReceiptIds(
+  claims: AmexStatementLine[],
+  displayedMonth: string,
+): Set<string> {
+  const out = new Set<string>();
+  for (const line of claims) {
+    if (
+      line.statement_month !== displayedMonth &&
+      line.matched_receipt_id &&
+      (line.match_status === "matched" || line.match_status === "confirmed")
+    ) {
+      out.add(line.matched_receipt_id);
+    }
+  }
+  return out;
+}
+
+/**
+ * Every receipt id claimed by ANY matched/confirmed AMEX line (any month) — the
+ * authoritative "is this receipt already matched" set, used by the AMEX
+ * duplicate helper to word its "compare with matched receipt" badge. Unlike
+ * crossMonthClaimedReceiptIds this includes the displayed month's own links too.
+ */
+export function allClaimedReceiptIds(claims: AmexStatementLine[]): Set<string> {
+  const out = new Set<string>();
+  for (const line of claims) {
+    if (
+      line.matched_receipt_id &&
+      (line.match_status === "matched" || line.match_status === "confirmed")
+    ) {
+      out.add(line.matched_receipt_id);
+    }
+  }
+  return out;
+}

--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -531,6 +531,91 @@ export async function listAllReceiptsInMonth(
   }
 }
 
+// Projected column list for the Reconcile candidate read. Excludes the two
+// heavy text/JSON blobs the reconcile path does not read — `search_text`
+// (full-text search copy) and `compliance_warnings_json` — to keep the
+// month-window read lean. `extraction_json` IS included: the matcher's
+// brand-on-receipt fallback (reconciliation.ts rawTextOf) reads rawText from it.
+const RECONCILE_RECEIPT_COLUMNS =
+  "id, captured_at, captured_by, source, original_filename, " +
+  "payment_path, expense_type, transaction_date, merchant, amount_minor, " +
+  "currency, tax_amount_minor, business_purpose, alcohol_present, " +
+  "attendees_required, status, original_r2_key, original_sha256, " +
+  "original_content_type, original_size_bytes, processed_r2_key, " +
+  "extraction_json, legacy, exported_month, export_statement_month, " +
+  "expense_category_code, deleted_at, deleted_by, delete_reason, " +
+  "retention_until, legal_hold, source_type, preservation_status, " +
+  "confirmed_at, confirmed_by, invoice_registration_number, " +
+  "invoice_registration_status, qualified_invoice_status, tax_rate, " +
+  "counterparty_name, extraction_state, extraction_enqueued_at, " +
+  "extraction_processed_at, extraction_attempts, extraction_processor, " +
+  "extraction_r2_key, needs_render";
+
+/**
+ * Exhaustive AMEX receipt read for the Reconcile candidate window — REPLACES
+ * the old global newest-200 query (audit 2026-07-21 Phase 1, Part D). Returns
+ * EVERY non-deleted AMEX receipt dated in [start, end] PLUS every non-deleted
+ * AMEX receipt with a NULL transaction_date. Undated receipts (pending
+ * extraction — the rows most needing review) are fetched in a SEPARATE query so
+ * the dated BETWEEN clause keeps using the transaction_date index (and so undated
+ * retrieval stays distinct from dated window candidates, per Part D).
+ *
+ * Never silently truncates: pages internally and THROWS if the combined set
+ * reaches `hardCap` (default 5000), since a truncated reconcile view would hide
+ * real receipts. extraction_json is included (matcher rawText fallback);
+ * search_text and compliance_warnings_json are projected out (unused here).
+ */
+export async function listAmexReceiptsForReconcile(
+  window: { start: string; end: string },
+  opts: { hardCap?: number } = {},
+): Promise<ReceiptRecord[]> {
+  const db = getReceiptsDb();
+  const hardCap = opts.hardCap ?? 5000;
+  const PAGE = 500;
+  const out: ReceiptRecord[] = [];
+
+  // Dated in-window (index-backed via idx_receipts_transaction_date).
+  let offset = 0;
+  for (;;) {
+    const page = await db
+      .prepare(
+        `SELECT ${RECONCILE_RECEIPT_COLUMNS} FROM receipt_records
+         WHERE deleted_at IS NULL AND payment_path = 'AMEX'
+           AND transaction_date BETWEEN ? AND ?
+         ORDER BY transaction_date ASC LIMIT ? OFFSET ?`,
+      )
+      .bind(window.start, window.end, PAGE, offset)
+      .all<ReceiptRecord>();
+    const rows = page.results ?? [];
+    out.push(...rows);
+    if (rows.length < PAGE) break;
+    offset += PAGE;
+    if (out.length >= hardCap) {
+      throw new Error(
+        `listAmexReceiptsForReconcile(${window.start}..${window.end}) hit the hard cap of ${hardCap} dated rows — silent truncation would hide receipts from reconcile. Inspect the data or raise the cap.`,
+      );
+    }
+  }
+
+  // Undated (separate query — see javadoc). Small in practice (pending queue).
+  const undated = await db
+    .prepare(
+      `SELECT ${RECONCILE_RECEIPT_COLUMNS} FROM receipt_records
+       WHERE deleted_at IS NULL AND payment_path = 'AMEX'
+         AND transaction_date IS NULL`,
+    )
+    .all<ReceiptRecord>();
+  out.push(...(undated.results ?? []));
+
+  if (out.length >= hardCap) {
+    throw new Error(
+      `listAmexReceiptsForReconcile(${window.start}..${window.end}) hit the hard cap of ${hardCap} after union with undated rows — silent truncation would hide receipts from reconcile.`,
+    );
+  }
+
+  return out;
+}
+
 // Extraction-queue data access (listPendingProcessingReceipts +
 // reconcileExtractionState) lives in lib/receipts/extraction-queue-db.ts now;
 // re-exported here so existing @/lib/receipts/db import sites are unchanged.

--- a/lib/receipts/orphan-classification.ts
+++ b/lib/receipts/orphan-classification.ts
@@ -1,0 +1,105 @@
+// Honest orphan classification for the Reconcile screen.
+//
+// The matcher's ±5-day padded window (deriveStatementWindow) is unchanged — it
+// stays the CANDIDATE pool so leading/trailing slack can still surface a match.
+// But for DISPLAY, an unmatched receipt is not honestly "an orphan" just because
+// it falls inside the padded window. Partition unmatched receipts against the
+// statement's ACTUAL line MIN/MAX transaction dates:
+//
+//   • true_in_period  — date within [min, max]. The only population counted and
+//                        labeled "Orphan receipts" (a real charge in this cycle
+//                        with no matching line).
+//   • leading_slack   — date before min but inside the leading pad. Belongs to
+//                        the PRIOR cycle; not a true orphan of this month.
+//   • upcoming        — date after max (or no statement dates at all). Awaiting
+//                        the NEXT statement; labeled "Awaiting next statement".
+//   • undated         — transaction_date is NULL. A separate "Needs date"
+//                        population; must not repeat as an orphan every month.
+//
+// Pure + client-safe (type-only import) so boundaries and the empty-line
+// fallback are unit-tested without D1.
+
+/** Structural minimum the classifier reads. Works for ReceiptRecord and fixtures. */
+export interface DateCarrying {
+  transaction_date: string | null;
+}
+
+/** The four honest display classes for an unmatched receipt. */
+export type OrphanClass =
+  | "true_in_period"
+  | "leading_slack"
+  | "upcoming"
+  | "undated";
+
+/** Actual (un-padded) min/max transaction dates of a statement's lines.
+ *  Both null when the statement has no dated lines (empty-line fallback). */
+export interface StatementDateRange {
+  minDate: string | null;
+  maxDate: string | null;
+}
+
+/**
+ * Compute the un-padded MIN/MAX transaction-date range from a statement's line
+ * dates. Null entries (undated lines) are ignored. Returns {null,null} when no
+ * line carries a date — the empty-line fallback signal.
+ */
+export function statementLineDateRange(
+  lineDates: Array<string | null | undefined>,
+): StatementDateRange {
+  const sorted = lineDates
+    .filter((d): d is string => typeof d === "string" && d.length > 0)
+    .slice()
+    .sort();
+  if (sorted.length === 0) return { minDate: null, maxDate: null };
+  return { minDate: sorted[0]!, maxDate: sorted[sorted.length - 1]! };
+}
+
+/**
+ * Classify a single unmatched receipt. ISO YYYY-MM-DD strings compare lexically
+ * in date order, so simple string comparisons are correct.
+ *
+ * Empty-line fallback (minDate/maxDate null): without statement dates there is
+ * no cycle to be "in", so every dated receipt is "upcoming" (awaiting the
+ * statement) and undated receipts are "undated".
+ */
+export function classifyUnmatchedReceipt<R extends DateCarrying>(
+  receipt: R,
+  range: StatementDateRange,
+): OrphanClass {
+  if (!receipt.transaction_date) return "undated";
+  const { minDate, maxDate } = range;
+  if (!minDate || !maxDate) return "upcoming";
+  const d = receipt.transaction_date;
+  // Inclusive on both ends: a charge on the first or last line date is in-period.
+  if (d < minDate) return "leading_slack";
+  if (d > maxDate) return "upcoming";
+  return "true_in_period";
+}
+
+export interface OrphanPartition<R extends DateCarrying> {
+  /** The ONLY population that counts as "Orphan receipts". */
+  true_in_period: R[];
+  /** Date before the cycle (in the leading pad) — prior-cycle, not an orphan. */
+  leading_slack: R[];
+  /** Date after the cycle, or no statement dates — "Awaiting next statement". */
+  upcoming: R[];
+  /** No transaction_date — "Needs date"; must not repeat as an orphan monthly. */
+  undated: R[];
+}
+
+/** Partition unmatched receipts into the four display classes. Pure. */
+export function partitionUnmatchedReceipts<R extends DateCarrying>(
+  receipts: R[],
+  range: StatementDateRange,
+): OrphanPartition<R> {
+  const out: OrphanPartition<R> = {
+    true_in_period: [],
+    leading_slack: [],
+    upcoming: [],
+    undated: [],
+  };
+  for (const r of receipts) {
+    out[classifyUnmatchedReceipt(r, range)].push(r);
+  }
+  return out;
+}

--- a/lib/receipts/receipt-status-policy.ts
+++ b/lib/receipts/receipt-status-policy.ts
@@ -1,0 +1,111 @@
+// Receipt lifecycle status-transition policy for the public review PATCH
+// (app/api/receipts/[id]/route.ts) and the review form
+// (components/receipts/review/form-pane.tsx).
+//
+// Authority split (audit 2026-07-21, orphan remediation Phase 1):
+//   • The public review PATCH owns ONLY the captured/needs_review → reviewed
+//     promotion. "Mark reviewed" is a promotion, never a lifecycle demotion.
+//   • The reconciliation flow (db.ts updateAmexReconciliation) owns
+//     → reconciled. The export flow owns → exported. Archived is terminal.
+//   • Ordinary field autosaves MUST omit status entirely — they must not even
+//     re-send the current status, because a stale client status value on a
+//     receipt that an internal flow has since advanced (e.g. reconciled) used
+//     to let the generic PATCH downgrade it back to "reviewed".
+//
+// Pure + client-safe (type-only import) so the policy is unit-tested without
+// D1/auth and reused client-side to decide whether "Mark reviewed" is shown.
+
+import type { ReceiptStatus } from "@/lib/receipts/types";
+
+/** The only status value the public review PATCH is permitted to request. */
+export const REVIEW_PATCH_ALLOWED_STATUS: ReceiptStatus = "reviewed";
+
+/**
+ * True when "Mark reviewed" is a meaningful promotion — i.e. the receipt is
+ * still in a pre-review state. Used by the form to hide/disable the button for
+ * reviewed/reconciled/exported/archived receipts (no-op at best, a forbidden
+ * downgrade at worst).
+ */
+export function canPromoteToReviewed(status: ReceiptStatus): boolean {
+  return status === "captured" || status === "needs_review";
+}
+
+/**
+ * The SINGLE shared gate for the "Mark reviewed" affordance — used by BOTH the
+ * button (disabled) and the `s` keyboard shortcut, so the two can never drift
+ * (audit 2026-07-21 architect review: the shortcut previously fired
+ * save-and-advance for a non-promotable, merely-unlocked receipt). True only
+ * when the form is unlocked AND the receipt is still in a pre-review state.
+ *
+ * Pure + testable: `locked` is the form's seal state (a boolean prop), so the
+ * full gate is unit-tested without a React/keyboard harness.
+ */
+export function canMarkReviewed(status: ReceiptStatus, locked: boolean): boolean {
+  return !locked && canPromoteToReviewed(status);
+}
+
+export type StatusTransitionPlan =
+  | { outcome: "apply"; status: "reviewed" } // promote captured/needs_review
+  | { outcome: "noop" } // no status field sent, or already reviewed (idempotent)
+  | { outcome: "reject"; httpStatus: 400 | 409; reason: string };
+
+/**
+ * Decide what the public review PATCH should do with a requested status.
+ *
+ * Callers pass the receipt's current status and the raw `status` value from the
+ * request body (undefined when the field is absent — the ordinary-autosave
+ * case). Returns one of:
+ *
+ *   • apply  — set status to "reviewed" (captured/needs_review → reviewed).
+ *   • noop   — leave status untouched. Covers both "field not sent" (autosave)
+ *              and "already reviewed, requested reviewed" (idempotent).
+ *   • reject — refuse with an HTTP status + reason. Non-"reviewed" values are
+ *              400 (this endpoint doesn't own them); attempts to demote a
+ *              reconciled/exported/archived receipt are 409.
+ *
+ * Internal reconciliation/export functions are unaffected — they write status
+ * through their own paths and never route through this planner.
+ */
+export function planReviewStatusTransition(args: {
+  currentStatus: ReceiptStatus;
+  requestedStatus: string | undefined;
+}): StatusTransitionPlan {
+  const { currentStatus, requestedStatus } = args;
+
+  // Ordinary field autosave: no status field → never touch lifecycle status.
+  if (requestedStatus === undefined) {
+    return { outcome: "noop" };
+  }
+
+  // This endpoint owns only the "reviewed" promotion. Any other requested
+  // status (including reconciled/exported/archived) belongs to a different
+  // flow and is rejected — the review PATCH is not a generic status setter.
+  if (requestedStatus !== REVIEW_PATCH_ALLOWED_STATUS) {
+    return {
+      outcome: "reject",
+      httpStatus: 400,
+      reason: `This endpoint only accepts status="reviewed"; status "${requestedStatus}" is not permitted here.`,
+    };
+  }
+
+  // requestedStatus === "reviewed"
+  if (currentStatus === "captured" || currentStatus === "needs_review") {
+    return { outcome: "apply", status: "reviewed" };
+  }
+  if (currentStatus === "reviewed") {
+    // Idempotent: already reviewed. Don't write (avoids a pointless UPDATE +
+    // keeps the audit trail quiet), but don't error either.
+    return { outcome: "noop" };
+  }
+
+  // currentStatus is reconciled/exported/archived — these lifecycle states are
+  // owned by reconciliation/export (and archived is terminal). Refusing the
+  // downgrade here is the authoritative guard. (exported/archived field edits
+  // are also refused earlier in the route, but a status-only request reaches
+  // this planner, so the guard must stand on its own.)
+  return {
+    outcome: "reject",
+    httpStatus: 409,
+    reason: `Receipt is "${currentStatus}" — its lifecycle status cannot be changed to "reviewed" from the review endpoint.`,
+  };
+}

--- a/tests/receipts/amex-duplicates.test.ts
+++ b/tests/receipts/amex-duplicates.test.ts
@@ -1,0 +1,134 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { findAmexDuplicateCandidates } from "@/lib/receipts/amex-duplicates";
+import type { ReceiptRecord } from "@/lib/receipts/types";
+
+let n = 0;
+function rc(partial: Partial<ReceiptRecord> & Pick<ReceiptRecord, "merchant" | "amount_minor" | "transaction_date">): ReceiptRecord {
+  n += 1;
+  return {
+    id: partial.id ?? `r${n}`,
+    captured_at: "2026-07-01T00:00:00Z",
+    captured_by: "op",
+    source: "mobile_capture",
+    original_filename: null,
+    payment_path: "AMEX",
+    expense_type: "UNKNOWN",
+    currency: partial.currency ?? "JPY",
+    tax_amount_minor: null,
+    business_purpose: null,
+    alcohol_present: 0,
+    attendees_required: 0,
+    status: partial.status ?? "reviewed",
+    original_r2_key: "k",
+    original_sha256: "s" + n,
+    original_content_type: "image/jpeg",
+    original_size_bytes: 100,
+    processed_r2_key: null,
+    extraction_json: null,
+    legacy: 0,
+    exported_month: null,
+    expense_category_code: null,
+    deleted_at: null,
+    deleted_by: null,
+    delete_reason: null,
+    ...partial,
+  } as ReceiptRecord;
+}
+
+const NONE = new Set<string>();
+
+// ─── Strong: same canonical merchant + currency + amount + date ──────────────
+
+test("strong candidate: same merchant/amount/date orphan vs matched partner", () => {
+  const orphan = rc({ id: "orphan-okadoku", merchant: "岡芳商店", amount_minor: 3862, transaction_date: "2026-06-19" });
+  const matched = rc({ id: "matched-okadoku", merchant: "岡芳商店", amount_minor: 3862, transaction_date: "2026-06-19", status: "reconciled" });
+  const out = findAmexDuplicateCandidates([orphan], [orphan, matched], new Set([matched.id]));
+  assert.equal(out.size, 1);
+  const cand = out.get("orphan-okadoku")!;
+  assert.equal(cand.length, 1);
+  assert.equal(cand[0]!.strength, "strong");
+  assert.equal(cand[0]!.otherReceiptId, "matched-okadoku");
+  assert.equal(cand[0]!.otherMatched, true);
+});
+
+test("canonicalization: garbled conbini variant clusters with the canonical spelling (strong)", () => {
+  // Two photos of one PASMO top-up: OCR-garbled "セブンーエレブン" vs "セブン-イレブン".
+  const orphan = rc({ id: "o", merchant: "セブンーエレブン", amount_minor: 10000, transaction_date: "2026-06-20" });
+  const partner = rc({ id: "p", merchant: "セブン-イレブン 東中野末広橋店", amount_minor: 10000, transaction_date: "2026-06-20" });
+  const out = findAmexDuplicateCandidates([orphan], [orphan, partner], NONE);
+  assert.equal(out.get("o")![0]!.strength, "strong");
+});
+
+// ─── Near: same currency/amount, ±1 day, differing merchant text ─────────────
+
+test("near candidate: same amount + same date but differing merchant text", () => {
+  // PERFECT (receipt) vs PBK四ッ谷/Air (descriptor) — same ¥14040 charge, 06-12.
+  const orphan = rc({ id: "o-perfect", merchant: "PERFECT", amount_minor: 14040, transaction_date: "2026-06-12" });
+  const matched = rc({ id: "m-pbk", merchant: "PBK四ッ谷/Air", amount_minor: 14040, transaction_date: "2026-06-12", status: "reconciled" });
+  const out = findAmexDuplicateCandidates([orphan], [orphan, matched], new Set([matched.id]));
+  const cand = out.get("o-perfect")!;
+  assert.equal(cand[0]!.strength, "near");
+  assert.equal(cand[0]!.otherMatched, true);
+});
+
+test("near candidate: same amount, 1 day apart, differing merchant", () => {
+  const orphan = rc({ id: "o", merchant: "株式会社ファイン・ラベル", amount_minor: 5940, transaction_date: "2026-06-09" });
+  const matched = rc({ id: "m", merchant: "NFCTAGS", amount_minor: 5940, transaction_date: "2026-06-08", status: "reconciled" });
+  const out = findAmexDuplicateCandidates([orphan], [orphan, matched], new Set([matched.id]));
+  assert.equal(out.get("o")![0]!.strength, "near");
+});
+
+// ─── Legitimacy: same-merchant ±1-day round-trips are NOT flagged ────────────
+
+test("round-trip: two same-merchant ±1-day receipts matched to distinct lines are not duplicate orphans", () => {
+  // JR outbound 06-26 + return 06-27, both reconciled to distinct AMEX lines.
+  const outbound = rc({ id: "jr-out", merchant: "JR東日本 えきねっと", amount_minor: 4280, transaction_date: "2026-06-26", status: "reconciled" });
+  const ret = rc({ id: "jr-ret", merchant: "JR東日本 えきねっと", amount_minor: 4280, transaction_date: "2026-06-27", status: "reconciled" });
+  const matched = new Set([outbound.id, ret.id]);
+  // They are matched → not orphans → no candidates produced at all.
+  const outMatched = findAmexDuplicateCandidates([], [outbound, ret], matched);
+  assert.equal(outMatched.size, 0);
+
+  // Even if one somehow appears as an orphan, same merchant + ±1 day is NOT a
+  // near candidate (near requires differing merchant text) nor strong (date
+  // differs). It must not be mislabeled a duplicate.
+  const outOrphan = findAmexDuplicateCandidates([outbound], [outbound, ret], new Set([ret.id]));
+  assert.equal(outOrphan.size, 0);
+});
+
+// ─── Non-destruction / shape ─────────────────────────────────────────────────
+
+test("undated or amount-less receipts produce no candidates", () => {
+  const orphan = rc({ merchant: "X", amount_minor: 100, transaction_date: null });
+  const partner = rc({ merchant: "X", amount_minor: 100, transaction_date: "2026-06-19" });
+  const out = findAmexDuplicateCandidates([orphan], [orphan, partner], NONE);
+  assert.equal(out.size, 0);
+});
+
+test("a receipt never candidates against itself", () => {
+  const orphan = rc({ id: "solo", merchant: "Solo", amount_minor: 500, transaction_date: "2026-06-19" });
+  const out = findAmexDuplicateCandidates([orphan], [orphan], NONE);
+  assert.equal(out.size, 0);
+});
+
+test("different amounts never match", () => {
+  const orphan = rc({ merchant: "M", amount_minor: 1000, transaction_date: "2026-06-19" });
+  const partner = rc({ merchant: "M", amount_minor: 1001, transaction_date: "2026-06-19" });
+  const out = findAmexDuplicateCandidates([orphan], [orphan, partner], NONE);
+  assert.equal(out.size, 0);
+});
+
+test("HOLIDAY triple: each orphan sees the other two as strong candidates", () => {
+  const a = rc({ id: "h1", merchant: "HOLIDAY SKY LOUNGE 新宿", amount_minor: 10680, transaction_date: "2026-06-06" });
+  const b = rc({ id: "h2", merchant: "Holiday Sky Lounge 新宿", amount_minor: 10680, transaction_date: "2026-06-06" });
+  const c = rc({ id: "h3", merchant: "HOLIDAY SKY LOUNGE 新宿", amount_minor: 10680, transaction_date: "2026-06-06" });
+  const out = findAmexDuplicateCandidates([a, b, c], [a, b, c], NONE);
+  // a & c share exact merchant; b differs only in case → normalized equal, so
+  // canonicalizeMerchant (raw passthrough) makes a-vs-b "strong" only if canon
+  // matches. canon for non-chain = raw string, so "HOLIDAY…" ≠ "Holiday…".
+  // a sees c (strong) and b (near, same date + merchant text differs by case).
+  const aCands = out.get("h1")!;
+  assert.ok(aCands.some((x) => x.otherReceiptId === "h3" && x.strength === "strong"));
+  assert.ok(aCands.length >= 1);
+});

--- a/tests/receipts/cross-month-claims.test.ts
+++ b/tests/receipts/cross-month-claims.test.ts
@@ -1,0 +1,119 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  crossMonthClaimedReceiptIds,
+  allClaimedReceiptIds,
+} from "@/lib/receipts/cross-month-claims";
+import type { AmexStatementLine } from "@/lib/receipts/types";
+
+function line(p: Partial<AmexStatementLine>): AmexStatementLine {
+  return {
+    id: p.id ?? "L1",
+    statement_month: p.statement_month ?? "2026-08",
+    transaction_date: p.transaction_date ?? "2026-07-01",
+    posting_date: null,
+    merchant: p.merchant ?? "M",
+    amount_minor: p.amount_minor ?? 1000,
+    currency: "JPY",
+    amex_reference: null,
+    matched_receipt_id: p.matched_receipt_id ?? null,
+    match_status: p.match_status ?? "unmatched",
+    raw_json: "{}",
+    created_at: "2026-07-01T00:00:00Z",
+    statement_artifact_id: null,
+    cardholder_name: null,
+    cardholder_flag: null,
+    payment_type: null,
+    prepayment_flag: null,
+    memo: null,
+    raw_csv_line_number: null,
+    source_file_sha256: null,
+    imported_at: "2026-07-01T00:00:00Z",
+    expense_category: null,
+    category_status: null,
+    receipt_status: "missing_receipt",
+    receipt_missing_reason: null,
+    business_trip_id: null,
+    business_trip_status: null,
+    updated_at: "2026-07-01T00:00:00Z",
+    expense_category_code: null,
+    re_review_needed: 0,
+    foreign_amount_minor: null,
+    foreign_currency: null,
+    foreign_exchange_rate: null,
+    memo_currency_parse_status: null,
+    ...p,
+  } as AmexStatementLine;
+}
+
+// ─── crossMonthClaimedReceiptIds ─────────────────────────────────────────────
+
+test("a confirmed line in another month marks the receipt cross-month-claimed", () => {
+  const claims = [
+    line({ id: "L-jul", statement_month: "2026-07", matched_receipt_id: "R-NFCTAGS", match_status: "confirmed" }),
+    line({ id: "L-aug", statement_month: "2026-08", matched_receipt_id: "R-other", match_status: "confirmed" }),
+  ];
+  const out = crossMonthClaimedReceiptIds(claims, "2026-08");
+  assert.deepEqual([...out], ["R-NFCTAGS"]); // R-other is in the displayed month → not included
+});
+
+test("same-month claims are NOT cross-month (consolidation stays available)", () => {
+  const claims = [
+    line({ statement_month: "2026-08", matched_receipt_id: "R1", match_status: "confirmed" }),
+  ];
+  assert.equal(crossMonthClaimedReceiptIds(claims, "2026-08").size, 0);
+});
+
+test("tentative (matched) cross-month claims also exclude; unmatched/no_receipt do not", () => {
+  const claims = [
+    line({ statement_month: "2026-07", matched_receipt_id: "R-tentative", match_status: "matched" }),
+    line({ statement_month: "2026-07", matched_receipt_id: "R-stale", match_status: "unmatched" }),
+    line({ statement_month: "2026-07", matched_receipt_id: "R-norec", match_status: "no_receipt" }),
+  ];
+  const out = crossMonthClaimedReceiptIds(claims, "2026-08");
+  assert.deepEqual([...out], ["R-tentative"]);
+});
+
+// ─── allClaimedReceiptIds (badge wording source) ─────────────────────────────
+
+test("allClaimedReceiptIds includes matched/confirmed across every month", () => {
+  const claims = [
+    line({ statement_month: "2026-07", matched_receipt_id: "A", match_status: "confirmed" }),
+    line({ statement_month: "2026-08", matched_receipt_id: "B", match_status: "matched" }),
+    line({ statement_month: "2026-08", matched_receipt_id: "C", match_status: "unmatched" }),
+  ];
+  assert.deepEqual([...allClaimedReceiptIds(claims)].sort(), ["A", "B"]);
+});
+
+// ─── Part B regression: the NFCTAGS shape (audit 2026-07-21) ──────────────────
+// A receipt with status "reviewed", confirmed against a 2026-07 line, whose
+// transaction_date (2026-06-08) falls inside 2026-08's padded window
+// (2026-06-05..2026-07-15), MUST NOT appear as a 2026-08 match candidate or
+// orphan. The page excludes it via crossMonthClaimedReceiptIds; this test pins
+// that the exclusion set contains it and that filtering the candidate/orphan
+// pools on the set removes it.
+
+test("NFCTAGS regression: cross-month-confirmed receipt is excluded from 2026-08 candidates & orphans", () => {
+  const displayedMonth = "2026-08";
+  const nfctagsId = "8d71768d";
+  // The receipt is dated 2026-06-08 — inside 2026-08's padded window
+  // (min line 2026-06-10 − 5d = 2026-06-05 .. max 2026-07-10 + 5d = 2026-07-15).
+  const nfctagsReceipt = { id: nfctagsId, transaction_date: "2026-06-08", status: "reviewed", payment_path: "AMEX" } as never;
+  const windowedReceipts = [
+    nfctagsReceipt,
+    { id: "real-orphan", transaction_date: "2026-06-29", status: "reviewed", payment_path: "AMEX" } as never,
+  ];
+
+  // The authoritative signal: a confirmed 2026-07 line points at NFCTAGS.
+  const claims = [
+    line({ statement_month: "2026-07", matched_receipt_id: nfctagsId, match_status: "confirmed" }),
+  ];
+  const excluded = crossMonthClaimedReceiptIds(claims, displayedMonth);
+  assert.ok(excluded.has(nfctagsId), "NFCTAGS must be in the cross-month exclusion set");
+
+  // Matcher candidates & orphan pool both filter on the exclusion set (as the
+  // page does). NFCTAGS drops out; the genuine in-period orphan remains.
+  const candidates = windowedReceipts.filter((r) => !excluded.has((r as { id: string }).id));
+  assert.equal(candidates.some((r) => (r as { id: string }).id === nfctagsId), false);
+  assert.equal(candidates.some((r) => (r as { id: string }).id === "real-orphan"), true);
+});

--- a/tests/receipts/orphan-classification.test.ts
+++ b/tests/receipts/orphan-classification.test.ts
@@ -1,0 +1,86 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  classifyUnmatchedReceipt,
+  partitionUnmatchedReceipts,
+  statementLineDateRange,
+} from "@/lib/receipts/orphan-classification";
+
+const RANGE = { minDate: "2026-06-10", maxDate: "2026-07-10" };
+const dated = (transaction_date: string) => ({ transaction_date });
+const undated = () => ({ transaction_date: null });
+
+// ─── classifyUnmatchedReceipt: boundaries ────────────────────────────────────
+
+test("date on first line date is in-period (inclusive lower bound)", () => {
+  assert.equal(classifyUnmatchedReceipt(dated("2026-06-10"), RANGE), "true_in_period");
+});
+
+test("date on last line date is in-period (inclusive upper bound)", () => {
+  assert.equal(classifyUnmatchedReceipt(dated("2026-07-10"), RANGE), "true_in_period");
+});
+
+test("date strictly inside the range is in-period", () => {
+  assert.equal(classifyUnmatchedReceipt(dated("2026-06-29"), RANGE), "true_in_period");
+});
+
+test("date before min (leading pad) is leading_slack, NOT an orphan", () => {
+  assert.equal(classifyUnmatchedReceipt(dated("2026-06-09"), RANGE), "leading_slack");
+  assert.equal(classifyUnmatchedReceipt(dated("2026-06-05"), RANGE), "leading_slack");
+});
+
+test("date after max is upcoming / awaiting next statement", () => {
+  assert.equal(classifyUnmatchedReceipt(dated("2026-07-11"), RANGE), "upcoming");
+  assert.equal(classifyUnmatchedReceipt(dated("2026-07-14"), RANGE), "upcoming");
+});
+
+test("null transaction_date is undated / needs date", () => {
+  assert.equal(classifyUnmatchedReceipt(undated(), RANGE), "undated");
+});
+
+// ─── empty-line fallback (no statement dates) ────────────────────────────────
+
+test("empty-line fallback: dated receipts become upcoming, undated stay undated", () => {
+  const empty = { minDate: null, maxDate: null };
+  assert.equal(classifyUnmatchedReceipt(dated("2026-06-10"), empty), "upcoming");
+  assert.equal(classifyUnmatchedReceipt(dated("2025-01-01"), empty), "upcoming");
+  assert.equal(classifyUnmatchedReceipt(undated(), empty), "undated");
+});
+
+// ─── statementLineDateRange ──────────────────────────────────────────────────
+
+test("statementLineDateRange ignores nulls and returns min/max", () => {
+  assert.deepEqual(
+    statementLineDateRange(["2026-07-06", null, "2026-05-05", undefined, "2026-06-01"]),
+    { minDate: "2026-05-05", maxDate: "2026-07-06" },
+  );
+});
+
+test("statementLineDateRange returns null/null when no dated lines", () => {
+  assert.deepEqual(statementLineDateRange([null, undefined]), { minDate: null, maxDate: null });
+  assert.deepEqual(statementLineDateRange([]), { minDate: null, maxDate: null });
+});
+
+// ─── partitionUnmatchedReceipts ──────────────────────────────────────────────
+
+test("partition splits into the four classes; only true_in_period are orphans", () => {
+  const receipts = [
+    dated("2026-06-10"), // in-period (min boundary)
+    dated("2026-07-02"), // in-period
+    dated("2026-06-06"), // leading slack
+    dated("2026-07-14"), // upcoming
+    undated(),           // undated
+  ];
+  const p = partitionUnmatchedReceipts(receipts, RANGE);
+  assert.equal(p.true_in_period.length, 2);
+  assert.equal(p.leading_slack.length, 1);
+  assert.equal(p.upcoming.length, 1);
+  assert.equal(p.undated.length, 1);
+});
+
+test("partition preserves element identity (generic over the input type)", () => {
+  const receipts = [{ id: "a", transaction_date: "2026-07-01" }, { id: "b", transaction_date: null }] as Array<{ id: string; transaction_date: string | null }>;
+  const p = partitionUnmatchedReceipts(receipts, RANGE);
+  assert.equal(p.true_in_period[0]!.id, "a");
+  assert.equal(p.undated[0]!.id, "b");
+});

--- a/tests/receipts/receipt-status-policy.test.ts
+++ b/tests/receipts/receipt-status-policy.test.ts
@@ -1,0 +1,105 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  canMarkReviewed,
+  canPromoteToReviewed,
+  planReviewStatusTransition,
+  REVIEW_PATCH_ALLOWED_STATUS,
+} from "@/lib/receipts/receipt-status-policy";
+import type { ReceiptStatus } from "@/lib/receipts/types";
+
+function plan(current: ReceiptStatus, requested: string | undefined) {
+  return planReviewStatusTransition({ currentStatus: current, requestedStatus: requested });
+}
+
+// ─── canPromoteToReviewed (drives the "Mark reviewed" button) ─────────────────
+
+test("canPromoteToReviewed: true only for pre-review states", () => {
+  assert.equal(canPromoteToReviewed("captured"), true);
+  assert.equal(canPromoteToReviewed("needs_review"), true);
+  assert.equal(canPromoteToReviewed("reviewed"), false);
+  assert.equal(canPromoteToReviewed("reconciled"), false);
+  assert.equal(canPromoteToReviewed("exported"), false);
+  assert.equal(canPromoteToReviewed("archived"), false);
+});
+
+// ─── canMarkReviewed: the shared button + `s`-shortcut gate ───────────────────
+// Both the "Mark reviewed" button (disabled) and the `s` keyboard shortcut route
+// through this single predicate, so they can never disagree. A non-promotable
+// but merely-unlocked receipt must not save-and-advance via the shortcut.
+
+test("canMarkReviewed: true only when unlocked AND pre-review", () => {
+  assert.equal(canMarkReviewed("captured", false), true);
+  assert.equal(canMarkReviewed("needs_review", false), true);
+  for (const s of ["reviewed", "reconciled", "exported", "archived"] as ReceiptStatus[]) {
+    assert.equal(canMarkReviewed(s, false), false, `${s} should not be mark-reviewable`);
+  }
+});
+
+test("canMarkReviewed: a locked form never allows the action, even for captured", () => {
+  assert.equal(canMarkReviewed("captured", true), false);
+  assert.equal(canMarkReviewed("needs_review", true), false);
+  assert.equal(canMarkReviewed("reconciled", true), false);
+});
+
+// ─── planReviewStatusTransition ───────────────────────────────────────────────
+
+test("autosave (no status field) is a noop — lifecycle status never touched", () => {
+  for (const current of ["captured", "needs_review", "reviewed", "reconciled", "exported", "archived"] as ReceiptStatus[]) {
+    assert.deepEqual(plan(current, undefined), { outcome: "noop" });
+  }
+});
+
+test("captured/needs_review → reviewed is applied", () => {
+  assert.deepEqual(plan("captured", "reviewed"), { outcome: "apply", status: "reviewed" });
+  assert.deepEqual(plan("needs_review", "reviewed"), { outcome: "apply", status: "reviewed" });
+});
+
+test("already reviewed + requested reviewed is an idempotent noop (no error)", () => {
+  assert.deepEqual(plan("reviewed", "reviewed"), { outcome: "noop" });
+});
+
+test("non-\"reviewed\" requested statuses are rejected 400 — this endpoint owns only the promotion", () => {
+  for (const bad of ["needs_review", "captured", "reconciled", "exported", "archived", "garbage", ""]) {
+    const r = plan("needs_review", bad);
+    assert.equal(r.outcome, "reject", `expected reject for "${bad}"`);
+    assert.equal((r as { httpStatus: number }).httpStatus, 400);
+  }
+});
+
+test("reconciled/exported/archived cannot be demoted to reviewed via the review endpoint (409)", () => {
+  for (const current of ["reconciled", "exported", "archived"] as ReceiptStatus[]) {
+    const r = plan(current, "reviewed");
+    assert.equal(r.outcome, "reject", `expected reject for ${current}`);
+    assert.equal((r as { httpStatus: number }).httpStatus, 409);
+  }
+});
+
+test("REVIEW_PATCH_ALLOWED_STATUS is exactly 'reviewed'", () => {
+  assert.equal(REVIEW_PATCH_ALLOWED_STATUS, "reviewed");
+});
+
+// ─── Request-shape contract (the two form-pane PATCH shapes through the planner)
+// These pin the client→server contract: an autosave body has no `status` key
+// (plan → noop), and a Mark-reviewed body carries `status:"reviewed"` only when
+// the receipt is still promotable (plan → apply), never on a reconciled receipt
+// (plan → reject). The server planner is the authoritative guard, so exercising
+// it with the exact request shapes covers the contract end-to-end here.
+
+test("request-shape: autosave body (no status key) leaves a reconciled receipt untouched", () => {
+  // Autosave never includes status, even on a reconciled receipt.
+  const autosaveBody = { merchant: "X", amountMinor: 100 } as Record<string, unknown>;
+  assert.equal("status" in autosaveBody, false);
+  assert.deepEqual(plan("reconciled", autosaveBody.status as string | undefined), { outcome: "noop" });
+});
+
+test("request-shape: Mark-reviewed on a promotable receipt sends status=reviewed and is applied", () => {
+  const markBody = { merchant: "X", status: "reviewed" };
+  assert.equal(markBody.status, "reviewed");
+  assert.deepEqual(plan("needs_review", markBody.status), { outcome: "apply", status: "reviewed" });
+});
+
+test("request-shape: a stale Mark-reviewed reaching a reconciled receipt is rejected (the downgrade guard)", () => {
+  // The client no longer sends this, but the server must still refuse it.
+  assert.deepEqual(plan("reconciled", "reviewed").outcome, "reject");
+});


### PR DESCRIPTION
## Summary

Code-only Phase 1 remediation from the 2026-07-21 read-only orphan audit. No receipt data mutated, no matches changed, no statements re-imported. Rebased onto `c0d7189` (PR #144); all sparse-PATCH and membership-hotfix behavior preserved.

- **Lifecycle-status downgrade prevention** — the public review PATCH owns only `captured`/`needs_review → reviewed`; ordinary autosaves omit `status` entirely; `reconciled`/`exported`/`archived` cannot be demoted via the review endpoint. Authority: `planReviewStatusTransition` (`lib/receipts/receipt-status-policy.ts`). The **Mark reviewed** button and the `s` shortcut share one pure gate, `canMarkReviewed`.
- **Cross-month claim exclusion** — a receipt claimed by a matched/confirmed AMEX line in another statement month is no longer offered as an automatic match or shown as an orphan in the displayed month, keyed on the AMEX line relationship (not `receipt.status`). `lib/receipts/cross-month-claims.ts`. (Fixes the 2026-07-21 NFCTAGS `8d71768d` cross-month leak.)
- **Honest orphan classification** — only true in-period (between actual line MIN/MAX) unmatched receipts count as **Orphan receipts**; leading-±5d → **Before statement range**; after-max → **Awaiting next statement**; null date → **Needs date** (separate, no longer repeats monthly). The matcher's padded window is unchanged. `lib/receipts/orphan-classification.ts`.
- **Exhaustive windowed reconcile query** — `listAmexReceiptsForReconcile` replaces the global newest-200 (dated in-window via an index-backed `BETWEEN` plus a separate undated query; paged with a hard cap that throws loudly; projects out `search_text`/`compliance_warnings_json`, keeps `extraction_json` for the matcher's rawText fallback).
- **Non-blocking AMEX duplicate candidates** — `lib/receipts/amex-duplicates.ts` surfaces possible re-captures as a badge/link only (strong = canonical merchant + currency + amount + date → "Possible re-capture"; near = same currency/amount ±1 day with differing merchant text → "Possible related receipt — same amount/date"). Spans all dated unmatched populations. Never auto-matches/deletes/suppresses. CASH/DIGITAL month-close warning semantics unchanged.

## Verification
- `npm test`: 811 pass / 0 fail (1 skipped) — includes PR #144 sparse-PATCH + membership tests.
- `npx tsc --noEmit`: clean.
- `npm run build:cf`: exit 0.
- New pure-module tests: status policy (incl. `canMarkReviewed` shared gate), orphan classification, AMEX duplicates (incl. round-trip legitimacy), cross-month claims (NFCTAGS regression).

See `AGENTS.md` backlog #8 for the dated audit history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)