### PR TITLE
feat(receipts): per-row closing-attention reason badges in review queue

### DIFF
--- a/app/(receipt-system)/receipts/review/[id]/page.tsx
+++ b/app/(receipt-system)/receipts/review/[id]/page.tsx
@@ -15,7 +15,7 @@ import { ImagePane } from "@/components/receipts/review/image-pane";
 import { FormPane } from "@/components/receipts/review/form-pane";
 import { listOpenExportMonths, naturalMonthForDate } from "@/lib/receipts/membership";
 import { getReceiptLocks, UNLOCKED_RECEIPT } from "@/lib/receipts/receipt-locks";
-import { collectClosingAttentionReceiptIds } from "@/lib/receipts/review-attention";
+import { collectClosingAttentionReasons } from "@/lib/receipts/review-attention";
 import { loadClosingScopeWorkingSet } from "@/lib/receipts/review-scope";
 import { DEFAULT_SORT, sortQueueItems } from "@/lib/receipts/queue-sort";
 import {
@@ -143,7 +143,8 @@ async function renderReceiptPage(
   const locks = await getReceiptLocks(dedupeReceipts([receipt, ...workingReceipts]));
   const activeLock = locks.get(receipt.id) ?? UNLOCKED_RECEIPT;
 
-  const attentionIds = await collectClosingAttentionReceiptIds(workingReceipts);
+  const attentionReasons = await collectClosingAttentionReasons(workingReceipts);
+  const attentionIds = new Set(attentionReasons.keys());
   const queue = filterReviewQueue(workingReceipts, filter, {
     statusFilter,
     paymentPathFilter,
@@ -156,17 +157,12 @@ async function renderReceiptPage(
   const amexFlags = await getAmexMatchFlagsByReceiptIds(
     queue.map((r) => r.id).concat(queue.some((r) => r.id === id) ? [] : [id]),
   );
-  const reReviewIds = new Set(
-    [...amexFlags.entries()]
-      .filter(([, f]) => f.reReviewNeeded)
-      .map(([rid]) => rid),
-  );
   const activeFlags = amexFlags.get(id);
 
   // Server-side default sort matches the hydrated client (date-asc, undated
   // last) so the next/prev fallback follows the same order as the sorted rail.
   const queueItems = sortQueueItems(
-    buildQueueItems(queue, reReviewIds, Date.now(), locks),
+    buildQueueItems(queue, attentionReasons, Date.now(), locks),
     DEFAULT_SORT,
   );
   const activeIndex = queueItems.findIndex((q) => q.id === id);

--- a/app/(receipt-system)/receipts/review/page.tsx
+++ b/app/(receipt-system)/receipts/review/page.tsx
@@ -1,7 +1,6 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import {
-  getAmexMatchFlagsByReceiptIds,
   listAmexLineCountsByMonth,
   listDistinctTransactionMonths,
   listReceiptRecords,
@@ -11,7 +10,7 @@ import { assertReceiptsPageAccess } from "@/lib/receipts/auth-request";
 import { ReviewLayout } from "@/components/receipts/review/review-layout";
 import { buildQueueItems } from "@/lib/receipts/queue-items";
 import { getReceiptLocks } from "@/lib/receipts/receipt-locks";
-import { collectClosingAttentionReceiptIds } from "@/lib/receipts/review-attention";
+import { collectClosingAttentionReasons } from "@/lib/receipts/review-attention";
 import { loadClosingScopeWorkingSet } from "@/lib/receipts/review-scope";
 import { DEFAULT_SORT, sortQueueItems } from "@/lib/receipts/queue-sort";
 import { resolveWorkMonth, withWorkMonth } from "@/lib/receipts/work-month";
@@ -90,7 +89,8 @@ async function renderReviewPage(
   }
 
   const locks = await getReceiptLocks(workingReceipts);
-  const attentionIds = await collectClosingAttentionReceiptIds(workingReceipts);
+  const attentionReasons = await collectClosingAttentionReasons(workingReceipts);
+  const attentionIds = new Set(attentionReasons.keys());
   const queue = filterReviewQueue(workingReceipts, filter, {
     statusFilter,
     paymentPathFilter,
@@ -100,17 +100,11 @@ async function renderReviewPage(
     amexMatchedIds,
   });
 
-  const amexFlags = await getAmexMatchFlagsByReceiptIds(queue.map((r) => r.id));
-  const reReviewIds = new Set(
-    [...amexFlags.entries()]
-      .filter(([, f]) => f.reReviewNeeded)
-      .map(([rid]) => rid),
-  );
   // Server-side default sort matches the hydrated client (date-asc, undated
   // last) so the bare-URL redirect + next/prev fallback land on the same row
   // the sorted rail shows.
   const queueItems = sortQueueItems(
-    buildQueueItems(queue, reReviewIds, Date.now(), locks),
+    buildQueueItems(queue, attentionReasons, Date.now(), locks),
     DEFAULT_SORT,
   );
 

--- a/components/receipts/review/queue-rail.tsx
+++ b/components/receipts/review/queue-rail.tsx
@@ -6,6 +6,7 @@ import { useEffect, useMemo, useRef } from "react";
 import { Kbd } from "@/components/ui/kbd";
 import { ReceiptThumb } from "@/components/receipts/ui/receipt-thumb";
 import { useKeyboardShortcuts } from "@/lib/receipts/keyboard";
+import { CLOSING_ATTENTION_LABELS } from "@/lib/receipts/attention-codes";
 import { useQueueControls } from "@/components/receipts/review/queue-controls";
 
 export function QueueRail({
@@ -98,9 +99,17 @@ export function QueueRail({
                   <span className="h-[3px] w-[3px] rounded-full bg-gray-300" />
                   <span className="truncate">{item.categoryLabel}</span>
                 </div>
-                {item.needs && (
-                  <span className="mt-1 inline-block rounded bg-amber-100 px-1.5 py-px text-[10px] font-semibold text-amber-700">
-                    needs {item.needs}
+                {item.attentionCodes.length > 0 && !item.locked && (
+                  <span
+                    className="mt-1 inline-block rounded bg-amber-100 px-1.5 py-px text-[10px] font-semibold text-amber-700"
+                    title={item.attentionCodes
+                      .map((c) => CLOSING_ATTENTION_LABELS[c])
+                      .join(" · ")}
+                  >
+                    {CLOSING_ATTENTION_LABELS[item.attentionCodes[0]]}
+                    {item.attentionCodes.length > 1
+                      ? ` +${item.attentionCodes.length - 1}`
+                      : ""}
                   </span>
                 )}
                 {item.stuck && (

--- a/lib/receipts/attention-codes.ts
+++ b/lib/receipts/attention-codes.ts
@@ -1,0 +1,68 @@
+// Client-safe closing-attention codes + labels.
+//
+// Pure data — no db / server imports — so the client-side queue-rail
+// (components/receipts/review/queue-rail.tsx, a "use client" component) can
+// render a per-row badge from the reason map produced by the closing-attention
+// authority (lib/receipts/review-attention.ts) WITHOUT dragging
+// @/lib/cloudflare-runtime into the browser bundle.
+//
+// The `import type` below is erased at compile time (isolatedModules), so
+// referencing AmexLineSignoffCode as a TYPE adds neither reconciliation-signoff.ts
+// nor any of its imports to the client bundle. (reconciliation-signoff.ts has no
+// server-runtime imports today anyway, but the type-only import is what keeps
+// this contract future-proof if that ever changes.)
+
+import type { AmexLineSignoffCode } from "@/lib/receipts/reconciliation-signoff";
+
+/**
+ * The reason(s) one receipt needs closing attention. Emitted in canonical
+ * check order (1)→(9) by {@link computeClosingAttentionReasons}. The `amex_*`
+ * codes mirror {@link AmexLineSignoffCode} one-for-one (provenance kept) plus
+ * `amex_total_mismatch` for a consolidated-line total mismatch.
+ */
+export type ClosingAttentionCode =
+  | "extraction_pending" // check (1): pending / stuck extraction
+  | "extraction_failed" // check (1): extraction_state === 'failed'
+  | "unreviewed" // check (2)
+  | "unknown_path" // check (3)
+  | "missing_date" // check (4) gates, one code per gate
+  | "missing_merchant"
+  | "missing_amount"
+  | "missing_category"
+  | "attendees_missing"
+  | "attendee_unresolved"
+  | "missing_proof_file"
+  | "compliance_open" // check (5)
+  | `amex_${AmexLineSignoffCode}` // check (6): line sign-off, provenance kept
+  | "amex_total_mismatch" // check (6): consolidated mismatch
+  | "cross_month_ambiguous" // check (7)
+  | "possible_duplicate" // check (8)
+  | "ic_topup_candidate"; // check (9)
+
+/** Short operator-facing labels for the rail badge + tooltip (render at 10px). */
+export const CLOSING_ATTENTION_LABELS: Record<ClosingAttentionCode, string> = {
+  extraction_pending: "processing",
+  extraction_failed: "extraction failed",
+  unreviewed: "unreviewed",
+  unknown_path: "unknown payment path",
+  missing_date: "no date",
+  missing_merchant: "no merchant",
+  missing_amount: "no amount",
+  missing_category: "no category",
+  attendees_missing: "attendees missing",
+  attendee_unresolved: "attendee not in directory",
+  missing_proof_file: "no proof file",
+  compliance_open: "compliance check",
+  amex_unresolved_match: "AMEX match unresolved",
+  amex_missing_category: "AMEX category missing",
+  amex_matched_not_confirmed: "AMEX match unconfirmed",
+  amex_missing_reason: "AMEX reason missing",
+  amex_attendees_required: "AMEX attendees required",
+  amex_attendee_unresolved: "AMEX attendee unresolved",
+  amex_business_trip_candidate: "business-trip candidate",
+  amex_re_review_needed: "re-review",
+  amex_total_mismatch: "AMEX total mismatch",
+  cross_month_ambiguous: "cross-month match",
+  possible_duplicate: "possible duplicate",
+  ic_topup_candidate: "IC top-up?",
+};

--- a/lib/receipts/queue-items.ts
+++ b/lib/receipts/queue-items.ts
@@ -1,10 +1,8 @@
-import {
-  requiresAttendees as categoryRequiresAttendees,
-  getCategoryByCode,
-} from "@/lib/receipts/categories";
+import { getCategoryByCode } from "@/lib/receipts/categories";
 import { isPendingProcessing } from "@/lib/receipts/extraction-state";
 import type { ReceiptLockInfo, ReceiptLockKind } from "@/lib/receipts/receipt-locks";
 import type { ReceiptRecord } from "@/lib/receipts/types";
+import type { ClosingAttentionCode } from "@/lib/receipts/attention-codes";
 
 /** Audit B6 / Task 4: per-receipt "stuck?" threshold for the review queue.
  *  Receipts pending extraction older than this get an amber badge in the
@@ -20,7 +18,10 @@ export type QueueItem = {
   dateLabel: string;
   categoryLabel: string;
   status: ReceiptRecord["status"];
-  needs: "attendees" | "purpose" | "re-review" | null;
+  /** Closing-attention reason codes for this receipt (empty when none). The
+   *  single authority is lib/receipts/review-attention.ts; the rail renders one
+   *  amber badge whose label is the first code and whose tooltip lists all. */
+  attentionCodes: ClosingAttentionCode[];
   /** True when this receipt is pending extraction and was enqueued/captured
    *  more than STUCK_PENDING_MS ago. The queue-rail renders an amber
    *  "stuck?" badge to flag a likely-stalled consumer. */
@@ -47,7 +48,7 @@ export type QueueItem = {
 
 export function buildQueueItems(
   receipts: ReceiptRecord[],
-  reReviewIds: ReadonlySet<string> = new Set(),
+  attentionReasons: ReadonlyMap<string, ClosingAttentionCode[]> = new Map(),
   now: number = Date.now(),
   locks: ReadonlyMap<string, ReceiptLockInfo> = new Map(),
 ): QueueItem[] {
@@ -64,7 +65,7 @@ export function buildQueueItems(
       dateLabel: formatDate(r.transaction_date ?? captured.slice(0, 10)),
       categoryLabel: cat ? cat.enName : code ? code : "Uncategorized",
       status: r.status,
-      needs: needsFlag(r, code, reReviewIds.has(r.id)),
+      attentionCodes: attentionReasons.get(r.id) ?? [],
       stuck: isStuckPending(r, now),
       extractionFailed: failure.failed,
       failureReason: failure.reason,
@@ -121,20 +122,6 @@ function isStuckPending(r: ReceiptRecord, now: number): boolean {
   const t = Date.parse(since);
   if (Number.isNaN(t)) return false;
   return now - t >= STUCK_PENDING_MS;
-}
-
-function needsFlag(
-  r: ReceiptRecord,
-  code: string,
-  reReviewNeeded: boolean,
-): "attendees" | "purpose" | "re-review" | null {
-  if (r.status === "exported" || r.status === "archived") return null;
-  if (reReviewNeeded) return "re-review";
-  if (categoryRequiresAttendees(code)) {
-    if (!r.business_purpose) return "attendees";
-  }
-  if (code === "meeting" && !r.business_purpose) return "purpose";
-  return null;
 }
 
 function formatAmount(amount: number | null, currency: string | null) {

--- a/lib/receipts/queue-sort.ts
+++ b/lib/receipts/queue-sort.ts
@@ -30,10 +30,11 @@ export const SORT_OPTIONS: ReadonlyArray<{ value: SortKey; label: string }> = [
   { value: "merchant-az", label: "Merchant A–Z" },
 ];
 
-/** True for "Needs first" partitioning: the row carries an attention badge,
- *  is stuck pending, or failed extraction. Shared by the comparator + tests. */
+/** True for "Needs first" partitioning: the row carries a closing-attention
+ *  reason (the same authority that drives the pill + "Needs review" tab), is
+ *  stuck pending, or failed extraction. Shared by the comparator + tests. */
 export function needsFirst(item: QueueItem): boolean {
-  return item.needs !== null || item.stuck || item.extractionFailed;
+  return item.attentionCodes.length > 0 || item.stuck || item.extractionFailed;
 }
 
 /** True when the row has no parseable date — sortDateMs is the 0 sentinel
@@ -59,7 +60,7 @@ function compareByDate(a: QueueItem, b: QueueItem, dir: 1 | -1): number {
  *  - date-asc / date-desc: by date, undated last in both orders.
  *  - amount-desc: by amount, unknown amounts (-1) last.
  *  - merchant-az: case-insensitive.
- *  - needs: needs/stuck/failed first, each group date-desc (undated last). */
+ *  - needs: attention/stuck/failed first, each group date-desc (undated last). */
 export function sortQueueItems(items: QueueItem[], sortKey: SortKey): QueueItem[] {
   const copy = items.slice();
   switch (sortKey) {

--- a/lib/receipts/review-attention.ts
+++ b/lib/receipts/review-attention.ts
@@ -2,16 +2,21 @@
 //
 // A receipt is in "Needs review" when it is implicated by a receipt-addressable
 // blocker or warning surfaced during monthly closing. This module is the SINGLE
-// authority for that set: both review pages (the queue filter) and the amber
-// "N need attention" pill consume the exact same Set<string> it returns, so the
-// count can never drift from the tab.
+// authority for that set: THREE consumers read one computation —
+//   - the queue filter ("Needs review" tab),
+//   - the amber "N need attention" pill (count = unlocked ∩ attention), and
+//   - the per-row reason badges in the queue-rail (which reason(s) fired).
+// They cannot drift from each other: the badges, the count, and the tab all
+// derive from {@link computeClosingAttentionReasons}.
 //
 // Architecture mirrors the finalize gate (lib/receipts/month-closing.ts): a PURE
-// synchronous core ({@link computeClosingAttentionReceiptIds}) that takes
-// pre-loaded supporting data, and an async wrapper
-// ({@link collectClosingAttentionReceiptIds}) that batch-loads it. The core is
-// unit-tested without D1; the wrapper does ONE batched query per data kind
-// (no per-receipt round-trips).
+// synchronous core ({@link computeClosingAttentionReasons}) that takes
+// pre-loaded supporting data and returns the reason CODES per receipt, and an
+// async wrapper ({@link collectClosingAttentionReasons}) that batch-loads it.
+// The core is unit-tested without D1; the wrapper does ONE batched query per
+// data kind (no per-receipt round-trips). Membership-only adapters
+// ({@link computeClosingAttentionReceiptIds} / {@link collectClosingAttentionReceiptIds})
+// remain so every existing membership test is unchanged.
 //
 // Rule predicates are SHARED with the monthly-close / reconciliation-signoff /
 // compliance / blockers authorities so the attention set cannot drift from
@@ -46,7 +51,24 @@ import {
   crossMonthAmbiguousReceiptIds,
   evaluateAmexLineSignoff,
 } from "@/lib/receipts/reconciliation-signoff";
+import type { AmexLineSignoffCode } from "@/lib/receipts/reconciliation-signoff";
 import type { AmexStatementLine, ReceiptRecord } from "@/lib/receipts/types";
+import type { ClosingAttentionCode } from "@/lib/receipts/attention-codes";
+
+/** Canonical emission order for check (6) — mirrors evaluateAmexLineSignoff's
+ *  push order so the per-receipt badge label is deterministic regardless of
+ *  which matched line fired first (the query order of amexLines is not
+ *  guaranteed to be this order). `amex_total_mismatch` is appended last. */
+const AMEX_SIGNOFF_ORDER: readonly AmexLineSignoffCode[] = [
+  "unresolved_match",
+  "missing_category",
+  "matched_not_confirmed",
+  "missing_reason",
+  "attendees_required",
+  "attendee_unresolved",
+  "business_trip_candidate",
+  "re_review_needed",
+];
 
 /** Inputs the pure core needs, fetched by the async wrapper. */
 export interface ClosingAttentionInput {
@@ -70,34 +92,42 @@ export interface ClosingAttentionInput {
 }
 
 /**
- * PURE core: the set of receipt ids (within `receipts`) that need closing
- * attention. Deterministic given the inputs — no I/O, no Date.now. Both the
- * "Needs review" filter tab and the amber need-attention pill consume this
- * exact set.
+ * PURE core: the reason codes per receipt (within `receipts`) that need closing
+ * attention. Deterministic given the inputs — no I/O, no Date.now. The "Needs
+ * review" filter tab, the amber need-attention pill, AND the per-row rail badges
+ * all derive from this map (the tab/pill use `.keys()`; the badges use the
+ * codes). A clean receipt is ABSENT from the map (not present with `[]`).
+ *
+ * Codes accumulate per receipt in the canonical check order (1)→(9); a receipt
+ * failing several gates carries several codes. The exception is check (1): a
+ * receipt still pending or that failed extraction is evaluated ONLY against (1)
+ * — it carries exactly `["extraction_pending"]` or `["extraction_failed"]` so a
+ * half-extracted row does not spray "no merchant / no amount" noise.
  *
  * A receipt is included when ANY of these hold (see the spec's categories):
- *   - pending/stuck/failed extraction (captured not yet processed, or failed);
- *   - unreviewed (needs_review, not still pending);
- *   - UNKNOWN payment path;
- *   - receipt-level closing gates: missing date / merchant / amount / category,
+ *   - (1) pending/stuck/failed extraction (captured not yet processed, or failed);
+ *   - (2) unreviewed (needs_review, not still pending);
+ *   - (3) UNKNOWN payment path;
+ *   - (4) receipt-level closing gates: missing date / merchant / amount / category,
  *     required attendees missing, an attendee not resolvable via the directory,
- *     or no proof file row;
- *   - an open compliance check at severity blocker OR warning;
- *   - implicated by an AMEX-line sign-off rule on one of its matched lines
+ *     or no proof file row (one code per failed gate);
+ *   - (5) an open compliance check at severity blocker OR warning;
+ *   - (6) implicated by an AMEX-line sign-off rule on one of its matched lines
  *     (unresolved/unconfirmed match, unresolved category, missing reason,
- *     attendee problem, business-trip candidate, re_review_needed) or a
- *     consolidated-line total mismatch;
- *   - matched to AMEX lines in more than one statement month (cross-month
+ *     attendee problem, business-trip candidate, re_review_needed) — one
+ *     `amex_*` code per fired rule, deduped across the receipt's lines — or a
+ *     consolidated-line total mismatch (`amex_total_mismatch`);
+ *   - (7) matched to AMEX lines in more than one statement month (cross-month
  *     ambiguity);
- *   - a member of a possible-duplicate CASH/DIGITAL cluster;
- *   - a likely IC-card top-up candidate.
+ *   - (8) a member of a possible-duplicate CASH/DIGITAL cluster;
+ *   - (9) a likely IC-card top-up candidate.
  *
  * Issues that live only on an AMEX line with no matched receipt cannot appear
  * here (there is no receipt to add) — they stay on Reconcile/Export.
  */
-export function computeClosingAttentionReceiptIds(
+export function computeClosingAttentionReasons(
   input: ClosingAttentionInput,
-): Set<string> {
+): Map<string, ClosingAttentionCode[]> {
   const {
     receipts,
     amexLines,
@@ -109,38 +139,41 @@ export function computeClosingAttentionReceiptIds(
     crossMonthMatchedLines,
   } = input;
 
-  const attention = new Set<string>();
+  const reasonsByReceipt = new Map<string, ClosingAttentionCode[]>();
   const workingSetIds = new Set(receipts.map((r) => r.id));
-  const add = (id: string | null | undefined) => {
-    if (id && workingSetIds.has(id)) attention.add(id);
-  };
 
   // Pre-compute the AMEX-derived attention signals once (they implicate matched
-  // receipts, independent of the per-receipt loop).
-  const signoffImplicated = new Set<string>();
+  // receipts, independent of the per-receipt loop). Collect the fired sign-off
+  // codes per receipt (deduped across the receipt's matched lines).
+  const signoffSets = new Map<string, Set<string>>();
+  const addSignoff = (receiptId: string, codes: Iterable<string>) => {
+    if (!workingSetIds.has(receiptId)) return; // line-only issue → no receipt
+    let set = signoffSets.get(receiptId);
+    if (!set) {
+      set = new Set();
+      signoffSets.set(receiptId, set);
+    }
+    for (const c of codes) set.add(c);
+  };
+  const receiptById = new Map(receipts.map((r) => [r.id, r]));
   for (const line of amexLines) {
-    const receipt = line.matched_receipt_id ? line.matched_receipt_id : null;
+    const receipt = line.matched_receipt_id;
     if (!receipt) continue; // line-only issue → no receipt to implicate
     const lineDirect = amexAttendees[line.id] ?? [];
     const receiptAttendees = receiptAttendeeMap.get(receipt) ?? [];
-    // The matched receipt object (for category resolution). It is in the
-    // working set by construction (lines are loaded by matched_receipt_id IN
-    // the working set); fall back to undefined if absent.
-    const receiptRecord = receipts.find((r) => r.id === receipt);
     const result = evaluateAmexLineSignoff(
       line,
-      receiptRecord ?? undefined,
+      receiptById.get(receipt) ?? undefined,
       lineDirect,
       receiptAttendees,
       attendeeDirectory,
     );
-    if (result.codes.length > 0) signoffImplicated.add(receipt);
+    if (result.codes.length > 0) {
+      addSignoff(receipt, result.codes.map((c) => `amex_${c}`));
+    }
   }
-  for (const m of collectConsolidatedMismatches(
-    amexLines,
-    new Map(receipts.map((r) => [r.id, r])),
-  )) {
-    signoffImplicated.add(m.receiptId);
+  for (const m of collectConsolidatedMismatches(amexLines, receiptById)) {
+    addSignoff(m.receiptId, ["amex_total_mismatch"]);
   }
   const crossMonthIds = crossMonthAmbiguousReceiptIds(crossMonthMatchedLines);
   const duplicateIds = new Set<string>();
@@ -150,87 +183,85 @@ export function computeClosingAttentionReceiptIds(
 
   for (const r of receipts) {
     const code = r.expense_category_code ?? "";
+    const reasons: ClosingAttentionCode[] = [];
 
-    // (1) Pending / stuck / failed extraction.
-    if (isPendingProcessing(r) || r.extraction_state === "failed") {
-      attention.add(r.id);
+    // (1) Pending / stuck / failed extraction. `failed` is not a pending state,
+    // so the two codes are mutually exclusive. Either way the receipt is NOT
+    // evaluated against (2)–(9): a half-extracted row must not spray
+    // "no merchant / no amount" noise.
+    if (isPendingProcessing(r)) reasons.push("extraction_pending");
+    if (r.extraction_state === "failed") reasons.push("extraction_failed");
+    if (reasons.length > 0) {
+      reasonsByReceipt.set(r.id, reasons);
       continue;
     }
+
     // (2) Unreviewed.
-    if (isUnreviewedReceipt(r)) {
-      attention.add(r.id);
-      continue;
-    }
+    if (isUnreviewedReceipt(r)) reasons.push("unreviewed");
     // (3) UNKNOWN payment path.
-    if (isUnknownPathReceipt(r)) {
-      attention.add(r.id);
-      continue;
-    }
-
-    // (4) Receipt-level closing gates.
-    let gate = false;
-    if (!r.transaction_date) gate = true;
-    if (!r.merchant) gate = true;
-    if (r.amount_minor === null) gate = true;
-    if (!r.expense_category_code) gate = true;
+    if (isUnknownPathReceipt(r)) reasons.push("unknown_path");
+    // (4) Receipt-level closing gates — one code per failed gate.
+    if (!r.transaction_date) reasons.push("missing_date");
+    if (!r.merchant) reasons.push("missing_merchant");
+    if (r.amount_minor === null) reasons.push("missing_amount");
+    if (!r.expense_category_code) reasons.push("missing_category");
     if (requiresAttendees(code)) {
       const names = receiptAttendeeMap.get(r.id) ?? [];
       if (names.length === 0) {
-        gate = true;
+        reasons.push("attendees_missing");
       } else {
         const { unresolved } = resolveAttendeeNames(names, attendeeDirectory);
-        if (unresolved.length > 0) gate = true;
+        if (unresolved.length > 0) reasons.push("attendee_unresolved");
       }
     }
-    if (isReceiptMissingProofFile(r.id, receiptFileCounts)) gate = true;
-    if (gate) {
-      attention.add(r.id);
-      continue;
+    if (isReceiptMissingProofFile(r.id, receiptFileCounts)) {
+      reasons.push("missing_proof_file");
     }
-
     // (5) Open compliance check (blocker or warning).
-    if (complianceFlaggedReceiptIds.has(r.id)) {
-      attention.add(r.id);
-      continue;
+    if (complianceFlaggedReceiptIds.has(r.id)) reasons.push("compliance_open");
+    // (6) AMEX sign-off / consolidated mismatch — deduped, canonical order.
+    const signoff = signoffSets.get(r.id);
+    if (signoff && signoff.size > 0) {
+      for (const sc of AMEX_SIGNOFF_ORDER) {
+        const key = `amex_${sc}` as ClosingAttentionCode;
+        if (signoff.has(key)) reasons.push(key);
+      }
+      if (signoff.has("amex_total_mismatch")) reasons.push("amex_total_mismatch");
     }
-
-    // (6) AMEX sign-off / consolidated mismatch.
-    if (signoffImplicated.has(r.id)) {
-      attention.add(r.id);
-      continue;
-    }
-
     // (7) Cross-month ambiguous match.
-    if (crossMonthIds.has(r.id)) {
-      attention.add(r.id);
-      continue;
-    }
-
+    if (crossMonthIds.has(r.id)) reasons.push("cross_month_ambiguous");
     // (8) Duplicate cluster member.
-    if (duplicateIds.has(r.id)) {
-      attention.add(r.id);
-      continue;
-    }
-
+    if (duplicateIds.has(r.id)) reasons.push("possible_duplicate");
     // (9) IC-card top-up candidate.
-    if (isIcCardTopUpCandidate(r)) {
-      attention.add(r.id);
-      continue;
-    }
+    if (isIcCardTopUpCandidate(r)) reasons.push("ic_topup_candidate");
+
+    if (reasons.length > 0) reasonsByReceipt.set(r.id, reasons);
   }
 
-  return attention;
+  return reasonsByReceipt;
+}
+
+/**
+ * PURE membership adapter: the set of receipt ids (within `receipts`) that need
+ * closing attention — i.e. the keys of {@link computeClosingAttentionReasons}.
+ * Deterministic given the inputs — no I/O, no Date.now. Both the "Needs review"
+ * filter tab and the amber need-attention pill consume this exact set.
+ */
+export function computeClosingAttentionReceiptIds(
+  input: ClosingAttentionInput,
+): Set<string> {
+  return new Set(computeClosingAttentionReasons(input).keys());
 }
 
 /**
  * Async wrapper: batch-load everything the core needs (one query per kind, no
- * per-receipt round-trips) and return the attention set for `receipts`.
- * `now` defaults to Date.now(); tests should pass an explicit value via the
- * pure core instead.
+ * per-receipt round-trips) and return the reason map for `receipts`. `now`
+ * defaults to Date.now(); tests should pass an explicit value via the pure core
+ * instead.
  */
-export async function collectClosingAttentionReceiptIds(
+export async function collectClosingAttentionReasons(
   receipts: ReceiptRecord[],
-): Promise<Set<string>> {
+): Promise<Map<string, ClosingAttentionCode[]>> {
   const ids = receipts.map((r) => r.id);
   const db = getReceiptsDb();
 
@@ -255,7 +286,7 @@ export async function collectClosingAttentionReceiptIds(
     matched_receipt_id: l.matched_receipt_id ?? "",
   }));
 
-  return computeClosingAttentionReceiptIds({
+  return computeClosingAttentionReasons({
     receipts,
     now: Date.now(),
     amexLines,
@@ -266,4 +297,12 @@ export async function collectClosingAttentionReceiptIds(
     receiptFileCounts,
     crossMonthMatchedLines,
   });
+}
+
+/** Async membership adapter: the attention id set, i.e. the keys of
+ *  {@link collectClosingAttentionReasons}. */
+export async function collectClosingAttentionReceiptIds(
+  receipts: ReceiptRecord[],
+): Promise<Set<string>> {
+  return new Set((await collectClosingAttentionReasons(receipts)).keys());
 }

--- a/tests/receipts/queue-items-locks.test.ts
+++ b/tests/receipts/queue-items-locks.test.ts
@@ -35,7 +35,7 @@ test("buildQueueItems: passes the locked flag + kind through from the locks map"
       receipt({ id: "sealed-export" }),
       receipt({ id: "sealed-recon" }),
     ],
-    new Set(),
+    new Map(),
     Date.UTC(2026, 6, 5),
     new Map([
       ["sealed-export", EXPORT_LOCK],

--- a/tests/receipts/queue-sort.test.ts
+++ b/tests/receipts/queue-sort.test.ts
@@ -15,7 +15,7 @@ function item(partial: Partial<QueueItem> & Pick<QueueItem, "id">): QueueItem {
     dateLabel: "Jul 1",
     categoryLabel: "Transportation",
     status: "reviewed",
-    needs: null,
+    attentionCodes: [],
     stuck: false,
     extractionFailed: false,
     failureReason: null,
@@ -33,8 +33,8 @@ test("needsFirst: false for a clean reviewed row", () => {
   assert.equal(needsFirst(item({ id: "a" })), false);
 });
 
-test("needsFirst: true when needs is set, stuck, OR extractionFailed", () => {
-  assert.equal(needsFirst(item({ id: "a", needs: "attendees" })), true);
+test("needsFirst: true when attentionCodes is non-empty, stuck, OR extractionFailed", () => {
+  assert.equal(needsFirst(item({ id: "a", attentionCodes: ["unreviewed"] })), true);
   assert.equal(needsFirst(item({ id: "a", stuck: true })), true);
   assert.equal(needsFirst(item({ id: "a", extractionFailed: true })), true);
 });
@@ -79,8 +79,8 @@ test("sortQueueItems: merchant-az is case-insensitive alpha", () => {
 test("sortQueueItems: 'needs' surfaces needs/stuck/failed before reviewed, date-desc within each group", () => {
   const items = [
     item({ id: "rev-old", sortDateMs: 1 }),
-    item({ id: "need-new", needs: "attendees", sortDateMs: 100 }),
-    item({ id: "need-old", needs: "purpose", sortDateMs: 50 }),
+    item({ id: "need-new", attentionCodes: ["unreviewed"], sortDateMs: 100 }),
+    item({ id: "need-old", attentionCodes: ["missing_date"], sortDateMs: 50 }),
     item({ id: "rev-new", sortDateMs: 90 }),
   ];
   const out = sortQueueItems(items, "needs");

--- a/tests/receipts/review-attention.test.ts
+++ b/tests/receipts/review-attention.test.ts
@@ -1,6 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { computeClosingAttentionReceiptIds } from "@/lib/receipts/review-attention";
+import {
+  computeClosingAttentionReasons,
+  computeClosingAttentionReceiptIds,
+} from "@/lib/receipts/review-attention";
 import type {
   AmexStatementLine,
   ReceiptRecord,
@@ -112,6 +115,10 @@ function input(
 
 function attentionFor(receipts: ReceiptRecord[], overrides?: Partial<Parameters<typeof computeClosingAttentionReceiptIds>[0]>) {
   return computeClosingAttentionReceiptIds(input(receipts, overrides));
+}
+
+function reasonsFor(receipts: ReceiptRecord[], overrides?: Partial<Parameters<typeof computeClosingAttentionReasons>[0]>) {
+  return computeClosingAttentionReasons(input(receipts, overrides));
 }
 
 // ─── clean receipt is excluded ──────────────────────────────────────────────
@@ -331,4 +338,50 @@ test("attention: only working-set ids are returned (a matched_receipt_id not in 
   const set = attentionFor([makeReceipt()], { amexLines: [line] });
   assert.equal(set.has("not-in-set"), false);
   assert.equal(set.size, 0);
+});
+
+// ─── reason codes (computeClosingAttentionReasons) ──────────────────────────
+
+test("reasons: a clean receipt is ABSENT from the reasons map (not present with [])", () => {
+  const map = reasonsFor([makeReceipt()]);
+  assert.equal(map.has("r-clean"), false);
+});
+
+test("reasons: a receipt failing two gates carries both codes in check order", () => {
+  // No date (gate 1) AND no proof-file row (gate 6) — both fire, in order.
+  const map = reasonsFor(
+    [makeReceipt({ id: "twogates", transaction_date: null })],
+    { receiptFileCounts: new Map() },
+  );
+  assert.deepEqual(map.get("twogates"), ["missing_date", "missing_proof_file"]);
+});
+
+test("reasons: a pending receipt carries exactly ['extraction_pending'] even when it would also fail gates", () => {
+  // Queued + every gate blank: the (1) skip must suppress the gate noise.
+  const map = reasonsFor(
+    [makeReceipt({
+      id: "pend",
+      extraction_state: "queued",
+      status: "captured",
+      transaction_date: null,
+      merchant: null,
+      amount_minor: null,
+      expense_category_code: null,
+    })],
+    { receiptFileCounts: new Map() },
+  );
+  assert.deepEqual(map.get("pend"), ["extraction_pending"]);
+});
+
+test("reasons: AMEX sign-off maps to an amex_ code; the same code from two lines is deduped", () => {
+  // Each confirmed line fires only re_review_needed → amex_re_review_needed;
+  // two lines collapse to one deduped entry. (Line amounts sum to the receipt
+  // total so no consolidated-mismatch code is also emitted.)
+  const lineA = makeLine({ id: "la", matched_receipt_id: "ax", match_status: "confirmed", re_review_needed: 1, amount_minor: 500, expense_category_code: "supplies" });
+  const lineB = makeLine({ id: "lb", matched_receipt_id: "ax", match_status: "confirmed", re_review_needed: 1, amount_minor: 500, expense_category_code: "supplies" });
+  const map = reasonsFor(
+    [makeReceipt({ id: "ax", payment_path: "AMEX" })],
+    { amexLines: [lineA, lineB], receiptFileCounts: new Map([["ax", 1]]) },
+  );
+  assert.deepEqual(map.get("ax"), ["amex_re_review_needed"]);
 });


### PR DESCRIPTION
## Summary

The amber "N need attention" pill on `/receipts/review` reported a count while the queue-rail rows carried no per-row marker from the same authority. The closing-attention core now returns the reason **codes** per receipt (`Map<id, ClosingAttentionCode[]>`); the pill count, the "Needs review" tab, and the new per-row badges all derive from that one computation.

- **New client-safe `lib/receipts/attention-codes.ts`** — `ClosingAttentionCode` union (incl. `amex_<AmexLineSignoffCode>`) + terse labels. Type-only import of `AmexLineSignoffCode` is erased, so the client rail imports labels with no server code in the bundle.
- **`review-attention.ts`** — `computeClosingAttentionReasons` replaces the short-circuit loop; accumulates every firing code in canonical order (1)→(9); pending/failed still skip (2)–(9); per-gate codes for (4); deduped `amex_*` codes for (6). The two `*ReceiptIds` exports become thin adapters over `.keys()` — existing membership tests unchanged.
- **`queue-items.ts`** — `QueueItem.needs` → `attentionCodes`; `needsFlag()` retired (its "re-review" case = `amex_re_review_needed`).
- **`queue-sort.ts`** — `needsFirst = attentionCodes.length>0 || stuck || extractionFailed`.
- **`queue-rail.tsx`** — one amber badge: first label + ` +N`, `title` lists all reasons joined by ` · `; suppressed on locked rows.
- **Both review pages** call `collectClosingAttentionReasons` once; list page drops the now-unused `getAmexMatchFlagsByReceiptIds` call (one query saved per render).

## Verification

- `npx tsc --noEmit` — clean (exit 0)
- `npm run lint` — 0 errors
- `npm test` — 1066 pass / 1 skip / 0 fail (4 new reasons cases)

## Outstanding (prod)

Local `/receipts/*` cannot be served (Clerk `pk_live` rejects localhost), so the live UI check happens in production after merge: pill count N == exactly N unlocked amber-badged rows; hover tooltip shows each row's reasons; "Needs review" tab and "Needs first" sort agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)