### PR TITLE
fix(receipts): email_attachment promote enqueues extraction + /enqueue recovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,15 @@ against mutable state for a sealed artifact. Whoever writes a value that
 crosses a boundary checks that boundary's constraints. Verification that only
 diffs outputs will not catch these.
 
+A concrete recurring boundary: any new `app/api/receipts/[id]/*` handler doing
+processor-key-OR-Clerk layered auth is correct in its module but **must also be
+added to `PUBLIC_ROUTES` in `middleware.ts`** — or Clerk's `auth.protect()`
+404-rewrites the processor-key request before the handler runs. This is the
+*second* occurrence of the PR #59 failure that silently dropped 17 receipts
+(2026-08-09, `/enqueue`; first occurrence documented at `middleware.ts:39-41`).
+The writer of a new processor-key route adds it to `PUBLIC_ROUTES` in the same
+change; `tests/middleware-routing.test.ts` asserts the exemption.
+
 ## Deployment
 
 - Cloudflare build: `npm run build:cf`
@@ -87,14 +96,15 @@ The receipts module (`app/(receipt-system)/receipts/`, `app/api/receipts/`, `lib
 - Owns `wrangler.jsonc` bindings for D1 (`RECEIPTS_DB`, `CRM_DB`), R2 (`RECEIPTS_BUCKET`, `RECEIPTS_ARCHIVE_BUCKET`), and any AI bindings
 - Holds Cloudflare Tunnel config, Access policies, and auth keys
 - Runs SQL migrations against live D1
-- Runs `npm run dev` for fast UI iteration and `npm run cf:dev` for end-to-end runtime testing against real bindings
+- Runs `npm run dev` for fast UI iteration
+- Runs `npm run cf:dev` (`opennextjs-cloudflare preview`) for runtime checks — **local miniflare bindings only**: empty local D1/R2/Queue, and `RECEIPTS_PROCESSOR_KEY` (a wrangler secret) is absent locally. It proves the worker boots and routes are mounted/auth-gated; it is NOT a real-data functional test. Do **not** add `--remote` to the default `cf:dev` script. The live functional gate is post-deploy `bash scripts/check-deployment.sh`.
 - Runs `npm run build:cf` to validate production builds
 - Deploys via `npm run deploy`
 
 ### Workflow
 
 1. Branch from `main` on the Mac
-2. Implement + run `npm run cf:dev` against real bindings to verify behavior
+2. Implement + run `npm run cf:dev` to verify boot/routing/auth-gating (local miniflare bindings — NOT real data; see Mac M4 note above)
 3. `npm run build:cf` must pass
 4. Smoke-test with `bash scripts/check-deployment.sh <base-url>` after deploy
 5. Commit, push, open PR, merge, deploy

--- a/app/api/receipts/[id]/enqueue/route.ts
+++ b/app/api/receipts/[id]/enqueue/route.ts
@@ -1,0 +1,144 @@
+import { NextResponse } from "next/server";
+import { requireReceiptsActor } from "@/lib/receipts/auth";
+import { getReceiptRecord } from "@/lib/receipts/db";
+import { createAuditEntry } from "@/lib/receipts/audit";
+import { nowIso, stringifyJson } from "@/lib/receipts/db-utils";
+import { buildExtractionJob, enqueueExtractionJob } from "@/lib/receipts/queue";
+import { getReceiptsDb, getReceiptsProcessorKey } from "@/lib/cloudflare-runtime";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+const PROCESSOR_ACTOR = "mlx-consumer@mac";
+
+// Constant-time string compare so the processor key can't be probed by timing.
+// Mirrors /proof and /render (the same processor-key path).
+function timingSafeEqual(a: string, b: string): boolean {
+  const enc = new TextEncoder();
+  const ab = enc.encode(a);
+  const bb = enc.encode(b);
+  const len = Math.max(ab.length, bb.length);
+  let mismatch = ab.length ^ bb.length;
+  for (let i = 0; i < len; i += 1) mismatch |= (ab[i] ?? 0) ^ (bb[i] ?? 0);
+  return mismatch === 0;
+}
+
+/**
+ * POST /api/receipts/[id]/enqueue
+ *
+ * Recovery tool for receipts that were captured but never enqueued for MLX
+ * extraction — the email-attachment promote path before its enqueue fix (3 rows
+ * stranded 2026-08-03), or any future capture path that leaves a receipt at
+ * extraction_state='captured' with extraction_enqueued_at IS NULL. Enqueues
+ * exactly one extraction job and advances extraction_state captured → queued so
+ * the Mac consumer drains it through the normal pipeline.
+ *
+ * NOT a general reprocess button. A strict 409 guard admits ONLY the genuine
+ * orphan state (needs_render = 0 AND extraction_state = 'captured' AND
+ * extraction_enqueued_at IS NULL). Anything else — already queued, processing,
+ * processed, failed, or awaiting a Mac render — is rejected with the actual
+ * state named, so the tool can neither re-enqueue a receipt the consumer is
+ * mid-flight on nor bypass the render pipeline (render receipts enqueue via
+ * /render once their derivative lands).
+ *
+ * Auth mirrors /render: a valid x-receipts-processor-key authenticates the Mac
+ * consumer; otherwise a Clerk-authenticated human may call it. Unlike the
+ * capture path, the enqueue here IS the whole point, so a queue send failure is
+ * surfaced as 500 (not swallowed best-effort) and leaves the receipt at
+ * 'captured' for a retry.
+ */
+export async function POST(request: Request, { params }: RouteContext) {
+  try {
+    const processorKey = getReceiptsProcessorKey();
+    const presentedKey = request.headers.get("x-receipts-processor-key");
+    const isProcessor =
+      !!processorKey && !!presentedKey && timingSafeEqual(presentedKey, processorKey);
+    const actor = isProcessor
+      ? PROCESSOR_ACTOR
+      : await requireReceiptsActor(request.headers);
+
+    const { id } = await params;
+
+    const receipt = await getReceiptRecord(id);
+    if (!receipt || receipt.deleted_at) {
+      return NextResponse.json({ error: "Receipt not found." }, { status: 404 });
+    }
+
+    // Strict 409 guard: only the genuine orphan state is admittable.
+    const needsRender = receipt.needs_render === 1;
+    const state = receipt.extraction_state ?? "captured";
+    const alreadyEnqueued = receipt.extraction_enqueued_at != null;
+    if (needsRender || state !== "captured" || alreadyEnqueued) {
+      return NextResponse.json(
+        {
+          error:
+            "Receipt is not in the recoverable state " +
+            "(requires needs_render=0 AND extraction_state='captured' AND extraction_enqueued_at IS NULL). " +
+            `Actual: needs_render=${receipt.needs_render ?? 0}, ` +
+            `extraction_state='${state}', ` +
+            `extraction_enqueued_at=${receipt.extraction_enqueued_at ?? "null"}.`,
+        },
+        { status: 409 },
+      );
+    }
+
+    // Job r2Key matches what /file serves and the consumer expects
+    // (extraction_r2_key ?? original_r2_key); contentType is the original's.
+    const r2Key = receipt.extraction_r2_key ?? receipt.original_r2_key;
+    const contentType = receipt.original_content_type ?? "application/octet-stream";
+    const now = nowIso();
+
+    const enqueued = await enqueueExtractionJob(
+      buildExtractionJob({ receiptId: id, r2Key, contentType, enqueuedAt: now }),
+    );
+    if (!enqueued) {
+      // The enqueue is the whole point of this tool — a silent best-effort false
+      // would defeat it. Surface a 500; the receipt stays at 'captured' for retry.
+      return NextResponse.json(
+        {
+          error:
+            "Extraction queue is unavailable or rejected the job; receipt left at 'captured'.",
+        },
+        { status: 500 },
+      );
+    }
+
+    const db = getReceiptsDb();
+    await db
+      .prepare(
+        `UPDATE receipt_records
+           SET extraction_state = 'queued',
+               extraction_enqueued_at = ?,
+               updated_at = ?
+         WHERE id = ?`,
+      )
+      .bind(now, now, id)
+      .run();
+
+    await createAuditEntry(db, {
+      actor,
+      action: "receipt.extraction_enqueued",
+      objectType: "receipt",
+      objectId: id,
+      newValueJson: stringifyJson({
+        r2Key,
+        contentType,
+        previousState: "captured",
+        via: isProcessor ? "mlx_consumer" : "human",
+      }),
+    });
+
+    return NextResponse.json(
+      { ok: true, receiptId: id, extractionState: "queued" },
+      { status: 200 },
+    );
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Unauthorized")) {
+      return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+    }
+    console.error("[api/receipts/[id]/enqueue] POST failed", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Enqueue failed." },
+      { status: 500 },
+    );
+  }
+}

--- a/lib/receipts/email-intake.ts
+++ b/lib/receipts/email-intake.ts
@@ -18,7 +18,11 @@
 // existing insert path. Do not add a second insert path into receipt_records.
 
 import { getReceiptsDb, getReceiptsBucket } from "@/lib/cloudflare-runtime";
-import { createReceiptRecord, updateReceiptRecord } from "@/lib/receipts/db";
+import {
+  createReceiptRecord,
+  hardDeleteReceipt,
+  updateReceiptRecord,
+} from "@/lib/receipts/db";
 import { createAuditEntry } from "@/lib/receipts/audit";
 import {
   buildExtractionJob,
@@ -32,7 +36,7 @@ import {
   sanitizeFilenameForR2,
   computeSha256Hex,
 } from "@/lib/receipts/storage";
-import { createReceiptFile } from "@/lib/receipts/files";
+import { createReceiptFile, type CreateReceiptFileInput } from "@/lib/receipts/files";
 import {
   ALLOWED_RECEIPT_MIME_TYPES,
   ALLOWED_RECEIPT_EXTENSIONS,
@@ -479,6 +483,40 @@ export function buildPromoteExtractionJob(input: {
 }
 
 /**
+ * Build the is_original receipt_files manifest row input for a just-promoted
+ * attachment receipt — the OTHER pure half of promoteIntake (alongside
+ * buildPromoteReceiptInput and buildPromoteExtractionJob). r2Key is the STANDARD
+ * receipts/... key from step 3, NEVER the intake key (r2_key is UNIQUE and step
+ * 5 deletes the intake object), and isOriginal is always true — the attachment
+ * IS the receipt's true original, mirroring promoteBodyIntake. Exported so the
+ * standard-key + isOriginal invariants are unit-testable without exercising the
+ * binding-coupled promoteIntake body. Before this, the attachment branch wrote
+ * the receipt but never its manifest row — leaving email_attachment receipts
+ * with zero file rows, which blocks month finalize under the proofs gate.
+ */
+export function buildPromoteFileInput(args: {
+  receiptId: string;
+  standardKey: string;
+  intake: EmailReceiptIntake;
+  fileSizeFallbackBytes: number;
+  actor: string;
+}): CreateReceiptFileInput {
+  return {
+    objectType: "receipt",
+    objectId: args.receiptId,
+    role: "original",
+    r2Bucket: "receipts",
+    r2Key: args.standardKey,
+    originalFilename: args.intake.attachment_filename ?? "attachment",
+    contentType: args.intake.attachment_content_type ?? "application/octet-stream",
+    fileSizeBytes: args.intake.attachment_size_bytes ?? args.fileSizeFallbackBytes,
+    sha256Hash: args.intake.attachment_sha256 as string,
+    uploadedBy: args.actor,
+    isOriginal: true,
+  };
+}
+
+/**
  * Refuse promotion for rows that have nothing to promote or are no longer
  * pending. Throws a plain Error whose message is safe to surface as 409 body.
  * ADR 0011 Phase B: a body-only row (no attachment, but a captured text/html
@@ -712,7 +750,58 @@ export async function promoteIntake(
     .bind(standardKey, now, receiptId)
     .run();
 
-  // 3.5. Enqueue the extraction job for the Mac MLX consumer (ADR 0001). Same
+  // 3.5. Write the is_original receipt_files manifest row — the OTHER step the
+  //      body branch (promoteBodyIntake) performs that this branch had skipped
+  //      (same divergence root cause as the enqueue). r2_key is the standard key
+  //      (UNIQUE; the intake key is deleted in step 5). Ordered BEFORE the
+  //      enqueue (3.6) so a fast consumer drain can't outrun the manifest, and
+  //      before the intake flip (step 4) so a failure here leaves the intake row
+  //      re-promotable. Unlike the enqueue (best-effort), a manifest-write
+  //      failure fails LOUDLY (backlog #5 / audit A1): the proofs gate counts
+  //      file rows (validateMonthReadyForExportCore), so a half-promoted receipt
+  //      with no manifest row would silently block month finalize. Follow the
+  //      upload-route precedent — compensating-delete the R2 object + receipt
+  //      and throw, rather than leave a half-promoted row.
+  try {
+    await createReceiptFile(
+      db,
+      buildPromoteFileInput({
+        receiptId,
+        standardKey,
+        intake,
+        fileSizeFallbackBytes: bytes.byteLength,
+        actor,
+      }),
+    );
+  } catch (fileError) {
+    console.error(
+      "[promoteIntake] file manifest write failed — compensating delete",
+      fileError,
+    );
+    try {
+      await bucket.delete(standardKey);
+    } catch (r2Err) {
+      console.error(
+        "[promoteIntake] R2 cleanup after manifest failure also failed",
+        r2Err,
+      );
+    }
+    try {
+      await hardDeleteReceipt(
+        receiptId,
+        actor,
+        "manifest write failed during email-attachment promote",
+      );
+    } catch (deleteErr) {
+      console.error(
+        "[promoteIntake] hardDeleteReceipt after manifest failure also failed — manual cleanup required",
+        deleteErr,
+      );
+    }
+    throw fileError;
+  }
+
+  // 3.6. Enqueue the extraction job for the Mac MLX consumer (ADR 0001). Same
   //      best-effort contract as /api/receipts/upload: a missing/failing queue
   //      must NOT fail the promotion — the receipt stays at
   //      extraction_state='captured' for the /enqueue recovery endpoint to pick

--- a/lib/receipts/email-intake.ts
+++ b/lib/receipts/email-intake.ts
@@ -20,7 +20,11 @@
 import { getReceiptsDb, getReceiptsBucket } from "@/lib/cloudflare-runtime";
 import { createReceiptRecord, updateReceiptRecord } from "@/lib/receipts/db";
 import { createAuditEntry } from "@/lib/receipts/audit";
-import { buildExtractionJob, enqueueExtractionJob } from "@/lib/receipts/queue";
+import {
+  buildExtractionJob,
+  enqueueExtractionJob,
+  type ExtractionJob,
+} from "@/lib/receipts/queue";
 import { nowIso, newUuid, stringifyJson } from "@/lib/receipts/db-utils";
 import {
   generateR2Key,
@@ -453,6 +457,28 @@ export function buildPromoteReceiptInput(intake: EmailReceiptIntake): CreateRece
 }
 
 /**
+ * Build the extraction job for a just-promoted attachment receipt — the pure
+ * half of promoteIntake's enqueue step, the way buildPromoteReceiptInput is the
+ * pure half of its createReceiptRecord step. r2Key is the STANDARD receipts/...
+ * key the object was copied to in step 2 — NEVER the intake key, which step 5
+ * deletes (the consumer would otherwise fetch a key about to vanish). Exported
+ * so that invariant is unit-testable without exercising the binding-coupled
+ * promoteIntake body, exactly as buildPromoteReceiptInput is tested while
+ * createReceiptRecord is not.
+ */
+export function buildPromoteExtractionJob(input: {
+  receiptId: string;
+  standardKey: string;
+  intakeContentType: string | null;
+}): ExtractionJob {
+  return buildExtractionJob({
+    receiptId: input.receiptId,
+    r2Key: input.standardKey,
+    contentType: input.intakeContentType ?? "application/octet-stream",
+  });
+}
+
+/**
  * Refuse promotion for rows that have nothing to promote or are no longer
  * pending. Throws a plain Error whose message is safe to surface as 409 body.
  * ADR 0011 Phase B: a body-only row (no attachment, but a captured text/html
@@ -690,25 +716,23 @@ export async function promoteIntake(
   //      best-effort contract as /api/receipts/upload: a missing/failing queue
   //      must NOT fail the promotion — the receipt stays at
   //      extraction_state='captured' for the /enqueue recovery endpoint to pick
-  //      up later. r2Key is the standard key set in step 3 (NEVER the intake
-  //      key, which step 5 deletes), and the enqueue happens AFTER the
-  //      original_r2_key patch so the consumer can never fetch a key that step
-  //      5 is about to delete. Before this step, every email_attachment receipt
-  //      sat at captured/never-enqueued forever (3 stranded on 2026-08-03).
-  const enqueuedAt = nowIso();
-  const enqueued = await enqueueExtractionJob(
-    buildExtractionJob({
-      receiptId,
-      r2Key: standardKey,
-      contentType: intake.attachment_content_type ?? "application/octet-stream",
-      enqueuedAt,
-    }),
-  );
+  //      up later. buildPromoteExtractionJob sets r2Key = the standard key from
+  //      step 3 (NEVER the intake key, which step 5 deletes — unit-tested), and
+  //      the enqueue happens AFTER the original_r2_key patch so the consumer
+  //      can never fetch a key that step 5 is about to delete. Before this
+  //      step, every email_attachment receipt sat at captured/never-enqueued
+  //      forever (3 stranded on 2026-08-03).
+  const job = buildPromoteExtractionJob({
+    receiptId,
+    standardKey,
+    intakeContentType: intake.attachment_content_type,
+  });
+  const enqueued = await enqueueExtractionJob(job);
   if (enqueued) {
     try {
       await updateReceiptRecord(
         receiptId,
-        { extractionState: "queued", extractionEnqueuedAt: enqueuedAt },
+        { extractionState: "queued", extractionEnqueuedAt: job.enqueuedAt },
         actor,
       );
     } catch (markError) {

--- a/lib/receipts/email-intake.ts
+++ b/lib/receipts/email-intake.ts
@@ -18,8 +18,9 @@
 // existing insert path. Do not add a second insert path into receipt_records.
 
 import { getReceiptsDb, getReceiptsBucket } from "@/lib/cloudflare-runtime";
-import { createReceiptRecord } from "@/lib/receipts/db";
+import { createReceiptRecord, updateReceiptRecord } from "@/lib/receipts/db";
 import { createAuditEntry } from "@/lib/receipts/audit";
+import { buildExtractionJob, enqueueExtractionJob } from "@/lib/receipts/queue";
 import { nowIso, newUuid, stringifyJson } from "@/lib/receipts/db-utils";
 import {
   generateR2Key,
@@ -684,6 +685,36 @@ export async function promoteIntake(
     )
     .bind(standardKey, now, receiptId)
     .run();
+
+  // 3.5. Enqueue the extraction job for the Mac MLX consumer (ADR 0001). Same
+  //      best-effort contract as /api/receipts/upload: a missing/failing queue
+  //      must NOT fail the promotion — the receipt stays at
+  //      extraction_state='captured' for the /enqueue recovery endpoint to pick
+  //      up later. r2Key is the standard key set in step 3 (NEVER the intake
+  //      key, which step 5 deletes), and the enqueue happens AFTER the
+  //      original_r2_key patch so the consumer can never fetch a key that step
+  //      5 is about to delete. Before this step, every email_attachment receipt
+  //      sat at captured/never-enqueued forever (3 stranded on 2026-08-03).
+  const enqueuedAt = nowIso();
+  const enqueued = await enqueueExtractionJob(
+    buildExtractionJob({
+      receiptId,
+      r2Key: standardKey,
+      contentType: intake.attachment_content_type ?? "application/octet-stream",
+      enqueuedAt,
+    }),
+  );
+  if (enqueued) {
+    try {
+      await updateReceiptRecord(
+        receiptId,
+        { extractionState: "queued", extractionEnqueuedAt: enqueuedAt },
+        actor,
+      );
+    } catch (markError) {
+      console.error("[promoteIntake] mark-queued failed", markError);
+    }
+  }
 
   // 4. Flip the intake row (idempotent guard on status). Null the intake key —
   //    the object was moved to the standard key.

--- a/lib/receipts/types.ts
+++ b/lib/receipts/types.ts
@@ -106,6 +106,7 @@ export type AuditAction =
   | "receipt.extraction_denied"
   | "receipt.extraction_date_deferred"
   | "receipt.extraction_failed"
+  | "receipt.extraction_enqueued"
   | "receipt.reviewed"
   | "receipt.reconciled"
   | "receipt.exported"

--- a/middleware.ts
+++ b/middleware.ts
@@ -51,6 +51,14 @@ export const PUBLIC_ROUTES: string[] = [
   // 404-rewrites the consumer's processor-key POST before the handler runs.
   "/api/receipts/:id/render",
   "/api/receipts/inbox/:id/promote",
+  // Recovery endpoint for receipts captured but never enqueued (email-attachment
+  // promote before its enqueue fix; any future stranded capture path). Same
+  // layered processor-key OR Clerk auth inside the handler (mirrors
+  // render/promote), so it MUST be exempt from auth.protect() here — without
+  // this, Clerk 404-rewrites the consumer's processor-key POST before the
+  // handler runs. cf:dev caught this boundary on this branch: an unlisted route
+  // returns a 404 HTML page instead of the handler's own 401.
+  "/api/receipts/:id/enqueue",
 ];
 
 // Exported so the middleware-routing test can assert a route is actually

--- a/scripts/backfill-missing-manifest.ts
+++ b/scripts/backfill-missing-manifest.ts
@@ -1,0 +1,152 @@
+#!/usr/bin/env -S npx tsx
+// Backfill the missing is_original receipt_files manifest row for receipts that
+// have an original_r2_key but ZERO receipt_files rows. Root cause: promoteIntake's
+// attachment branch (ADR 0011) wrote the receipt but never its manifest row — the
+// same divergence as the enqueue bug, fixed in lib/receipts/email-intake.ts
+// (Task A). This heals the stranded email_attachment receipts (and any other
+// zero-file receipt) so the proofs gate (validateMonthReadyForExportCore /
+// countReceiptFilesByObjectIds) no longer flags them missing_receipt and blocks
+// month finalize. Backlog #5 (receipt_files write integrity) recurring in a path
+// that postdates it.
+//
+// WHERE THIS RUNS: the Mac, with live Cloudflare bindings (shells out to
+// wrangler). Run with tsx: `npx tsx scripts/backfill-missing-manifest.ts`.
+//
+// SAFETY: scoped by INVARIANT (zero file rows AND original_r2_key IS NOT NULL),
+// NOT a hardcoded id list. Verifies the R2 object exists before inserting — a
+// manifest row pointing at nothing is worse than no row. Dry-run by default;
+// pass --write to persist.
+//
+// USAGE:
+//   npx tsx scripts/backfill-missing-manifest.ts            # dry-run: candidate set + planned inserts
+//   npx tsx scripts/backfill-missing-manifest.ts --write    # insert the manifest rows + audit
+
+import { execFileSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+
+const DB = "RECEIPTS_DB";
+const BUCKET = "dazbeez-receipts";
+const args = process.argv.slice(2);
+const WRITE = args.includes("--write");
+const ACTOR = "backfill-missing-manifest.ts";
+
+function d1(sql: string): Record<string, unknown>[] {
+  const raw = execFileSync(
+    "npx",
+    ["wrangler", "d1", "execute", DB, "--remote", "--json", "--command", sql],
+    { encoding: "utf8", maxBuffer: 256 * 1024 * 1024 },
+  );
+  const parsed = JSON.parse(raw);
+  return (Array.isArray(parsed) ? parsed[0] : parsed)?.results ?? [];
+}
+
+const esc = (v: string | null | undefined) =>
+  v == null || v === "" ? "NULL" : `'${String(v).replace(/'/g, "''")}'`;
+
+// Candidate set: zero receipt_files rows AND a non-null original_r2_key.
+const rows = d1(`
+  SELECT rr.id, rr.source_type, rr.original_r2_key, rr.original_sha256,
+         rr.original_content_type, rr.original_size_bytes, rr.original_filename
+  FROM receipt_records rr
+  WHERE rr.deleted_at IS NULL
+    AND rr.original_r2_key IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM receipt_files rf
+      WHERE rf.object_type = 'receipt' AND rf.object_id = rr.id
+    )
+  ORDER BY rr.captured_at DESC;
+`);
+
+console.log(
+  `Backfill candidates: ${rows.length} receipt(s)${WRITE ? " [WRITE]" : " [dry-run]"}\n`,
+);
+
+// Report the candidate set by source_type (sanity gate — expected only
+// email_attachment; anything else is a different capture path with the same
+// defect and must be reported before writing).
+const bySource = new Map<string, number>();
+for (const r of rows) {
+  const st = String(r.source_type ?? "null");
+  bySource.set(st, (bySource.get(st) ?? 0) + 1);
+}
+console.log("By source_type:");
+for (const [st, n] of [...bySource.entries()].sort()) console.log(`  ${st}: ${n}`);
+console.log("");
+
+if (rows.length === 0) {
+  console.log("Nothing to backfill.");
+  process.exit(0);
+}
+
+// wrangler r2 object has no `head` subcommand; `get --pipe` is the existence
+// probe (exit 0 = exists, throws on missing). Output is discarded.
+function r2ObjectExists(key: string): boolean {
+  try {
+    execFileSync(
+      "npx",
+      ["wrangler", "r2", "object", "get", `${BUCKET}/${key}`, "--remote", "--pipe"],
+      { encoding: "utf8", stdio: ["ignore", "ignore", "ignore"] },
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+let inserted = 0;
+let skipped = 0;
+for (const r of rows) {
+  const id = String(r.id);
+  const key = String(r.original_r2_key);
+  const filename =
+    (r.original_filename as string | null) ?? key.split("/").pop() ?? "attachment";
+  const contentType =
+    (r.original_content_type as string | null) ?? "application/octet-stream";
+  const size = (r.original_size_bytes as number | null) ?? 0;
+  const sha = (r.original_sha256 as string | null) ?? "";
+
+  if (!r2ObjectExists(key)) {
+    skipped++;
+    console.log(`• ${id} [${r.source_type}] SKIP — R2 object missing at ${key}`);
+    continue;
+  }
+
+  console.log(
+    `• ${id} [${r.source_type}] ${filename} · ${contentType} · ${size}B` +
+      (sha ? ` · sha ${sha.slice(0, 8)}` : ""),
+  );
+
+  if (WRITE) {
+    const now = new Date().toISOString();
+    const fileId = randomUUID();
+    const auditId = randomUUID();
+    const auditJson = JSON.stringify({
+      reason:
+        "backfilled is_original receipt_files manifest row (missing from promoteIntake attachment branch)",
+      r2_key: key,
+      filename,
+      content_type: contentType,
+      size_bytes: size,
+    });
+    d1(
+      `INSERT INTO receipt_files
+         (id, object_type, object_id, role, r2_bucket, r2_key, original_filename,
+          content_type, file_size_bytes, sha256_hash, uploaded_by, uploaded_at,
+          is_original, created_at, updated_at)
+       VALUES (${esc(fileId)}, 'receipt', ${esc(id)}, 'original', 'receipts',
+               ${esc(key)}, ${esc(filename)}, ${esc(contentType)}, ${size},
+               ${esc(sha)}, ${esc(ACTOR)}, ${esc(now)}, 1, ${esc(now)}, ${esc(now)});
+       INSERT INTO receipt_audit_log
+         (id, actor, action, object_type, object_id, new_value_json, created_at)
+       VALUES (${esc(auditId)}, ${esc(ACTOR)}, 'receipt.updated', 'receipt',
+               ${esc(id)}, ${esc(auditJson)}, ${esc(now)});`,
+    );
+    inserted++;
+  }
+}
+
+const plan = rows.length - skipped;
+console.log(
+  `\n${WRITE ? `${inserted} manifest row(s) inserted; ${skipped} skipped.` : `${plan} would insert; ${skipped} would skip (R2 missing).`}`,
+);
+if (!WRITE && plan > 0) console.log("Re-run with --write to persist.");

--- a/tests/middleware-routing.test.ts
+++ b/tests/middleware-routing.test.ts
@@ -77,3 +77,19 @@ test("matcher: the monthly-delivery send endpoint is Clerk-protected (auth.prote
     "the send route must NOT be exempted from auth.protect() (not in PUBLIC_ROUTES)",
   );
 });
+
+test("PUBLIC_ROUTES: the /enqueue recovery endpoint IS exempted (processor-key auth reaches the handler)", () => {
+  // POST /api/receipts/[id]/enqueue does layered processor-key OR Clerk auth
+  // inside the handler (mirroring /render, /promote). It MUST be in PUBLIC_ROUTES
+  // or Clerk's auth.protect() 404-rewrites the consumer's processor-key POST
+  // before the handler runs — the exact boundary bug cf:dev caught on this
+  // branch (unauth returned a 404 HTML page, not the handler's 401 JSON).
+  const enqueueRequest = new NextRequest(
+    "https://dazbeez.com/api/receipts/00000000-0000-0000-0000-000000000000/enqueue",
+    { method: "POST" },
+  );
+  assert.ok(
+    isPublicRoute(enqueueRequest),
+    "/enqueue must be exempted from auth.protect() so its handler's processor-key path runs",
+  );
+});

--- a/tests/receipts/email-intake.test.ts
+++ b/tests/receipts/email-intake.test.ts
@@ -18,6 +18,7 @@ import {
   listPendingIntake,
   rejectIntake,
   buildPromoteReceiptInput,
+  buildPromoteExtractionJob,
   assertPromotable,
   isBodyOnlyIntake,
 } from "@/lib/receipts/email-intake";
@@ -525,6 +526,43 @@ test("buildPromoteReceiptInput: copies R2 metadata from the intake row", () => {
   assert.equal(input.originalContentType, "application/pdf");
   assert.equal(input.originalSizeBytes, 99);
   assert.equal(input.originalFilename, "f.pdf");
+});
+
+// ─── buildPromoteExtractionJob (pure half of the attachment enqueue) ────────
+
+test("buildPromoteExtractionJob: r2Key is the STANDARD key, NEVER the intake key", () => {
+  const standardKey = "receipts/2026/08/rcpt-1/abc-r.pdf";
+  const intakeKey = "receipts-intake/2026/08/intake-1/xyz-r.pdf";
+  const job = buildPromoteExtractionJob({
+    receiptId: "rcpt-1",
+    standardKey,
+    intakeContentType: "application/pdf",
+  });
+  assert.equal(job.r2Key, standardKey, "enqueues the standard key");
+  assert.notEqual(
+    job.r2Key,
+    intakeKey,
+    "never enqueues the intake key (deleted in step 5)",
+  );
+  assert.ok(
+    !job.r2Key.startsWith("receipts-intake/"),
+    "standard key uses the receipts/ prefix, not receipts-intake/",
+  );
+});
+
+test("buildPromoteExtractionJob: stamps receiptId + falls back contentType to octet-stream when null", () => {
+  const job = buildPromoteExtractionJob({
+    receiptId: "rcpt-2",
+    standardKey: "receipts/2026/08/rcpt-2/abc.png",
+    intakeContentType: null,
+  });
+  assert.equal(job.receiptId, "rcpt-2");
+  assert.equal(
+    job.contentType,
+    "application/octet-stream",
+    "null intake contentType falls back to a safe default",
+  );
+  assert.ok(job.enqueuedAt, "enqueuedAt is stamped on the job");
 });
 
 // ─── assertPromotable (pure half of promote) ────────────────────────────────

--- a/tests/receipts/email-intake.test.ts
+++ b/tests/receipts/email-intake.test.ts
@@ -19,6 +19,7 @@ import {
   rejectIntake,
   buildPromoteReceiptInput,
   buildPromoteExtractionJob,
+  buildPromoteFileInput,
   assertPromotable,
   isBodyOnlyIntake,
 } from "@/lib/receipts/email-intake";
@@ -563,6 +564,66 @@ test("buildPromoteExtractionJob: stamps receiptId + falls back contentType to oc
     "null intake contentType falls back to a safe default",
   );
   assert.ok(job.enqueuedAt, "enqueuedAt is stamped on the job");
+});
+
+// ─── buildPromoteFileInput (pure half of the attachment manifest write) ─────
+
+test("buildPromoteFileInput: r2Key is the STANDARD key (never the intake key); isOriginal true", () => {
+  const standardKey = "receipts/2026/08/rcpt-1/abc-r.pdf";
+  const intakeKey = "receipts-intake/2026/08/intake-1/xyz-r.pdf";
+  const file = buildPromoteFileInput({
+    receiptId: "rcpt-1",
+    standardKey,
+    intake: intakeRow({ attachment_r2_key: intakeKey, attachment_sha256: "deadbeef" }),
+    fileSizeFallbackBytes: 999,
+    actor: "operator@dazbeez.com",
+  });
+  assert.equal(file.r2Key, standardKey, "manifest row points at the standard key");
+  assert.notEqual(file.r2Key, intakeKey, "never the intake key (deleted in step 5)");
+  assert.ok(!file.r2Key.startsWith("receipts-intake/"), "uses the receipts/ prefix");
+  assert.equal(file.isOriginal, true, "the attachment IS the receipt's true original");
+  assert.equal(file.objectType, "receipt");
+  assert.equal(file.objectId, "rcpt-1");
+  assert.equal(file.role, "original");
+  assert.equal(file.r2Bucket, "receipts");
+  assert.equal(file.uploadedBy, "operator@dazbeez.com");
+});
+
+test("buildPromoteFileInput: maps intake metadata with safe fallbacks", () => {
+  const file = buildPromoteFileInput({
+    receiptId: "rcpt-2",
+    standardKey: "receipts/2026/08/rcpt-2/abc.pdf",
+    intake: intakeRow({
+      attachment_filename: "invoice.pdf",
+      attachment_content_type: "application/pdf",
+      attachment_size_bytes: 4321,
+      attachment_sha256: "abc123",
+    }),
+    fileSizeFallbackBytes: 0,
+    actor: "a",
+  });
+  assert.equal(file.originalFilename, "invoice.pdf");
+  assert.equal(file.contentType, "application/pdf");
+  assert.equal(file.fileSizeBytes, 4321, "uses stored size when present");
+  assert.equal(file.sha256Hash, "abc123");
+});
+
+test("buildPromoteFileInput: falls back filename/contentType/size when intake metadata is null", () => {
+  const file = buildPromoteFileInput({
+    receiptId: "rcpt-3",
+    standardKey: "receipts/2026/08/rcpt-3/abc",
+    intake: intakeRow({
+      attachment_filename: null,
+      attachment_content_type: null,
+      attachment_size_bytes: null,
+      attachment_sha256: "h",
+    }),
+    fileSizeFallbackBytes: 7000,
+    actor: "a",
+  });
+  assert.equal(file.originalFilename, "attachment");
+  assert.equal(file.contentType, "application/octet-stream");
+  assert.equal(file.fileSizeBytes, 7000, "falls back to the provided byte length");
 });
 
 // ─── assertPromotable (pure half of promote) ────────────────────────────────


