### PR TITLE
fix: lint for CI — @ts-expect-error + unused vars

### DIFF
--- a/components/receipts/reconcile/duplicate-resolution-modal.tsx
+++ b/components/receipts/reconcile/duplicate-resolution-modal.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import { ReceiptImageViewer } from "@/components/receipts/receipt-image-viewer";
 import { Btn } from "@/components/ui/btn";
 import { Pill } from "@/components/ui/pill";
-import { WarningIcon, CheckIcon } from "@/components/ui/icons";
+import { CheckIcon } from "@/components/ui/icons";
 import { assessSelection, type DuplicateMemberInput } from "@/lib/receipts/duplicate-resolution-policy";
 
 export interface ClusterMemberView {

--- a/lib/receipts/duplicate-purge.ts
+++ b/lib/receipts/duplicate-purge.ts
@@ -840,7 +840,6 @@ export async function retryR2Cleanup(args: {
   // mark the job completed). It stays storage_failed.
   const keys = parsePendingKeys(job.pending_keys_json);
   if (keys === null) {
-    const ts = nowIso();
     await args.db
       .prepare(`UPDATE duplicate_purge_log SET status='storage_failed', error_text=? WHERE id=?`)
       .bind(`Malformed or missing pending key inventory for ${args.purgeJobId}`, args.purgeJobId)

--- a/lib/receipts/duplicate-resolution-policy.ts
+++ b/lib/receipts/duplicate-resolution-policy.ts
@@ -300,7 +300,6 @@ export function recommendRetention(
   const retainedReasons: string[] = [];
   if (retainedAssessment.tier === "protected") retainedReasons.push("Protected — cannot purge");
   if (retainedAssessment.tier === "registered") retainedReasons.push("Registered linkage");
-  const tierGroups = new Set(members.map((m) => assessments.get(m.id)!.tierRank));
   // "More complete record" only when it actually won on completeness among its tier.
   const sameTier = members.filter((m) => assessments.get(m.id)!.tierRank === retainedAssessment.tierRank);
   if (sameTier.length > 1 && retainedAssessment.completeness.score === Math.max(...sameTier.map((m) => assessments.get(m.id)!.completeness.score))) {

--- a/tests/receipts/duplicate-purge.test.ts
+++ b/tests/receipts/duplicate-purge.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-// @ts-ignore — node:sqlite is available at runtime in Node 25 but not yet in @types/node.
+// @ts-expect-error — node:sqlite is available at runtime in Node 25 but not yet in @types/node.
 import { DatabaseSync } from "node:sqlite";
 import { readFileSync } from "node:fs";
 import {


### PR DESCRIPTION
Fixes the CI lint failure from PR #149 merge. Replaces @ts-ignore with @ts-expect-error (ESLint rule) and removes 3 unused vars. No code logic change.