### PR TITLE
fix: newsyslog rotation creates root-owned logs, blocking launchd

### DIFF
--- a/scripts/receipts-consumer/newsyslog.d/dazbeez-receipts-consumer.conf
+++ b/scripts/receipts-consumer/newsyslog.d/dazbeez-receipts-consumer.conf
@@ -1,22 +1,32 @@
-# newsyslog rotation for the MLX receipts consumer.
+# newsyslog rotation for the Dazbeez receipts consumer schedulers.
 # Install (one-time, requires sudo):
 #   sudo cp dazbeez-receipts-consumer.conf /etc/newsyslog.d/
 #
 # Format (see `man newsyslog.conf`):
 #   logfilename [owner:group] mode count size  when  flags
-# - count 5     keep 5 archived generations
-# - size 1024   rotate when file exceeds 1 MB
-# - when *      no time-based rotation (size-only)
-# - flags Z     gzip-compress rolled files
 #
-# Note on launchd + rotation: launchd re-opens StandardOutPath /
-# StandardErrorPath at each --once invocation (every 600s by default),
-# so a fresh run after rotation picks up the new inode automatically.
-# Worst case is one ~10-minute run writing to the renamed file before
-# the next run opens the fresh one. Acceptable for the consumer's low
-# log volume.
+# CRITICAL: owner:group is mandatory here. Without it, newsyslog creates
+# rotated files as root:admin (the default). A root-owned log file prevents
+# the user LaunchAgent (running as dklan) from opening its StandardErrorPath,
+# causing launchd to refuse spawning the job with EX_CONFIG (exit code 78).
+# This happened on 2026-07-22 when newsyslog rotated receipts-consumer.err.log
+# to root:admin and the primary extraction consumer could not restart.
+#
+# Explicit dklan:staff ensures every rotated generation stays writable by the
+# LaunchAgent user so launchd can always spawn the job.
+#
+# Both schedulers are covered:
+#   - com.dazbeez.receipts-consumer            (primary MLX extraction)
+#   - com.dazbeez.receipts-auto-promote-render (auto-promote + render)
 #
 # Replace /Users/dklan below with the actual home directory if installing
 # on a different user account.
-/Users/dklan/Library/Logs/dazbeez/receipts-consumer.log      644  5  1024  *  Z
-/Users/dklan/Library/Logs/dazbeez/receipts-consumer.err.log  644  5  1024  *  Z
+#
+# Flags ZN:
+#   Z = gzip-compress rolled files
+#   N = no daemon PID to signal (launchd opens paths per short-lived invocation)
+
+/Users/dklan/Library/Logs/dazbeez/receipts-consumer.log               dklan:staff  644  5  1024  *  ZN
+/Users/dklan/Library/Logs/dazbeez/receipts-consumer.err.log           dklan:staff  644  5  1024  *  ZN
+/Users/dklan/Library/Logs/dazbeez/receipts-auto-promote-render.log    dklan:staff  644  5  1024  *  ZN
+/Users/dklan/Library/Logs/dazbeez/receipts-auto-promote-render.err.log dklan:staff 644  5  1024  *  ZN


### PR DESCRIPTION
## Root Cause

On 2026-07-22 at ~11:30 JST, newsyslog rotated `receipts-consumer.err.log` and recreated it as `root:admin` (the default when `owner:group` is omitted). The primary extraction LaunchAgent (`com.dazbeez.receipts-consumer`) runs as `dklan` and cannot open a root-owned `StandardErrorPath`, so launchd refused to spawn the job — `EX_CONFIG` (exit code 78), `job state = spawn failed`. The consumer was down for ~8 hours.

## Fix

Explicitly set `dklan:staff` in all four newsyslog entries so every rotated generation stays writable by the LaunchAgent user. Changed flags from `Z` to `ZN` (`N` = no daemon PID to signal, correct for launchd's per-invocation path opening).

Covers all four scheduler logs:
- `receipts-consumer.log` / `.err.log` (primary MLX extraction)
- `receipts-auto-promote-render.log` / `.err.log` (auto-promote + render)

## Production Status

- **Repository fix:** committed and pushed.
- **Production repair (sudo required):** the operator must run:
  1. `sudo cp .../newsyslog.d/dazbeez-receipts-consumer.conf /etc/newsyslog.d/`
  2. `sudo chown dklan:staff .../receipts-consumer.err.log`
  3. `launchctl kickstart gui/$(id -u)/com.dazbeez.receipts-consumer`
- **Auto-promote/render scheduler:** healthy (exit 0, not affected — its logs were already `dklan:staff`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)