### PR DESCRIPTION
## Summary
Two defects in `promoteIntake`'s **attachment branch** (the 4th receipt capture path) — same root cause: it diverged from the body branch (`promoteBodyIntake`) and omitted two steps the body branch performs. Both left `email_attachment` receipts in incomplete state. 3 receipts stranded since 2026-08-03: `e1fa5527`, `c74908f2`, `020ba685`.

### Defect 1 — never enqueued extraction (`2f2474f`)
The attachment branch inserted at `extraction_state='captured'` but never called `enqueueExtractionJob` — the only capture path without it. Fix: step 3.5 enqueues with `r2Key = standardKey` (never the intake key), best-effort (mirrors `upload/route.ts`). Body branch unchanged.

### Defect 2 — never wrote the `receipt_files` manifest row (`1cea51c`)
The attachment branch created the receipt but never wrote its `is_original receipt_files` row, so every `email_attachment` receipt had **zero file rows** → the proofs gate (`validateMonthReadyForExportCore` / `countReceiptFilesByObjectIds`) flagged them `missing_receipt` and **blocked month finalize** (backlog #5 recurring). Fix: new step 3.5 calls `createReceiptFile` via a pure `buildPromoteFileInput` helper; a manifest-write failure fails **loudly** (compensating-delete R2 + receipt via `hardDeleteReceipt`, throw), per audit A1 / the upload-route precedent.

### P1 boundary fix — middleware `PUBLIC_ROUTES` (`2dbcb91`)
`/enqueue` was missing from `PUBLIC_ROUTES` in `middleware.ts`, so Clerk's `auth.protect()` 404-rewrote the processor-key POST pre-handler — the **2nd instance** of the PR #59 failure that dropped 17 receipts. cf:dev caught it (404 HTML vs the handler's 401 JSON).

