### PR TITLE
receipts: safe duplicate merge and field resolution

### DIFF
--- a/app/api/receipts/duplicates/merge/route.ts
+++ b/app/api/receipts/duplicates/merge/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from "next/server";
+import { requireReceiptsActor } from "@/lib/receipts/auth";
+import { getReceiptsDb } from "@/lib/cloudflare-runtime";
+import { applyDuplicateMerge, MergeError } from "@/lib/receipts/duplicate-merge";
+import type { PreservationField } from "@/lib/receipts/duplicate-resolution-policy";
+
+// POST /api/receipts/duplicates/merge
+// Server-authoritative duplicate-merge: resolves target-only/conflicting
+// accounting data onto the retained canonical receipt BEFORE purge. Nothing is
+// copied automatically; the operator provides a resolution plan. Source receipts
+// remain untouched. Never performs purge.
+export async function POST(request: Request) {
+  try {
+    const actor = await requireReceiptsActor(request.headers);
+    const body = (await request.json()) as {
+      retainedReceiptId?: string;
+      retainedExpectedUpdatedAt?: string;
+      sources?: Array<{ receiptId: string; expectedUpdatedAt: string }>;
+      resolutionPlan?: Array<{
+        field: PreservationField;
+        action: "copy_from_source" | "keep_retained" | "manual_value";
+        sourceReceiptId?: string;
+        manualValue?: string | number | null;
+      }>;
+      correctionReason?: string;
+    };
+
+    if (!body.retainedReceiptId || typeof body.retainedExpectedUpdatedAt !== "string" || !Array.isArray(body.sources) || !Array.isArray(body.resolutionPlan)) {
+      return NextResponse.json(
+        { error: "retainedReceiptId, retainedExpectedUpdatedAt, sources[], and resolutionPlan[] are required." },
+        { status: 400 },
+      );
+    }
+
+    const result = await applyDuplicateMerge({
+      db: getReceiptsDb(),
+      retainedReceiptId: body.retainedReceiptId,
+      retainedExpectedUpdatedAt: body.retainedExpectedUpdatedAt,
+      sources: body.sources,
+      resolutionPlan: body.resolutionPlan,
+      actor,
+      correctionReason: body.correctionReason,
+    });
+
+    return NextResponse.json(result, { status: 200 });
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Unauthorized")) {
+      return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+    }
+    if (error instanceof MergeError) {
+      return NextResponse.json(
+        { error: error.message, code: error.code, month: error.month },
+        { status: error.status },
+      );
+    }
+    console.error("[api/receipts/duplicates/merge] POST failed", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Merge failed." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/receipts/duplicates/merge/route.ts
+++ b/app/api/receipts/duplicates/merge/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { requireReceiptsActor } from "@/lib/receipts/auth";
 import { getReceiptsDb } from "@/lib/cloudflare-runtime";
 import { applyDuplicateMerge, MergeError } from "@/lib/receipts/duplicate-merge";
-import type { PreservationField } from "@/lib/receipts/duplicate-resolution-policy";
+import type { FieldResolution } from "@/lib/receipts/duplicate-merge-contract";
 
 // POST /api/receipts/duplicates/merge
 // Server-authoritative duplicate-merge: resolves target-only/conflicting
@@ -16,13 +16,7 @@ export async function POST(request: Request) {
       retainedReceiptId?: string;
       retainedExpectedUpdatedAt?: string;
       sources?: Array<{ receiptId: string; expectedUpdatedAt: string }>;
-      resolutionPlan?: Array<{
-        field: PreservationField;
-        action: "copy_from_source" | "keep_retained" | "manual_value";
-        sourceReceiptId?: string;
-        manualValue?: string | number | null;
-      }>;
-      correctionReason?: string;
+      resolutionPlan?: FieldResolution[];
     };
 
     if (!body.retainedReceiptId || typeof body.retainedExpectedUpdatedAt !== "string" || !Array.isArray(body.sources) || !Array.isArray(body.resolutionPlan)) {
@@ -39,7 +33,6 @@ export async function POST(request: Request) {
       sources: body.sources,
       resolutionPlan: body.resolutionPlan,
       actor,
-      correctionReason: body.correctionReason,
     });
 
     return NextResponse.json(result, { status: 200 });

--- a/components/receipts/reconcile/duplicate-resolution-modal.tsx
+++ b/components/receipts/reconcile/duplicate-resolution-modal.tsx
@@ -6,8 +6,9 @@ import { ReceiptImageViewer } from "@/components/receipts/receipt-image-viewer";
 import { Btn } from "@/components/ui/btn";
 import { Pill } from "@/components/ui/pill";
 import { CheckIcon } from "@/components/ui/icons";
-import { assessSelection, type DuplicateMemberInput, type SelectionAssessment } from "@/lib/receipts/duplicate-resolution-policy";
+import { assessSelection, type DuplicateMemberInput } from "@/lib/receipts/duplicate-resolution-policy";
 import { MergeResolutionSection } from "@/components/receipts/reconcile/merge-resolution-section";
+import type { DuplicateMergeApiResult } from "@/lib/receipts/duplicate-merge-contract";
 
 export interface ClusterMemberView {
   input: DuplicateMemberInput;
@@ -66,6 +67,10 @@ export function DuplicateResolutionModal({
   const [partialWarning, setPartialWarning] = useState<
     Array<{ purgeJobId: string; receiptId: string; remainingKeys: number; error: string | null }> | null
   >(null);
+  const [mergeNotice, setMergeNotice] = useState<{
+    tone: "green" | "amber";
+    message: string;
+  } | null>(null);
 
   // Reload the cluster from the server (used on mount and after merge). After a
   // merge, ALL destructive confirmations must be cleared (post-merge reset).
@@ -75,7 +80,11 @@ export function DuplicateResolutionModal({
     const json = (await res.json().catch(() => ({}))) as ClusterResponse | { error?: string };
     if (res.ok && "members" in json) {
       setData(json);
-      if (!postMerge) setRetainedId(json.recommendation.retainedId);
+      setRetainedId((current) =>
+        postMerge && current && json.members.some((member) => member.input.id === current)
+          ? current
+          : json.recommendation.retainedId,
+      );
       // Post-merge reset: clear every destructive confirmation so the operator
       // must re-examine the updated retained record and reselect targets.
       setPurgeSelected(new Set());
@@ -89,6 +98,33 @@ export function DuplicateResolutionModal({
     if (!res.ok) setError((json as { error?: string }).error ?? "Failed to load cluster.");
     return false;
   }, [clusterIds]);
+
+  async function handleMerged(result: DuplicateMergeApiResult) {
+    // Clear destructive state immediately after the server confirms the merge,
+    // before any reload can fail or race with another operator action.
+    setPurgeSelected(new Set());
+    setConfirmText("");
+    setVisualConfirmed(false);
+    setLegalAck(false);
+    setMergeNotice({ tone: "green", message: "Merge committed. Reloading the comparison…" });
+    try {
+      const reloaded = await reloadCluster(true);
+      if (!reloaded) {
+        setMergeNotice({ tone: "amber", message: "Merge committed, but the comparison could not reload. Close and reopen this dialog before purging." });
+        return;
+      }
+      const correctionText = result.correction
+        ? ` Correction draft ${result.correction.month} revision ${result.correction.revision} remains open and must be re-finalized.`
+        : "";
+      const warningText = result.warnings.length ? ` ${result.warnings.join(" ")}` : "";
+      setMergeNotice({
+        tone: result.warnings.length ? "amber" : "green",
+        message: `Merge committed (${result.updatedFields.join(", ") || "attendees"}). Recheck the retained receipt and reselect purge targets.${correctionText}${warningText}`,
+      });
+    } catch {
+      setMergeNotice({ tone: "amber", message: "Merge committed, but the comparison reload failed. Close and reopen this dialog before purging." });
+    }
+  }
 
   useEffect(() => {
     let cancelled = false;
@@ -106,7 +142,7 @@ export function DuplicateResolutionModal({
     return () => { cancelled = true; };
   }, [reloadCluster]);
 
-  const members = data?.members ?? [];
+  const members = useMemo(() => data?.members ?? [], [data]);
 
   // Changing the retained receipt clears all purge selections and recomputes the
   // preview/blockers for the operator's actual selection (correction §1/§3).
@@ -256,6 +292,11 @@ export function DuplicateResolutionModal({
               </ul>
             </div>
           )}
+          {mergeNotice && (
+            <div className={`mb-3 rounded-lg border px-3 py-2 text-sm ${mergeNotice.tone === "green" ? "border-green-200 bg-green-50 text-green-800" : "border-amber-300 bg-amber-50 text-amber-900"}`}>
+              {mergeNotice.message}
+            </div>
+          )}
 
           {data && !loading && (
             <>
@@ -342,14 +383,13 @@ export function DuplicateResolutionModal({
               </div>
 
               {/* Data-resolution section: resolve target-only fields before purge */}
-              {selectionBlocked && selection && retainedId && retainedRow && (
+              {selectedTargetIds.length > 0 && selection && retainedId && retainedRow && (
                 <MergeResolutionSection
                   retainedId={retainedId}
                   retainedUpdatedAt={retainedRow.input.updated_at}
                   targets={selectedTargetIds}
                   members={members}
-                  selection={selection}
-                  onMerged={() => void reloadCluster(true)}
+                  onMerged={handleMerged}
                 />
               )}
             </>

--- a/components/receipts/reconcile/duplicate-resolution-modal.tsx
+++ b/components/receipts/reconcile/duplicate-resolution-modal.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { ReceiptImageViewer } from "@/components/receipts/receipt-image-viewer";
 import { Btn } from "@/components/ui/btn";
 import { Pill } from "@/components/ui/pill";
 import { CheckIcon } from "@/components/ui/icons";
-import { assessSelection, type DuplicateMemberInput } from "@/lib/receipts/duplicate-resolution-policy";
+import { assessSelection, type DuplicateMemberInput, type SelectionAssessment } from "@/lib/receipts/duplicate-resolution-policy";
+import { MergeResolutionSection } from "@/components/receipts/reconcile/merge-resolution-section";
 
 export interface ClusterMemberView {
   input: DuplicateMemberInput;
@@ -66,34 +67,44 @@ export function DuplicateResolutionModal({
     Array<{ purgeJobId: string; receiptId: string; remainingKeys: number; error: string | null }> | null
   >(null);
 
+  // Reload the cluster from the server (used on mount and after merge). After a
+  // merge, ALL destructive confirmations must be cleared (post-merge reset).
+  const reloadCluster = useCallback(async (postMerge = false) => {
+    const params = new URLSearchParams({ ids: clusterIds.join(",") });
+    const res = await fetch(`/api/receipts/duplicates/cluster?${params}`);
+    const json = (await res.json().catch(() => ({}))) as ClusterResponse | { error?: string };
+    if (res.ok && "members" in json) {
+      setData(json);
+      if (!postMerge) setRetainedId(json.recommendation.retainedId);
+      // Post-merge reset: clear every destructive confirmation so the operator
+      // must re-examine the updated retained record and reselect targets.
+      setPurgeSelected(new Set());
+      setConfirmText("");
+      if (postMerge) {
+        setVisualConfirmed(false);
+        setLegalAck(false);
+      }
+      return true;
+    }
+    if (!res.ok) setError((json as { error?: string }).error ?? "Failed to load cluster.");
+    return false;
+  }, [clusterIds]);
+
   useEffect(() => {
     let cancelled = false;
     void (async () => {
       setLoading(true);
       setError(null);
       try {
-        // §7: encode query using URLSearchParams (not manual string concat).
-        const params = new URLSearchParams({ ids: clusterIds.join(",") });
-        const res = await fetch(`/api/receipts/duplicates/cluster?${params}`);
-        const json = (await res.json().catch(() => ({}))) as ClusterResponse | { error?: string };
-        if (!res.ok || !("members" in json)) {
-          setError((json as { error?: string }).error ?? "Failed to load cluster.");
-          return;
-        }
-        if (cancelled) return;
-        setData(json);
-        setRetainedId(json.recommendation.retainedId);
-        setPurgeSelected(new Set()); // none by default
+        await reloadCluster();
       } catch {
-        setError("Network error.");
+        if (!cancelled) setError("Network error.");
       } finally {
         if (!cancelled) setLoading(false);
       }
     })();
-    return () => {
-      cancelled = true;
-    };
-  }, [clusterIds]);
+    return () => { cancelled = true; };
+  }, [reloadCluster]);
 
   const members = data?.members ?? [];
 
@@ -329,6 +340,18 @@ export function DuplicateResolutionModal({
                   );
                 })}
               </div>
+
+              {/* Data-resolution section: resolve target-only fields before purge */}
+              {selectionBlocked && selection && retainedId && retainedRow && (
+                <MergeResolutionSection
+                  retainedId={retainedId}
+                  retainedUpdatedAt={retainedRow.input.updated_at}
+                  targets={selectedTargetIds}
+                  members={members}
+                  selection={selection}
+                  onMerged={() => void reloadCluster(true)}
+                />
+              )}
             </>
           )}
         </div>

--- a/components/receipts/reconcile/merge-resolution-section.tsx
+++ b/components/receipts/reconcile/merge-resolution-section.tsx
@@ -1,0 +1,317 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Btn } from "@/components/ui/btn";
+import { Pill } from "@/components/ui/pill";
+import { EXPENSE_CATEGORIES, formatCategoryLabel } from "@/lib/receipts/categories";
+import type { ClusterMemberView } from "./duplicate-resolution-modal";
+import type { SelectionAssessment } from "@/lib/receipts/duplicate-resolution-policy";
+
+type ResAction = "copy_from_source" | "manual_value";
+interface FieldRes { action: ResAction; manualValue?: string; sourceId: string }
+
+const FIELD_LABELS: Record<string, string> = {
+  transaction_date: "Transaction date",
+  merchant: "Merchant",
+  amount: "Amount",
+  category: "Expense category",
+  business_purpose: "Business purpose",
+  alcohol_present: "Alcohol present",
+  tax_amount: "Consumption tax amount",
+  tax_rate: "Tax rate",
+  invoice_number: "Invoice registration number",
+  counterparty: "Counterparty",
+  attendees: "Attendees",
+};
+
+function getSourceValue(member: ClusterMemberView, field: string): string {
+  const i = member.input;
+  switch (field) {
+    case "transaction_date": return i.transaction_date ?? "—";
+    case "merchant": return i.merchant ?? "—";
+    case "amount": return `${i.currency} ${i.amount_minor ?? "—"}`;
+    case "category": return i.expense_category_code ?? "—";
+    case "business_purpose": return i.business_purpose ?? "—";
+    case "alcohol_present": return i.alcoholPresent ? "Yes" : "No";
+    case "tax_amount": return i.tax_amount_minor != null ? String(i.tax_amount_minor) : "—";
+    case "tax_rate": return i.tax_rate ?? "—";
+    case "invoice_number": return i.invoice_registration_number ?? "—";
+    case "counterparty": return i.counterparty_name ?? "—";
+    case "attendees": return member.attendees.join(", ") || "—";
+    default: return "—";
+  }
+}
+
+export function MergeResolutionSection({
+  retainedId,
+  retainedUpdatedAt,
+  targets,
+  members,
+  selection,
+  onMerged,
+}: {
+  retainedId: string;
+  retainedUpdatedAt: string;
+  targets: string[];
+  members: ClusterMemberView[];
+  selection: SelectionAssessment;
+  onMerged: () => void;
+}) {
+  const [resolutions, setResolutions] = useState<Record<string, FieldRes>>({});
+  const [mergeBusy, setMergeBusy] = useState(false);
+  const [mergeError, setMergeError] = useState<string | null>(null);
+  const [mergeSuccess, setMergeSuccess] = useState<string[] | null>(null);
+  const [correctionRequired, setCorrectionRequired] = useState<{ month: string } | null>(null);
+  const [correctionReason, setCorrectionReason] = useState("");
+
+  // Compute blocking target-only fields per target.
+  const blockingFields = useMemo(() => {
+    const result: Array<{ targetId: string; target: ClusterMemberView; fields: string[] }> = [];
+    for (const targetId of targets) {
+      const targetAssessment = selection.perTarget.find((t) => t.id === targetId);
+      if (!targetAssessment?.missingFieldsToCopy.length) continue;
+      const target = members.find((m) => m.input.id === targetId);
+      if (!target) continue;
+      result.push({ targetId, target, fields: targetAssessment.missingFieldsToCopy });
+    }
+    return result;
+  }, [targets, selection, members]);
+
+  if (blockingFields.length === 0 && !mergeSuccess) return null;
+
+  function setRes(key: string, action: ResAction, sourceId: string, manualValue?: string) {
+    setResolutions((prev) => ({ ...prev, [key]: { action, sourceId, manualValue } }));
+  }
+
+  // Check if all blocking fields have a resolution.
+  const allResolved = blockingFields.every(({ targetId, fields }) =>
+    fields.every((f) => resolutions[`${targetId}:${f}`]),
+  );
+
+  async function applyMerge() {
+    if (!allResolved) return;
+    setMergeBusy(true);
+    setMergeError(null);
+    setMergeSuccess(null);
+
+    // Build the resolution plan from the UI state.
+    const plan: Array<{
+      field: string;
+      action: "copy_from_source" | "keep_retained" | "manual_value";
+      sourceReceiptId?: string;
+      manualValue?: string | number | null;
+    }> = [];
+    const sourceIds = new Set<string>();
+    for (const { targetId, fields } of blockingFields) {
+      sourceIds.add(targetId);
+      for (const field of fields) {
+        const key = `${targetId}:${field}`;
+        const res = resolutions[key];
+        if (!res) continue;
+        plan.push({
+          field,
+          action: res.action,
+          sourceReceiptId: res.action === "copy_from_source" ? res.sourceId : undefined,
+          manualValue: res.action === "manual_value" ? res.manualValue : undefined,
+        });
+      }
+    }
+
+    try {
+      const res = await fetch("/api/receipts/duplicates/merge", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          retainedReceiptId: retainedId,
+          retainedExpectedUpdatedAt: retainedUpdatedAt,
+          sources: [...sourceIds].map((id) => {
+            const m = members.find((x) => x.input.id === id);
+            return { receiptId: id, expectedUpdatedAt: m?.input.updated_at ?? "" };
+          }),
+          resolutionPlan: plan,
+          correctionReason: correctionReason.trim() || undefined,
+        }),
+      });
+      const json = (await res.json().catch(() => ({}))) as {
+        error?: string;
+        code?: string;
+        month?: string;
+        updatedFields?: string[];
+      };
+      if (!res.ok) {
+        if (json.code === "CORRECTION_DRAFT_REQUIRED") {
+          setCorrectionRequired({ month: json.month ?? "unknown" });
+          setMergeError(json.error ?? "A correction draft is required.");
+        } else {
+          setMergeError(json.error ?? "Merge failed.");
+        }
+        return;
+      }
+      // Success — reset and notify parent to reload.
+      setMergeSuccess(json.updatedFields ?? []);
+      setCorrectionRequired(null);
+      setResolutions({});
+      onMerged();
+    } catch {
+      setMergeError("Network error.");
+    } finally {
+      setMergeBusy(false);
+    }
+  }
+
+  async function createCorrectionDraft() {
+    if (!correctionRequired || !correctionReason.trim()) return;
+    setMergeBusy(true);
+    setMergeError(null);
+    try {
+      const res = await fetch(`/api/receipts/export/${correctionRequired.month}?correction=true`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ correctionReason: correctionReason.trim() }),
+      });
+      if (!res.ok) {
+        const json = (await res.json().catch(() => ({}))) as { error?: string };
+        setMergeError(json.error ?? "Failed to create correction draft.");
+        return;
+      }
+      // Draft created — retry the merge.
+      setCorrectionRequired(null);
+      await applyMerge();
+    } catch {
+      setMergeError("Network error creating correction draft.");
+    } finally {
+      setMergeBusy(false);
+    }
+  }
+
+  return (
+    <div className="mt-4 rounded-xl border border-amber-300 bg-amber-50 p-4">
+      <div className="mb-2 flex items-center gap-2">
+        <span className="text-sm font-bold text-amber-900">⚠ Prepare retained receipt</span>
+        <span className="text-xs text-amber-700">
+          Target-only accounting data must be resolved before purge. Copy or enter values; the server revalidates.
+        </span>
+      </div>
+
+      {mergeError && (
+        <div className="mb-3 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">
+          {mergeError}
+        </div>
+      )}
+
+      {mergeSuccess && (
+        <div className="mb-3 rounded-lg border border-green-200 bg-green-50 px-3 py-2 text-xs text-green-700">
+          ✓ Applied {mergeSuccess.length} field(s): {mergeSuccess.join(", ")}. Comparison reloaded —
+          reselect purge targets below.
+        </div>
+      )}
+
+      {correctionRequired && (
+        <div className="mb-3 rounded-lg border border-amber-400 bg-amber-100 px-3 py-3 text-xs text-amber-900">
+          <div className="font-semibold">
+            The retained receipt is in finalized export {correctionRequired.month}. A correction draft is required.
+          </div>
+          <div className="mt-1">
+            Reason:{" "}
+            <input
+              value={correctionReason}
+              onChange={(e) => setCorrectionReason(e.target.value)}
+              placeholder="Why is this correction needed?"
+              className="h-8 w-64 rounded border border-amber-300 px-2 text-xs"
+            />
+          </div>
+          <Btn
+            kind="primary"
+            size="sm"
+            onClick={createCorrectionDraft}
+            disabled={!correctionReason.trim() || mergeBusy}
+            className="mt-2"
+          >
+            Create correction draft and apply
+          </Btn>
+        </div>
+      )}
+
+      {/* Per-target blocking fields with resolution controls */}
+      {blockingFields.map(({ targetId, target, fields }) => (
+        <div key={targetId} className="mb-3 rounded-lg border border-amber-200 bg-white p-3">
+          <div className="mb-2 text-xs font-semibold text-gray-700">
+            From {target.input.merchant ?? targetId.slice(0, 8)} ({targetId.slice(0, 8)}):
+          </div>
+          {fields.map((field) => {
+            const key = `${targetId}:${field}`;
+            const res = resolutions[key];
+            const sourceVal = getSourceValue(target, field);
+            return (
+              <div key={field} className="mb-2 flex items-start gap-3 text-xs">
+                <div className="w-40 shrink-0 font-medium text-gray-600">
+                  {FIELD_LABELS[field] ?? field}
+                </div>
+                <div className="min-w-0 flex-1">
+                  <span className="text-gray-400">Source: </span>
+                  <span className="font-mono text-gray-700">{sourceVal}</span>
+                  <div className="mt-1 flex flex-wrap items-center gap-2">
+                    <label className="flex items-center gap-1">
+                      <input
+                        type="radio"
+                        name={key}
+                        checked={res?.action === "copy_from_source"}
+                        onChange={() => setRes(key, "copy_from_source", targetId)}
+                      />
+                      Copy to retained
+                    </label>
+                    <label className="flex items-center gap-1">
+                      <input
+                        type="radio"
+                        name={key}
+                        checked={res?.action === "manual_value"}
+                        onChange={() => setRes(key, "manual_value", targetId, getSourceValue(target, field))}
+                      />
+                      Enter corrected value
+                    </label>
+                    {res?.action === "manual_value" && (
+                      <input
+                        value={res.manualValue ?? ""}
+                        onChange={(e) => setRes(key, "manual_value", targetId, e.target.value)}
+                        className="h-7 w-40 rounded border border-gray-200 px-2 text-xs"
+                        placeholder="Corrected value"
+                      />
+                    )}
+                    {field === "category" && res?.action === "manual_value" && (
+                      <select
+                        value={res.manualValue ?? ""}
+                        onChange={(e) => setRes(key, "manual_value", targetId, e.target.value)}
+                        className="h-7 rounded border border-gray-200 px-1 text-xs"
+                      >
+                        <option value="">— Select —</option>
+                        {EXPENSE_CATEGORIES.map((c) => (
+                          <option key={c.code} value={c.code}>{formatCategoryLabel(c.code)}</option>
+                        ))}
+                      </select>
+                    )}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      ))}
+
+      {blockingFields.length > 0 && (
+        <Btn
+          kind="primary"
+          size="sm"
+          onClick={applyMerge}
+          disabled={!allResolved || mergeBusy || !!correctionRequired}
+        >
+          {mergeBusy ? "Applying…" : "Apply changes to retained receipt"}
+        </Btn>
+      )}
+      {!allResolved && blockingFields.length > 0 && (
+        <span className="ml-2 text-xs text-amber-700">
+          Resolve all fields above before applying.
+        </span>
+      )}
+    </div>
+  );
+}

--- a/components/receipts/reconcile/merge-resolution-section.tsx
+++ b/components/receipts/reconcile/merge-resolution-section.tsx
@@ -2,44 +2,56 @@
 
 import { useMemo, useState } from "react";
 import { Btn } from "@/components/ui/btn";
-import { Pill } from "@/components/ui/pill";
 import { EXPENSE_CATEGORIES, formatCategoryLabel } from "@/lib/receipts/categories";
+import type {
+  DuplicateMergeApiResult,
+  FieldResolution,
+  ResolutionAction,
+} from "@/lib/receipts/duplicate-merge-contract";
+import {
+  buildResolutionNeeds,
+  FIELD_LABELS,
+  type ResolutionNeed,
+} from "@/lib/receipts/duplicate-merge-ui";
+import { ALLOWED_CURRENCIES } from "@/lib/receipts/validation";
 import type { ClusterMemberView } from "./duplicate-resolution-modal";
-import type { SelectionAssessment } from "@/lib/receipts/duplicate-resolution-policy";
 
-type ResAction = "copy_from_source" | "manual_value";
-interface FieldRes { action: ResAction; manualValue?: string; sourceId: string }
+interface DraftResolution {
+  action: ResolutionAction;
+  sourceIds: string[];
+  manualText: string;
+  manualCurrency: string;
+  manualBoolean: boolean;
+}
 
-const FIELD_LABELS: Record<string, string> = {
-  transaction_date: "Transaction date",
-  merchant: "Merchant",
-  amount: "Amount",
-  category: "Expense category",
-  business_purpose: "Business purpose",
-  alcohol_present: "Alcohol present",
-  tax_amount: "Consumption tax amount",
-  tax_rate: "Tax rate",
-  invoice_number: "Invoice registration number",
-  counterparty: "Counterparty",
-  attendees: "Attendees",
+const EMPTY_DRAFT: DraftResolution = {
+  action: "copy_from_source",
+  sourceIds: [],
+  manualText: "",
+  manualCurrency: "JPY",
+  manualBoolean: true,
 };
 
-function getSourceValue(member: ClusterMemberView, field: string): string {
-  const i = member.input;
-  switch (field) {
-    case "transaction_date": return i.transaction_date ?? "—";
-    case "merchant": return i.merchant ?? "—";
-    case "amount": return `${i.currency} ${i.amount_minor ?? "—"}`;
-    case "category": return i.expense_category_code ?? "—";
-    case "business_purpose": return i.business_purpose ?? "—";
-    case "alcohol_present": return i.alcoholPresent ? "Yes" : "No";
-    case "tax_amount": return i.tax_amount_minor != null ? String(i.tax_amount_minor) : "—";
-    case "tax_rate": return i.tax_rate ?? "—";
-    case "invoice_number": return i.invoice_registration_number ?? "—";
-    case "counterparty": return i.counterparty_name ?? "—";
-    case "attendees": return member.attendees.join(", ") || "—";
-    default: return "—";
+function manualValue(need: ResolutionNeed, draft: DraftResolution): unknown {
+  switch (need.field) {
+    case "amount": return { amountMinor: Number(draft.manualText), currency: draft.manualCurrency };
+    case "tax_amount": return Number(draft.manualText);
+    case "alcohol_present": return draft.manualBoolean;
+    case "attendees": return {
+      attendees: draft.manualText.split("\n").map((name) => name.trim()).filter(Boolean)
+        .map((attendeeName) => ({ attendeeName })),
+    };
+    default: return draft.manualText;
   }
+}
+
+function manualComplete(need: ResolutionNeed, draft: DraftResolution): boolean {
+  if (need.field === "alcohol_present") return true;
+  if (!draft.manualText.trim()) return false;
+  if (need.field === "amount" || need.field === "tax_amount") {
+    return Number.isInteger(Number(draft.manualText)) && Number(draft.manualText) >= 0;
+  }
+  return true;
 }
 
 export function MergeResolutionSection({
@@ -47,271 +59,263 @@ export function MergeResolutionSection({
   retainedUpdatedAt,
   targets,
   members,
-  selection,
   onMerged,
 }: {
   retainedId: string;
   retainedUpdatedAt: string;
   targets: string[];
   members: ClusterMemberView[];
-  selection: SelectionAssessment;
-  onMerged: () => void;
+  onMerged: (result: DuplicateMergeApiResult) => Promise<void>;
 }) {
-  const [resolutions, setResolutions] = useState<Record<string, FieldRes>>({});
-  const [mergeBusy, setMergeBusy] = useState(false);
-  const [mergeError, setMergeError] = useState<string | null>(null);
-  const [mergeSuccess, setMergeSuccess] = useState<string[] | null>(null);
-  const [correctionRequired, setCorrectionRequired] = useState<{ month: string } | null>(null);
+  const needs = useMemo(
+    () => buildResolutionNeeds(members.map((member) => member.input), retainedId, targets),
+    [members, retainedId, targets],
+  );
+  const [drafts, setDrafts] = useState<Record<string, DraftResolution>>({});
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [correctionRequired, setCorrectionRequired] = useState<string | null>(null);
   const [correctionReason, setCorrectionReason] = useState("");
 
-  // Compute blocking target-only fields per target.
-  const blockingFields = useMemo(() => {
-    const result: Array<{ targetId: string; target: ClusterMemberView; fields: string[] }> = [];
-    for (const targetId of targets) {
-      const targetAssessment = selection.perTarget.find((t) => t.id === targetId);
-      if (!targetAssessment?.missingFieldsToCopy.length) continue;
-      const target = members.find((m) => m.input.id === targetId);
-      if (!target) continue;
-      result.push({ targetId, target, fields: targetAssessment.missingFieldsToCopy });
-    }
-    return result;
-  }, [targets, selection, members]);
+  if (needs.length === 0) return null;
 
-  if (blockingFields.length === 0 && !mergeSuccess) return null;
-
-  function setRes(key: string, action: ResAction, sourceId: string, manualValue?: string) {
-    setResolutions((prev) => ({ ...prev, [key]: { action, sourceId, manualValue } }));
+  function update(field: string, patch: Partial<DraftResolution>) {
+    setDrafts((previous) => ({
+      ...previous,
+      [field]: { ...EMPTY_DRAFT, ...previous[field], ...patch },
+    }));
   }
 
-  // Check if all blocking fields have a resolution.
-  const allResolved = blockingFields.every(({ targetId, fields }) =>
-    fields.every((f) => resolutions[`${targetId}:${f}`]),
-  );
+  function usable(need: ResolutionNeed): boolean {
+    const draft = drafts[need.field];
+    if (!draft) return !need.required;
+    if (draft.action === "keep_retained") return need.kind === "conflict";
+    if (draft.action === "copy_from_source") return draft.sourceIds.length > 0;
+    return manualComplete(need, draft);
+  }
+
+  function buildPlan(): FieldResolution[] {
+    return needs.flatMap((need) => {
+      const draft = drafts[need.field];
+      if (!draft) return [];
+      return [{
+        field: need.field,
+        action: draft.action,
+        sourceReceiptIds: draft.action === "copy_from_source" ? draft.sourceIds : undefined,
+        manualValue: draft.action === "manual_value" ? manualValue(need, draft) : undefined,
+      }];
+    });
+  }
+
+  async function submitPlan(): Promise<boolean> {
+    const response = await fetch("/api/receipts/duplicates/merge", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        retainedReceiptId: retainedId,
+        retainedExpectedUpdatedAt: retainedUpdatedAt,
+        sources: targets.map((receiptId) => ({
+          receiptId,
+          expectedUpdatedAt: members.find((member) => member.input.id === receiptId)?.input.updated_at ?? "",
+        })),
+        resolutionPlan: buildPlan(),
+      }),
+    });
+    const json = (await response.json().catch(() => ({}))) as DuplicateMergeApiResult & {
+      error?: string;
+      code?: string;
+      month?: string;
+    };
+    if (!response.ok) {
+      if (json.code === "CORRECTION_DRAFT_REQUIRED") setCorrectionRequired(json.month ?? "unknown");
+      setError(json.error ?? "Merge failed.");
+      return false;
+    }
+    setCorrectionRequired(null);
+    setDrafts({});
+    await onMerged(json);
+    return true;
+  }
 
   async function applyMerge() {
-    if (!allResolved) return;
-    setMergeBusy(true);
-    setMergeError(null);
-    setMergeSuccess(null);
-
-    // Build the resolution plan from the UI state.
-    const plan: Array<{
-      field: string;
-      action: "copy_from_source" | "keep_retained" | "manual_value";
-      sourceReceiptId?: string;
-      manualValue?: string | number | null;
-    }> = [];
-    const sourceIds = new Set<string>();
-    for (const { targetId, fields } of blockingFields) {
-      sourceIds.add(targetId);
-      for (const field of fields) {
-        const key = `${targetId}:${field}`;
-        const res = resolutions[key];
-        if (!res) continue;
-        plan.push({
-          field,
-          action: res.action,
-          sourceReceiptId: res.action === "copy_from_source" ? res.sourceId : undefined,
-          manualValue: res.action === "manual_value" ? res.manualValue : undefined,
-        });
-      }
-    }
-
+    if (!needs.filter((need) => need.required).every(usable) || buildPlan().length === 0) return;
+    setBusy(true);
+    setError(null);
     try {
-      const res = await fetch("/api/receipts/duplicates/merge", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          retainedReceiptId: retainedId,
-          retainedExpectedUpdatedAt: retainedUpdatedAt,
-          sources: [...sourceIds].map((id) => {
-            const m = members.find((x) => x.input.id === id);
-            return { receiptId: id, expectedUpdatedAt: m?.input.updated_at ?? "" };
-          }),
-          resolutionPlan: plan,
-          correctionReason: correctionReason.trim() || undefined,
-        }),
-      });
-      const json = (await res.json().catch(() => ({}))) as {
-        error?: string;
-        code?: string;
-        month?: string;
-        updatedFields?: string[];
-      };
-      if (!res.ok) {
-        if (json.code === "CORRECTION_DRAFT_REQUIRED") {
-          setCorrectionRequired({ month: json.month ?? "unknown" });
-          setMergeError(json.error ?? "A correction draft is required.");
-        } else {
-          setMergeError(json.error ?? "Merge failed.");
-        }
-        return;
-      }
-      // Success — reset and notify parent to reload.
-      setMergeSuccess(json.updatedFields ?? []);
-      setCorrectionRequired(null);
-      setResolutions({});
-      onMerged();
+      await submitPlan();
     } catch {
-      setMergeError("Network error.");
+      setError("Network error while applying the merge.");
     } finally {
-      setMergeBusy(false);
+      setBusy(false);
     }
   }
 
-  async function createCorrectionDraft() {
+  async function createCorrectionAndRetry() {
     if (!correctionRequired || !correctionReason.trim()) return;
-    setMergeBusy(true);
-    setMergeError(null);
+    setBusy(true);
+    setError(null);
     try {
-      const res = await fetch(`/api/receipts/export/${correctionRequired.month}?correction=true`, {
+      const response = await fetch(`/api/receipts/export/${correctionRequired}?correction=true`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ correctionReason: correctionReason.trim() }),
       });
-      if (!res.ok) {
-        const json = (await res.json().catch(() => ({}))) as { error?: string };
-        setMergeError(json.error ?? "Failed to create correction draft.");
+      if (!response.ok) {
+        const json = (await response.json().catch(() => ({}))) as { error?: string };
+        setError(json.error ?? "Failed to create correction draft.");
         return;
       }
-      // Draft created — retry the merge.
       setCorrectionRequired(null);
-      await applyMerge();
+      await submitPlan();
     } catch {
-      setMergeError("Network error creating correction draft.");
+      setError("Network error creating the correction draft.");
     } finally {
-      setMergeBusy(false);
+      setBusy(false);
     }
   }
 
+  const requiredReady = needs.filter((need) => need.required).every(usable);
+
   return (
     <div className="mt-4 rounded-xl border border-amber-300 bg-amber-50 p-4">
-      <div className="mb-2 flex items-center gap-2">
-        <span className="text-sm font-bold text-amber-900">⚠ Prepare retained receipt</span>
-        <span className="text-xs text-amber-700">
-          Target-only accounting data must be resolved before purge. Copy or enter values; the server revalidates.
-        </span>
-      </div>
+      <div className="font-bold text-amber-950">Prepare the retained receipt</div>
+      <p className="mt-1 text-xs text-amber-800">
+        Required rows preserve data that would otherwise be purged. Conflicts are optional, but can be resolved here before deletion.
+      </p>
 
-      {mergeError && (
-        <div className="mb-3 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">
-          {mergeError}
-        </div>
-      )}
-
-      {mergeSuccess && (
-        <div className="mb-3 rounded-lg border border-green-200 bg-green-50 px-3 py-2 text-xs text-green-700">
-          ✓ Applied {mergeSuccess.length} field(s): {mergeSuccess.join(", ")}. Comparison reloaded —
-          reselect purge targets below.
-        </div>
-      )}
+      {error && <div className="mt-3 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">{error}</div>}
 
       {correctionRequired && (
-        <div className="mb-3 rounded-lg border border-amber-400 bg-amber-100 px-3 py-3 text-xs text-amber-900">
-          <div className="font-semibold">
-            The retained receipt is in finalized export {correctionRequired.month}. A correction draft is required.
-          </div>
-          <div className="mt-1">
-            Reason:{" "}
-            <input
-              value={correctionReason}
-              onChange={(e) => setCorrectionReason(e.target.value)}
-              placeholder="Why is this correction needed?"
-              className="h-8 w-64 rounded border border-amber-300 px-2 text-xs"
-            />
-          </div>
-          <Btn
-            kind="primary"
-            size="sm"
-            onClick={createCorrectionDraft}
-            disabled={!correctionReason.trim() || mergeBusy}
-            className="mt-2"
-          >
-            Create correction draft and apply
+        <div className="mt-3 rounded-lg border border-amber-400 bg-white p-3 text-xs text-amber-950">
+          <div className="font-semibold">Month {correctionRequired} is sealed. Open a correction draft to apply this merge.</div>
+          <input
+            value={correctionReason}
+            onChange={(event) => setCorrectionReason(event.target.value)}
+            placeholder="Correction reason (required)"
+            className="mt-2 h-9 w-full rounded-lg border border-amber-300 px-2"
+          />
+          <Btn kind="primary" size="sm" className="mt-2" disabled={busy || !correctionReason.trim()} onClick={createCorrectionAndRetry}>
+            Open correction draft and apply merge
           </Btn>
         </div>
       )}
 
-      {/* Per-target blocking fields with resolution controls */}
-      {blockingFields.map(({ targetId, target, fields }) => (
-        <div key={targetId} className="mb-3 rounded-lg border border-amber-200 bg-white p-3">
-          <div className="mb-2 text-xs font-semibold text-gray-700">
-            From {target.input.merchant ?? targetId.slice(0, 8)} ({targetId.slice(0, 8)}):
-          </div>
-          {fields.map((field) => {
-            const key = `${targetId}:${field}`;
-            const res = resolutions[key];
-            const sourceVal = getSourceValue(target, field);
-            return (
-              <div key={field} className="mb-2 flex items-start gap-3 text-xs">
-                <div className="w-40 shrink-0 font-medium text-gray-600">
-                  {FIELD_LABELS[field] ?? field}
-                </div>
-                <div className="min-w-0 flex-1">
-                  <span className="text-gray-400">Source: </span>
-                  <span className="font-mono text-gray-700">{sourceVal}</span>
-                  <div className="mt-1 flex flex-wrap items-center gap-2">
-                    <label className="flex items-center gap-1">
-                      <input
-                        type="radio"
-                        name={key}
-                        checked={res?.action === "copy_from_source"}
-                        onChange={() => setRes(key, "copy_from_source", targetId)}
-                      />
-                      Copy to retained
-                    </label>
-                    <label className="flex items-center gap-1">
-                      <input
-                        type="radio"
-                        name={key}
-                        checked={res?.action === "manual_value"}
-                        onChange={() => setRes(key, "manual_value", targetId, getSourceValue(target, field))}
-                      />
-                      Enter corrected value
-                    </label>
-                    {res?.action === "manual_value" && (
-                      <input
-                        value={res.manualValue ?? ""}
-                        onChange={(e) => setRes(key, "manual_value", targetId, e.target.value)}
-                        className="h-7 w-40 rounded border border-gray-200 px-2 text-xs"
-                        placeholder="Corrected value"
-                      />
-                    )}
-                    {field === "category" && res?.action === "manual_value" && (
-                      <select
-                        value={res.manualValue ?? ""}
-                        onChange={(e) => setRes(key, "manual_value", targetId, e.target.value)}
-                        className="h-7 rounded border border-gray-200 px-1 text-xs"
-                      >
-                        <option value="">— Select —</option>
-                        {EXPENSE_CATEGORIES.map((c) => (
-                          <option key={c.code} value={c.code}>{formatCategoryLabel(c.code)}</option>
-                        ))}
-                      </select>
-                    )}
-                  </div>
-                </div>
+      <div className="mt-3 space-y-3">
+        {needs.map((need) => {
+          const draft = drafts[need.field];
+          const firstSource = need.sources[0]?.receiptId;
+          return (
+            <div key={need.field} className="rounded-lg border border-amber-200 bg-white p-3 text-xs">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="font-semibold text-gray-900">{FIELD_LABELS[need.field]}</span>
+                <span className={`rounded-full px-2 py-0.5 ${need.required ? "bg-red-100 text-red-700" : "bg-blue-100 text-blue-700"}`}>
+                  {need.required ? "Required preservation" : "Conflict"}
+                </span>
+                <span className="text-gray-500">Retained: {need.retainedValue}</span>
               </div>
-            );
-          })}
-        </div>
-      ))}
+              <div className="mt-2 flex flex-wrap items-center gap-3">
+                <label className="flex items-center gap-1">
+                  <input
+                    type="radio"
+                    name={`action-${need.field}`}
+                    checked={draft?.action === "copy_from_source"}
+                    onChange={() => update(need.field, {
+                      action: "copy_from_source",
+                      sourceIds: need.field === "attendees" ? need.sources.map((source) => source.receiptId) : firstSource ? [firstSource] : [],
+                    })}
+                  />
+                  Copy from receipt
+                </label>
+                <label className="flex items-center gap-1">
+                  <input
+                    type="radio"
+                    name={`action-${need.field}`}
+                    checked={draft?.action === "manual_value"}
+                    onChange={() => update(need.field, { action: "manual_value", sourceIds: [] })}
+                  />
+                  Enter corrected value
+                </label>
+                {need.kind === "conflict" && (
+                  <label className="flex items-center gap-1">
+                    <input
+                      type="radio"
+                      name={`action-${need.field}`}
+                      checked={draft?.action === "keep_retained"}
+                      onChange={() => update(need.field, { action: "keep_retained", sourceIds: [] })}
+                    />
+                    Keep retained value
+                  </label>
+                )}
+              </div>
 
-      {blockingFields.length > 0 && (
-        <Btn
-          kind="primary"
-          size="sm"
-          onClick={applyMerge}
-          disabled={!allResolved || mergeBusy || !!correctionRequired}
-        >
-          {mergeBusy ? "Applying…" : "Apply changes to retained receipt"}
+              {draft?.action === "copy_from_source" && (
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {need.sources.map((source) => {
+                    const checked = draft.sourceIds.includes(source.receiptId);
+                    return (
+                      <label key={source.receiptId} className="flex items-center gap-1 rounded border border-gray-200 px-2 py-1">
+                        <input
+                          type={need.field === "attendees" ? "checkbox" : "radio"}
+                          name={`source-${need.field}`}
+                          checked={checked}
+                          onChange={() => update(need.field, {
+                            sourceIds: need.field === "attendees"
+                              ? checked
+                                ? draft.sourceIds.filter((id) => id !== source.receiptId)
+                                : [...draft.sourceIds, source.receiptId]
+                              : [source.receiptId],
+                          })}
+                        />
+                        {source.receiptId.slice(0, 8)}: {source.displayValue}
+                      </label>
+                    );
+                  })}
+                </div>
+              )}
+
+              {draft?.action === "manual_value" && (
+                <div className="mt-2">
+                  {need.field === "category" ? (
+                    <select value={draft.manualText} onChange={(event) => update(need.field, { manualText: event.target.value })} className="h-9 rounded border border-gray-300 px-2">
+                      <option value="">Select a category</option>
+                      {EXPENSE_CATEGORIES.map((category) => <option key={category.code} value={category.code}>{formatCategoryLabel(category.code)}</option>)}
+                    </select>
+                  ) : need.field === "alcohol_present" ? (
+                    <select value={draft.manualBoolean ? "true" : "false"} onChange={(event) => update(need.field, { manualBoolean: event.target.value === "true" })} className="h-9 rounded border border-gray-300 px-2">
+                      <option value="true">Yes</option><option value="false">No</option>
+                    </select>
+                  ) : need.field === "attendees" ? (
+                    <textarea value={draft.manualText} onChange={(event) => update(need.field, { manualText: event.target.value })} placeholder="One attendee name per line" className="h-20 w-full rounded border border-gray-300 p-2" />
+                  ) : (
+                    <div className="flex gap-2">
+                      <input
+                        type={need.field === "transaction_date" ? "date" : need.field === "amount" || need.field === "tax_amount" ? "number" : "text"}
+                        min={need.field === "amount" || need.field === "tax_amount" ? 0 : undefined}
+                        step={need.field === "amount" || need.field === "tax_amount" ? 1 : undefined}
+                        value={draft.manualText}
+                        onChange={(event) => update(need.field, { manualText: event.target.value })}
+                        className="h-9 min-w-64 rounded border border-gray-300 px-2"
+                      />
+                      {need.field === "amount" && (
+                        <select value={draft.manualCurrency} onChange={(event) => update(need.field, { manualCurrency: event.target.value })} className="h-9 rounded border border-gray-300 px-2">
+                          {ALLOWED_CURRENCIES.map((currency) => <option key={currency}>{currency}</option>)}
+                        </select>
+                      )}
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="mt-3 flex items-center gap-2">
+        <Btn kind="primary" size="sm" onClick={applyMerge} disabled={busy || !requiredReady || buildPlan().length === 0 || Boolean(correctionRequired)}>
+          {busy ? "Applying…" : "Apply merge to retained receipt"}
         </Btn>
-      )}
-      {!allResolved && blockingFields.length > 0 && (
-        <span className="ml-2 text-xs text-amber-700">
-          Resolve all fields above before applying.
-        </span>
-      )}
+        {!requiredReady && <span className="text-xs text-amber-800">Resolve every required preservation row.</span>}
+      </div>
     </div>
   );
 }

--- a/db/receipts/0033_duplicate_merge_log.sql
+++ b/db/receipts/0033_duplicate_merge_log.sql
@@ -1,0 +1,143 @@
+-- Atomic duplicate-merge operation record and write-time guards.
+-- The merge log is inserted as the first statement of one D1 batch. Any stale
+-- receipt, changed attendee set, newly protected source, or re-sealed month
+-- aborts the whole batch before the retained receipt is modified.
+CREATE TABLE IF NOT EXISTS duplicate_merge_log (
+  id TEXT PRIMARY KEY,
+  retained_receipt_id TEXT NOT NULL,
+  retained_expected_updated_at TEXT NOT NULL,
+  retained_attendees_json TEXT NOT NULL,
+  source_snapshots_json TEXT NOT NULL,
+  actor TEXT NOT NULL,
+  resolution_plan_json TEXT NOT NULL,
+  old_value_json TEXT NOT NULL,
+  new_value_json TEXT NOT NULL,
+  candidate_strengths_json TEXT NOT NULL,
+  correction_export_id TEXT,
+  correction_month TEXT,
+  correction_revision INTEGER,
+  correction_reason TEXT,
+  created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_duplicate_merge_retained
+  ON duplicate_merge_log(retained_receipt_id, created_at);
+
+CREATE TRIGGER IF NOT EXISTS duplicate_merge_guard_before_insert
+BEFORE INSERT ON duplicate_merge_log
+BEGIN
+  SELECT RAISE(ROLLBACK, 'duplicate-merge guard: malformed snapshots')
+   WHERE json_valid(NEW.source_snapshots_json) = 0
+      OR json_type(NEW.source_snapshots_json) != 'array'
+      OR json_array_length(NEW.source_snapshots_json) = 0
+      OR json_valid(NEW.retained_attendees_json) = 0
+      OR json_type(NEW.retained_attendees_json) != 'array';
+
+  SELECT RAISE(ROLLBACK, 'duplicate-merge guard: retained missing or changed')
+   WHERE NOT EXISTS (
+     SELECT 1 FROM receipt_records r
+      WHERE r.id = NEW.retained_receipt_id
+        AND r.deleted_at IS NULL
+        AND r.payment_path = 'AMEX'
+        AND r.status != 'archived'
+        AND r.updated_at = NEW.retained_expected_updated_at
+   );
+
+  SELECT RAISE(ROLLBACK, 'duplicate-merge guard: retained attendee set changed')
+   WHERE (SELECT COUNT(*) FROM receipt_attendees a
+           WHERE a.receipt_id = NEW.retained_receipt_id)
+         != json_array_length(NEW.retained_attendees_json)
+      OR EXISTS (
+        SELECT 1 FROM receipt_attendees a
+         WHERE a.receipt_id = NEW.retained_receipt_id
+           AND NOT EXISTS (
+             SELECT 1 FROM json_each(NEW.retained_attendees_json) j
+              WHERE json_extract(j.value, '$.id') = a.id
+                AND json_extract(j.value, '$.attendeeName') = a.attendee_name
+                AND json_extract(j.value, '$.company') IS a.company
+                AND json_extract(j.value, '$.relationship') IS a.relationship
+                AND json_extract(j.value, '$.isDazbeezEmployee') = a.is_dazbeez_employee
+                AND json_extract(j.value, '$.notes') IS a.notes
+                AND json_extract(j.value, '$.createdAt') = a.created_at
+           )
+      );
+
+  SELECT RAISE(ROLLBACK, 'duplicate-merge guard: source missing, changed, or protected')
+   WHERE EXISTS (
+     SELECT 1 FROM json_each(NEW.source_snapshots_json) s
+      WHERE NOT EXISTS (
+        SELECT 1 FROM receipt_records r
+         WHERE r.id = json_extract(s.value, '$.id')
+           AND r.id != NEW.retained_receipt_id
+           AND r.deleted_at IS NULL
+           AND r.payment_path = 'AMEX'
+           AND r.status IN ('captured','needs_review','reviewed')
+           AND NOT (
+             r.extraction_state IN ('captured','queued','processing')
+             OR (r.extraction_state IS NULL AND r.status = 'captured')
+           )
+           AND r.updated_at = json_extract(s.value, '$.updatedAt')
+           AND NOT EXISTS (
+             SELECT 1 FROM amex_statement_lines l
+              WHERE l.matched_receipt_id = r.id
+                AND l.match_status IN ('matched','confirmed')
+           )
+           AND NOT EXISTS (
+             SELECT 1 FROM receipt_export_items i
+              WHERE i.item_type = 'receipt' AND i.item_id = r.id
+           )
+      )
+   );
+
+  SELECT RAISE(ROLLBACK, 'duplicate-merge guard: source attendee set changed')
+   WHERE EXISTS (
+     SELECT 1 FROM json_each(NEW.source_snapshots_json) s
+      WHERE (SELECT COUNT(*) FROM receipt_attendees a
+              WHERE a.receipt_id = json_extract(s.value, '$.id'))
+            != json_array_length(json_extract(s.value, '$.attendees'))
+         OR EXISTS (
+           SELECT 1 FROM receipt_attendees a
+            WHERE a.receipt_id = json_extract(s.value, '$.id')
+              AND NOT EXISTS (
+                SELECT 1 FROM json_each(json_extract(s.value, '$.attendees')) j
+                 WHERE json_extract(j.value, '$.id') = a.id
+                   AND json_extract(j.value, '$.attendeeName') = a.attendee_name
+                   AND json_extract(j.value, '$.company') IS a.company
+                   AND json_extract(j.value, '$.relationship') IS a.relationship
+                   AND json_extract(j.value, '$.isDazbeezEmployee') = a.is_dazbeez_employee
+                   AND json_extract(j.value, '$.notes') IS a.notes
+                   AND json_extract(j.value, '$.createdAt') = a.created_at
+              )
+         )
+   );
+
+  -- ADR 0012: a finalized export/reconciliation locks receipt edits unless a
+  -- draft export revision for that same month is open.
+  SELECT RAISE(ROLLBACK, 'duplicate-merge guard: retained month is locked')
+   WHERE EXISTS (
+     SELECT 1 FROM (
+       SELECT r.exported_month AS month
+         FROM receipt_records r
+        WHERE r.id = NEW.retained_receipt_id AND r.exported_month IS NOT NULL
+       UNION
+       SELECT e.export_month
+         FROM receipt_export_items i
+         JOIN receipt_exports e ON e.id = i.export_id
+        WHERE i.item_type = 'receipt' AND i.item_id = NEW.retained_receipt_id
+       UNION
+       SELECT ar.statement_month
+         FROM amex_statement_lines l
+         JOIN amex_reconciliations ar
+           ON ar.statement_month = l.statement_month AND ar.status = 'finalized'
+        WHERE l.matched_receipt_id = NEW.retained_receipt_id
+     ) months
+     WHERE EXISTS (
+       SELECT 1 FROM receipt_exports f
+        WHERE f.export_month = months.month AND f.status = 'finalized'
+     )
+       AND NOT EXISTS (
+         SELECT 1 FROM receipt_exports d
+          WHERE d.export_month = months.month AND d.status = 'draft'
+       )
+   );
+END;

--- a/lib/receipts/duplicate-merge-contract.ts
+++ b/lib/receipts/duplicate-merge-contract.ts
@@ -1,0 +1,43 @@
+import type { PreservationField } from "@/lib/receipts/duplicate-resolution-policy";
+
+export type ResolutionAction = "copy_from_source" | "keep_retained" | "manual_value";
+
+export interface ManualAmountValue {
+  amountMinor: number;
+  currency: string;
+}
+
+export interface ManualAttendeeValue {
+  attendeeName: string;
+  company?: string | null;
+  relationship?: string | null;
+  isDazbeezEmployee?: boolean;
+  notes?: string | null;
+}
+
+export interface ManualAttendeesValue {
+  attendees: ManualAttendeeValue[];
+}
+
+export interface FieldResolution {
+  field: PreservationField;
+  action: ResolutionAction;
+  /** Scalar copies use exactly one source; attendee copies may union several. */
+  sourceReceiptIds?: string[];
+  manualValue?: unknown;
+}
+
+export interface DuplicateMergeApiResult {
+  applied: true;
+  updatedFields: PreservationField[];
+  attendeeAdditions: ManualAttendeeValue[];
+  resolvedFields: PreservationField[];
+  warnings: string[];
+  correction: {
+    exportId: string;
+    month: string;
+    revision: number;
+    reason: string;
+  } | null;
+  auditId: string;
+}

--- a/lib/receipts/duplicate-merge-ui.ts
+++ b/lib/receipts/duplicate-merge-ui.ts
@@ -1,0 +1,107 @@
+import {
+  missingPreservationFields,
+  preservationFieldPopulated,
+  PRESERVATION_FIELDS,
+  type DuplicateMemberInput,
+  type PreservationField,
+} from "@/lib/receipts/duplicate-resolution-policy";
+
+export interface ResolutionSourceOption {
+  receiptId: string;
+  value: unknown;
+  displayValue: string;
+}
+
+export interface ResolutionNeed {
+  field: PreservationField;
+  kind: "missing" | "conflict";
+  required: boolean;
+  retainedValue: string;
+  sources: ResolutionSourceOption[];
+}
+
+export const FIELD_LABELS: Record<PreservationField, string> = {
+  transaction_date: "Transaction date",
+  merchant: "Merchant",
+  amount: "Amount and currency",
+  category: "Expense category",
+  business_purpose: "Business purpose",
+  alcohol_present: "Alcohol present",
+  tax_amount: "Consumption tax amount",
+  tax_rate: "Tax rate",
+  invoice_number: "Invoice registration number",
+  counterparty: "Counterparty",
+  attendees: "Attendees",
+};
+
+export function preservationValue(member: DuplicateMemberInput, field: PreservationField): unknown {
+  switch (field) {
+    case "transaction_date": return member.transaction_date;
+    case "merchant": return member.merchant;
+    case "amount": return member.amount_minor == null ? null : { amountMinor: member.amount_minor, currency: member.currency };
+    case "category": return member.expense_category_code;
+    case "business_purpose": return member.business_purpose;
+    case "alcohol_present": return member.alcoholPresent ? true : null;
+    case "tax_amount": return member.tax_amount_minor;
+    case "tax_rate": return member.tax_rate;
+    case "invoice_number": return member.invoice_registration_number;
+    case "counterparty": return member.counterparty_name;
+    case "attendees": return member.attendeeNames.length ? member.attendeeNames : null;
+  }
+}
+
+export function displayPreservationValue(value: unknown): string {
+  if (value === null || value === undefined || value === "") return "—";
+  if (Array.isArray(value)) return value.join(", ");
+  if (typeof value === "boolean") return value ? "Yes" : "No";
+  if (typeof value === "object") {
+    const amount = value as { amountMinor?: unknown; currency?: unknown };
+    return `${String(amount.currency ?? "")} ${String(amount.amountMinor ?? "")}`.trim();
+  }
+  return String(value);
+}
+
+function comparisonValue(value: unknown): string {
+  if (Array.isArray(value)) {
+    return JSON.stringify(value.map((v) => String(v).normalize("NFKC").toLocaleLowerCase().trim()).sort());
+  }
+  return JSON.stringify(value);
+}
+
+/** One aggregated row per accounting field, even if several purge targets have
+ * it. Missing target-only data is required; populated disagreement is offered
+ * as an optional explicit conflict resolution. */
+export function buildResolutionNeeds(
+  members: DuplicateMemberInput[],
+  retainedId: string,
+  targetIds: string[],
+): ResolutionNeed[] {
+  const retained = members.find((member) => member.id === retainedId);
+  if (!retained) return [];
+  const targets = targetIds
+    .map((id) => members.find((member) => member.id === id))
+    .filter((member): member is DuplicateMemberInput => Boolean(member));
+  const required = new Set(targets.flatMap((target) => missingPreservationFields(target, retained)));
+  const needs: ResolutionNeed[] = [];
+  for (const field of PRESERVATION_FIELDS) {
+    const sources = targets
+      .filter((target) => preservationFieldPopulated(field, target))
+      .map((target) => {
+        const value = preservationValue(target, field);
+        return { receiptId: target.id, value, displayValue: displayPreservationValue(value) };
+      });
+    const populatedValues = [retained, ...targets]
+      .filter((member) => preservationFieldPopulated(field, member))
+      .map((member) => comparisonValue(preservationValue(member, field)));
+    const conflict = populatedValues.length > 1 && new Set(populatedValues).size > 1;
+    if (!required.has(field) && !conflict) continue;
+    needs.push({
+      field,
+      kind: required.has(field) ? "missing" : "conflict",
+      required: required.has(field),
+      retainedValue: displayPreservationValue(preservationValue(retained, field)),
+      sources,
+    });
+  }
+  return needs;
+}

--- a/lib/receipts/duplicate-merge.ts
+++ b/lib/receipts/duplicate-merge.ts
@@ -1,0 +1,361 @@
+// Server-authoritative duplicate-merge service.
+//
+// Resolves target-only and conflicting accounting data from purge targets onto
+// the retained canonical receipt BEFORE purge. Nothing is copied automatically —
+// the operator provides a resolution plan and the server revalidates everything
+// from D1.
+//
+// The merge NEVER performs purge. Source receipts remain untouched. The retained
+// receipt is updated via the existing updateReceiptRecord path (preserving
+// compliance checks, membership behavior, sparse-update guarantees) plus a
+// dedicated receipt.duplicate_merge_applied audit entry.
+
+import { getReceiptsDb } from "@/lib/cloudflare-runtime";
+import { nowIso, stringifyJson } from "@/lib/receipts/db-utils";
+import { createAuditEntry } from "@/lib/receipts/audit";
+import { updateReceiptRecord } from "@/lib/receipts/db";
+import { fetchMemberAssessment, type MemberAssessmentRecord } from "@/lib/receipts/duplicate-purge";
+import { findAmexDuplicateCandidates } from "@/lib/receipts/amex-duplicates";
+import {
+  populatedPreservationFields,
+  type DuplicateMemberInput,
+  type PreservationField,
+} from "@/lib/receipts/duplicate-resolution-policy";
+import {
+  validateAmountMinor,
+  validateCurrency,
+  validateReceiptDate,
+} from "@/lib/receipts/validation";
+import { isCanonicalCode } from "@/lib/receipts/categories";
+import { validateInvoiceRegistrationNumber } from "@/lib/receipts/invoice";
+import { isMonthLockedForEdits } from "@/lib/receipts/month-lock";
+import type { ReceiptRecord, QualifiedInvoiceStatus, UpdateReceiptInput } from "@/lib/receipts/types";
+
+// ─── types ──────────────────────────────────────────────────────────────────
+
+export type ResolutionAction = "copy_from_source" | "keep_retained" | "manual_value";
+
+export interface FieldResolution {
+  field: PreservationField;
+  action: ResolutionAction;
+  /** For copy_from_source: which source receipt to derive the value from. */
+  sourceReceiptId?: string;
+  /** For manual_value: the operator-entered value (validated server-side). */
+  manualValue?: string | number | null;
+}
+
+export interface MergeRequest {
+  db: D1Database;
+  retainedReceiptId: string;
+  retainedExpectedUpdatedAt: string;
+  sources: Array<{ receiptId: string; expectedUpdatedAt: string }>;
+  resolutionPlan: FieldResolution[];
+  actor: string;
+  /** Operator-entered correction reason (when a correction draft is needed). */
+  correctionReason?: string;
+}
+
+export class MergeError extends Error {
+  constructor(
+    public status: number,
+    message: string,
+    public code?: string,
+    public month?: string,
+  ) {
+    super(message);
+    this.name = "MergeError";
+  }
+}
+
+export interface MergeResult {
+  applied: boolean;
+  updatedFields: PreservationField[];
+  attendeeAdditions: string[];
+  correctionMonth?: string;
+  auditId: string;
+}
+
+// ─── allowlist ──────────────────────────────────────────────────────────────
+
+const ALLOWED_FIELDS: ReadonlySet<string> = new Set([
+  "transaction_date", "merchant", "amount", "category", "business_purpose",
+  "alcohol_present", "tax_amount", "tax_rate", "invoice_number",
+  "counterparty", "attendees",
+]);
+
+// ─── merge service ──────────────────────────────────────────────────────────
+
+export async function applyDuplicateMerge(req: MergeRequest): Promise<MergeResult> {
+  const db = req.db;
+
+  // ── 1. Validate request shape ──
+  if (req.resolutionPlan.length === 0) {
+    throw new MergeError(400, "Resolution plan is empty.");
+  }
+  for (const res of req.resolutionPlan) {
+    if (!ALLOWED_FIELDS.has(res.field)) {
+      throw new MergeError(400, `Field "${res.field}" is not on the merge allowlist.`);
+    }
+    if (res.action === "copy_from_source" && !res.sourceReceiptId) {
+      throw new MergeError(400, `copy_from_source for "${res.field}" requires sourceReceiptId.`);
+    }
+  }
+  if (req.sources.length === 0) {
+    throw new MergeError(400, "At least one source receipt is required.");
+  }
+  if (req.sources.some((s) => s.receiptId === req.retainedReceiptId)) {
+    throw new MergeError(400, "Source receipt must differ from retained.");
+  }
+  const sourceIds = req.sources.map((s) => s.receiptId);
+  if (new Set(sourceIds).size !== sourceIds.length) {
+    throw new MergeError(400, "Duplicate source IDs.");
+  }
+
+  // ── 2. Load retained + sources from D1 ──
+  const retained = await fetchMemberAssessment(db, req.retainedReceiptId);
+  if (!retained) {
+    throw new MergeError(409, "Retained receipt not found or deleted.");
+  }
+  if (retained.row.status === "archived") {
+    throw new MergeError(409, "Retained receipt is archived.");
+  }
+  if (retained.row.updated_at !== req.retainedExpectedUpdatedAt) {
+    throw new MergeError(409, "Retained receipt changed (stale) — reload the comparison.");
+  }
+
+  const sourceRecs: Array<{ rec: MemberAssessmentRecord; expected: string }> = [];
+  for (const s of req.sources) {
+    const rec = await fetchMemberAssessment(db, s.receiptId);
+    if (!rec) throw new MergeError(409, `Source ${s.receiptId.slice(0, 8)} not found or deleted.`);
+    if (rec.row.updated_at !== s.expectedUpdatedAt) {
+      throw new MergeError(409, `Source ${s.receiptId.slice(0, 8)} changed (stale).`);
+    }
+    // Revalidate as a duplicate candidate of retained.
+    const strength = findAmexDuplicateCandidates(
+      [rec.row], [retained.row, rec.row], new Set([retained.row.id]),
+    );
+    if (!strength.has(rec.row.id)) {
+      throw new MergeError(409, `Source ${s.receiptId.slice(0, 8)} is not a duplicate candidate of the retained receipt.`);
+    }
+    sourceRecs.push({ rec, expected: s.expectedUpdatedAt });
+  }
+
+  // ── 3. Check export/reconciliation lock ──
+  let correctionMonth: string | undefined;
+  if (retained.row.status === "exported" && retained.row.exported_month) {
+    const locked = await isMonthLockedForEdits(db, retained.row.exported_month);
+    if (locked) {
+      throw new MergeError(
+        409,
+        `A correction draft is required before editing this retained receipt.`,
+        "CORRECTION_DRAFT_REQUIRED",
+        retained.row.exported_month,
+      );
+    }
+    correctionMonth = retained.row.exported_month;
+  }
+
+  // ── 4. Build the update from the resolution plan ──
+  const update: UpdateReceiptInput = {};
+  const updatedFields: PreservationField[] = [];
+  const resolutionLog: Array<{ field: PreservationField; action: ResolutionAction; source?: string; manualValue?: unknown }> = [];
+  let attendeeNames: string[] | undefined;
+
+  for (const res of req.resolutionPlan) {
+    let valueApplied = false;
+    if (res.action === "keep_retained") {
+      // No change to the retained field; record the explicit decision.
+      resolutionLog.push({ field: res.field, action: "keep_retained" });
+      continue;
+    }
+
+    let sourceRec: ReceiptRecord | undefined;
+    if (res.action === "copy_from_source") {
+      const src = sourceRecs.find((s) => s.rec.row.id === res.sourceReceiptId);
+      if (!src) throw new MergeError(400, `Unknown source ${res.sourceReceiptId} for "${res.field}".`);
+      sourceRec = src.rec.row;
+      // Verify the source actually has this field populated.
+      const sourcePopulated = new Set(populatedPreservationFields(src.rec.input));
+      if (!sourcePopulated.has(res.field)) {
+        throw new MergeError(409, `Source ${src.rec.row.id.slice(0, 8)} does not have "${res.field}" populated.`);
+      }
+    }
+
+    // Apply the field to the update object (validate manual values).
+    switch (res.field) {
+      case "transaction_date": {
+        const val = res.action === "manual_value" ? String(res.manualValue ?? "") : sourceRec!.transaction_date ?? "";
+        if (val && !validateReceiptDate(val)) throw new MergeError(400, `Invalid date: ${val}`);
+        update.transactionDate = val || null;
+        valueApplied = true;
+        break;
+      }
+      case "merchant": {
+        const val = res.action === "manual_value" ? String(res.manualValue ?? "").trim() : (sourceRec!.merchant ?? "").trim();
+        update.merchant = val || null;
+        valueApplied = true;
+        break;
+      }
+      case "amount": {
+        // Amount + currency are coupled. For copy_from_source, copy both.
+        // For manual_value, the manualValue is the amount; currency stays unless also specified.
+        if (res.action === "copy_from_source") {
+          update.amountMinor = sourceRec!.amount_minor;
+          update.currency = sourceRec!.currency;
+        } else {
+          const parsed = validateAmountMinor(Number(res.manualValue));
+          if (parsed === null) throw new MergeError(400, `Invalid amount: ${res.manualValue}`);
+          update.amountMinor = parsed;
+        }
+        valueApplied = true;
+        break;
+      }
+      case "category": {
+        const val = res.action === "manual_value" ? String(res.manualValue ?? "") : sourceRec!.expense_category_code ?? "";
+        if (val && !isCanonicalCode(val)) throw new MergeError(400, `Invalid category: ${val}`);
+        update.expenseCategoryCode = val || null;
+        valueApplied = true;
+        break;
+      }
+      case "business_purpose": {
+        const val = res.action === "manual_value" ? String(res.manualValue ?? "").trim() : (sourceRec!.business_purpose ?? "").trim();
+        update.businessPurpose = val || null;
+        valueApplied = true;
+        break;
+      }
+      case "alcohol_present": {
+        const val = res.action === "copy_from_source" ? sourceRec!.alcohol_present === 1 : Boolean(res.manualValue);
+        update.alcoholPresent = val;
+        valueApplied = true;
+        break;
+      }
+      case "tax_amount": {
+        if (res.action === "copy_from_source") {
+          update.taxAmountMinor = sourceRec!.tax_amount_minor;
+        } else {
+          const n = Number(res.manualValue);
+          if (isNaN(n) || n < 0) throw new MergeError(400, `Invalid tax amount: ${res.manualValue}`);
+          update.taxAmountMinor = Math.round(n);
+        }
+        valueApplied = true;
+        break;
+      }
+      case "tax_rate": {
+        const val = res.action === "manual_value" ? String(res.manualValue ?? "").trim() : (sourceRec!.tax_rate ?? "").trim();
+        update.taxRate = val || null;
+        valueApplied = true;
+        break;
+      }
+      case "invoice_number": {
+        const val = res.action === "manual_value" ? String(res.manualValue ?? "").trim() : (sourceRec!.invoice_registration_number ?? "").trim();
+        if (val) {
+          const v = validateInvoiceRegistrationNumber(val);
+          if (v.registrationStatus === "format_invalid") {
+            throw new MergeError(400, v.message ?? `Invalid invoice number: ${val}`);
+          }
+          update.invoiceRegistrationNumber = v.normalizedNumber;
+          // Derive qualified_invoice_status from the invoice authority.
+          (update as Record<string, unknown>).qualifiedInvoiceStatus = v.qualifiedInvoiceStatus;
+        } else {
+          update.invoiceRegistrationNumber = null;
+        }
+        valueApplied = true;
+        break;
+      }
+      case "counterparty": {
+        const val = res.action === "manual_value" ? String(res.manualValue ?? "").trim() : (sourceRec!.counterparty_name ?? "").trim();
+        (update as Record<string, unknown>).counterpartyName = val || null;
+        valueApplied = true;
+        break;
+      }
+      case "attendees": {
+        // Union attendees from retained + source(s), deduplicated.
+        if (res.action === "copy_from_source") {
+          const srcAttendees = (await db
+            .prepare(`SELECT attendee_name FROM receipt_attendees WHERE receipt_id = ? ORDER BY created_at`)
+            .bind(res.sourceReceiptId)
+            .all<{ attendee_name: string }>()).results ?? [];
+          const retainedAttendees = (await db
+            .prepare(`SELECT attendee_name FROM receipt_attendees WHERE receipt_id = ? ORDER BY created_at`)
+            .bind(req.retainedReceiptId)
+            .all<{ attendee_name: string }>()).results ?? [];
+          const seen = new Set<string>();
+          attendeeNames = [];
+          for (const a of [...retainedAttendees, ...srcAttendees]) {
+            const name = a.attendee_name.trim();
+            if (name && !seen.has(name)) { seen.add(name); attendeeNames.push(name); }
+          }
+        } else if (res.action === "manual_value" && typeof res.manualValue === "string") {
+          // Manual: comma-separated list of attendee names.
+          attendeeNames = res.manualValue.split(",").map((s) => s.trim()).filter(Boolean);
+        }
+        valueApplied = true;
+        break;
+      }
+    }
+
+    if (valueApplied) {
+      updatedFields.push(res.field);
+      resolutionLog.push({
+        field: res.field,
+        action: res.action,
+        source: res.sourceReceiptId,
+        manualValue: res.manualValue,
+      });
+    }
+  }
+
+  // No-op check: if no fields changed and no attendees to add.
+  const hasUpdate = Object.keys(update).length > 0 || attendeeNames !== undefined;
+  if (!hasUpdate) {
+    throw new MergeError(400, "Resolution plan produces no changes (all keep_retained).");
+  }
+
+  // ── 5. Apply the retained-field update atomically ──
+  // updateReceiptRecord handles compliance, membership, sparse-update, recon-sealed gate.
+  if (Object.keys(update).length > 0) {
+    await updateReceiptRecord(req.retainedReceiptId, update, req.actor);
+  }
+  // Attendees handled separately (createAttendees replaces the full set).
+  if (attendeeNames !== undefined) {
+    const { createAttendees } = await import("@/lib/receipts/db");
+    await createAttendees(req.retainedReceiptId, attendeeNames.map((n) => ({ attendeeName: n })), req.actor);
+  }
+
+  // ── 6. Write the dedicated merge audit ──
+  const auditId = (
+    await db
+      .prepare(
+        `INSERT INTO receipt_audit_log
+          (id, actor, action, object_type, object_id, old_value_json, new_value_json, created_at)
+         VALUES (?, ?, 'receipt.duplicate_merge_applied', 'receipt', ?, ?, ?, ?)
+         RETURNING id`,
+      )
+      .bind(
+        // old/new are summary metadata, not full receipt images.
+        crypto.randomUUID(),
+        req.actor,
+        req.retainedReceiptId,
+        JSON.stringify({
+          retainedExpectedUpdatedAt: req.retainedExpectedUpdatedAt,
+          sources: req.sources.map((s) => ({ id: s.receiptId, expectedUpdatedAt: s.expectedUpdatedAt })),
+          resolutionPlan: resolutionLog,
+        }),
+        JSON.stringify({
+          updatedFields,
+          attendeeAdditions: attendeeNames ?? [],
+          correctionMonth: correctionMonth ?? null,
+        }),
+        nowIso(),
+      )
+      .first<{ id: string }>()
+  )?.id ?? "unknown";
+
+  return {
+    applied: true,
+    updatedFields,
+    attendeeAdditions: attendeeNames ?? [],
+    correctionMonth,
+    auditId,
+  };
+}

--- a/lib/receipts/duplicate-merge.ts
+++ b/lib/receipts/duplicate-merge.ts
@@ -1,48 +1,37 @@
-// Server-authoritative duplicate-merge service.
-//
-// Resolves target-only and conflicting accounting data from purge targets onto
-// the retained canonical receipt BEFORE purge. Nothing is copied automatically —
-// the operator provides a resolution plan and the server revalidates everything
-// from D1.
-//
-// The merge NEVER performs purge. Source receipts remain untouched. The retained
-// receipt is updated via the existing updateReceiptRecord path (preserving
-// compliance checks, membership behavior, sparse-update guarantees) plus a
-// dedicated receipt.duplicate_merge_applied audit entry.
+// Server-authoritative, non-destructive duplicate merge. All retained-row and
+// attendee mutations plus both audit records commit in one guarded D1 batch.
+// Source receipts are read-only and purge remains a separate operator action.
 
-import { getReceiptsDb } from "@/lib/cloudflare-runtime";
-import { nowIso, stringifyJson } from "@/lib/receipts/db-utils";
-import { createAuditEntry } from "@/lib/receipts/audit";
-import { updateReceiptRecord } from "@/lib/receipts/db";
-import { fetchMemberAssessment, type MemberAssessmentRecord } from "@/lib/receipts/duplicate-purge";
-import { findAmexDuplicateCandidates } from "@/lib/receipts/amex-duplicates";
+import { isCanonicalCode } from "@/lib/receipts/categories";
+import { computeReceiptChecks, persistReceiptChecks } from "@/lib/receipts/compliance";
+import { nowIso, newUuid } from "@/lib/receipts/db-utils";
 import {
-  populatedPreservationFields,
+  deriveCandidateStrength,
+  fetchMemberAssessment,
+  PURGE_TARGET_CAP,
+  type MemberAssessmentRecord,
+} from "@/lib/receipts/duplicate-purge";
+import {
+  assessSelection,
+  missingPreservationFields,
   type DuplicateMemberInput,
   type PreservationField,
 } from "@/lib/receipts/duplicate-resolution-policy";
-import {
-  validateAmountMinor,
-  validateCurrency,
-  validateReceiptDate,
-} from "@/lib/receipts/validation";
-import { isCanonicalCode } from "@/lib/receipts/categories";
+import { isPendingProcessing } from "@/lib/receipts/extraction-state";
 import { validateInvoiceRegistrationNumber } from "@/lib/receipts/invoice";
 import { isMonthLockedForEdits } from "@/lib/receipts/month-lock";
-import type { ReceiptRecord, QualifiedInvoiceStatus, UpdateReceiptInput } from "@/lib/receipts/types";
+import { parseComplianceSettings } from "@/lib/receipts/settings";
+import type {
+  DuplicateMergeApiResult,
+  FieldResolution,
+  ManualAttendeeValue,
+  ManualAmountValue,
+  ManualAttendeesValue,
+} from "@/lib/receipts/duplicate-merge-contract";
+import type { ReceiptAttendee, ReceiptFile, ReceiptRecord } from "@/lib/receipts/types";
+import { validateAmountMinor, validateCurrency, validateReceiptDate } from "@/lib/receipts/validation";
 
-// ─── types ──────────────────────────────────────────────────────────────────
-
-export type ResolutionAction = "copy_from_source" | "keep_retained" | "manual_value";
-
-export interface FieldResolution {
-  field: PreservationField;
-  action: ResolutionAction;
-  /** For copy_from_source: which source receipt to derive the value from. */
-  sourceReceiptId?: string;
-  /** For manual_value: the operator-entered value (validated server-side). */
-  manualValue?: string | number | null;
-}
+export type { FieldResolution, ResolutionAction } from "@/lib/receipts/duplicate-merge-contract";
 
 export interface MergeRequest {
   db: D1Database;
@@ -51,8 +40,6 @@ export interface MergeRequest {
   sources: Array<{ receiptId: string; expectedUpdatedAt: string }>;
   resolutionPlan: FieldResolution[];
   actor: string;
-  /** Operator-entered correction reason (when a correction draft is needed). */
-  correctionReason?: string;
 }
 
 export class MergeError extends Error {
@@ -67,295 +54,510 @@ export class MergeError extends Error {
   }
 }
 
-export interface MergeResult {
-  applied: boolean;
-  updatedFields: PreservationField[];
-  attendeeAdditions: string[];
-  correctionMonth?: string;
-  auditId: string;
-}
-
-// ─── allowlist ──────────────────────────────────────────────────────────────
-
-const ALLOWED_FIELDS: ReadonlySet<string> = new Set([
+const ALLOWED_FIELDS = new Set<PreservationField>([
   "transaction_date", "merchant", "amount", "category", "business_purpose",
   "alcohol_present", "tax_amount", "tax_rate", "invoice_number",
   "counterparty", "attendees",
 ]);
+const PRE_RECON_STATUSES = new Set(["captured", "needs_review", "reviewed"]);
 
-// ─── merge service ──────────────────────────────────────────────────────────
+interface AttendeeSnapshot {
+  id: string;
+  attendeeName: string;
+  company: string | null;
+  relationship: string | null;
+  isDazbeezEmployee: number;
+  notes: string | null;
+  createdAt: string;
+}
 
-export async function applyDuplicateMerge(req: MergeRequest): Promise<MergeResult> {
-  const db = req.db;
+interface LoadedMember {
+  assessment: MemberAssessmentRecord;
+  attendees: AttendeeSnapshot[];
+}
 
-  // ── 1. Validate request shape ──
-  if (req.resolutionPlan.length === 0) {
-    throw new MergeError(400, "Resolution plan is empty.");
-  }
-  for (const res of req.resolutionPlan) {
-    if (!ALLOWED_FIELDS.has(res.field)) {
-      throw new MergeError(400, `Field "${res.field}" is not on the merge allowlist.`);
-    }
-    if (res.action === "copy_from_source" && !res.sourceReceiptId) {
-      throw new MergeError(400, `copy_from_source for "${res.field}" requires sourceReceiptId.`);
-    }
-  }
-  if (req.sources.length === 0) {
-    throw new MergeError(400, "At least one source receipt is required.");
-  }
-  if (req.sources.some((s) => s.receiptId === req.retainedReceiptId)) {
-    throw new MergeError(400, "Source receipt must differ from retained.");
-  }
-  const sourceIds = req.sources.map((s) => s.receiptId);
-  if (new Set(sourceIds).size !== sourceIds.length) {
-    throw new MergeError(400, "Duplicate source IDs.");
-  }
+interface CorrectionContext {
+  exportId: string;
+  month: string;
+  revision: number;
+  reason: string;
+}
 
-  // ── 2. Load retained + sources from D1 ──
-  const retained = await fetchMemberAssessment(db, req.retainedReceiptId);
-  if (!retained) {
-    throw new MergeError(409, "Retained receipt not found or deleted.");
-  }
-  if (retained.row.status === "archived") {
-    throw new MergeError(409, "Retained receipt is archived.");
-  }
-  if (retained.row.updated_at !== req.retainedExpectedUpdatedAt) {
-    throw new MergeError(409, "Retained receipt changed (stale) — reload the comparison.");
-  }
+function attendeeKey(name: string): string {
+  return name.normalize("NFKC").toLocaleLowerCase().replace(/\s+/g, " ").trim();
+}
 
-  const sourceRecs: Array<{ rec: MemberAssessmentRecord; expected: string }> = [];
-  for (const s of req.sources) {
-    const rec = await fetchMemberAssessment(db, s.receiptId);
-    if (!rec) throw new MergeError(409, `Source ${s.receiptId.slice(0, 8)} not found or deleted.`);
-    if (rec.row.updated_at !== s.expectedUpdatedAt) {
-      throw new MergeError(409, `Source ${s.receiptId.slice(0, 8)} changed (stale).`);
-    }
-    // Revalidate as a duplicate candidate of retained.
-    const strength = findAmexDuplicateCandidates(
-      [rec.row], [retained.row, rec.row], new Set([retained.row.id]),
-    );
-    if (!strength.has(rec.row.id)) {
-      throw new MergeError(409, `Source ${s.receiptId.slice(0, 8)} is not a duplicate candidate of the retained receipt.`);
-    }
-    sourceRecs.push({ rec, expected: s.expectedUpdatedAt });
+function nonEmptyString(value: unknown, label: string, max: number): string {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new MergeError(400, `${label} must be a non-empty string.`);
   }
+  const trimmed = value.trim();
+  if (trimmed.length > max) throw new MergeError(400, `${label} must be ${max} characters or fewer.`);
+  return trimmed;
+}
 
-  // ── 3. Check export/reconciliation lock ──
-  let correctionMonth: string | undefined;
-  if (retained.row.status === "exported" && retained.row.exported_month) {
-    const locked = await isMonthLockedForEdits(db, retained.row.exported_month);
-    if (locked) {
+function attendeeSnapshot(row: ReceiptAttendee): AttendeeSnapshot {
+  return {
+    id: row.id,
+    attendeeName: row.attendee_name,
+    company: row.company,
+    relationship: row.relationship,
+    isDazbeezEmployee: row.is_dazbeez_employee,
+    notes: row.notes,
+    createdAt: row.created_at,
+  };
+}
+
+async function loadMember(db: D1Database, id: string): Promise<LoadedMember | null> {
+  const assessment = await fetchMemberAssessment(db, id);
+  if (!assessment) return null;
+  const result = await db.prepare(
+    `SELECT * FROM receipt_attendees WHERE receipt_id = ? ORDER BY created_at, id`,
+  ).bind(id).all<ReceiptAttendee>();
+  return { assessment, attendees: (result.results ?? []).map(attendeeSnapshot) };
+}
+
+function sourceValue(member: LoadedMember, field: PreservationField): unknown {
+  const row = member.assessment.row;
+  switch (field) {
+    case "transaction_date": return row.transaction_date;
+    case "merchant": return row.merchant;
+    case "amount": return { amountMinor: row.amount_minor, currency: row.currency };
+    case "category": return row.expense_category_code;
+    case "business_purpose": return row.business_purpose;
+    case "alcohol_present": return row.alcohol_present === 1;
+    case "tax_amount": return row.tax_amount_minor;
+    case "tax_rate": return row.tax_rate;
+    case "invoice_number": return row.invoice_registration_number;
+    case "counterparty": return row.counterparty_name;
+    case "attendees": return member.attendees;
+  }
+}
+
+function fieldConflict(members: LoadedMember[], field: PreservationField): boolean {
+  const values = members
+    .filter((m) => {
+      if (field === "attendees") return m.attendees.length > 0;
+      return sourceValue(m, field) !== null && sourceValue(m, field) !== "";
+    })
+    .map((m) => {
+      if (field === "attendees") {
+        return JSON.stringify(m.attendees.map((a) => attendeeKey(a.attendeeName)).sort());
+      }
+      return JSON.stringify(sourceValue(m, field));
+    });
+  return values.length > 1 && new Set(values).size > 1;
+}
+
+function validateManualAttendee(value: unknown): ManualAttendeeValue {
+  if (!value || typeof value !== "object") throw new MergeError(400, "Each attendee must be an object.");
+  const row = value as Record<string, unknown>;
+  const attendeeName = nonEmptyString(row.attendeeName, "Attendee name", 200);
+  const optional = (key: string, max: number): string | null => {
+    const raw = row[key];
+    if (raw === undefined || raw === null || raw === "") return null;
+    return nonEmptyString(raw, key, max);
+  };
+  if (row.isDazbeezEmployee !== undefined && typeof row.isDazbeezEmployee !== "boolean") {
+    throw new MergeError(400, "isDazbeezEmployee must be boolean.");
+  }
+  return {
+    attendeeName,
+    company: optional("company", 200),
+    relationship: optional("relationship", 200),
+    isDazbeezEmployee: row.isDazbeezEmployee === true,
+    notes: optional("notes", 500),
+  };
+}
+
+function manualAttendees(value: unknown): ManualAttendeeValue[] {
+  if (!value || typeof value !== "object" || !Array.isArray((value as ManualAttendeesValue).attendees)) {
+    throw new MergeError(400, "Manual attendees must contain an attendees array.");
+  }
+  const attendees = (value as ManualAttendeesValue).attendees.map(validateManualAttendee);
+  if (attendees.length === 0 || attendees.length > 50) {
+    throw new MergeError(400, "Manual attendees must contain 1–50 people.");
+  }
+  return attendees;
+}
+
+async function relevantCorrection(
+  db: D1Database,
+  retained: MemberAssessmentRecord,
+): Promise<CorrectionContext | null> {
+  if (retained.row.status === "exported" && !retained.row.exported_month) {
+    throw new MergeError(409, "Exported retained receipt has no export month; repair lifecycle metadata before merging.");
+  }
+  const monthRows = await db.prepare(
+    `SELECT export_month AS month FROM receipt_exports e
+      JOIN receipt_export_items i ON i.export_id=e.id
+     WHERE i.item_type='receipt' AND i.item_id=?
+     UNION
+     SELECT ar.statement_month AS month FROM amex_statement_lines l
+      JOIN amex_reconciliations ar ON ar.statement_month=l.statement_month
+       AND ar.status='finalized'
+     WHERE l.matched_receipt_id=?`,
+  ).bind(retained.row.id, retained.row.id).all<{ month: string }>();
+  const months = new Set((monthRows.results ?? []).map((r) => r.month));
+  if (retained.row.exported_month) months.add(retained.row.exported_month);
+  for (const month of months) {
+    if (await isMonthLockedForEdits(db, month)) {
       throw new MergeError(
         409,
-        `A correction draft is required before editing this retained receipt.`,
+        `A correction draft is required before editing the retained receipt for ${month}.`,
         "CORRECTION_DRAFT_REQUIRED",
-        retained.row.exported_month,
+        month,
       );
     }
-    correctionMonth = retained.row.exported_month;
+  }
+  if (months.size === 0) return null;
+  return db.prepare(
+    `SELECT id AS exportId, export_month AS month, export_revision AS revision,
+            correction_reason AS reason
+       FROM receipt_exports
+      WHERE status='draft' AND correction_reason IS NOT NULL
+        AND export_month IN (${[...months].map(() => "?").join(",")})
+      ORDER BY export_revision DESC LIMIT 1`,
+  ).bind(...months).first<CorrectionContext>();
+}
+
+function applyScalar(
+  proposed: ReceiptRecord,
+  field: PreservationField,
+  raw: unknown,
+): void {
+  switch (field) {
+    case "transaction_date": {
+      const value = nonEmptyString(raw, "Transaction date", 10);
+      if (!validateReceiptDate(value)) throw new MergeError(400, `Invalid transaction date: ${value}`);
+      proposed.transaction_date = value;
+      return;
+    }
+    case "merchant": proposed.merchant = nonEmptyString(raw, "Merchant", 200); return;
+    case "amount": {
+      if (!raw || typeof raw !== "object") throw new MergeError(400, "Amount requires amountMinor and currency.");
+      const amount = raw as Partial<ManualAmountValue>;
+      const parsed = validateAmountMinor(amount.amountMinor);
+      if (parsed === null || typeof amount.currency !== "string" || !validateCurrency(amount.currency)) {
+        throw new MergeError(400, "Amount requires a non-negative integer amountMinor and supported currency.");
+      }
+      proposed.amount_minor = parsed;
+      proposed.currency = amount.currency.toUpperCase();
+      return;
+    }
+    case "category": {
+      const value = nonEmptyString(raw, "Expense category", 80);
+      if (!isCanonicalCode(value)) throw new MergeError(400, `Invalid expense category: ${value}`);
+      proposed.expense_category_code = value;
+      return;
+    }
+    case "business_purpose": proposed.business_purpose = nonEmptyString(raw, "Business purpose", 500); return;
+    case "alcohol_present": {
+      if (typeof raw !== "boolean") throw new MergeError(400, "Alcohol present must be boolean.");
+      proposed.alcohol_present = raw ? 1 : 0;
+      return;
+    }
+    case "tax_amount": {
+      const parsed = validateAmountMinor(raw);
+      if (parsed === null) throw new MergeError(400, "Tax amount must be a non-negative integer.");
+      proposed.tax_amount_minor = parsed;
+      return;
+    }
+    case "tax_rate": proposed.tax_rate = nonEmptyString(raw, "Tax rate", 16); return;
+    case "invoice_number": {
+      const value = nonEmptyString(raw, "Invoice registration number", 32);
+      const validated = validateInvoiceRegistrationNumber(value);
+      if (validated.registrationStatus === "format_invalid") {
+        throw new MergeError(400, validated.message ?? "Invalid invoice registration number.");
+      }
+      proposed.invoice_registration_number = validated.normalizedNumber;
+      proposed.invoice_registration_status = validated.registrationStatus;
+      proposed.qualified_invoice_status = validated.qualifiedInvoiceStatus;
+      return;
+    }
+    case "counterparty": proposed.counterparty_name = nonEmptyString(raw, "Counterparty", 200); return;
+    case "attendees": throw new MergeError(500, "Attendees must use the attendee merge path.");
+  }
+}
+
+function updateColumns(before: ReceiptRecord, after: ReceiptRecord): Array<[string, unknown]> {
+  const fields: Array<[keyof ReceiptRecord, string]> = [
+    ["transaction_date", "transaction_date"], ["merchant", "merchant"],
+    ["amount_minor", "amount_minor"], ["currency", "currency"],
+    ["expense_category_code", "expense_category_code"], ["business_purpose", "business_purpose"],
+    ["alcohol_present", "alcohol_present"], ["tax_amount_minor", "tax_amount_minor"],
+    ["tax_rate", "tax_rate"], ["invoice_registration_number", "invoice_registration_number"],
+    ["invoice_registration_status", "invoice_registration_status"],
+    ["qualified_invoice_status", "qualified_invoice_status"], ["counterparty_name", "counterparty_name"],
+  ];
+  return fields.filter(([key]) => before[key] !== after[key]).map(([key, column]) => [column, after[key]]);
+}
+
+async function refreshCompliance(db: D1Database, receiptId: string): Promise<void> {
+  const [receipt, attendees, files, settings] = await Promise.all([
+    db.prepare(`SELECT * FROM receipt_records WHERE id=?`).bind(receiptId).first<ReceiptRecord>(),
+    db.prepare(`SELECT * FROM receipt_attendees WHERE receipt_id=?`).bind(receiptId).all<ReceiptAttendee>(),
+    db.prepare(`SELECT * FROM receipt_files WHERE object_type='receipt' AND object_id=?`).bind(receiptId).all<ReceiptFile>(),
+    db.prepare(`SELECT key,value FROM receipt_settings`).all<{ key: string; value: string }>(),
+  ]);
+  if (!receipt) throw new Error("Retained receipt disappeared after merge.");
+  await persistReceiptChecks(db, receiptId, computeReceiptChecks({
+    receipt,
+    attendees: attendees.results ?? [],
+    files: files.results ?? [],
+    settings: parseComplianceSettings(settings.results ?? []),
+  }));
+}
+
+export async function applyDuplicateMerge(req: MergeRequest): Promise<DuplicateMergeApiResult> {
+  if (!req.actor.trim()) throw new MergeError(400, "Actor is required.");
+  if (req.sources.length < 1 || req.sources.length > PURGE_TARGET_CAP) {
+    throw new MergeError(400, `Merge requires 1–${PURGE_TARGET_CAP} source receipts.`);
+  }
+  const sourceIds = req.sources.map((s) => s.receiptId);
+  if (sourceIds.includes(req.retainedReceiptId) || new Set(sourceIds).size !== sourceIds.length) {
+    throw new MergeError(400, "Sources must be unique and differ from retained.");
+  }
+  if (req.resolutionPlan.length === 0) throw new MergeError(400, "Resolution plan is empty.");
+  const fields = req.resolutionPlan.map((r) => r.field);
+  if (new Set(fields).size !== fields.length) throw new MergeError(400, "Each field may be resolved only once.");
+  for (const resolution of req.resolutionPlan) {
+    if (!ALLOWED_FIELDS.has(resolution.field)) throw new MergeError(400, `Field "${resolution.field}" is not mergeable.`);
+    if (!["copy_from_source", "keep_retained", "manual_value"].includes(resolution.action)) {
+      throw new MergeError(400, `Invalid action for ${resolution.field}.`);
+    }
   }
 
-  // ── 4. Build the update from the resolution plan ──
-  const update: UpdateReceiptInput = {};
-  const updatedFields: PreservationField[] = [];
-  const resolutionLog: Array<{ field: PreservationField; action: ResolutionAction; source?: string; manualValue?: unknown }> = [];
-  let attendeeNames: string[] | undefined;
+  const retained = await loadMember(req.db, req.retainedReceiptId);
+  if (!retained) throw new MergeError(409, "Retained receipt not found or deleted.");
+  if (retained.assessment.row.updated_at !== req.retainedExpectedUpdatedAt) {
+    throw new MergeError(409, "Retained receipt changed — reload the comparison.");
+  }
+  if (retained.assessment.row.payment_path !== "AMEX" || retained.assessment.row.status === "archived") {
+    throw new MergeError(409, "Retained receipt must be a non-archived AMEX receipt.");
+  }
 
-  for (const res of req.resolutionPlan) {
-    let valueApplied = false;
-    if (res.action === "keep_retained") {
-      // No change to the retained field; record the explicit decision.
-      resolutionLog.push({ field: res.field, action: "keep_retained" });
+  const sources: LoadedMember[] = [];
+  const strengths: Record<string, "strong" | "near"> = {};
+  for (const expected of req.sources) {
+    const source = await loadMember(req.db, expected.receiptId);
+    if (!source) throw new MergeError(409, `Source ${expected.receiptId.slice(0, 8)} not found or deleted.`);
+    const row = source.assessment.row;
+    if (row.updated_at !== expected.expectedUpdatedAt) throw new MergeError(409, `Source ${row.id.slice(0, 8)} changed — reload.`);
+    if (row.payment_path !== "AMEX" || !PRE_RECON_STATUSES.has(row.status) || isPendingProcessing(row)) {
+      throw new MergeError(409, `Source ${row.id.slice(0, 8)} is not an eligible reviewed AMEX duplicate.`);
+    }
+    if (source.assessment.amexClaimCount > 0 || source.assessment.exportItemsCount > 0) {
+      throw new MergeError(409, `Source ${row.id.slice(0, 8)} is protected by a claim or export.`);
+    }
+    const strength = deriveCandidateStrength(retained.assessment.row, row);
+    if (!strength) throw new MergeError(409, `Source ${row.id.slice(0, 8)} is no longer a duplicate candidate.`);
+    strengths[row.id] = strength;
+    sources.push(source);
+  }
+
+  const correction = await relevantCorrection(req.db, retained.assessment);
+  const allMembers = [retained, ...sources];
+  const initiallyMissing = new Set(
+    sources.flatMap((source) => missingPreservationFields(source.assessment.input, retained.assessment.input)),
+  );
+  const relevant = new Set<PreservationField>([
+    ...initiallyMissing,
+    ...ALLOWED_FIELDS.values().filter((field) => fieldConflict(allMembers, field)),
+  ]);
+  for (const resolution of req.resolutionPlan) {
+    if (!relevant.has(resolution.field)) throw new MergeError(400, `${resolution.field} is neither missing nor conflicting.`);
+    if (resolution.action === "keep_retained" && !fieldConflict(allMembers, resolution.field)) {
+      throw new MergeError(400, `keep_retained is valid only for a conflict (${resolution.field}).`);
+    }
+  }
+
+  const proposed = { ...retained.assessment.row };
+  const proposedInput: DuplicateMemberInput = { ...retained.assessment.input };
+  const attendeeAdditions: Array<ManualAttendeeValue & { sourceId?: string }> = [];
+  const existingNames = new Set(retained.attendees.map((a) => attendeeKey(a.attendeeName)));
+  for (const resolution of req.resolutionPlan) {
+    if (resolution.action === "keep_retained") continue;
+    if (resolution.field === "attendees") {
+      let candidates: Array<ManualAttendeeValue & { sourceId?: string }>;
+      if (resolution.action === "manual_value") {
+        candidates = manualAttendees(resolution.manualValue);
+      } else {
+        const ids = resolution.sourceReceiptIds ?? [];
+        if (ids.length === 0) throw new MergeError(400, "Attendee copy requires one or more sourceReceiptIds.");
+        candidates = ids.flatMap((id) => {
+          const source = sources.find((s) => s.assessment.row.id === id);
+          if (!source) throw new MergeError(400, `Unknown attendee source ${id}.`);
+          return source.attendees.map((a) => ({
+            attendeeName: a.attendeeName,
+            company: a.company,
+            relationship: a.relationship,
+            isDazbeezEmployee: a.isDazbeezEmployee === 1,
+            notes: a.notes,
+            sourceId: id,
+          }));
+        });
+      }
+      for (const candidate of candidates) {
+        const key = attendeeKey(candidate.attendeeName);
+        if (key && !existingNames.has(key)) {
+          existingNames.add(key);
+          attendeeAdditions.push(candidate);
+        }
+      }
+      proposedInput.attendeeNames = [...retained.assessment.input.attendeeNames, ...attendeeAdditions.map((a) => a.attendeeName)];
+      proposedInput.attendeesCount = proposedInput.attendeeNames.length;
       continue;
     }
-
-    let sourceRec: ReceiptRecord | undefined;
-    if (res.action === "copy_from_source") {
-      const src = sourceRecs.find((s) => s.rec.row.id === res.sourceReceiptId);
-      if (!src) throw new MergeError(400, `Unknown source ${res.sourceReceiptId} for "${res.field}".`);
-      sourceRec = src.rec.row;
-      // Verify the source actually has this field populated.
-      const sourcePopulated = new Set(populatedPreservationFields(src.rec.input));
-      if (!sourcePopulated.has(res.field)) {
-        throw new MergeError(409, `Source ${src.rec.row.id.slice(0, 8)} does not have "${res.field}" populated.`);
-      }
+    let raw = resolution.manualValue;
+    if (resolution.action === "copy_from_source") {
+      const ids = resolution.sourceReceiptIds ?? [];
+      if (ids.length !== 1) throw new MergeError(400, `${resolution.field} copy requires exactly one sourceReceiptId.`);
+      const source = sources.find((s) => s.assessment.row.id === ids[0]);
+      if (!source) throw new MergeError(400, `Unknown source ${ids[0]}.`);
+      raw = sourceValue(source, resolution.field);
     }
+    applyScalar(proposed, resolution.field, raw);
+  }
 
-    // Apply the field to the update object (validate manual values).
-    switch (res.field) {
-      case "transaction_date": {
-        const val = res.action === "manual_value" ? String(res.manualValue ?? "") : sourceRec!.transaction_date ?? "";
-        if (val && !validateReceiptDate(val)) throw new MergeError(400, `Invalid date: ${val}`);
-        update.transactionDate = val || null;
-        valueApplied = true;
-        break;
-      }
-      case "merchant": {
-        const val = res.action === "manual_value" ? String(res.manualValue ?? "").trim() : (sourceRec!.merchant ?? "").trim();
-        update.merchant = val || null;
-        valueApplied = true;
-        break;
-      }
-      case "amount": {
-        // Amount + currency are coupled. For copy_from_source, copy both.
-        // For manual_value, the manualValue is the amount; currency stays unless also specified.
-        if (res.action === "copy_from_source") {
-          update.amountMinor = sourceRec!.amount_minor;
-          update.currency = sourceRec!.currency;
-        } else {
-          const parsed = validateAmountMinor(Number(res.manualValue));
-          if (parsed === null) throw new MergeError(400, `Invalid amount: ${res.manualValue}`);
-          update.amountMinor = parsed;
-        }
-        valueApplied = true;
-        break;
-      }
-      case "category": {
-        const val = res.action === "manual_value" ? String(res.manualValue ?? "") : sourceRec!.expense_category_code ?? "";
-        if (val && !isCanonicalCode(val)) throw new MergeError(400, `Invalid category: ${val}`);
-        update.expenseCategoryCode = val || null;
-        valueApplied = true;
-        break;
-      }
-      case "business_purpose": {
-        const val = res.action === "manual_value" ? String(res.manualValue ?? "").trim() : (sourceRec!.business_purpose ?? "").trim();
-        update.businessPurpose = val || null;
-        valueApplied = true;
-        break;
-      }
-      case "alcohol_present": {
-        const val = res.action === "copy_from_source" ? sourceRec!.alcohol_present === 1 : Boolean(res.manualValue);
-        update.alcoholPresent = val;
-        valueApplied = true;
-        break;
-      }
-      case "tax_amount": {
-        if (res.action === "copy_from_source") {
-          update.taxAmountMinor = sourceRec!.tax_amount_minor;
-        } else {
-          const n = Number(res.manualValue);
-          if (isNaN(n) || n < 0) throw new MergeError(400, `Invalid tax amount: ${res.manualValue}`);
-          update.taxAmountMinor = Math.round(n);
-        }
-        valueApplied = true;
-        break;
-      }
-      case "tax_rate": {
-        const val = res.action === "manual_value" ? String(res.manualValue ?? "").trim() : (sourceRec!.tax_rate ?? "").trim();
-        update.taxRate = val || null;
-        valueApplied = true;
-        break;
-      }
-      case "invoice_number": {
-        const val = res.action === "manual_value" ? String(res.manualValue ?? "").trim() : (sourceRec!.invoice_registration_number ?? "").trim();
-        if (val) {
-          const v = validateInvoiceRegistrationNumber(val);
-          if (v.registrationStatus === "format_invalid") {
-            throw new MergeError(400, v.message ?? `Invalid invoice number: ${val}`);
-          }
-          update.invoiceRegistrationNumber = v.normalizedNumber;
-          // Derive qualified_invoice_status from the invoice authority.
-          (update as Record<string, unknown>).qualifiedInvoiceStatus = v.qualifiedInvoiceStatus;
-        } else {
-          update.invoiceRegistrationNumber = null;
-        }
-        valueApplied = true;
-        break;
-      }
-      case "counterparty": {
-        const val = res.action === "manual_value" ? String(res.manualValue ?? "").trim() : (sourceRec!.counterparty_name ?? "").trim();
-        (update as Record<string, unknown>).counterpartyName = val || null;
-        valueApplied = true;
-        break;
-      }
-      case "attendees": {
-        // Union attendees from retained + source(s), deduplicated.
-        if (res.action === "copy_from_source") {
-          const srcAttendees = (await db
-            .prepare(`SELECT attendee_name FROM receipt_attendees WHERE receipt_id = ? ORDER BY created_at`)
-            .bind(res.sourceReceiptId)
-            .all<{ attendee_name: string }>()).results ?? [];
-          const retainedAttendees = (await db
-            .prepare(`SELECT attendee_name FROM receipt_attendees WHERE receipt_id = ? ORDER BY created_at`)
-            .bind(req.retainedReceiptId)
-            .all<{ attendee_name: string }>()).results ?? [];
-          const seen = new Set<string>();
-          attendeeNames = [];
-          for (const a of [...retainedAttendees, ...srcAttendees]) {
-            const name = a.attendee_name.trim();
-            if (name && !seen.has(name)) { seen.add(name); attendeeNames.push(name); }
-          }
-        } else if (res.action === "manual_value" && typeof res.manualValue === "string") {
-          // Manual: comma-separated list of attendee names.
-          attendeeNames = res.manualValue.split(",").map((s) => s.trim()).filter(Boolean);
-        }
-        valueApplied = true;
-        break;
-      }
-    }
+  Object.assign(proposedInput, {
+    transaction_date: proposed.transaction_date,
+    merchant: proposed.merchant,
+    amount_minor: proposed.amount_minor,
+    currency: proposed.currency,
+    expense_category_code: proposed.expense_category_code,
+    business_purpose: proposed.business_purpose,
+    tax_amount_minor: proposed.tax_amount_minor,
+    tax_rate: proposed.tax_rate,
+    invoice_registration_number: proposed.invoice_registration_number,
+    qualified_invoice_status: proposed.qualified_invoice_status,
+    counterparty_name: proposed.counterparty_name,
+    alcoholPresent: proposed.alcohol_present === 1,
+  });
 
-    if (valueApplied) {
-      updatedFields.push(res.field);
-      resolutionLog.push({
-        field: res.field,
-        action: res.action,
-        source: res.sourceReceiptId,
-        manualValue: res.manualValue,
-      });
+  for (const source of sources) {
+    const missing = missingPreservationFields(source.assessment.input, proposedInput);
+    if (missing.length > 0) {
+      throw new MergeError(422, `Resolve ${missing.join(", ")} before purge; source ${source.assessment.row.id.slice(0, 8)} still has data not preserved.`);
     }
   }
+  const postSelection = assessSelection(
+    [proposedInput, ...sources.map((s) => s.assessment.input)],
+    proposedInput.id,
+    sourceIds,
+  );
+  const nonPreservationBlockers = postSelection.perTarget.flatMap((target) =>
+    target.blockers.filter((blocker) => !blocker.includes("missing from the retained") && !blocker.includes("more complete")),
+  );
+  if (nonPreservationBlockers.length > 0) throw new MergeError(409, nonPreservationBlockers.join(" "));
 
-  // No-op check: if no fields changed and no attendees to add.
-  const hasUpdate = Object.keys(update).length > 0 || attendeeNames !== undefined;
-  if (!hasUpdate) {
-    throw new MergeError(400, "Resolution plan produces no changes (all keep_retained).");
+  const changedColumns = updateColumns(retained.assessment.row, proposed);
+  if (changedColumns.length === 0 && attendeeAdditions.length === 0) {
+    throw new MergeError(400, "Resolution plan produces no retained-receipt changes.");
   }
 
-  // ── 5. Apply the retained-field update atomically ──
-  // updateReceiptRecord handles compliance, membership, sparse-update, recon-sealed gate.
-  if (Object.keys(update).length > 0) {
-    await updateReceiptRecord(req.retainedReceiptId, update, req.actor);
+  const now = nowIso();
+  const mergeId = newUuid();
+  const auditId = newUuid();
+  const genericAuditId = newUuid();
+  const updatedFields = req.resolutionPlan
+    .filter((r) => r.action !== "keep_retained")
+    .map((r) => r.field);
+  const oldValue = {
+    receipt: Object.fromEntries(updateColumns(proposed, retained.assessment.row)),
+    attendees: retained.attendees,
+  };
+  const newValue = {
+    receipt: Object.fromEntries(changedColumns),
+    attendeeAdditions,
+  };
+  const sourceSnapshots = sources.map((source) => ({
+    id: source.assessment.row.id,
+    updatedAt: source.assessment.row.updated_at,
+    attendees: source.attendees,
+  }));
+  const statements: D1PreparedStatement[] = [
+    req.db.prepare(
+      `INSERT INTO duplicate_merge_log
+        (id, retained_receipt_id, retained_expected_updated_at,
+         retained_attendees_json, source_snapshots_json, actor,
+         resolution_plan_json, old_value_json, new_value_json,
+         candidate_strengths_json, correction_export_id, correction_month,
+         correction_revision, correction_reason, created_at)
+       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+    ).bind(
+      mergeId, req.retainedReceiptId, req.retainedExpectedUpdatedAt,
+      JSON.stringify(retained.attendees), JSON.stringify(sourceSnapshots), req.actor,
+      JSON.stringify(req.resolutionPlan), JSON.stringify(oldValue), JSON.stringify(newValue),
+      JSON.stringify(strengths), correction?.exportId ?? null, correction?.month ?? null,
+      correction?.revision ?? null, correction?.reason ?? null, now,
+    ),
+  ];
+  if (changedColumns.length > 0) {
+    statements.push(req.db.prepare(
+      `UPDATE receipt_records SET ${changedColumns.map(([column]) => `${column}=?`).join(",")}, updated_at=?
+        WHERE id=? AND updated_at=? AND deleted_at IS NULL`,
+    ).bind(...changedColumns.map(([, value]) => value), now, req.retainedReceiptId, req.retainedExpectedUpdatedAt));
+  } else {
+    statements.push(req.db.prepare(
+      `UPDATE receipt_records SET updated_at=? WHERE id=? AND updated_at=? AND deleted_at IS NULL`,
+    ).bind(now, req.retainedReceiptId, req.retainedExpectedUpdatedAt));
   }
-  // Attendees handled separately (createAttendees replaces the full set).
-  if (attendeeNames !== undefined) {
-    const { createAttendees } = await import("@/lib/receipts/db");
-    await createAttendees(req.retainedReceiptId, attendeeNames.map((n) => ({ attendeeName: n })), req.actor);
+  for (const attendee of attendeeAdditions) {
+    statements.push(req.db.prepare(
+      `INSERT INTO receipt_attendees
+        (id,receipt_id,attendee_name,company,relationship,is_dazbeez_employee,notes,created_at)
+       VALUES (?,?,?,?,?,?,?,?)`,
+    ).bind(
+      newUuid(), req.retainedReceiptId, attendee.attendeeName, attendee.company ?? null,
+      attendee.relationship ?? null, attendee.isDazbeezEmployee ? 1 : 0, attendee.notes ?? null, now,
+    ));
+  }
+  statements.push(
+    req.db.prepare(
+      `INSERT INTO receipt_audit_log
+        (id,actor,action,object_type,object_id,old_value_json,new_value_json,created_at)
+       VALUES (?,?,'receipt.updated','receipt',?,?,?,?)`,
+    ).bind(genericAuditId, req.actor, req.retainedReceiptId, JSON.stringify(oldValue), JSON.stringify(newValue), now),
+    req.db.prepare(
+      `INSERT INTO receipt_audit_log
+        (id,actor,action,object_type,object_id,old_value_json,new_value_json,created_at)
+       VALUES (?,?,'receipt.duplicate_merge_applied','receipt',?,?,?,?)`,
+    ).bind(auditId, req.actor, req.retainedReceiptId, JSON.stringify({
+      retainedExpectedUpdatedAt: req.retainedExpectedUpdatedAt,
+      sources: sourceSnapshots,
+      candidateStrengths: strengths,
+    }), JSON.stringify({ mergeId, resolutionPlan: req.resolutionPlan, ...newValue, correction }), now),
+  );
+
+  try {
+    const results = await req.db.batch(statements);
+    if ((results[1]?.meta.changes ?? 0) !== 1) {
+      throw new Error("retained update did not affect exactly one row");
+    }
+  } catch (error) {
+    throw new MergeError(
+      409,
+      `Merge was not applied because a receipt, attendee set, or month lock changed. Reload and try again. (${error instanceof Error ? error.message : "guard failed"})`,
+      "MERGE_STALE",
+    );
   }
 
-  // ── 6. Write the dedicated merge audit ──
-  const auditId = (
-    await db
-      .prepare(
-        `INSERT INTO receipt_audit_log
-          (id, actor, action, object_type, object_id, old_value_json, new_value_json, created_at)
-         VALUES (?, ?, 'receipt.duplicate_merge_applied', 'receipt', ?, ?, ?, ?)
-         RETURNING id`,
-      )
-      .bind(
-        // old/new are summary metadata, not full receipt images.
-        crypto.randomUUID(),
-        req.actor,
-        req.retainedReceiptId,
-        JSON.stringify({
-          retainedExpectedUpdatedAt: req.retainedExpectedUpdatedAt,
-          sources: req.sources.map((s) => ({ id: s.receiptId, expectedUpdatedAt: s.expectedUpdatedAt })),
-          resolutionPlan: resolutionLog,
-        }),
-        JSON.stringify({
-          updatedFields,
-          attendeeAdditions: attendeeNames ?? [],
-          correctionMonth: correctionMonth ?? null,
-        }),
-        nowIso(),
-      )
-      .first<{ id: string }>()
-  )?.id ?? "unknown";
+  const warnings: string[] = [];
+  try {
+    await refreshCompliance(req.db, req.retainedReceiptId);
+  } catch (error) {
+    console.error("[duplicate-merge] compliance refresh failed after committed merge", error);
+    warnings.push("Merge committed, but compliance checks could not be refreshed. Reload Review before purge.");
+  }
 
   return {
     applied: true,
     updatedFields,
-    attendeeAdditions: attendeeNames ?? [],
-    correctionMonth,
+    attendeeAdditions: attendeeAdditions.map(({ sourceId: _sourceId, ...attendee }) => attendee),
+    resolvedFields: fields,
+    warnings,
+    correction,
     auditId,
   };
 }

--- a/lib/receipts/duplicate-purge.ts
+++ b/lib/receipts/duplicate-purge.ts
@@ -166,6 +166,7 @@ function buildInput(
     businessTripLinked: boolean;
     emailIntakePromoted: boolean;
     attendeesCount: number;
+    attendeeNames: string[];
     hasProofFile: boolean;
     exported: boolean;
   },
@@ -194,6 +195,7 @@ function buildInput(
     // Category-driven attendee requirement (correction §3) — never hardcoded.
     attendeesRequired: requiresAttendees(row.expense_category_code),
     attendeesCount: signals.attendeesCount,
+    attendeeNames: signals.attendeeNames,
     alcoholPresent: row.alcohol_present === 1,
     extractionState: row.extraction_state ?? null,
     hasOriginalFile: Boolean(row.original_r2_key),
@@ -257,6 +259,7 @@ export async function fetchMemberAssessment(
     businessTripLinked: (tripRows.results ?? []).length > 0,
     emailIntakePromoted: !!email,
     attendeesCount: attendees.length,
+    attendeeNames: attendees,
     hasProofFile: !!proof,
     // §1 correction: export-item membership is authoritative, not just status.
     // A receipt in receipt_export_items is protected even if status drifted.

--- a/lib/receipts/duplicate-purge.ts
+++ b/lib/receipts/duplicate-purge.ts
@@ -194,6 +194,7 @@ function buildInput(
     // Category-driven attendee requirement (correction §3) — never hardcoded.
     attendeesRequired: requiresAttendees(row.expense_category_code),
     attendeesCount: signals.attendeesCount,
+    alcoholPresent: row.alcohol_present === 1,
     extractionState: row.extraction_state ?? null,
     hasOriginalFile: Boolean(row.original_r2_key),
     hasProofFile: signals.hasProofFile,

--- a/lib/receipts/duplicate-resolution-policy.ts
+++ b/lib/receipts/duplicate-resolution-policy.ts
@@ -52,6 +52,7 @@ export interface DuplicateMemberInput {
   counterparty_name: string | null;
   attendeesRequired: boolean;
   attendeesCount: number;
+  alcoholPresent: boolean;
   extractionState: ExtractionState | null;
   hasOriginalFile: boolean;
   hasProofFile: boolean;
@@ -148,6 +149,69 @@ export function populatedScoreFields(m: DuplicateMemberInput): ScoreField[] {
   return SCORE_FIELDS.filter((f) => fieldPopulated(f, m));
 }
 
+// ─── Preservation fields (merge workflow: tax split) ────────────────────────
+// Completeness treats "tax" as ONE score dimension (either amount OR rate
+// populated = complete). But PRESERVATION must inspect tax_amount_minor and
+// tax_rate INDEPENDENTLY — having one must not make the other appear resolved.
+// The MIURA case: target has tax_amount_minor=829 + tax_rate="10.0"; retained
+// has neither. Both must be individually transferable.
+
+/** A field that can be preserved through the merge workflow. Splits "tax" into
+ *  its two independent components. */
+export type PreservationField =
+  | "transaction_date"
+  | "merchant"
+  | "amount"
+  | "category"
+  | "business_purpose"
+  | "alcohol_present"
+  | "tax_amount"
+  | "tax_rate"
+  | "invoice_number"
+  | "counterparty"
+  | "attendees";
+
+export const PRESERVATION_FIELDS: readonly PreservationField[] = [
+  "transaction_date",
+  "merchant",
+  "amount",
+  "category",
+  "business_purpose",
+  "alcohol_present",
+  "tax_amount",
+  "tax_rate",
+  "invoice_number",
+  "counterparty",
+  "attendees",
+];
+
+/** Whether a preservation field is populated (has actual transferable data). */
+export function preservationFieldPopulated(
+  field: PreservationField,
+  m: DuplicateMemberInput,
+): boolean {
+  switch (field) {
+    case "tax_amount":
+      return m.tax_amount_minor != null;
+    case "tax_rate":
+      return !!m.tax_rate && m.tax_rate.trim().length > 0;
+    case "alcohol_present":
+      // Meaningful only when true on the source.
+      return m.alcoholPresent;
+    default:
+      // Reuse the existing populatedScoreFields logic for the non-split fields.
+      if (field === "attendees") return m.attendeesCount > 0;
+      return fieldPopulated(field as ScoreField, m);
+  }
+}
+
+/** Preservation-level populated fields (tax split into amount + rate). Pure. */
+export function populatedPreservationFields(
+  m: DuplicateMemberInput,
+): PreservationField[] {
+  return PRESERVATION_FIELDS.filter((f) => preservationFieldPopulated(f, m));
+}
+
 /**
  * Protection/registration tier (rule A.1). A PROTECTED receipt can never be
  * purged; REGISTERED (business-trip / email-intake linkage) is purgeable only
@@ -185,10 +249,11 @@ export interface FieldConflict {
 }
 
 /** A populated accounting field on a purge target that is MISSING on the retained
- *  receipt — must be copied/resolved before purge (rule A.6). */
+ *  receipt — must be copied/resolved before purge (rule A.6). Uses
+ *  PreservationField (tax split into amount + rate independently). */
 export interface RequiredTransfer {
   fromId: string;
-  fields: ScoreField[];
+  fields: PreservationField[];
 }
 
 export interface RetentionRecommendation {
@@ -324,13 +389,12 @@ export function recommendRetention(
   }
 
   // Required transfers (A.6): populated on a purge target, missing on retained.
-  // §4: Uses populatedScoreFields (strict attendees = count > 0), not
-  // completeness().completed (which treats not-required attendees as completed).
-  const retainedPopulated = new Set<ScoreField>(populatedScoreFields(retained));
+  // Uses populatedPreservationFields (tax split into amount + rate independently).
+  const retainedPopulated = new Set<PreservationField>(populatedPreservationFields(retained));
   const requiredTransfers: RequiredTransfer[] = [];
   for (const m of members) {
     if (m.id === retained.id) continue;
-    const targetPopulated = populatedScoreFields(m);
+    const targetPopulated = populatedPreservationFields(m);
     const missingFromRetained = targetPopulated.filter((f) => !retainedPopulated.has(f));
     if (missingFromRetained.length > 0) {
       requiredTransfers.push({ fromId: m.id, fields: missingFromRetained });
@@ -378,8 +442,9 @@ export interface TargetAssessment {
   id: string;
   purgeable: boolean;
   blockers: string[];
-  /** Target-only populated accounting fields missing from the retained receipt. */
-  missingFieldsToCopy: ScoreField[];
+  /** Target-only populated accounting fields missing from the retained receipt
+   *  (PreservationField: tax split into amount + rate independently). */
+  missingFieldsToCopy: PreservationField[];
 }
 
 export interface SelectionAssessment {
@@ -413,12 +478,12 @@ export function assessSelection(
 
   const retainedTierRank = retained ? protectionTier(retained).rank : 0;
   const retainedPopulated = retained
-    ? new Set<ScoreField>(populatedScoreFields(retained))
-    : new Set<ScoreField>();
+    ? new Set<PreservationField>(populatedPreservationFields(retained))
+    : new Set<PreservationField>();
 
   for (const targetId of targetIds) {
     const blockers: string[] = [];
-    const missingFieldsToCopy: ScoreField[] = [];
+    const missingFieldsToCopy: PreservationField[] = [];
     const target = members.find((m) => m.id === targetId) ?? null;
     if (!retained) {
       blockers.push("Retained receipt not in cluster.");
@@ -438,11 +503,9 @@ export function assessSelection(
       if (tTier.rank === retainedTierRank && tComp.score > completeness(retained!).score) {
         blockers.push("Target is more complete than the retained receipt — copy its fields first or retain it.");
       }
-      // §4: Use populatedScoreFields (strict: attendees populated = count > 0),
-      // NOT completeness().completed (which treats not-required attendees as
-      // "completed"). This prevents false "missing field" detection for
-      // categories that don't require attendees.
-      for (const f of populatedScoreFields(target)) {
+      // §4: Use populatedPreservationFields (tax split into amount + rate
+      // independently; attendees populated = count > 0), NOT completeness.
+      for (const f of populatedPreservationFields(target)) {
         if (!retainedPopulated.has(f)) missingFieldsToCopy.push(f);
       }
       if (missingFieldsToCopy.length > 0) {

--- a/lib/receipts/duplicate-resolution-policy.ts
+++ b/lib/receipts/duplicate-resolution-policy.ts
@@ -52,6 +52,8 @@ export interface DuplicateMemberInput {
   counterparty_name: string | null;
   attendeesRequired: boolean;
   attendeesCount: number;
+  /** Actual names are used only for preservation/loss detection. */
+  attendeeNames: string[];
   alcoholPresent: boolean;
   extractionState: ExtractionState | null;
   hasOriginalFile: boolean;
@@ -210,6 +212,29 @@ export function populatedPreservationFields(
   m: DuplicateMemberInput,
 ): PreservationField[] {
   return PRESERVATION_FIELDS.filter((f) => preservationFieldPopulated(f, m));
+}
+
+function attendeeComparisonKey(name: string): string {
+  return name.normalize("NFKC").toLocaleLowerCase().replace(/\s+/g, " ").trim();
+}
+
+/** Populated target fields whose actual value would be lost by retaining the
+ * other member. Attendees are compared as sets rather than a boolean/count. */
+export function missingPreservationFields(
+  target: DuplicateMemberInput,
+  retained: DuplicateMemberInput,
+): PreservationField[] {
+  const retainedPopulated = new Set(populatedPreservationFields(retained));
+  const missing = populatedPreservationFields(target).filter(
+    (field) => !retainedPopulated.has(field),
+  );
+  if (target.attendeeNames.length > 0 && retained.attendeeNames.length > 0) {
+    const retainedNames = new Set(retained.attendeeNames.map(attendeeComparisonKey));
+    if (target.attendeeNames.some((name) => !retainedNames.has(attendeeComparisonKey(name)))) {
+      if (!missing.includes("attendees")) missing.push("attendees");
+    }
+  }
+  return missing;
 }
 
 /**
@@ -390,12 +415,10 @@ export function recommendRetention(
 
   // Required transfers (A.6): populated on a purge target, missing on retained.
   // Uses populatedPreservationFields (tax split into amount + rate independently).
-  const retainedPopulated = new Set<PreservationField>(populatedPreservationFields(retained));
   const requiredTransfers: RequiredTransfer[] = [];
   for (const m of members) {
     if (m.id === retained.id) continue;
-    const targetPopulated = populatedPreservationFields(m);
-    const missingFromRetained = targetPopulated.filter((f) => !retainedPopulated.has(f));
+    const missingFromRetained = missingPreservationFields(m, retained);
     if (missingFromRetained.length > 0) {
       requiredTransfers.push({ fromId: m.id, fields: missingFromRetained });
     }
@@ -477,10 +500,6 @@ export function assessSelection(
   const blockReasons: string[] = [];
 
   const retainedTierRank = retained ? protectionTier(retained).rank : 0;
-  const retainedPopulated = retained
-    ? new Set<PreservationField>(populatedPreservationFields(retained))
-    : new Set<PreservationField>();
-
   for (const targetId of targetIds) {
     const blockers: string[] = [];
     const missingFieldsToCopy: PreservationField[] = [];
@@ -505,9 +524,7 @@ export function assessSelection(
       }
       // §4: Use populatedPreservationFields (tax split into amount + rate
       // independently; attendees populated = count > 0), NOT completeness.
-      for (const f of populatedPreservationFields(target)) {
-        if (!retainedPopulated.has(f)) missingFieldsToCopy.push(f);
-      }
+      missingFieldsToCopy.push(...missingPreservationFields(target, retained));
       if (missingFieldsToCopy.length > 0) {
         blockers.push(
           `Target has accounting field(s) {${missingFieldsToCopy.join(", ")}} missing from the retained receipt — copy/resolve first.`,

--- a/lib/receipts/types.ts
+++ b/lib/receipts/types.ts
@@ -116,6 +116,7 @@ export type AuditAction =
   | "receipt.file_downloaded"
   | "receipt.search_performed"
   | "receipt.compliance_checked"
+  | "receipt.duplicate_merge_applied"
   | "amex.imported"
   | "amex.artifact_created"
   | "amex.line_categorized"

--- a/tests/receipts/duplicate-merge-service.test.ts
+++ b/tests/receipts/duplicate-merge-service.test.ts
@@ -1,0 +1,186 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { applyDuplicateMerge, MergeError } from "@/lib/receipts/duplicate-merge";
+import type { ReceiptAttendee, ReceiptRecord } from "@/lib/receipts/types";
+
+function receipt(id: string, over: Partial<ReceiptRecord> = {}): ReceiptRecord {
+  return {
+    id, captured_at: "2026-05-03T00:00:00Z", captured_by: "test", source: "mobile_capture",
+    original_filename: "r.jpg", payment_path: "AMEX", expense_type: "UNKNOWN",
+    transaction_date: "2026-05-03", merchant: "THE MIURA ROOFTOP TERRACE",
+    amount_minor: 7362, currency: "JPY", tax_amount_minor: null, business_purpose: null,
+    alcohol_present: 0, attendees_required: 0, status: "reviewed",
+    original_r2_key: `${id}.jpg`, original_sha256: id, original_content_type: "image/jpeg",
+    original_size_bytes: 10, processed_r2_key: null, extraction_json: null, legacy: 0,
+    exported_month: null, expense_category_code: null, deleted_at: null, deleted_by: null,
+    delete_reason: null, updated_at: `${id}-v1`, tax_rate: null,
+    invoice_registration_number: null, invoice_registration_status: null,
+    qualified_invoice_status: "not_checked", counterparty_name: null,
+    extraction_state: "completed", ...over,
+  } as ReceiptRecord;
+}
+
+function attendee(receiptId: string, name: string, over: Partial<ReceiptAttendee> = {}): ReceiptAttendee {
+  return {
+    id: `${receiptId}-${name}`, receipt_id: receiptId, attendee_name: name,
+    company: null, relationship: null, is_dazbeez_employee: 0, notes: null,
+    created_at: "2026-07-01T00:00:00Z", ...over,
+  };
+}
+
+interface Fixture {
+  receipts: Record<string, ReceiptRecord>;
+  attendees: Record<string, ReceiptAttendee[]>;
+  batchError?: Error;
+}
+
+function makeDb(fixture: Fixture) {
+  const batches: Array<Array<{ sql: string; binds: unknown[] }>> = [];
+  function response(sql: string, binds: unknown[]) {
+    const compact = sql.replace(/\s+/g, " ").trim();
+    const id = String(binds[0] ?? "");
+    if (compact.includes("FROM receipt_records WHERE id = ?") || compact.includes("FROM receipt_records WHERE id=?")) {
+      const row = fixture.receipts[id];
+      return { first: row ?? null, results: row ? [row] : [] };
+    }
+    if (compact.includes("FROM amex_statement_lines WHERE matched_receipt_id = ?")) {
+      return compact.includes("COUNT(*)")
+        ? { first: { n: 0 }, results: [] }
+        : { first: null, results: [] };
+    }
+    if (compact.includes("FROM receipt_export_items WHERE item_type='receipt'")) return { first: { n: 0 }, results: [] };
+    if (compact.includes("DISTINCT e.export_month")) return { first: null, results: [] };
+    if (compact.includes("DISTINCT business_trip_report_id")) return { first: null, results: [] };
+    if (compact.includes("FROM email_receipt_intake")) return { first: null, results: [] };
+    if (compact.includes("FROM receipt_attendees WHERE receipt_id = ?")) {
+      return { first: null, results: fixture.attendees[id] ?? [] };
+    }
+    if (compact.includes("role='proof_copy'")) return { first: null, results: [] };
+    if (compact.includes("SELECT export_month AS month")) return { first: null, results: [] };
+    if (compact.includes("FROM receipt_files")) return { first: null, results: [] };
+    if (compact.includes("FROM receipt_settings")) return { first: null, results: [] };
+    if (compact.includes("FROM receipt_compliance_checks")) return { first: null, results: [] };
+    return { first: null, results: [] };
+  }
+  function prepare(sql: string): D1PreparedStatement {
+    let binds: unknown[] = [];
+    const statement = {
+      _sql: sql,
+      _binds: binds,
+      bind(...values: unknown[]) { binds = values; this._binds = values; return this; },
+      async first<T>() { return response(sql, binds).first as T | null; },
+      async all<T>() { return { results: response(sql, binds).results as T[], success: true, meta: { changes: 0 } }; },
+      async run() { return { success: true, meta: { changes: 1 } }; },
+    };
+    return statement as unknown as D1PreparedStatement;
+  }
+  return {
+    prepare,
+    async batch(statements: D1PreparedStatement[]) {
+      batches.push(statements.map((statement) => ({
+        sql: (statement as unknown as { _sql: string })._sql,
+        binds: (statement as unknown as { _binds: unknown[] })._binds,
+      })));
+      if (fixture.batchError) throw fixture.batchError;
+      return statements.map(() => ({ success: true, meta: { changes: 1 } }));
+    },
+    batches,
+  };
+}
+
+function fixture(): Fixture {
+  return {
+    receipts: {
+      retained: receipt("retained"),
+      source: receipt("source", { tax_amount_minor: 829, tax_rate: "10.0" }),
+    },
+    attendees: { retained: [], source: [] },
+  };
+}
+
+test("MIURA: tax amount and rate are merged in one guarded D1 batch", async () => {
+  const data = fixture();
+  const db = makeDb(data);
+  const result = await applyDuplicateMerge({
+    db: db as unknown as D1Database,
+    retainedReceiptId: "retained",
+    retainedExpectedUpdatedAt: "retained-v1",
+    sources: [{ receiptId: "source", expectedUpdatedAt: "source-v1" }],
+    resolutionPlan: [
+      { field: "tax_amount", action: "copy_from_source", sourceReceiptIds: ["source"] },
+      { field: "tax_rate", action: "copy_from_source", sourceReceiptIds: ["source"] },
+    ],
+    actor: "operator@example.com",
+  });
+  assert.deepEqual(result.updatedFields, ["tax_amount", "tax_rate"]);
+  assert.equal(db.batches.length, 1);
+  const batch = db.batches[0]!;
+  assert.match(batch[0]!.sql, /INSERT INTO duplicate_merge_log/);
+  const update = batch.find((statement) => statement.sql.includes("UPDATE receipt_records"))!;
+  assert.match(update.sql, /tax_amount_minor=\?/);
+  assert.match(update.sql, /tax_rate=\?/);
+  assert.deepEqual(update.binds.slice(0, 2), [829, "10.0"]);
+  assert.equal(batch.filter((statement) => statement.sql.includes("receipt_audit_log")).length, 2);
+});
+
+test("attendee copy appends only the missing person and preserves metadata", async () => {
+  const data = fixture();
+  data.receipts.retained.expense_category_code = "meeting";
+  data.receipts.source.expense_category_code = "meeting";
+  data.receipts.source.tax_amount_minor = null;
+  data.receipts.source.tax_rate = null;
+  data.attendees.retained = [attendee("retained", "Alice", { company: "Dazbeez" })];
+  data.attendees.source = [attendee("source", "Bob", { company: "Client Co", relationship: "client", notes: "Host" })];
+  const db = makeDb(data);
+  const result = await applyDuplicateMerge({
+    db: db as unknown as D1Database,
+    retainedReceiptId: "retained",
+    retainedExpectedUpdatedAt: "retained-v1",
+    sources: [{ receiptId: "source", expectedUpdatedAt: "source-v1" }],
+    resolutionPlan: [{ field: "attendees", action: "copy_from_source", sourceReceiptIds: ["source"] }],
+    actor: "operator@example.com",
+  });
+  assert.equal(result.attendeeAdditions.length, 1);
+  assert.equal(result.attendeeAdditions[0]!.attendeeName, "Bob");
+  assert.equal(result.attendeeAdditions[0]!.company, "Client Co");
+  const insert = db.batches[0]!.find((statement) => statement.sql.includes("INSERT INTO receipt_attendees"))!;
+  assert.deepEqual(insert.binds.slice(2, 7), ["Bob", "Client Co", "client", 0, "Host"]);
+  assert.equal(data.attendees.retained[0]!.company, "Dazbeez", "existing attendee is never deleted/recreated");
+});
+
+test("batch failure is reported as stale and never reported as applied", async () => {
+  const data = fixture();
+  data.batchError = new Error("duplicate-merge guard: source attendee set changed");
+  const db = makeDb(data);
+  await assert.rejects(
+    applyDuplicateMerge({
+      db: db as unknown as D1Database,
+      retainedReceiptId: "retained",
+      retainedExpectedUpdatedAt: "retained-v1",
+      sources: [{ receiptId: "source", expectedUpdatedAt: "source-v1" }],
+      resolutionPlan: [
+        { field: "tax_amount", action: "copy_from_source", sourceReceiptIds: ["source"] },
+        { field: "tax_rate", action: "copy_from_source", sourceReceiptIds: ["source"] },
+      ],
+      actor: "operator@example.com",
+    }),
+    (error: unknown) => error instanceof MergeError && error.code === "MERGE_STALE" && error.status === 409,
+  );
+});
+
+test("manual tax amount rejects fractional values instead of rounding", async () => {
+  const data = fixture();
+  const db = makeDb(data);
+  await assert.rejects(
+    applyDuplicateMerge({
+      db: db as unknown as D1Database,
+      retainedReceiptId: "retained",
+      retainedExpectedUpdatedAt: "retained-v1",
+      sources: [{ receiptId: "source", expectedUpdatedAt: "source-v1" }],
+      resolutionPlan: [{ field: "tax_amount", action: "manual_value", manualValue: 828.5 }],
+      actor: "operator@example.com",
+    }),
+    /non-negative integer/i,
+  );
+  assert.equal(db.batches.length, 0);
+});

--- a/tests/receipts/duplicate-merge-trigger.test.ts
+++ b/tests/receipts/duplicate-merge-trigger.test.ts
@@ -1,0 +1,96 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+// @ts-expect-error node:sqlite is present in the project test runtime.
+import { DatabaseSync } from "node:sqlite";
+import { readFileSync } from "node:fs";
+
+function setup() {
+  const db = new DatabaseSync(":memory:");
+  db.exec(`
+    CREATE TABLE receipt_records (
+      id TEXT PRIMARY KEY, updated_at TEXT NOT NULL, deleted_at TEXT,
+      payment_path TEXT NOT NULL, status TEXT NOT NULL, exported_month TEXT,
+      extraction_state TEXT
+    );
+    CREATE TABLE receipt_attendees (
+      id TEXT PRIMARY KEY, receipt_id TEXT NOT NULL, attendee_name TEXT NOT NULL,
+      company TEXT, relationship TEXT, is_dazbeez_employee INTEGER NOT NULL DEFAULT 0,
+      notes TEXT, created_at TEXT NOT NULL
+    );
+    CREATE TABLE amex_statement_lines (
+      id TEXT PRIMARY KEY, statement_month TEXT NOT NULL, matched_receipt_id TEXT, match_status TEXT
+    );
+    CREATE TABLE amex_reconciliations (id TEXT PRIMARY KEY, statement_month TEXT, status TEXT);
+    CREATE TABLE receipt_exports (
+      id TEXT PRIMARY KEY, export_month TEXT, status TEXT, export_revision INTEGER,
+      correction_reason TEXT
+    );
+    CREATE TABLE receipt_export_items (id TEXT PRIMARY KEY, export_id TEXT, item_type TEXT, item_id TEXT);
+    CREATE TABLE receipt_audit_log (id TEXT PRIMARY KEY, action TEXT);
+  `);
+  db.exec(readFileSync("db/receipts/0033_duplicate_merge_log.sql", "utf8"));
+  db.prepare("INSERT INTO receipt_records VALUES (?,?,?,?,?,NULL,'processed')").run("retained", "rv1", null, "AMEX", "reviewed");
+  db.prepare("INSERT INTO receipt_records VALUES (?,?,?,?,?,NULL,'processed')").run("source", "sv1", null, "AMEX", "reviewed");
+  return db;
+}
+
+const insertMerge = `INSERT INTO duplicate_merge_log
+  (id,retained_receipt_id,retained_expected_updated_at,retained_attendees_json,
+   source_snapshots_json,actor,resolution_plan_json,old_value_json,new_value_json,
+   candidate_strengths_json,created_at)
+ VALUES (?,?,?,?,?,?,?,?,?,?,?)`;
+
+function args(sourceVersion = "sv1") {
+  return [
+    "merge-1", "retained", "rv1", "[]",
+    JSON.stringify([{ id: "source", updatedAt: sourceVersion, attendees: [] }]),
+    "operator", "[]", "{}", "{}", '{"source":"strong"}', "now",
+  ];
+}
+
+test("0033 trigger accepts unchanged AMEX snapshots", () => {
+  const db = setup();
+  db.prepare(insertMerge).run(...args());
+  assert.equal(db.prepare("SELECT COUNT(*) AS n FROM duplicate_merge_log").get().n, 1);
+});
+
+test("0033 trigger rejects a stale source before retained mutation", () => {
+  const db = setup();
+  assert.throws(() => db.prepare(insertMerge).run(...args("old")), /source missing, changed, or protected/i);
+  assert.equal(db.prepare("SELECT updated_at FROM receipt_records WHERE id='retained'").get().updated_at, "rv1");
+});
+
+test("0033 trigger rejects a source that returned to pending extraction", () => {
+  const db = setup();
+  db.prepare("UPDATE receipt_records SET extraction_state='queued' WHERE id='source'").run();
+  assert.throws(() => db.prepare(insertMerge).run(...args()), /source missing, changed, or protected/i);
+});
+
+test("0033 trigger rejects changed attendee metadata, not only changed names", () => {
+  const db = setup();
+  db.prepare("INSERT INTO receipt_attendees VALUES ('a1','source','Bob','Client','client',0,'Host','now')").run();
+  const staleSnapshot = [{
+    id: "source", updatedAt: "sv1", attendees: [{
+      id: "a1", attendeeName: "Bob", company: "Client", relationship: "client",
+      isDazbeezEmployee: 0, notes: "different", createdAt: "now",
+    }],
+  }];
+  const values = args();
+  values[4] = JSON.stringify(staleSnapshot);
+  assert.throws(() => db.prepare(insertMerge).run(...values), /source attendee set changed/i);
+});
+
+test("merge transaction rolls back log and retained update when a later audit statement fails", () => {
+  const db = setup();
+  db.prepare("INSERT INTO receipt_audit_log VALUES ('audit-1','existing')").run();
+  assert.throws(() => {
+    db.exec("BEGIN");
+    db.prepare(insertMerge).run(...args());
+    db.prepare("UPDATE receipt_records SET updated_at='rv2' WHERE id='retained'").run();
+    db.prepare("INSERT INTO receipt_audit_log VALUES ('audit-1','duplicate')").run();
+    db.exec("COMMIT");
+  }, /UNIQUE/i);
+  try { db.exec("ROLLBACK"); } catch { /* SQLite RAISE/constraint may already close it. */ }
+  assert.equal(db.prepare("SELECT updated_at FROM receipt_records WHERE id='retained'").get().updated_at, "rv1");
+  assert.equal(db.prepare("SELECT COUNT(*) AS n FROM duplicate_merge_log").get().n, 0);
+});

--- a/tests/receipts/duplicate-merge-ui.test.ts
+++ b/tests/receipts/duplicate-merge-ui.test.ts
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildResolutionNeeds } from "@/lib/receipts/duplicate-merge-ui";
+import type { DuplicateMemberInput } from "@/lib/receipts/duplicate-resolution-policy";
+
+function member(id: string, over: Partial<DuplicateMemberInput> = {}): DuplicateMemberInput {
+  return {
+    id, captured_at: "2026-05-03", updated_at: "v1", status: "reviewed",
+    exported: false, archived: false, claimedByConfirmedAmexLine: false,
+    businessTripLinked: false, emailIntakePromoted: false, transaction_date: "2026-05-03",
+    merchant: "MIURA", amount_minor: 7362, currency: "JPY", expense_category_code: null,
+    business_purpose: null, tax_amount_minor: null, tax_rate: null,
+    invoice_registration_number: null, qualified_invoice_status: "not_checked",
+    counterparty_name: null, attendeesRequired: false, attendeesCount: 0, attendeeNames: [],
+    alcoholPresent: false, extractionState: "processed", hasOriginalFile: true, hasProofFile: false,
+    ...over,
+  };
+}
+
+test("MIURA produces separate required controls for tax amount and tax rate", () => {
+  const needs = buildResolutionNeeds([
+    member("retained"),
+    member("source", { tax_amount_minor: 829, tax_rate: "10.0" }),
+  ], "retained", ["source"]);
+  assert.deepEqual(needs.filter((need) => need.required).map((need) => need.field), ["tax_amount", "tax_rate"]);
+  assert.equal(needs[0]!.sources[0]!.receiptId, "source");
+});
+
+test("target-only attendee is required even when retained already has attendees", () => {
+  const needs = buildResolutionNeeds([
+    member("retained", { attendeesCount: 1, attendeeNames: ["Alice"] }),
+    member("source", { attendeesCount: 2, attendeeNames: ["Alice", "Bob"] }),
+  ], "retained", ["source"]);
+  const attendees = needs.find((need) => need.field === "attendees");
+  assert.equal(attendees?.required, true);
+  assert.equal(attendees?.sources[0]?.displayValue, "Alice, Bob");
+});
+
+test("populated disagreement is offered as an optional conflict", () => {
+  const needs = buildResolutionNeeds([
+    member("retained", { merchant: "THE MIURA ROOFTOP TERRACE" }),
+    member("source", { merchant: "MIURA TERRACE" }),
+  ], "retained", ["source"]);
+  const merchant = needs.find((need) => need.field === "merchant");
+  assert.equal(merchant?.kind, "conflict");
+  assert.equal(merchant?.required, false);
+});

--- a/tests/receipts/duplicate-merge.test.ts
+++ b/tests/receipts/duplicate-merge.test.ts
@@ -107,3 +107,86 @@ test("actual attendees on target → blocks (data to preserve)", () => {
   assert.equal(s.blocked, true);
   assert.ok(s.perTarget[0]!.missingFieldsToCopy.includes("attendees"));
 });
+
+// ─── Field-level transfer scenarios ──────────────────────────────────────────
+
+test("tax_rate copied independently without tax_amount", () => {
+  const retained = m({ id: "retained", claimedByConfirmedAmexLine: true, merchant: "X", amount_minor: 100 });
+  // Target has only tax_rate, no tax_amount.
+  const target = m({ id: "target", merchant: "X", amount_minor: 100, tax_rate: "10.0" });
+  const s = assessSelection([retained, target], "retained", ["target"]);
+  assert.equal(s.blocked, true);
+  const missing = s.perTarget[0]!.missingFieldsToCopy;
+  assert.ok(missing.includes("tax_rate"), "tax_rate must be missing");
+  assert.ok(!missing.includes("tax_amount"), "tax_amount NOT missing (source doesn't have it)");
+});
+
+test("category + purpose + invoice + counterparty + date copying blocks", () => {
+  const retained = m({ id: "retained", claimedByConfirmedAmexLine: true, merchant: "X", amount_minor: 100 });
+  const target = m({
+    id: "target", merchant: "X", amount_minor: 100,
+    expense_category_code: "supplies", business_purpose: "office run",
+    invoice_registration_number: "T1234567890123",
+    counterparty_name: "Acme Corp", transaction_date: "2026-06-19",
+  });
+  const s = assessSelection([retained, target], "retained", ["target"]);
+  assert.equal(s.blocked, true);
+  const missing = s.perTarget[0]!.missingFieldsToCopy;
+  for (const f of ["category", "business_purpose", "invoice_number", "counterparty", "transaction_date"]) {
+    assert.ok(missing.includes(f as never), `${f} must be in missingFieldsToCopy`);
+  }
+});
+
+test("amount + currency are coupled (amount field covers both)", () => {
+  const retained = m({ id: "retained", claimedByConfirmedAmexLine: true, merchant: "X" });
+  const target = m({ id: "target", merchant: "X", amount_minor: 7362, currency: "JPY" });
+  const s = assessSelection([retained, target], "retained", ["target"]);
+  assert.equal(s.blocked, true);
+  assert.ok(s.perTarget[0]!.missingFieldsToCopy.includes("amount"));
+});
+
+test("conflict: different merchant values both populated — not a missing field", () => {
+  // When both retained and target have the field populated but with different
+  // values, it's a CONFLICT, not a missing field. assessSelection checks
+  // missingFieldsToCopy (target populated, retained NOT). A conflict where both
+  // are populated does NOT block purge via the missing-field rule — the operator
+  // resolves it by choosing to keep retained.
+  const retained = m({ id: "retained", claimedByConfirmedAmexLine: true, merchant: "HOLIDAY SKY LOUNGE 新宿", amount_minor: 10680 });
+  const target = m({ id: "target", merchant: "Holiday Sky Lounge 新宿", amount_minor: 10680 });
+  const s = assessSelection([retained, target], "retained", ["target"]);
+  // No target-only fields — both have the same populated fields.
+  assert.equal(s.perTarget[0]!.missingFieldsToCopy.length, 0);
+  assert.equal(s.blocked, false, "no missing fields → not blocked");
+});
+
+// ─── Merge plan validation (pure extraction) ────────────────────────────────
+
+test("merge plan: empty plan is invalid", () => {
+  // An empty resolution plan should be rejected. This is validated server-side
+  // but the pure check is: are there any non-keep-retained entries?
+  const plan: Array<{ action: string }> = [
+    { action: "keep_retained" },
+    { action: "keep_retained" },
+  ];
+  const hasChanges = plan.some((p) => p.action !== "keep_retained");
+  assert.equal(hasChanges, false, "all-keep-retained plan has no changes");
+});
+
+test("merge plan: copy_from_source with unknown source rejects", () => {
+  // Server checks: sourceReceiptId must be in the sources list.
+  const sourceIds = ["src-a", "src-b"];
+  const plan = { action: "copy_from_source", sourceReceiptId: "src-c" };
+  assert.ok(!sourceIds.includes(plan.sourceReceiptId!), "unknown source");
+});
+
+test("merge plan: allowlisted fields only", () => {
+  const allowed = new Set([
+    "transaction_date", "merchant", "amount", "category", "business_purpose",
+    "alcohol_present", "tax_amount", "tax_rate", "invoice_number",
+    "counterparty", "attendees",
+  ]);
+  // Internal/derived fields must be rejected.
+  for (const bad of ["id", "status", "payment_path", "extraction_state", "original_r2_key"]) {
+    assert.ok(!allowed.has(bad), `"${bad}" must not be allowlisted`);
+  }
+});

--- a/tests/receipts/duplicate-merge.test.ts
+++ b/tests/receipts/duplicate-merge.test.ts
@@ -16,7 +16,7 @@ function m(partial: Partial<DuplicateMemberInput> & Pick<DuplicateMemberInput, "
     transaction_date: null, merchant: null, amount_minor: null, currency: "JPY",
     expense_category_code: null, business_purpose: null, tax_amount_minor: null,
     tax_rate: null, invoice_registration_number: null, qualified_invoice_status: "not_checked",
-    counterparty_name: null, attendeesRequired: false, attendeesCount: 0,
+    counterparty_name: null, attendeesRequired: false, attendeesCount: 0, attendeeNames: [],
     alcoholPresent: false, extractionState: null, hasOriginalFile: false, hasProofFile: false,
     ...partial,
   } as DuplicateMemberInput;

--- a/tests/receipts/duplicate-merge.test.ts
+++ b/tests/receipts/duplicate-merge.test.ts
@@ -1,0 +1,109 @@
+// Tests for the duplicate-merge policy fix (tax split) + merge service.
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  populatedPreservationFields,
+  populatedScoreFields,
+  assessSelection,
+  type DuplicateMemberInput,
+} from "@/lib/receipts/duplicate-resolution-policy";
+
+function m(partial: Partial<DuplicateMemberInput> & Pick<DuplicateMemberInput, "id">): DuplicateMemberInput {
+  return {
+    captured_at: "2026-06-19T00:00:00Z", updated_at: "v1", status: "reviewed",
+    exported: false, archived: false, claimedByConfirmedAmexLine: false,
+    businessTripLinked: false, emailIntakePromoted: false,
+    transaction_date: null, merchant: null, amount_minor: null, currency: "JPY",
+    expense_category_code: null, business_purpose: null, tax_amount_minor: null,
+    tax_rate: null, invoice_registration_number: null, qualified_invoice_status: "not_checked",
+    counterparty_name: null, attendeesRequired: false, attendeesCount: 0,
+    alcoholPresent: false, extractionState: null, hasOriginalFile: false, hasProofFile: false,
+    ...partial,
+  } as DuplicateMemberInput;
+}
+
+// ─── Policy fix: tax split in preservation ──────────────────────────────────
+
+test("preservation: tax_amount and tax_rate are independent fields", () => {
+  const amtOnly = m({ id: "a", tax_amount_minor: 829 });
+  const rateOnly = m({ id: "b", tax_rate: "10.0" });
+  const both = m({ id: "c", tax_amount_minor: 829, tax_rate: "10.0" });
+  const neither = m({ id: "d" });
+
+  const amt = populatedPreservationFields(amtOnly);
+  assert.ok(amt.includes("tax_amount"), "tax_amount populated");
+  assert.ok(!amt.includes("tax_rate"), "tax_rate NOT populated when only amount");
+
+  const rate = populatedPreservationFields(rateOnly);
+  assert.ok(rate.includes("tax_rate"), "tax_rate populated");
+  assert.ok(!rate.includes("tax_amount"), "tax_amount NOT populated when only rate");
+
+  const bothFields = populatedPreservationFields(both);
+  assert.ok(bothFields.includes("tax_amount"));
+  assert.ok(bothFields.includes("tax_rate"));
+
+  const none = populatedPreservationFields(neither);
+  assert.ok(!none.includes("tax_amount"));
+  assert.ok(!none.includes("tax_rate"));
+});
+
+test("preservation: completeness still treats tax as one dimension", () => {
+  const amtOnly = m({ id: "a", tax_amount_minor: 829 });
+  const scoreFields = populatedScoreFields(amtOnly);
+  assert.ok(scoreFields.includes("tax"), "completeness 'tax' dimension populated");
+  // But preservation splits it.
+  const presFields = populatedPreservationFields(amtOnly);
+  assert.ok(!(presFields as readonly string[]).includes("tax"), "preservation does NOT have 'tax' (it has tax_amount/tax_rate)");
+});
+
+test("MIURA acceptance: target tax_amount missing from retained → blocks purge", () => {
+  // MIURA: retained c26d2d25 (protected, no tax), target 219471f9 (tax_amount=829, tax_rate=10.0).
+  const retained = m({ id: "retained", claimedByConfirmedAmexLine: true, merchant: "MIURA", amount_minor: 7362 });
+  const target = m({ id: "target", merchant: "MIURA", amount_minor: 7362, tax_amount_minor: 829, tax_rate: "10.0" });
+  const s = assessSelection([retained, target], "retained", ["target"]);
+  assert.equal(s.blocked, true);
+  const missing = s.perTarget[0]!.missingFieldsToCopy;
+  assert.ok(missing.includes("tax_amount"), "tax_amount must be in missingFieldsToCopy");
+  assert.ok(missing.includes("tax_rate"), "tax_rate must be in missingFieldsToCopy");
+});
+
+test("MIURA acceptance: copying only tax_amount leaves tax_rate still blocking", () => {
+  // Simulate: after copying tax_amount to retained, retained has tax_amount but not tax_rate.
+  const retainedAfterPartial = m({ id: "retained", claimedByConfirmedAmexLine: true, merchant: "MIURA", amount_minor: 7362, tax_amount_minor: 829 });
+  const target = m({ id: "target", merchant: "MIURA", amount_minor: 7362, tax_amount_minor: 829, tax_rate: "10.0" });
+  const s = assessSelection([retainedAfterPartial, target], "retained", ["target"]);
+  assert.equal(s.blocked, true, "still blocked because tax_rate is missing");
+  assert.ok(s.perTarget[0]!.missingFieldsToCopy.includes("tax_rate"));
+  assert.ok(!s.perTarget[0]!.missingFieldsToCopy.includes("tax_amount"), "tax_amount no longer missing");
+});
+
+test("MIURA acceptance: copying both tax fields → purgeable", () => {
+  const retainedComplete = m({ id: "retained", claimedByConfirmedAmexLine: true, merchant: "MIURA", amount_minor: 7362, tax_amount_minor: 829, tax_rate: "10.0" });
+  const target = m({ id: "target", merchant: "MIURA", amount_minor: 7362, tax_amount_minor: 829, tax_rate: "10.0" });
+  const s = assessSelection([retainedComplete, target], "retained", ["target"]);
+  assert.equal(s.blocked, false, "both tax fields present → purgeable");
+});
+
+test("alcohol_present: true on target, false on retained → blocks", () => {
+  const retained = m({ id: "retained", claimedByConfirmedAmexLine: true, merchant: "X", amount_minor: 100 });
+  const target = m({ id: "target", merchant: "X", amount_minor: 100, alcoholPresent: true });
+  const s = assessSelection([retained, target], "retained", ["target"]);
+  assert.equal(s.blocked, true);
+  assert.ok(s.perTarget[0]!.missingFieldsToCopy.includes("alcohol_present"));
+});
+
+test("non-required attendees with zero count does NOT block (no data to lose)", () => {
+  const retained = m({ id: "retained", claimedByConfirmedAmexLine: true, merchant: "X", amount_minor: 100 });
+  const target = m({ id: "target", merchant: "X", amount_minor: 100, attendeesCount: 0 });
+  const s = assessSelection([retained, target], "retained", ["target"]);
+  // attendees count 0 → not populated → not a missing field → not blocked.
+  assert.equal(s.blocked, false);
+});
+
+test("actual attendees on target → blocks (data to preserve)", () => {
+  const retained = m({ id: "retained", claimedByConfirmedAmexLine: true, merchant: "X", amount_minor: 100 });
+  const target = m({ id: "target", merchant: "X", amount_minor: 100, attendeesCount: 2 });
+  const s = assessSelection([retained, target], "retained", ["target"]);
+  assert.equal(s.blocked, true);
+  assert.ok(s.perTarget[0]!.missingFieldsToCopy.includes("attendees"));
+});

--- a/tests/receipts/duplicate-purge.test.ts
+++ b/tests/receipts/duplicate-purge.test.ts
@@ -43,6 +43,7 @@ function m(partial: Partial<DuplicateMemberInput> & Pick<DuplicateMemberInput, "
     counterparty_name: null,
     attendeesRequired: false,
     attendeesCount: 0,
+    attendeeNames: [],
     extractionState: null,
     hasOriginalFile: false,
     hasProofFile: false,

--- a/tests/receipts/duplicate-resolution-policy.test.ts
+++ b/tests/receipts/duplicate-resolution-policy.test.ts
@@ -34,6 +34,7 @@ function m(partial: Partial<DuplicateMemberInput> & Pick<DuplicateMemberInput, "
     counterparty_name: null,
     attendeesRequired: false,
     attendeesCount: 0,
+    attendeeNames: [],
     extractionState: null,
     hasOriginalFile: false,
     hasProofFile: false,


### PR DESCRIPTION
## Outcome

Operators can now preserve target-only accounting data on the retained receipt without leaving the duplicate-resolution page, then re-evaluate and purge separately. The MIURA case exposes independent copy controls for tax amount 829 and tax rate 10.0.

## Root cause fixed

The earlier implementation performed the receipt update, attendee replacement, and audit as separate operations. It could lose attendee metadata, race after preflight, silently round manual tax, and lose its success message when the modal child unmounted.

## Changes

- Adds typed resolution controls for missing and conflicting fields: source copy, manual correction, and keep-retained for genuine conflicts.
- Treats amount and currency as one typed value; treats tax amount and tax rate as independent preservation fields.
- Compares attendees by normalized names and appends missing people while preserving company, relationship, employee, notes, and existing retained rows.
- Adds migration 0033 with a durable merge record and insert-time guards for retained/source versions, AMEX eligibility, source protection, pending extraction, attendee snapshots, and ADR 0012 month locks.
- Commits the retained update, attendee additions, generic audit, and dedicated duplicate-merge audit in one D1 batch. Sources are never mutated and purge remains separate.
- Recomputes compliance checks after commit; a refresh failure is returned as a post-commit warning rather than misreporting the merge as failed.
- Opens the existing correction-draft flow when a sealed month blocks the edit and keeps the revision reminder visible after merge.
- Clears all purge selections and confirmations immediately after merge, reloads the comparison, and retains a visible success or reload-failure notice.

## Safety and validation

- Full test suite: 945 pass, 0 fail, 1 pre-existing skip.
- Focused duplicate-merge tests: 12 pass, including MIURA, attendee metadata preservation, batch failure, write-time stale guards, pending extraction, transaction rollback, and typed UI needs.
- TypeScript: clean.
- ESLint: no warnings in changed files; two unrelated pre-existing warnings remain.
- All 33 receipt migrations apply in order to an in-memory SQLite database.
- Cloudflare production build: successful.

No production receipt, D1, or R2 data was mutated by this implementation.
