### PR TITLE
fix(receipts): extract every PDF page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -302,14 +302,20 @@ starts. Design consequences:
     (PR #65 completed #9(a) consumer failed-state marking). Every failure
     path from the audit now surfaces or dies visibly. C-class accepted
     as documented.
-13. **Multi-page PDF handling.** Real-world case: 5608427143.pdf
-    (5c1ab53f…) has 2 pages; the consumer renders page 0 only and drops the
-    rest with a stderr-only warning — invisible to the operator. Design:
-    (a) render all pages and pass multiple images to the VLM (mlx-vlm
-    supports num_images > 1) or stack pages into one tall image; (b) record
-    page_count on the receipt and surface a "N pages, only p.1 extracted"
-    badge in the review UI until (a) ships. Feeds theme #12: warnings must
-    land where the operator works, not in a Mac log file.
+13. **Multi-page PDF handling.** IMPLEMENTED (code complete; Mac consumer
+    restart + surgical re-extraction still required). Real-world case:
+    5608427143.pdf (5c1ab53f…) has 2 pages; the old consumer rendered page 0
+    only. The consumer now renders every PDF page to an ordered ~200-DPI PNG
+    list, passes all images to mlx-vlm with `num_images` and a page-scaled
+    output budget, cleans up all page files on success/failure, and persists
+    `sourcePageCount` in extraction_json. Five focused regressions cover
+    single-page compatibility, multi-page order/completeness, partial-failure
+    cleanup, multi-image model input, and empty-input rejection; the complete
+    consumer suite is 84 passing. Automation/backfill scanning is deliberately
+    parked. Live follow-up: restart the launchd consumer from the committed
+    code, then re-extract only receipt 5c1ab53f… and verify
+    `sourcePageCount=2` plus page-2 text before considering this operationally
+    closed.
 14. **Extraction quality: 登録番号 recall.** Extractor missed a clearly
     printed T-number (receipt 92418c1a, T2810074043972 visible on image).
     Improve Mac-side extractor recall; consider a re-extract pass over

--- a/app/api/receipts/[id]/extract/route.ts
+++ b/app/api/receipts/[id]/extract/route.ts
@@ -3,6 +3,7 @@ import { requireReceiptsActor } from "@/lib/receipts/auth";
 import { getReceiptRecord, reconcileExtractionState, updateReceiptRecord } from "@/lib/receipts/db";
 import {
   buildGuardedExtraction,
+  coerceSourcePageCount,
   type ModelExtractionFields,
 } from "@/lib/receipts/extraction";
 import { createAuditEntry } from "@/lib/receipts/audit";
@@ -38,6 +39,9 @@ interface ApplyBody {
    * review UI can badge "Structured parse failed" instead of silently
    * rendering empty fields. */
   structuredParseFailed?: boolean;
+  /** Number of ordered source pages/images processed by the MLX consumer.
+   * Persisted as extraction provenance; one for ordinary image receipts. */
+  sourcePageCount?: number;
 }
 
 /**
@@ -105,10 +109,12 @@ export async function POST(request: Request, { params }: RouteContext) {
 
     // Resolve the OCR text: fresh from the model, else the text already stored.
     let rawText = body?.rawText?.trim() || "";
+    let priorSourcePageCount: number | undefined;
     if (!rawText && receipt.extraction_json) {
       try {
         const prior = JSON.parse(receipt.extraction_json) as Partial<ExtractionResult>;
         rawText = (prior.rawText ?? "").trim();
+        priorSourcePageCount = coerceSourcePageCount(prior.sourcePageCount);
       } catch {
         /* ignore malformed prior extraction */
       }
@@ -144,6 +150,8 @@ export async function POST(request: Request, { params }: RouteContext) {
     });
 
     const provider = body?.model || (isProcessor ? "mlx_local" : "regex_reprocess");