### Backfill (`1f79f1b`)
`scripts/backfill-missing-manifest.ts` — invariant-scoped (`zero file rows AND original_r2_key IS NOT NULL`), verifies the R2 object exists before inserting, dry-run/`--write`. **Run live 2026-08-09**: 3 manifest rows inserted; dry-run confirmed `email_attachment: 3` only (no other capture path affected).

## Verification
- `tsc --noEmit` clean · `npm test` **1152 pass / 0 fail** (+ `buildPromoteExtractionJob`, `buildPromoteFileInput`, middleware exemption tests)
- `build:cf` green · cf:dev boots clean, `/enqueue` handler reached (401 unauth after the middleware fix)
- Deployed twice (Worker now `af14391c`); `check-deployment.sh` smoke passed both times; prod `POST /enqueue` unauth → `401 JSON`

## Task C (next, in-session)
After both fixes shipped: David runs the 3 Clerk-authenticated `POST /enqueue` calls (human actor, per audit-provenance); watch the consumer move each `captured → queued → processed`; confirm merchant/amount/date land AND the `missing_receipt` blocker is gone AND 2026-08 no longer reports these 3 under the proofs gate.

## Note
Deployed manually from this branch (endpoint live for Task C). **Merge to master to persist** — master doesn't yet contain these commits, so a future master auto-deploy would revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)