+    const sourcePageCount =
+      coerceSourcePageCount(body?.sourcePageCount) ?? priorSourcePageCount;
     const { result, discrepancies } = buildGuardedExtraction(
       rawText,
       body?.fields ?? {},
@@ -158,7 +166,11 @@ export async function POST(request: Request, { params }: RouteContext) {
       overwrite || current === null || current === undefined || current === "";
 
     const updates: Parameters<typeof updateReceiptRecord>[1] = {
-      extractionJson: JSON.stringify({ ...result, discrepancies }),
+      extractionJson: JSON.stringify({
+        ...result,
+        discrepancies,
+        ...(sourcePageCount ? { sourcePageCount } : {}),
+      }),
       extractionState: "processed",
       extractionProcessedAt: nowIso(),
       extractionProcessor: provider,
@@ -235,7 +247,11 @@ export async function POST(request: Request, { params }: RouteContext) {
       action: "receipt.extraction_completed",
       objectType: "receipt",
       objectId: id,
-      newValueJson: stringifyJson({ provider, discrepancies }),
+      newValueJson: stringifyJson({
+        provider,
+        discrepancies,
+        ...(sourcePageCount ? { sourcePageCount } : {}),
+      }),
     });
 
     return NextResponse.json(

--- a/docs/receipt-module.md
+++ b/docs/receipt-module.md
@@ -142,6 +142,12 @@ The application does not expose hard-delete flows for retained tax records. Soft
 
 Extraction is **store-and-forward**, not synchronous. Capture writes the image to R2, inserts the receipt at `status='captured'` (`extraction_state='captured'`), and enqueues a job on the `RECEIPTS_QUEUE` Cloudflare Queue. The **Mac MLX consumer** (`scripts/receipts-consumer/`) is the only processor: it pulls a batch, runs a local vision-language model, and POSTs the result to `POST /api/receipts/[id]/extract` (authenticated with `RECEIPTS_PROCESSOR_KEY`), which runs the deterministic regex parser as a **guardrail** over the model output, merges fields, and advances the receipt to `needs_review`.
 
+PDF receipts are rendered to one ordered image per page at approximately
+200 DPI. The MLX prompt receives every page in document order, scales its
+output-token budget for multi-page transcription, and records
+`sourcePageCount` in `extraction_json`. Single-page PDFs and raster uploads use
+the same path with a page count of one.
+
 Consequences enforced in code:
 
 - **Pending processing is a first-class state.** A captured-but-unprocessed receipt shows as "Receipts pending processing" (CTA: *Process queue*), never as a missing or unreviewed receipt.

--- a/lib/receipts/extraction.ts
+++ b/lib/receipts/extraction.ts
@@ -377,6 +377,15 @@ function coerceMinor(v: unknown): number | null {
   return null;
 }
 
+/** Validate untyped extraction provenance before persisting it. */
+export function coerceSourcePageCount(value: unknown): number | undefined {
+  return typeof value === "number" &&
+    Number.isSafeInteger(value) &&
+    value > 0
+    ? value
+    : undefined;
+}
+
 /**
  * Build an ExtractionResult from OCR text produced off-Worker (MLX) plus any
  * structured fields the model emitted, running the deterministic regex parser
@@ -457,4 +466,3 @@ export function buildGuardedExtraction(
     },
   };
 }
-

--- a/lib/receipts/types.ts
+++ b/lib/receipts/types.ts
@@ -783,6 +783,9 @@ export interface ExtractionResult {
   // JSON). Review UI uses this to badge "Structured parse failed — raw
   // text available" instead of silently rendering empty fields.
   structuredParseFailed?: boolean;
+  // Extraction provenance from the Mac consumer. Raster uploads report 1;
+  // multi-page PDFs report the number of ordered page images sent to MLX.
+  sourcePageCount?: number;
 }
 
 // ─── Reconciliation ────────────────────────────────────────────────────────

--- a/scripts/receipts-consumer/consumer.py
+++ b/scripts/receipts-consumer/consumer.py
@@ -60,6 +60,8 @@ PROCESSOR_KEY = os.environ["RECEIPTS_PROCESSOR_KEY"]
 # Validated on the M4 Max (128 GB): 32B-4bit ≈ 18 GB on disk, ~21.6 GB RAM
 # (17%), ~26 tok/s. Strong JA accuracy incl. T-invoice numbers + tax math.
 MLX_MODEL = os.environ.get("MLX_MODEL", "mlx-community/Qwen3-VL-32B-Instruct-4bit")
+MLX_MAX_TOKENS_PER_PAGE = 1500
+MLX_MAX_TOKENS_TOTAL = 6000
 
 QUEUES_API = (
     f"https://api.cloudflare.com/client/v4/accounts/{CF_ACCOUNT_ID}"
@@ -74,6 +76,8 @@ CF_HEADERS = {"Authorization": f"Bearer {CF_API_TOKEN}", "Content-Type": "applic
 
 PROMPT = (
     "You are reading a receipt or tax invoice (Japanese or English). "
+    "When multiple images are provided, they are consecutive pages of the "
+    "same document in page order; read and transcribe every page. "
     "First transcribe ALL visible text exactly, preserving line breaks. "
     "Then output a single JSON object on the final line with keys: "
     "rawText (the full transcription), merchant, transactionDate (YYYY-MM-DD), "
@@ -106,16 +110,16 @@ def ack(lease_ids: list[str]) -> None:
     ).raise_for_status()
 
 
-def fetch_image(receipt_id: str, r2_key: str) -> str:
+def fetch_images(receipt_id: str, r2_key: str) -> list[str]:
     """Download the original image via the Worker's /file endpoint.
 
     The Worker proxies R2 with the same processor key the consumer uses to POST
     extraction results (ADR 0001) — so the consumer needs no R2 scope on its
     Cloudflare API token, and never shells out to wrangler per image.
 
-    PDFs are rasterized to PNG (page 0, ~200 DPI) before returning so the MLX
-    VLM (which expects a raster input) can read them. Multi-page PDFs warn to
-    stderr — receipts should be single-page; we want to know if they aren't.
+    PDFs are rasterized to one PNG per page (~200 DPI) and returned in page
+    order so the MLX VLM reads the complete document. Raster uploads return a
+    one-item list.
     Any fitz exception propagates to the caller's existing retry handling.
     """
     suffix = os.path.splitext(r2_key)[1] or ".bin"
@@ -134,60 +138,107 @@ def fetch_image(receipt_id: str, r2_key: str) -> str:
             if chunk:
                 fh.write(chunk)
 
-    # PDF → PNG (page 0 only). Lazy import so --help works without pymupdf.
+    # PDF → one PNG per page. Lazy import so --help works without pymupdf.
     if suffix.lower() == ".pdf":
-        return _rasterize_pdf(receipt_id, path)
+        return _rasterize_pdf_pages(receipt_id, path)
 
-    return path
+    return [path]
 
 
-def _rasterize_pdf(receipt_id: str, pdf_path: str) -> str:
-    """Render page 0 of a PDF to a ~200 DPI PNG. Returns the PNG path.
+def _unlink_paths(paths: list[str]) -> None:
+    """Best-effort cleanup for temporary extraction inputs."""
+    for path in paths:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
 
-    The .pdf temp file is unlinked before returning so the caller's normal
-    os.unlink cleanup runs on the PNG instead. Any fitz exception propagates.
+
+def _rasterize_pdf_pages(receipt_id: str, pdf_path: str) -> list[str]:
+    """Render every PDF page to an ordered list of ~200 DPI PNG paths.
+
+    The downloaded PDF is always unlinked. If any page fails, already-rendered
+    PNGs are also removed before the exception propagates to the existing
+    permanent/transient failure handling.
     """
     import fitz  # pymupdf — pure-Python wheel, no system deps
 
-    doc = fitz.open(pdf_path)
+    doc = None
+    png_paths: list[str] = []
     try:
+        doc = fitz.open(pdf_path)
         page_count = doc.page_count
+        if page_count < 1:
+            raise PermanentExtractionFailure("PDF has no pages")
         if page_count > 1:
             print(
-                f"[warn] {receipt_id}: PDF has {page_count} pages; "
-                "only rendering page 0 (receipts should be single-page).",
-                file=sys.stderr,
+                f"[info] {receipt_id}: PDF has {page_count} pages; "
+                "rendering all pages for extraction.",
             )
-        page = doc.load_page(0)
-        # 200 DPI: 72 DPI is PDF's native scale, so 200/72 ≈ 2.78×.
-        # Captures fine JA receipt text including small 領収書 numbers.
         matrix = fitz.Matrix(200 / 72, 200 / 72)
-        pixmap = page.get_pixmap(matrix=matrix, alpha=False)
-        fd, png_path = tempfile.mkstemp(suffix=".png")
-        os.close(fd)
-        pixmap.save(png_path)
+        for page_index in range(page_count):
+            page = doc.load_page(page_index)
+            # 200 DPI: 72 DPI is PDF's native scale, so 200/72 ≈ 2.78×.
+            # Captures fine JA receipt text including small 領収書 numbers.
+            pixmap = page.get_pixmap(matrix=matrix, alpha=False)
+            fd, png_path = tempfile.mkstemp(suffix=".png")
+            os.close(fd)
+            try:
+                pixmap.save(png_path)
+            except Exception:
+                _unlink_paths([png_path])
+                raise
+            png_paths.append(png_path)
+        return png_paths
+    except Exception:
+        _unlink_paths(png_paths)
+        raise
     finally:
-        doc.close()
+        if doc is not None:
+            doc.close()
+        _unlink_paths([pdf_path])
 
-    os.unlink(pdf_path)
-    return png_path
 
-
-def run_mlx(image_path: str) -> dict[str, Any]:
+def run_mlx(image_paths: list[str]) -> dict[str, Any]:
     """Run the local MLX VLM and return {rawText, fields}."""
+    if not image_paths:
+        raise PermanentExtractionFailure("no images available for extraction")
+
     from mlx_vlm import generate  # imported lazily so --help works without MLX
     from mlx_vlm.prompt_utils import apply_chat_template
     from mlx_vlm.utils import load_config
 
     model, processor = _load_model()
     config = load_config(MLX_MODEL)
-    formatted = apply_chat_template(processor, config, PROMPT, num_images=1)
-    result = generate(model, processor, formatted, [image_path], max_tokens=1500, verbose=False)
+    formatted = apply_chat_template(
+        processor,
+        config,
+        PROMPT,
+        num_images=len(image_paths),
+    )
+    result = generate(
+        model,
+        processor,
+        formatted,
+        image_paths,
+        # Preserve the existing single-page budget while giving multi-page
+        # documents enough room to transcribe every page plus the final JSON.
+        max_tokens=min(
+            MLX_MAX_TOKENS_PER_PAGE * len(image_paths),
+            MLX_MAX_TOKENS_TOTAL,
+        ),
+        verbose=False,
+    )
     # mlx-vlm >= 0.5 returns GenerationResult; older returned str. Handle both.
     output = result.text if hasattr(result, "text") else result
 
     raw_text, fields, parse_failed = _parse_model_output(output)
-    return {"rawText": raw_text, "fields": fields, "structuredParseFailed": parse_failed}
+    return {
+        "rawText": raw_text,
+        "fields": fields,
+        "structuredParseFailed": parse_failed,
+        "sourcePageCount": len(image_paths),
+    }
 
 
 _MODEL_CACHE: dict[str, Any] = {}
@@ -347,10 +398,10 @@ def make_proof_derivative(image_path: str) -> tuple[bytes, str] | None:
 def fetch_original_bytes(receipt_id: str) -> bytes | None:
     """Fetch the receipt's ORIGINAL file bytes via the Worker /file endpoint.
 
-    Same processor-key proxy as fetch_image, but WITHOUT PDF rasterization.
+    Same processor-key proxy as fetch_images, but WITHOUT PDF rasterization.
     Used for proof generation where PDFs must pass through uncompressed:
-    fetch_image rasterizes PDFs to PNG for MLX and discards the original, so the
-    PDF proof path re-fetches the raw bytes here. Returns None on failure
+    fetch_images rasterizes PDFs to PNGs for MLX and discards the original, so
+    the PDF proof path re-fetches the raw bytes here. Returns None on failure
     (caller skips the proof for this receipt).
     """
     headers = {"x-receipts-processor-key": PROCESSOR_KEY}
@@ -397,7 +448,7 @@ def generate_proof(
     """Build the proof derivative for a just-extracted receipt.
 
     For raster images, reuse the file already fetched for MLX (it IS the
-    original). For PDFs, fetch_image rasterized to PNG and discarded the
+    original). For PDFs, fetch_images rasterized to PNGs and discarded the
     original — re-fetch the raw PDF here so it passes through uncompressed.
     Returns (bytes, content_type) or None (skip).
     """
@@ -658,16 +709,13 @@ def process_backfill(dry_run: bool, only_id: str | None = None) -> None:
             continue
 
         try:
-            image_path = fetch_image(rid, r2_key)
+            image_paths = fetch_images(rid, r2_key)
             try:
-                if os.path.getsize(image_path) == 0:
+                if any(os.path.getsize(path) == 0 for path in image_paths):
                     raise PermanentExtractionFailure("downloaded file is zero bytes")
-                result = run_mlx(image_path)
+                result = run_mlx(image_paths)
             finally:
-                try:
-                    os.unlink(image_path)
-                except OSError:
-                    pass
+                _unlink_paths(image_paths)
             apply_to_worker(rid, result)
             stats["extract_ok"] += 1
             print(f"  [ok]          {label}")
@@ -921,31 +969,28 @@ def process_once() -> int:
         try:
             job = msg["body"] if isinstance(msg["body"], dict) else json.loads(msg["body"])
             receipt_id, r2_key = job["receiptId"], job["r2Key"]
-            image_path = fetch_image(receipt_id, r2_key)
+            image_paths = fetch_images(receipt_id, r2_key)
             # Zero-byte downloads are deterministic-permanent: a 200 OK with
             # an empty body means R2 has nothing for this key. MLX would
             # either crash or produce gibberish; either way retrying won't
             # help. Post failure + ack.
-            proof: tuple[bytes, str] | None = None  # built while image_path exists
+            proof: tuple[bytes, str] | None = None  # built while image_paths exist
             try:
-                if os.path.getsize(image_path) == 0:
+                if any(os.path.getsize(path) == 0 for path in image_paths):
                     raise PermanentExtractionFailure("downloaded file is zero bytes")
-                result = run_mlx(image_path)
+                result = run_mlx(image_paths)
                 # Proof derivative (advisory). Built inside the try so the
                 # raster image is still on disk; a build failure is swallowed
                 # — it must never block extraction.
                 try:
-                    proof = generate_proof(receipt_id, r2_key, image_path)
+                    proof = generate_proof(receipt_id, r2_key, image_paths[0])
                 except Exception as exc:  # noqa: BLE001
                     print(
                         f"[warn] {receipt_id}: proof build failed ({exc})",
                         file=sys.stderr,
                     )
             finally:
-                try:
-                    os.unlink(image_path)
-                except OSError:
-                    pass
+                _unlink_paths(image_paths)
             apply_to_worker(receipt_id, result)
             # Post the proof only after extraction is confirmed. Advisory: a
             # failure is logged and swallowed (backfill_proof_copies.py recovers

--- a/scripts/receipts-consumer/requirements.txt
+++ b/scripts/receipts-consumer/requirements.txt
@@ -5,7 +5,7 @@ requests>=2.31
 mlx-vlm>=0.1.0
 # PDF→PNG rasterization for PDF receipts (fitz). Pure-Python wheels for
 # Apple Silicon — no poppler or other system deps. Lazy-imported inside
-# fetch_image() so --help works without it installed.
+# fetch_images() so --help works without it installed.
 pymupdf>=1.24
 # Image handling: failure classifier (PIL.UnidentifiedImageError) + proof-copy
 # derivative generation at ingest (resize/q75/EXIF strip). Was transitive via

--- a/scripts/receipts-consumer/test_multi_page_pdf.py
+++ b/scripts/receipts-consumer/test_multi_page_pdf.py
@@ -1,0 +1,140 @@
+"""Regression tests for complete multi-page PDF extraction.
+
+Run:
+  cd scripts/receipts-consumer && \
+  CF_ACCOUNT_ID=d CF_QUEUE_ID=d CF_API_TOKEN=d \
+  RECEIPTS_EXTRACT_URL=http://d RECEIPTS_PROCESSOR_KEY=d MLX_MODEL=d \
+  .venv/bin/python3 -m unittest test_multi_page_pdf -v
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+os.environ.setdefault("CF_ACCOUNT_ID", "d")
+os.environ.setdefault("CF_QUEUE_ID", "d")
+os.environ.setdefault("CF_API_TOKEN", "d")
+os.environ.setdefault("RECEIPTS_EXTRACT_URL", "http://d")
+os.environ.setdefault("RECEIPTS_PROCESSOR_KEY", "d")
+os.environ.setdefault("MLX_MODEL", "d")
+
+import consumer  # type: ignore  # noqa: E402
+import fitz  # noqa: E402
+from PIL import Image  # noqa: E402
+
+
+def _write_colored_pdf(path: str, colors: list[tuple[float, float, float]]) -> None:
+    doc = fitz.open()
+    try:
+        for index, color in enumerate(colors):
+            page = doc.new_page(width=144, height=72)
+            page.draw_rect(page.rect, color=color, fill=color)
+            page.insert_text((12, 36), f"PAGE {index + 1}", color=(0, 0, 0))
+        doc.save(path)
+    finally:
+        doc.close()
+
+
+class TestMultiPagePdf(unittest.TestCase):
+    def test_single_page_pdf_renders_one_png_and_removes_pdf(self):
+        fd, pdf_path = tempfile.mkstemp(suffix=".pdf")
+        os.close(fd)
+        _write_colored_pdf(pdf_path, [(1, 0, 0)])
+
+        png_paths = consumer._rasterize_pdf_pages("receipt-1", pdf_path)
+        try:
+            self.assertEqual(len(png_paths), 1)
+            self.assertFalse(os.path.exists(pdf_path))
+            with Image.open(png_paths[0]) as image:
+                self.assertEqual(image.format, "PNG")
+                self.assertGreater(image.width, image.height)
+        finally:
+            consumer._unlink_paths(png_paths)
+
+    def test_multi_page_pdf_renders_every_page_in_order(self):
+        fd, pdf_path = tempfile.mkstemp(suffix=".pdf")
+        os.close(fd)
+        _write_colored_pdf(pdf_path, [(1, 0, 0), (0, 1, 0)])
+
+        png_paths = consumer._rasterize_pdf_pages("receipt-2", pdf_path)
+        try:
+            self.assertEqual(len(png_paths), 2)
+            self.assertFalse(os.path.exists(pdf_path))
+            with Image.open(png_paths[0]) as first, Image.open(png_paths[1]) as second:
+                first_pixel = first.convert("RGB").getpixel((5, 5))
+                second_pixel = second.convert("RGB").getpixel((5, 5))
+                self.assertGreater(first_pixel[0], first_pixel[1])
+                self.assertGreater(second_pixel[1], second_pixel[0])
+        finally:
+            consumer._unlink_paths(png_paths)
+
+    def test_partial_render_failure_removes_pdf_and_completed_pngs(self):
+        fd, pdf_path = tempfile.mkstemp(suffix=".pdf")
+        os.close(fd)
+        _write_colored_pdf(pdf_path, [(1, 0, 0), (0, 1, 0)])
+
+        original_get_pixmap = fitz.Page.get_pixmap
+        original_mkstemp = tempfile.mkstemp
+        created_pngs: list[str] = []
+
+        def fail_second_page(page, *args, **kwargs):
+            if page.number == 1:
+                raise RuntimeError("synthetic second-page failure")
+            return original_get_pixmap(page, *args, **kwargs)
+
+        def track_tempfile(*args, **kwargs):
+            descriptor, path = original_mkstemp(*args, **kwargs)
+            if kwargs.get("suffix") == ".png":
+                created_pngs.append(path)
+            return descriptor, path
+
+        with (
+            patch.object(fitz.Page, "get_pixmap", new=fail_second_page),
+            patch.object(consumer.tempfile, "mkstemp", side_effect=track_tempfile),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "second-page failure"):
+                consumer._rasterize_pdf_pages("receipt-3", pdf_path)
+
+        self.assertFalse(os.path.exists(pdf_path))
+        self.assertGreaterEqual(len(created_pngs), 1)
+        self.assertTrue(all(not os.path.exists(path) for path in created_pngs))
+
+    def test_run_mlx_sends_all_pages_and_records_page_count(self):
+        output = SimpleNamespace(
+            text='{"rawText":"PAGE 1\\nPAGE 2","merchant":null}'
+        )
+        with (
+            patch.object(consumer, "_load_model", return_value=("model", "processor")),
+            patch("mlx_vlm.utils.load_config", return_value={"model_type": "test"}),
+            patch(
+                "mlx_vlm.prompt_utils.apply_chat_template",
+                return_value="formatted prompt",
+            ) as apply_template,
+            patch("mlx_vlm.generate", return_value=output) as generate,
+        ):
+            result = consumer.run_mlx(["page-1.png", "page-2.png"])
+
+        apply_template.assert_called_once_with(
+            "processor",
+            {"model_type": "test"},
+            consumer.PROMPT,
+            num_images=2,
+        )
+        self.assertEqual(generate.call_args.args[3], ["page-1.png", "page-2.png"])
+        self.assertEqual(generate.call_args.kwargs["max_tokens"], 3000)
+        self.assertEqual(result["sourcePageCount"], 2)
+        self.assertEqual(result["rawText"], "PAGE 1\nPAGE 2")
+
+    def test_run_mlx_rejects_empty_image_list(self):
+        with self.assertRaisesRegex(
+            consumer.PermanentExtractionFailure,
+            "no images available",
+        ):
+            consumer.run_mlx([])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/receipts/extraction-provenance.test.ts
+++ b/tests/receipts/extraction-provenance.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { coerceSourcePageCount } from "@/lib/receipts/extraction";
+
+test("source page count accepts positive safe integers", () => {
+  assert.equal(coerceSourcePageCount(1), 1);
+  assert.equal(coerceSourcePageCount(2), 2);
+  assert.equal(coerceSourcePageCount(Number.MAX_SAFE_INTEGER), Number.MAX_SAFE_INTEGER);
+});
+
+test("source page count rejects malformed or unsafe provenance", () => {
+  for (const value of [
+    undefined,
+    null,
+    0,
+    -1,
+    1.5,
+    Number.POSITIVE_INFINITY,
+    Number.MAX_SAFE_INTEGER + 1,
+    "2",
+  ]) {
+    assert.equal(coerceSourcePageCount(value), undefined);
+  }
+});


### PR DESCRIPTION
## Summary

Completes multi-page PDF extraction (backlog #13). The Mac MLX consumer previously rendered only page 0 of a PDF; multi-page receipts lost every subsequent page from OCR.

- **consumer.py**: `fetch_image` → `fetch_images` renders one ~200 DPI PNG per page in order; `run_mlx` passes all page images to mlx-vlm with `num_images` and a page-scaled output budget (`min(1500 × pages, 6000)`); `sourcePageCount` persisted to extraction result. All temp page files cleaned up on success/failure; partial-failure cleanup added. Zero-byte / empty-input / no-page cases become permanent failures.
- **route.ts** (`/api/receipts/[id]/extract`): accepts and persists `sourcePageCount` as extraction provenance via new `coerceSourcePageCount` validator; carries forward prior provenance when rawText is reused.
- **extraction.ts / types.ts**: `coerceSourcePageCount` (positive safe integer) + `ExtractionResult.sourcePageCount`.

Automation and bulk backfill remain PARKED (per backlog). This only unblocks correct extraction for new/queued captures once the consumer is restarted.

## Verification (Mac, live bindings)

- `npm run build:cf` ✅
- `npm run cf:dev` ✅ boots, all bindings resolved, serves HTTP 200
- `npm run test` ✅ 1060 pass / 0 fail / 1 skipped (incl. new `extraction-provenance.test.ts`)
- Consumer regression suite (`test_multi_page_pdf.py`) covers single-page compat, multi-page order/completeness, partial-failure cleanup, multi-image model input, empty-input rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)