### PR TITLE
feat(receipts): capture contract — one door + structural enforcement (#18, #20)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -482,6 +482,40 @@ starts. Design consequences:
     (attachment), `promoteBodyIntake` (defers enqueue to `/render`). This is
     the AGENTS.md "boundary checks are the writer's job" failure at the level
     of a whole subsystem.
+    DECISIONS (2026-08-09, architect, on the worker's B2 proposal):
+    (i) Full `captureReceipt()` wrapper in `lib/receipts/capture.ts`, NOT a
+    thinner `completeCapture()` — one door, not a step you can skip.
+    (ii) **The real deliverable is enforcement, not the wrapper.** After the
+    refactor there must be exactly ONE importer of `createReceiptRecord`:
+    `lib/receipts/capture.ts`. Add a test that reads the source tree and
+    asserts that importer set. Without it the contract is convention, and
+    convention is what failed. This is the only part of #18 that protects the
+    NEXT path rather than the four current ones.
+    (iii) Failure semantics stay deliberately different: manifest fails LOUD
+    (`hardDeleteReceipt` + throw), enqueue fails BEST-EFFORT. Do not unify.
+    (iv) `needs_render` opts out via an `enqueue: false` parameter, not a
+    branch on source type.
+    (v) #20 marker = nullable `extraction_enqueue_failed_at` column, NOT a
+    fourth `extraction_state` (which would enter `PENDING_EXTRACTION_STATES`
+    and touch every consumer). Migration is additive, no backfill, and ships in
+    the same PR as the code that writes it.
+    (vi) Surface it as a separate health class 1b, not folded into class 1 —
+    "never tried" is a code defect to report, "queue outage" is a retry, and
+    folding them dilutes class 1's provable-not-heuristic property.
+
+22. **Render-leg failures are stderr-only.** `process_renders`
+    (`scripts/receipts-consumer/consumer.py:955`) catches every exception and
+    prints to `~/Library/Logs/dazbeez/receipts-auto-promote-render.err.log`.
+    No D1 write, no `extraction_state='failed'`, no badge — a failing render
+    leg leaves receipts at `needs_render=1` silently and indefinitely. Backlog
+    #19's class 3 DETECTS the aging, but cannot name which receipt failed or
+    why. Note this is backlog #12 ("error-surfacing hardening", declared
+    CLOSED) not covering a path that shipped after it — the same
+    fix-applied-path-by-path pattern as #5 recurring in `promoteIntake` and
+    #9's backfill net missing never-extracted receipts. Design: mirror the
+    extraction leg — classify permanent render failures and POST a
+    processor-key-guarded endpoint that records the failure, so it surfaces
+    like `extraction_state='failed'` does.
 
 19. **Never-enqueued receipts are undetectable — wire a pipeline health
     surface.** NOT DISPATCHED — same prompt as #18, Part A (do it FIRST).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -491,6 +491,34 @@ starts. Design consequences:
     asserts that importer set. Without it the contract is convention, and
     convention is what failed. This is the only part of #18 that protects the
     NEXT path rather than the four current ones.
+    **PREMISE CORRECTED 2026-08-09 (worker finding).** #18 assumed
+    `createReceiptRecord` is the single insert path. It is not: there are TWO
+    `INSERT INTO receipt_records` — `db.ts:91` and `mobile-upload.ts:56`
+    (`createMobileReceiptRecord`, adding `device_id`, `client_capture_id`,
+    `captured_at_client`, `upload_origin`). The mobile route never imports
+    `createReceiptRecord`, so the importer test alone would PASS while the
+    mobile path bypassed the contract. Note `email-intake.ts:18` already said
+    "Do not add a second insert path" — migration 0015 added one anyway. A rule
+    in a comment, unenforced, silently violated.
+    So the test must assert BOTH: (1) exactly one `createReceiptRecord`
+    importer, AND (2) no `INSERT INTO receipt_records` outside `db.ts`.
+    Resolution = **Option A**: extend `CreateReceiptInput` +
+    `createReceiptRecord` with the optional mobile fields, delete
+    `createMobileReceiptRecord`, mobile route calls `captureReceipt`. Option B
+    (insert-then-UPDATE) is rejected on CORRECTNESS, not taste: the partial
+    UNIQUE index (`0015`, `WHERE device_id IS NOT NULL AND client_capture_id IS
+    NOT NULL`) only fires when both columns are set AT INSERT, so a
+    NULL-at-insert window lets two concurrent mobile uploads both succeed and
+    silently breaks idempotency.
+    (ii-b) **Merging the two INSERTs must not silently pick a winner.** Report a
+    column-by-column divergence audit before the merge lands. One is already
+    known: `preservation_status` is hardcoded `'needs_review'` in db.ts,
+    `'captured'` in mobile-upload.ts, while migration 0014's own backfill maps
+    `status='captured'` → `'needs_metadata'`. Three answers, no reader.
+    RULING: derive it from `status` using 0014's CASE as the single authority
+    (pure + unit-testable); do not hardcode either literal. Do NOT backfill
+    existing rows in this PR — that writes to every receipt including sealed
+    months and could trip the export-lock/finalized guards; file separately.
     (iii) Failure semantics stay deliberately different: manifest fails LOUD
     (`hardDeleteReceipt` + throw), enqueue fails BEST-EFFORT. Do not unify.
     (iv) `needs_render` opts out via an `enqueue: false` parameter, not a
@@ -516,6 +544,25 @@ starts. Design consequences:
     extraction leg — classify permanent render failures and POST a
     processor-key-guarded endpoint that records the failure, so it surfaces
     like `extraction_state='failed'` does.
+
+23. **`preservation_status` is a three-way inconsistency in existing rows —
+    backfill SEPARATELY (not in the capture-contract PR).** Found during the #18
+    column-by-column divergence audit: at insert, `createReceiptRecord`
+    hardcodes `'needs_review'`, `createMobileReceiptRecord` hardcodes
+    `'captured'`, and migration 0014's own backfill CASE maps
+    `status='captured' → 'needs_metadata'`. Three answers for one concept on a
+    10-year tax record, undetected because nothing reads the column. The
+    capture-contract merge FIXES the insert (derives `preservation_status` from
+    `status` via 0014's CASE as the single authority — pure, unit-tested, no
+    literal on either path), but deliberately does NOT backfill existing rows
+    in that PR. **Open question for the backfill (filed here, NOT resolved):**
+    a backfill writes to EVERY receipt including finalized/sealed statement
+    months, which could trip the export-lock / finalized-reconciliation guards
+    (a sealed month's rows are supposed to be immutable). Decide before
+    backfilling whether (a) `preservation_status` is exempt from those seals
+    (it's display-only — nothing reads it today), permitting a blanket UPDATE,
+    or (b) the backfill must respect the seal and skip/defer sealed-month rows.
+    Do NOT backfill until that is answered.
 
 19. **Never-enqueued receipts are undetectable — wire a pipeline health
     surface.** NOT DISPATCHED — same prompt as #18, Part A (do it FIRST).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -518,7 +518,30 @@ starts. Design consequences:
     RULING: derive it from `status` using 0014's CASE as the single authority
     (pure + unit-testable); do not hardcode either literal. Do NOT backfill
     existing rows in this PR — that writes to every receipt including sealed
-    months and could trip the export-lock/finalized guards; file separately.
+    months and could trip the export-lock/finalized guards; file separately
+    (filed as #23).
+    (ii-c) **A column audit cannot see the real risks — they live AROUND the
+    INSERT.** Four behavioural divergences found 2026-08-09, two with teeth:
+    (a) **Audit payload.** Both emit action `receipt.uploaded`, but db.ts writes
+    `{paymentPath, expenseType, source}` while mobile writes eight fields
+    including `device_id`, `client_capture_id`, `app_version`, `note`.
+    `app_version` and `note` never reach `receipt_records` at all — they exist
+    only in the audit JSON, so a column-by-column diff is structurally blind to
+    them. The merged payload MUST be a superset or every mobile capture loses
+    device provenance from a 10-year tax record.
+    (b) **Error taxonomy.** `createMobileReceiptRecord` throws on the 0015
+    unique-index collision and the ROUTE (`app/api/mobile/receipts/upload/route.ts:98`)
+    catches it, looks up `findMobileReceiptByIdempotency`, deletes the R2
+    object, and returns 200 `{duplicate:true}`. `captureReceipt`'s manifest-LOUD
+    policy also throws (after `hardDeleteReceipt`), and that catch block cannot
+    tell the two apart — a manifest failure would be mis-handled as an
+    idempotency race and vice versa. `captureReceipt` MUST throw typed errors
+    (e.g. `CaptureIdempotencyConflict` vs `CaptureManifestFailure`) so the route
+    branches on cause, not on "something threw".
+    (c) After the merge the mobile path gains `assertTransactionMonthEditable`
+    (split lock, audit A5) and (d) `assignMembershipForReceipt` (ADR 0008).
+    Both are no-ops today because mobile inserts with no `transaction_date` —
+    recorded as deliberate findings, not assumptions.
     (iii) Failure semantics stay deliberately different: manifest fails LOUD
     (`hardDeleteReceipt` + throw), enqueue fails BEST-EFFORT. Do not unify.
     (iv) `needs_render` opts out via an `enqueue: false` parameter, not a

--- a/app/api/mobile/receipts/upload/route.ts
+++ b/app/api/mobile/receipts/upload/route.ts
@@ -1,16 +1,11 @@
 import { NextResponse } from "next/server";
-import { getReceiptsBucket, getReceiptsDb } from "@/lib/cloudflare-runtime";
-import { createReceiptFile } from "@/lib/receipts/files";
+import { getReceiptsBucket } from "@/lib/cloudflare-runtime";
 import { generateR2Key, uploadOriginal } from "@/lib/receipts/storage";
 import { requireMobileActor } from "@/lib/receipts/trusted-devices";
 import { validateReceiptFile } from "@/lib/receipts/validation";
-import {
-  createMobileReceiptRecord,
-  findMobileReceiptByIdempotency,
-} from "@/lib/receipts/mobile-upload";
-import { hardDeleteReceipt, updateReceiptRecord } from "@/lib/receipts/db";
+import { findMobileReceiptByIdempotency } from "@/lib/receipts/mobile-upload";
+import { captureReceipt, CaptureIdempotencyConflict } from "@/lib/receipts/capture";
 import { ExportFinalizedError } from "@/lib/receipts/month-lock";
-import { buildExtractionJob, enqueueExtractionJob } from "@/lib/receipts/queue";
 import type { PaymentPath } from "@/lib/receipts/types";
 
 async function sha256Hex(data: ArrayBuffer): Promise<string> {
@@ -80,132 +75,78 @@ export async function POST(request: Request) {
 
     await uploadOriginal(r2Key, bytes, contentType);
 
-    let receiptId: string;
+    // Backlog #18: captureReceipt is the single door. Mobile provenance
+    // (device_id/client_capture_id/captured_at_client/upload_origin) + the
+    // audit-only app_version/note flow through CreateReceiptInput; the 0015
+    // partial UNIQUE index enforces idempotency AT INSERT, so a concurrent
+    // retry surfaces as CaptureIdempotencyConflict (not a bare error the route
+    // can't distinguish from a manifest failure — #18 ii-c(b)).
+    let capture: { receiptId: string; enqueued: boolean };
     try {
-      receiptId = await createMobileReceiptRecord({
+      capture = await captureReceipt({
+        record: {
+          capturedBy: device.actor,
+          source: "mobile_capture",
+          sourceType: "paper_scanned",
+          uploadOrigin: "mobile",
+          deviceId: device.deviceId,
+          clientCaptureId,
+          capturedAtClient,
+          appVersion,
+          note,
+          paymentPath,
+          originalFilename: file.name,
+          originalR2Key: r2Key,
+          originalSha256: sha256,
+          originalContentType: contentType,
+          originalSizeBytes: file.size,
+          status: "captured",
+        },
+        file: { sha256, sizeBytes: file.size, contentType, filename: file.name },
+        r2Strategy: { kind: "uploaded" },
+        enqueue: true,
         actor: device.actor,
-        deviceId: device.deviceId,
-        clientCaptureId,
-        capturedAtClient,
-        appVersion,
-        note,
-        paymentPath,
-        originalFilename: file.name,
-        originalR2Key: r2Key,
-        originalSha256: sha256,
-        originalContentType: contentType,
-        originalSizeBytes: file.size,
       });
-    } catch (dbError) {
-      // If the unique index races against a concurrent retry, surface the
-      // already-saved receipt instead of leaving an orphan.
-      const existingOnRace = await findMobileReceiptByIdempotency(
-        device.deviceId,
-        clientCaptureId,
-      );
+    } catch (err) {
+      // Clean up the uploaded object (captureReceipt handles receipt rollback
+      // for a manifest failure; for an idempotency collision the row belongs to
+      // the concurrent winner). Then: collision + the winner exists → duplicate;
+      // anything else (CaptureManifestFailure, other DB error) → surface as error.
       try {
         await getReceiptsBucket().delete(r2Key);
       } catch {
         // best-effort
       }
-      if (existingOnRace) {
-        return NextResponse.json(
-          {
-            ok: true,
-            duplicate: true,
-            receiptId: existingOnRace.id,
-            status: existingOnRace.status,
-            reviewUrl: `/receipts/review/${existingOnRace.id}`,
-          },
-          { status: 200 },
+      if (err instanceof CaptureIdempotencyConflict) {
+        const existingOnRace = await findMobileReceiptByIdempotency(
+          device.deviceId,
+          clientCaptureId,
         );
+        if (existingOnRace) {
+          return NextResponse.json(
+            {
+              ok: true,
+              duplicate: true,
+              receiptId: existingOnRace.id,
+              status: existingOnRace.status,
+              reviewUrl: `/receipts/review/${existingOnRace.id}`,
+            },
+            { status: 200 },
+          );
+        }
       }
-      throw dbError;
-    }
-
-    // Audit finding A1: a failed manifest write previously left an orphan
-    // receipt_records row + R2 object. Mobile retries are normal (offline
-    // queue), but the idempotency key protects against re-running the
-    // compensating delete on a successful retry — by the time the retry
-    // lands, either the original failed (and was hard-deleted, so the
-    // idempotency lookup misses) or the original succeeded (no rollback).
-    try {
-      await createReceiptFile(getReceiptsDb(), {
-        objectType: "receipt",
-        objectId: receiptId,
-        role: "original",
-        r2Bucket: "receipts",
-        r2Key,
-        originalFilename: file.name,
-        contentType,
-        fileSizeBytes: file.size,
-        sha256Hash: sha256,
-        uploadedBy: device.actor,
-        isOriginal: true,
-      });
-    } catch (fileError) {
-      console.error(
-        "[mobile/receipts/upload] file manifest write failed — compensating delete",
-        fileError,
-      );
-      try {
-        await getReceiptsBucket().delete(r2Key);
-      } catch (r2CleanupError) {
-        console.error(
-          "[mobile/receipts/upload] R2 cleanup after manifest failure also failed",
-          r2CleanupError,
-        );
-      }
-      try {
-        await hardDeleteReceipt(
-          receiptId,
-          device.actor,
-          "manifest write failed during mobile upload",
-        );
-      } catch (deleteError) {
-        console.error(
-          "[mobile/receipts/upload] hardDeleteReceipt after manifest failure also failed — manual cleanup required",
-          deleteError,
-        );
-      }
-      return NextResponse.json(
-        {
-          ok: false,
-          error:
-            "Upload failed: file manifest could not be written. Receipt rolled back.",
-        },
-        { status: 500 },
-      );
-    }
-
-    // ADR 0001: enqueue the extraction job (best-effort). If the queue is
-    // unavailable the receipt stays captured/extraction_state='captured' and a
-    // backfill can pick it up — capture must not fail on queue errors.
-    const enqueuedAt = new Date().toISOString();
-    const enqueued = await enqueueExtractionJob(
-      buildExtractionJob({ receiptId, r2Key, contentType, enqueuedAt }),
-    );
-    if (enqueued) {
-      try {
-        await updateReceiptRecord(
-          receiptId,
-          { extractionState: "queued", extractionEnqueuedAt: enqueuedAt },
-          device.actor,
-        );
-      } catch (markError) {
-        console.error("[mobile/receipts/upload] mark-queued failed", markError);
-      }
+      throw err;
     }
 
     return NextResponse.json(
       {
         ok: true,
         duplicate: false,
-        receiptId,
+        receiptId: capture.receiptId,
         status: "captured",
-        extractionState: enqueued ? "queued" : "captured",
+        extractionState: capture.enqueued ? "queued" : "captured",
         pendingProcessing: true,
-        reviewUrl: `/receipts/review/${receiptId}`,
+        reviewUrl: `/receipts/review/${capture.receiptId}`,
       },
       { status: 201 },
     );

--- a/app/api/receipts/[id]/enqueue/route.ts
+++ b/app/api/receipts/[id]/enqueue/route.ts
@@ -108,6 +108,7 @@ export async function POST(request: Request, { params }: RouteContext) {
         `UPDATE receipt_records
            SET extraction_state = 'queued',
                extraction_enqueued_at = ?,
+               extraction_enqueue_failed_at = NULL,
                updated_at = ?
          WHERE id = ?`,
       )

--- a/app/api/receipts/upload/route.ts
+++ b/app/api/receipts/upload/route.ts
@@ -8,11 +8,9 @@ import {
   type Source,
 } from "@/lib/receipts/upload-policy";
 import { generateR2Key, uploadOriginal } from "@/lib/receipts/storage";
-import { createReceiptRecord, hardDeleteReceipt, updateReceiptRecord } from "@/lib/receipts/db";
-import { createReceiptFile } from "@/lib/receipts/files";
+import { captureReceipt } from "@/lib/receipts/capture";
 import { ExportFinalizedError } from "@/lib/receipts/month-lock";
-import { buildExtractionJob, enqueueExtractionJob } from "@/lib/receipts/queue";
-import { getReceiptsBucket, getReceiptsDb } from "@/lib/cloudflare-runtime";
+import { getReceiptsBucket } from "@/lib/cloudflare-runtime";
 import type { PaymentPath } from "@/lib/receipts/types";
 
 async function sha256Hex(data: ArrayBuffer): Promise<string> {
@@ -80,10 +78,14 @@ export async function POST(request: Request) {
 
     await uploadOriginal(r2Key, bytes, contentType);
 
-    let receiptId: string;
+    // ADR 0001 + backlog #18: captureReceipt is the single door — createReceiptRecord
+    // (a) + the is_original manifest row (b) + enqueue (c), with manifest LOUD
+    // (compensating delete on failure) and enqueue best-effort. Nothing else
+    // imports createReceiptRecord (enforced by tests/receipts/capture-contract.test.ts).
+    let capture: { receiptId: string; enqueued: boolean };
     try {
-      receiptId = await createReceiptRecord(
-        {
+      capture = await captureReceipt({
+        record: {
           capturedBy: actor,
           source,
           sourceType,
@@ -94,105 +96,34 @@ export async function POST(request: Request) {
           originalSha256: sha256,
           originalContentType: contentType,
           originalSizeBytes: file.size,
-          // ADR 0001: capture path is async store-and-forward. The receipt lands
-          // as 'captured' (pending processing) and an extraction job is enqueued
-          // for the Mac MLX consumer to drain. No AI runs in the Worker.
           status: "captured",
         },
+        file: { sha256, sizeBytes: file.size, contentType, filename: file.name },
+        r2Strategy: { kind: "uploaded" },
+        enqueue: true,
         actor,
-      );
-    } catch (dbError) {
+      });
+    } catch (captureError) {
+      // captureReceipt handles manifest-failure rollback (hardDeleteReceipt +
+      // r2Key delete) internally. For a createReceiptRecord failure there is no
+      // receipt yet — clean up the object we uploaded.
       try {
         await getReceiptsBucket().delete(r2Key);
       } catch {
-        console.error("[receipts/upload] R2 cleanup failed after DB error", dbError);
+        console.error("[receipts/upload] R2 cleanup after capture failure", captureError);
       }
-      throw dbError;
-    }
-
-    // Manifest row for the original file. Audit finding A1: a failed
-    // manifest write previously left an orphan receipt_records row + R2
-    // object (15-orphan incident on 2026-07-04). Now we compensating-delete
-    // both and surface a 500 to the client. The desktop client renders an
-    // error tile (4a08f92); the queue enqueue below only runs on success.
-    try {
-      await createReceiptFile(getReceiptsDb(), {
-        objectType: "receipt",
-        objectId: receiptId,
-        role: "original",
-        r2Bucket: "receipts",
-        r2Key,
-        originalFilename: file.name,
-        contentType,
-        fileSizeBytes: file.size,
-        sha256Hash: sha256,
-        uploadedBy: actor,
-        isOriginal: true,
-      });
-    } catch (fileError) {
-      console.error(
-        "[receipts/upload] file manifest write failed — compensating delete",
-        fileError,
-      );
-      try {
-        await getReceiptsBucket().delete(r2Key);
-      } catch (r2CleanupError) {
-        console.error(
-          "[receipts/upload] R2 cleanup after manifest failure also failed",
-          r2CleanupError,
-        );
-      }
-      try {
-        await hardDeleteReceipt(
-          receiptId,
-          actor,
-          "manifest write failed during upload",
-        );
-      } catch (deleteError) {
-        console.error(
-          "[receipts/upload] hardDeleteReceipt after manifest failure also failed — manual cleanup required",
-          deleteError,
-        );
-      }
-      return NextResponse.json(
-        {
-          ok: false,
-          error:
-            "Upload failed: file manifest could not be written. Receipt rolled back.",
-        },
-        { status: 500 },
-      );
-    }
-
-    // ADR 0001: enqueue the extraction job. Best-effort — if the queue binding
-    // is missing or send fails, the receipt remains at status='captured' /
-    // extraction_state='captured' and a backfill can enqueue it later. Capture
-    // must never fail because the queue is unavailable.
-    const enqueuedAt = new Date().toISOString();
-    const enqueued = await enqueueExtractionJob(
-      buildExtractionJob({ receiptId, r2Key, contentType, enqueuedAt }),
-    );
-    if (enqueued) {
-      try {
-        await updateReceiptRecord(
-          receiptId,
-          { extractionState: "queued", extractionEnqueuedAt: enqueuedAt },
-          actor,
-        );
-      } catch (markError) {
-        console.error("[receipts/upload] mark-queued failed", markError);
-      }
+      throw captureError;
     }
 
     return NextResponse.json(
       {
         ok: true,
-        receiptId,
+        receiptId: capture.receiptId,
         status: "captured",
-        extractionState: enqueued ? "queued" : "captured",
+        extractionState: capture.enqueued ? "queued" : "captured",
         pendingProcessing: true,
         sourceType,
-        reviewUrl: `/receipts/review/${receiptId}`,
+        reviewUrl: `/receipts/review/${capture.receiptId}`,
       },
       { status: 201 },
     );

--- a/db/receipts/0038_extraction_enqueue_failed_at.sql
+++ b/db/receipts/0038_extraction_enqueue_failed_at.sql
@@ -1,0 +1,19 @@
+-- 0038_extraction_enqueue_failed_at.sql
+--
+-- Distinguish a queue OUTAGE from a forgotten enqueue (backlog #20). Before this
+-- column, both left a receipt at extraction_state='captured' with a NULL
+-- extraction_enqueued_at — indistinguishable, which is why the 2026-08-09
+-- three-receipt diagnosis needed a code read rather than a query.
+--
+-- captureReceipt() (lib/receipts/capture.ts, backlog #18) sets this when
+-- enqueueExtractionJob returns false (best-effort: capture must never fail
+-- because the queue is down). The dashboard pipeline-health surface reports it
+-- as a SEPARATE class 1b ("enqueue failed" — a retry) from class 1 ("never
+-- tried" — a code defect to report); folding them would dilute class 1's
+-- provable-not-heuristic property.
+--
+-- A nullable column, NOT a fourth extraction_state: a new state value would
+-- enter PENDING_EXTRACTION_STATES and touch every consumer (month-close gate,
+-- queue-items, review-attention, …). The column is local. Additive only; NULL
+-- when the enqueue succeeded or was never attempted (the needs_render path).
+ALTER TABLE receipt_records ADD COLUMN extraction_enqueue_failed_at TEXT;

--- a/lib/receipts/capture.ts
+++ b/lib/receipts/capture.ts
@@ -1,0 +1,216 @@
+// The capture-completeness contract (backlog #18). ONE door for every capture
+// path: createReceiptRecord (a) → is_original receipt_files manifest row (b) →
+// enqueued extraction job OR needs_render=1 (c). createReceiptRecord stays
+// fiercely single-sourced and is imported ONLY here — enforced by
+// tests/receipts/capture-contract.test.ts (that test is the real deliverable of
+// #18: it protects the NEXT path, not the four current ones).
+//
+// Failure semantics are deliberately different (do not unify):
+//   - manifest (b) fails → LOUD: hardDeleteReceipt + throw. A receipt with no
+//     manifest row blocks month finalize; roll back the whole capture.
+//   - enqueue (c) fails → BEST-EFFORT: capture never fails because the queue is
+//     down. The #20 marker (extraction_enqueue_failed_at) is set so a queue
+//     outage is distinguishable from a forgotten enqueue (backlog #20).
+
+import { getReceiptsBucket, getReceiptsDb } from "@/lib/cloudflare-runtime";
+import { createReceiptRecord, hardDeleteReceipt } from "@/lib/receipts/db";
+import { createReceiptFile, type CreateReceiptFileInput } from "@/lib/receipts/files";
+import { buildExtractionJob, enqueueExtractionJob } from "@/lib/receipts/queue";
+import { generateR2Key, uploadOriginal } from "@/lib/receipts/storage";
+import { nowIso } from "@/lib/receipts/db-utils";
+import type { CreateReceiptInput } from "@/lib/receipts/types";
+
+/** Manifest metadata for the original file. The bytes themselves are either
+ *  already in R2 (`uploaded`) or read from the intake object (`intake-copy`),
+ *  so this carries only what the manifest row needs. */
+export interface CaptureFile {
+  sha256: string;
+  sizeBytes: number;
+  contentType: string;
+  filename: string;
+}
+
+/** How the original lands at its final standard key.
+ *  - `uploaded`: the caller already put the object in R2 at
+ *    `record.originalR2Key` (the upload routes).
+ *  - `intake-copy`: copy the object from `intakeKey` to the standard
+ *    `receipts/{id}/...` key and patch `original_r2_key` (the promote paths).
+ *    The caller owns the intake object's lifecycle (row flip + deletion). */
+export type CaptureR2Strategy =
+  | { kind: "uploaded" }
+  | { kind: "intake-copy"; intakeKey: string };
+
+export interface CaptureInput {
+  record: CreateReceiptInput;
+  file: CaptureFile;
+  r2Strategy: CaptureR2Strategy;
+  /** false only for the body path — it defers enqueue to /render (needs_render=1
+   *  is seeded by createReceiptRecord from sourceType 'email_body'). Not a
+   *  branch on source type; the caller states it. */
+  enqueue: boolean;
+  actor: string;
+}
+
+export interface CaptureResult {
+  receiptId: string;
+  /** true only when an enqueue was attempted and succeeded. False for the
+   *  needs_render path (intentionally not enqueued). */
+  enqueued: boolean;
+  /** The standard key the manifest row (and, if enqueued, the job) reference. */
+  r2Key: string;
+}
+
+/** Pure: the extraction-state mark for a capture, given the enqueue outcome.
+ *  Encodes the #20 distinction: success → queued+enqueued_at; failure →
+ *  captured+failed_at (the marker); not-attempted (needs_render) → captured with
+ *  neither timestamp (createReceiptRecord's defaults already stand). */
+export function decideCaptureMark(args: {
+  attempted: boolean;
+  enqueued: boolean;
+  now: string;
+}): {
+  extractionState: "queued" | "captured";
+  extractionEnqueuedAt: string | null;
+  extractionEnqueueFailedAt: string | null;
+} {
+  if (!args.attempted) {
+    return {
+      extractionState: "captured",
+      extractionEnqueuedAt: null,
+      extractionEnqueueFailedAt: null,
+    };
+  }
+  if (args.enqueued) {
+    return {
+      extractionState: "queued",
+      extractionEnqueuedAt: args.now,
+      extractionEnqueueFailedAt: null,
+    };
+  }
+  return {
+    extractionState: "captured",
+    extractionEnqueuedAt: null,
+    extractionEnqueueFailedAt: args.now,
+  };
+}
+
+/** Pure: the is_original manifest row input. r2Key is the standard key (never a
+ *  temporary intake/staging key); isOriginal is always true. */
+export function buildCaptureFileInput(args: {
+  receiptId: string;
+  r2Key: string;
+  file: CaptureFile;
+  actor: string;
+}): CreateReceiptFileInput {
+  return {
+    objectType: "receipt",
+    objectId: args.receiptId,
+    role: "original",
+    r2Bucket: "receipts",
+    r2Key: args.r2Key,
+    originalFilename: args.file.filename,
+    contentType: args.file.contentType,
+    fileSizeBytes: args.file.sizeBytes,
+    sha256Hash: args.file.sha256,
+    uploadedBy: args.actor,
+    isOriginal: true,
+  };
+}
+
+async function compensate(receiptId: string, actor: string, reason: string): Promise<void> {
+  try {
+    await hardDeleteReceipt(receiptId, actor, reason);
+  } catch (err) {
+    console.error("[captureReceipt] compensating hardDeleteReceipt also failed — manual cleanup required", err);
+  }
+}
+
+/**
+ * The single capture door. Performs (a) createReceiptRecord → (b) manifest →
+ * (c) enqueue-or-needs_render, with the R2 key resolved per `r2Strategy`.
+ * Binding-coupled (D1 + R2 + Queue); the pure decisions are extracted above for
+ * unit testing. Always satisfies the contract (a) ∧ (b) ∧ ((c₁) ∨ c₂)) — a path
+ * cannot skip a step because there is no other path.
+ */
+export async function captureReceipt(input: CaptureInput): Promise<CaptureResult> {
+  const db = getReceiptsDb();
+
+  // (a) the receipt record — the sacred single insert path.
+  const receiptId = await createReceiptRecord(input.record, input.actor);
+
+  // Resolve the final standard key + (for intake-copy) move the object there.
+  let r2Key: string;
+  if (input.r2Strategy.kind === "uploaded") {
+    r2Key = input.record.originalR2Key;
+    if (!r2Key) {
+      await compensate(receiptId, input.actor, "captureReceipt: uploaded strategy with no originalR2Key");
+      throw new Error("captureReceipt: 'uploaded' strategy requires record.originalR2Key");
+    }
+  } else {
+    const bucket = getReceiptsBucket();
+    const intakeKey = input.r2Strategy.intakeKey;
+    const obj = await bucket.get(intakeKey);
+    if (!obj) {
+      await compensate(receiptId, input.actor, `intake object missing during capture (${intakeKey})`);
+      throw new Error(`captureReceipt: intake object missing at ${intakeKey}`);
+    }
+    const bytes = await obj.arrayBuffer();
+    const now = nowIso();
+    r2Key = generateR2Key(receiptId, input.file.filename, now);
+    await uploadOriginal(r2Key, bytes, input.file.contentType);
+    await db
+      .prepare(`UPDATE receipt_records SET original_r2_key = ?, updated_at = ? WHERE id = ?`)
+      .bind(r2Key, now, receiptId)
+      .run();
+  }
+
+  // (b) the manifest row — LOUD. A receipt with no manifest row blocks finalize,
+  // so roll back the whole capture on failure rather than leave a half-write.
+  try {
+    await createReceiptFile(
+      db,
+      buildCaptureFileInput({ receiptId, r2Key, file: input.file, actor: input.actor }),
+    );
+  } catch (fileError) {
+    console.error("[captureReceipt] manifest write failed — compensating delete", fileError);
+    try {
+      await getReceiptsBucket().delete(r2Key);
+    } catch (r2Err) {
+      console.error("[captureReceipt] R2 cleanup after manifest failure also failed", r2Err);
+    }
+    await compensate(receiptId, input.actor, "manifest write failed during capture");
+    throw fileError;
+  }
+
+  // (c) enqueue — BEST-EFFORT. Capture never fails because the queue is down;
+  // a failure sets the #20 marker so it's distinguishable from "never tried".
+  let enqueued = false;
+  if (input.enqueue) {
+    const now = nowIso();
+    enqueued = await enqueueExtractionJob(
+      buildExtractionJob({ receiptId, r2Key, contentType: input.file.contentType, enqueuedAt: now }),
+    );
+    const mark = decideCaptureMark({ attempted: true, enqueued, now });
+    await db
+      .prepare(
+        `UPDATE receipt_records
+           SET extraction_state = ?,
+               extraction_enqueued_at = ?,
+               extraction_enqueue_failed_at = ?,
+               updated_at = ?
+         WHERE id = ?`,
+      )
+      .bind(
+        mark.extractionState,
+        mark.extractionEnqueuedAt,
+        mark.extractionEnqueueFailedAt,
+        now,
+        receiptId,
+      )
+      .run();
+  }
+  // When !enqueue (needs_render), createReceiptRecord already seeded
+  // extraction_state='captured' + needs_render=1 — nothing to update.
+
+  return { receiptId, enqueued, r2Key };
+}

--- a/lib/receipts/capture.ts
+++ b/lib/receipts/capture.ts
@@ -20,6 +20,42 @@ import { generateR2Key, uploadOriginal } from "@/lib/receipts/storage";
 import { nowIso } from "@/lib/receipts/db-utils";
 import type { CreateReceiptInput } from "@/lib/receipts/types";
 
+/** Thrown when the receipt_records INSERT collides on the 0015 partial UNIQUE
+ *  index (device_id + client_capture_id both set) — a mobile-capture retry the
+ *  client already processed. The route catches this to return { duplicate: true }
+ *  rather than an error. Distinct from CaptureManifestFailure so the route's
+ *  catch cannot mistake a manifest failure for a race (#18 ii-c(b)). */
+export class CaptureIdempotencyConflict extends Error {
+  readonly kind = "CaptureIdempotencyConflict" as const;
+  constructor(message = "mobile capture idempotency conflict") {
+    super(message);
+    this.name = "CaptureIdempotencyConflict";
+  }
+}
+
+/** Thrown when the manifest (receipt_files) write fails after the receipt was
+ *  created — the receipt is compensating-deleted (hardDeleteReceipt) first, then
+ *  this is thrown. Typed so the route does NOT treat it as an idempotency race
+ *  (#18 ii-c(b)): a manifest failure must surface as an error, not duplicate. */
+export class CaptureManifestFailure extends Error {
+  readonly kind = "CaptureManifestFailure" as const;
+  constructor(
+    message = "manifest write failed during capture",
+    public readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = "CaptureManifestFailure";
+  }
+}
+
+/** True when a D1 error is the 0015 mobile-idempotency UNIQUE collision. D1/SQLite
+ *  surfaces it as "UNIQUE constraint failed: receipt_records.device_id, …".
+ *  Exported so the race-vs-manifest classification (#18 ii-c(b)) is unit-testable. */
+export function isMobileIdempotencyCollision(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return /UNIQUE constraint/i.test(msg) && /device_id|client_capture_id/i.test(msg);
+}
+
 /** Manifest metadata for the original file. The bytes themselves are either
  *  already in R2 (`uploaded`) or read from the intake object (`intake-copy`),
  *  so this carries only what the manifest row needs. */
@@ -135,8 +171,17 @@ async function compensate(receiptId: string, actor: string, reason: string): Pro
 export async function captureReceipt(input: CaptureInput): Promise<CaptureResult> {
   const db = getReceiptsDb();
 
-  // (a) the receipt record — the sacred single insert path.
-  const receiptId = await createReceiptRecord(input.record, input.actor);
+  // (a) the receipt record — the sacred single insert path. A collision on the
+  // 0015 mobile-idempotency index (device_id+client_capture_id) throws
+  // CaptureIdempotencyConflict so the route returns { duplicate: true }; any
+  // other DB error propagates.
+  let receiptId: string;
+  try {
+    receiptId = await createReceiptRecord(input.record, input.actor);
+  } catch (err) {
+    if (isMobileIdempotencyCollision(err)) throw new CaptureIdempotencyConflict();
+    throw err;
+  }
 
   // Resolve the final standard key + (for intake-copy) move the object there.
   let r2Key: string;
@@ -179,7 +224,7 @@ export async function captureReceipt(input: CaptureInput): Promise<CaptureResult
       console.error("[captureReceipt] R2 cleanup after manifest failure also failed", r2Err);
     }
     await compensate(receiptId, input.actor, "manifest write failed during capture");
-    throw fileError;
+    throw new CaptureManifestFailure("manifest write failed during capture", fileError);
   }
 
   // (c) enqueue — BEST-EFFORT. Capture never fails because the queue is down;

--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -52,6 +52,31 @@ import type {
 
 // ─── Receipt records ─────────────────────────────────────────────────────────
 
+/**
+ * preservation_status derived from lifecycle status — migration 0014's backfill
+ * CASE as the SINGLE authority (backlog #18 audit / #23). Both capture paths
+ * previously hardcoded a literal ('needs_review' / 'captured'), disagreeing with
+ * 0014's 'needs_metadata' for status='captured' — three answers for one concept,
+ * undetected because nothing reads the column. Pure + unit-tested; no path
+ * writes a preservation_status literal. (Existing rows are NOT backfilled here —
+ * see backlog #23 + its sealed-month question.)
+ */
+export function derivePreservationStatus(status: ReceiptStatus | undefined): string {
+  switch (status) {
+    case "archived":
+      return "archived";
+    case "exported":
+      return "exported";
+    case "reconciled":
+    case "reviewed":
+      return "reviewed";
+    case "captured":
+      return "needs_metadata";
+    default:
+      return "needs_review";
+  }
+}
+
 export async function createReceiptRecord(
   input: CreateReceiptInput,
   actor: string,
@@ -97,8 +122,9 @@ export async function createReceiptRecord(
          original_r2_key, original_sha256, original_content_type, original_size_bytes,
          legacy, retention_until, legal_hold,
          source_type, preservation_status, qualified_invoice_status,
-         created_at, updated_at, extraction_r2_key, needs_render)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, 1, ?, 'needs_review', 'not_checked', ?, ?, ?, ?)`,
+         created_at, updated_at, extraction_r2_key, needs_render,
+         device_id, client_capture_id, captured_at_client, upload_origin)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, 1, ?, ?, 'not_checked', ?, ?, ?, ?, ?, ?, ?, ?)`,
     )
     .bind(
       id,
@@ -115,13 +141,8 @@ export async function createReceiptRecord(
       input.taxAmountMinor ?? null,
       input.businessPurpose ?? null,
       input.alcoholPresent ? 1 : 0,
-      // expense_type is deprecated (Expense Type field removed from the
-      // review form; category — expense_category_code — is now the single
-      // classification input). It's always "UNKNOWN" at insert time
-      // regardless (extraction never invents category, per ADR — see
-      // extraction.ts), so this branch never fired live. attendees_required
-      // is derived from category client-side (categoryRequiresAttendees in
-      // form-pane.tsx) rather than stored per-insert.
+      // attendees_required is derived client-side from category
+      // (categoryRequiresAttendees in form-pane.tsx), not stored per-insert.
       0,
       status,
       extractionState,
@@ -131,14 +152,25 @@ export async function createReceiptRecord(
       input.originalSizeBytes,
       retentionUntilIso(now),
       sourceType,
+      // preservation_status: derived from status via 0014's CASE — no literal
+      // on either path (backlog #18 audit / #23).
+      derivePreservationStatus(status),
       now,
       now,
       null, // extraction_r2_key — NULL until the Mac render completes (/render).
       // ADR 0011 Phase B: email_body receipts must be rendered to PDF/image on
       // the Mac before MLX extraction. needs_render=1 keeps them out of the
-      // pending-extraction query (and thus off month-close / backfill) until
-      // /render clears it and enqueues. Every other source is render-ready now.
+      // pending-extraction query until /render clears it and enqueues.
       sourceType === "email_body" ? 1 : 0,
+      // Mobile provenance (backlog #18 merge — createMobileReceiptRecord folded
+      // in). NULL for non-mobile captures; the 0015 partial UNIQUE index on
+      // (device_id, client_capture_id) only fires when both are NOT NULL, so
+      // non-mobile rows never collide. captureReceipt throws
+      // CaptureIdempotencyConflict on a collision so the route returns duplicate.
+      input.deviceId ?? null,
+      input.clientCaptureId ?? null,
+      input.capturedAtClient ?? null,
+      input.uploadOrigin ?? null,
     )
     .run();
 
@@ -147,7 +179,21 @@ export async function createReceiptRecord(
     action: "receipt.uploaded",
     objectType: "receipt",
     objectId: id,
-    newValueJson: stringifyJson({ paymentPath, expenseType, source: input.source ?? "upload" }),
+    // Superset (backlog #18 ii-c(a)): emit mobile provenance when present, so a
+    // mobile capture does not silently lose device_id/client_capture_id/
+    // app_version/note from this 10-year record's audit trail. app_version +
+    // note are audit-JSON ONLY (never columns) — a column diff is blind to them.
+    newValueJson: stringifyJson({
+      paymentPath,
+      expenseType,
+      source: input.source ?? "upload",
+      ...(input.sourceType ? { source_type: input.sourceType } : {}),
+      ...(input.uploadOrigin ? { upload_origin: input.uploadOrigin } : {}),
+      ...(input.deviceId ? { device_id: input.deviceId } : {}),
+      ...(input.clientCaptureId ? { client_capture_id: input.clientCaptureId } : {}),
+      ...(input.appVersion ? { app_version: input.appVersion } : {}),
+      ...(input.note ? { note: input.note } : {}),
+    }),
   });
 
   // ADR 0008 (was ADR 0006 PR #2): assign calendar-month membership at capture

--- a/lib/receipts/email-intake.ts
+++ b/lib/receipts/email-intake.ts
@@ -18,25 +18,10 @@
 // existing insert path. Do not add a second insert path into receipt_records.
 
 import { getReceiptsDb, getReceiptsBucket } from "@/lib/cloudflare-runtime";
-import {
-  createReceiptRecord,
-  hardDeleteReceipt,
-  updateReceiptRecord,
-} from "@/lib/receipts/db";
 import { createAuditEntry } from "@/lib/receipts/audit";
-import {
-  buildExtractionJob,
-  enqueueExtractionJob,
-  type ExtractionJob,
-} from "@/lib/receipts/queue";
+import { captureReceipt } from "@/lib/receipts/capture";
 import { nowIso, newUuid, stringifyJson } from "@/lib/receipts/db-utils";
-import {
-  generateR2Key,
-  uploadOriginal,
-  sanitizeFilenameForR2,
-  computeSha256Hex,
-} from "@/lib/receipts/storage";
-import { createReceiptFile, type CreateReceiptFileInput } from "@/lib/receipts/files";
+import { sanitizeFilenameForR2, computeSha256Hex } from "@/lib/receipts/storage";
 import {
   ALLOWED_RECEIPT_MIME_TYPES,
   ALLOWED_RECEIPT_EXTENSIONS,
@@ -461,62 +446,6 @@ export function buildPromoteReceiptInput(intake: EmailReceiptIntake): CreateRece
 }
 
 /**
- * Build the extraction job for a just-promoted attachment receipt — the pure
- * half of promoteIntake's enqueue step, the way buildPromoteReceiptInput is the
- * pure half of its createReceiptRecord step. r2Key is the STANDARD receipts/...
- * key the object was copied to in step 2 — NEVER the intake key, which step 5
- * deletes (the consumer would otherwise fetch a key about to vanish). Exported
- * so that invariant is unit-testable without exercising the binding-coupled
- * promoteIntake body, exactly as buildPromoteReceiptInput is tested while
- * createReceiptRecord is not.
- */
-export function buildPromoteExtractionJob(input: {
-  receiptId: string;
-  standardKey: string;
-  intakeContentType: string | null;
-}): ExtractionJob {
-  return buildExtractionJob({
-    receiptId: input.receiptId,
-    r2Key: input.standardKey,
-    contentType: input.intakeContentType ?? "application/octet-stream",
-  });
-}
-
-/**
- * Build the is_original receipt_files manifest row input for a just-promoted
- * attachment receipt — the OTHER pure half of promoteIntake (alongside
- * buildPromoteReceiptInput and buildPromoteExtractionJob). r2Key is the STANDARD
- * receipts/... key from step 3, NEVER the intake key (r2_key is UNIQUE and step
- * 5 deletes the intake object), and isOriginal is always true — the attachment
- * IS the receipt's true original, mirroring promoteBodyIntake. Exported so the
- * standard-key + isOriginal invariants are unit-testable without exercising the
- * binding-coupled promoteIntake body. Before this, the attachment branch wrote
- * the receipt but never its manifest row — leaving email_attachment receipts
- * with zero file rows, which blocks month finalize under the proofs gate.
- */
-export function buildPromoteFileInput(args: {
-  receiptId: string;
-  standardKey: string;
-  intake: EmailReceiptIntake;
-  fileSizeFallbackBytes: number;
-  actor: string;
-}): CreateReceiptFileInput {
-  return {
-    objectType: "receipt",
-    objectId: args.receiptId,
-    role: "original",
-    r2Bucket: "receipts",
-    r2Key: args.standardKey,
-    originalFilename: args.intake.attachment_filename ?? "attachment",
-    contentType: args.intake.attachment_content_type ?? "application/octet-stream",
-    fileSizeBytes: args.intake.attachment_size_bytes ?? args.fileSizeFallbackBytes,
-    sha256Hash: args.intake.attachment_sha256 as string,
-    uploadedBy: args.actor,
-    isOriginal: true,
-  };
-}
-
-/**
  * Refuse promotion for rows that have nothing to promote or are no longer
  * pending. Throws a plain Error whose message is safe to surface as 409 body.
  * ADR 0011 Phase B: a body-only row (no attachment, but a captured text/html
@@ -580,19 +509,20 @@ async function promoteBodyIntake(
   const bodyBytes = encoded.buffer.slice(0, encoded.byteLength) as ArrayBuffer;
   const sha256 = await computeSha256Hex(bodyBytes);
 
-  // Staging key: write the body so createReceiptRecord has a real original_r2_key
-  // to insert (the column is NOT NULL). After we know the receipt id, copy to the
-  // standard receipts/{id}/... key, patch original_r2_key, create the is_original
-  // receipt_files row, and delete the staging object — same move-semantics as the
-  // attachment promote path below.
-  const now = nowIso();
+  // Staging key: captureReceipt (intake-copy) needs an object to read + move,
+  // and createReceiptRecord's original_r2_key is NOT NULL. Write the body to a
+  // staging key; captureReceipt copies it to the standard key.
   const stagingKey = `receipts-render-staging/${intake.id}/${newUuid()}-${sanitizeFilenameForR2(filename)}`;
   await bucket.put(stagingKey, bodyBytes, {
     httpMetadata: { contentType },
   });
 
-  const receiptId = await createReceiptRecord(
-    {
+  // captureReceipt (backlog #18 single door): create (staging key) → copy
+  // staging→standard → patch original_r2_key → is_original manifest row. enqueue
+  // is FALSE: sourceType 'email_body' seeds needs_render=1, so /render enqueues
+  // later (the body is rendered to PDF/image on the Mac before MLX extraction).
+  const { receiptId } = await captureReceipt({
+    record: {
       capturedBy: intake.from_address,
       source: "email",
       sourceType: "email_body",
@@ -603,31 +533,10 @@ async function promoteBodyIntake(
       originalSizeBytes: bodyBytes.byteLength,
       originalFilename: filename,
     },
+    file: { sha256, sizeBytes: bodyBytes.byteLength, contentType, filename },
+    r2Strategy: { kind: "intake-copy", intakeKey: stagingKey },
+    enqueue: false,
     actor,
-  );
-
-  // Copy to the standard key + patch original_r2_key + create the is_original
-  // receipt_files row.
-  const standardKey = generateR2Key(receiptId, filename, now);
-  await uploadOriginal(standardKey, bodyBytes, contentType);
-  await db
-    .prepare(
-      `UPDATE receipt_records SET original_r2_key = ?, updated_at = ? WHERE id = ?`,
-    )
-    .bind(standardKey, now, receiptId)
-    .run();
-  await createReceiptFile(db, {
-    objectType: "receipt",
-    objectId: receiptId,
-    role: "original",
-    r2Bucket: "receipts",
-    r2Key: standardKey,
-    originalFilename: filename,
-    contentType,
-    fileSizeBytes: bodyBytes.byteLength,
-    sha256Hash: sha256,
-    uploadedBy: actor,
-    isOriginal: true,
   });
 
   // Flip the intake row (idempotent guard on status). attachment_r2_key is
@@ -713,121 +622,26 @@ export async function promoteIntake(
     return promoteBodyIntake(intake, actor);
   }
 
-  // Read the intake object so we can copy it to the standard key.
+  // captureReceipt (backlog #18 single door): create (intake key) → copy
+  // intake→standard → patch original_r2_key → is_original manifest (standard) →
+  // enqueue (standard). It reads + moves the intake object itself; a missing
+  // object or a manifest-write failure throws (LOUD — compensating delete) and
+  // the enqueue is best-effort, per the contract. Leaves the intake row
+  // pending_triage on any failure (the flip below hasn't run) so it's
+  // re-promotable.
   const originalIntakeKey = intake.attachment_r2_key as string;
-  const obj = await bucket.get(originalIntakeKey);
-  if (!obj) {
-    throw new Error(
-      `Intake ${id} attachment object is missing from R2 (key ${originalIntakeKey}).`,
-    );
-  }
-  const bytes = await obj.arrayBuffer();
-
-  // 1. Create the receipt via the canonical path. originalR2Key is the intake
-  //    key for now; patched below once we know the standard key.
-  const receiptId = await createReceiptRecord(buildPromoteReceiptInput(intake), actor);
-
-  // 2. Copy the object to the standard receipts/... key (retention metadata
-  //    IS correct here — this is now a tax record). generateR2Key embeds the
-  //    receipt id, matching the rest of the system's key convention.
-  const now = nowIso();
-  const standardKey = generateR2Key(
-    receiptId,
-    intake.attachment_filename ?? "attachment",
-    now,
-  );
-  await uploadOriginal(
-    standardKey,
-    bytes,
-    intake.attachment_content_type ?? "application/octet-stream",
-  );
-
-  // 3. Patch the receipt's original_r2_key to the standard key.
-  await db
-    .prepare(
-      `UPDATE receipt_records SET original_r2_key = ?, updated_at = ? WHERE id = ?`,
-    )
-    .bind(standardKey, now, receiptId)
-    .run();
-
-  // 3.5. Write the is_original receipt_files manifest row — the OTHER step the
-  //      body branch (promoteBodyIntake) performs that this branch had skipped
-  //      (same divergence root cause as the enqueue). r2_key is the standard key
-  //      (UNIQUE; the intake key is deleted in step 5). Ordered BEFORE the
-  //      enqueue (3.6) so a fast consumer drain can't outrun the manifest, and
-  //      before the intake flip (step 4) so a failure here leaves the intake row
-  //      re-promotable. Unlike the enqueue (best-effort), a manifest-write
-  //      failure fails LOUDLY (backlog #5 / audit A1): the proofs gate counts
-  //      file rows (validateMonthReadyForExportCore), so a half-promoted receipt
-  //      with no manifest row would silently block month finalize. Follow the
-  //      upload-route precedent — compensating-delete the R2 object + receipt
-  //      and throw, rather than leave a half-promoted row.
-  try {
-    await createReceiptFile(
-      db,
-      buildPromoteFileInput({
-        receiptId,
-        standardKey,
-        intake,
-        fileSizeFallbackBytes: bytes.byteLength,
-        actor,
-      }),
-    );
-  } catch (fileError) {
-    console.error(
-      "[promoteIntake] file manifest write failed — compensating delete",
-      fileError,
-    );
-    try {
-      await bucket.delete(standardKey);
-    } catch (r2Err) {
-      console.error(
-        "[promoteIntake] R2 cleanup after manifest failure also failed",
-        r2Err,
-      );
-    }
-    try {
-      await hardDeleteReceipt(
-        receiptId,
-        actor,
-        "manifest write failed during email-attachment promote",
-      );
-    } catch (deleteErr) {
-      console.error(
-        "[promoteIntake] hardDeleteReceipt after manifest failure also failed — manual cleanup required",
-        deleteErr,
-      );
-    }
-    throw fileError;
-  }
-
-  // 3.6. Enqueue the extraction job for the Mac MLX consumer (ADR 0001). Same
-  //      best-effort contract as /api/receipts/upload: a missing/failing queue
-  //      must NOT fail the promotion — the receipt stays at
-  //      extraction_state='captured' for the /enqueue recovery endpoint to pick
-  //      up later. buildPromoteExtractionJob sets r2Key = the standard key from
-  //      step 3 (NEVER the intake key, which step 5 deletes — unit-tested), and
-  //      the enqueue happens AFTER the original_r2_key patch so the consumer
-  //      can never fetch a key that step 5 is about to delete. Before this
-  //      step, every email_attachment receipt sat at captured/never-enqueued
-  //      forever (3 stranded on 2026-08-03).
-  const job = buildPromoteExtractionJob({
-    receiptId,
-    standardKey,
-    intakeContentType: intake.attachment_content_type,
+  const { receiptId } = await captureReceipt({
+    record: buildPromoteReceiptInput(intake),
+    file: {
+      sha256: intake.attachment_sha256 as string,
+      sizeBytes: intake.attachment_size_bytes ?? 0,
+      contentType: intake.attachment_content_type ?? "application/octet-stream",
+      filename: intake.attachment_filename ?? "attachment",
+    },
+    r2Strategy: { kind: "intake-copy", intakeKey: originalIntakeKey },
+    enqueue: true,
+    actor,
   });
-  const enqueued = await enqueueExtractionJob(job);
-  if (enqueued) {
-    try {
-      await updateReceiptRecord(
-        receiptId,
-        { extractionState: "queued", extractionEnqueuedAt: job.enqueuedAt },
-        actor,
-      );
-    } catch (markError) {
-      console.error("[promoteIntake] mark-queued failed", markError);
-    }
-  }
 
   // 4. Flip the intake row (idempotent guard on status). Null the intake key —
   //    the object was moved to the standard key.

--- a/lib/receipts/mobile-upload.ts
+++ b/lib/receipts/mobile-upload.ts
@@ -1,23 +1,14 @@
-import { getReceiptsDb } from "@/lib/cloudflare-runtime";
-import { createAuditEntry } from "@/lib/receipts/audit";
-import { newUuid, nowIso, stringifyJson } from "@/lib/receipts/db-utils";
-import { retentionUntilIso } from "@/lib/receipts/retention";
-import type { PaymentPath } from "@/lib/receipts/types";
+// Mobile-upload idempotency lookup.
+//
+// createMobileReceiptRecord — the second INSERT INTO receipt_records (raw, with
+// device_id/client_capture_id/captured_at_client/upload_origin) — was FOLDED
+// into createReceiptRecord (lib/receipts/db.ts) by backlog #18's capture
+// contract merge. Those columns are now optional fields on CreateReceiptInput,
+// written by the single insert path; captureReceipt (lib/receipts/capture.ts)
+// is the one door. This module keeps only the idempotency lookup the mobile
+// route uses for its pre-check + race handling.
 
-export interface MobileReceiptInput {
-  actor: string;
-  deviceId: string;
-  clientCaptureId: string;
-  capturedAtClient: string | null;
-  appVersion: string | null;
-  note: string | null;
-  paymentPath: PaymentPath;
-  originalFilename: string;
-  originalR2Key: string;
-  originalSha256: string;
-  originalContentType: string;
-  originalSizeBytes: number;
-}
+import { getReceiptsDb } from "@/lib/cloudflare-runtime";
 
 export interface MobileReceiptIdempotencyHit {
   id: string;
@@ -38,77 +29,4 @@ export async function findMobileReceiptByIdempotency(
     .bind(deviceId, clientCaptureId)
     .first<{ id: string; status: string }>();
   return row ?? null;
-}
-
-export async function createMobileReceiptRecord(input: MobileReceiptInput): Promise<string> {
-  const db = getReceiptsDb();
-  const id = newUuid();
-  const now = nowIso();
-
-  await db
-    .prepare(
-      // ADR 0001: mobile field captures are async like the web path — land as
-      // status='captured' / extraction_state='captured' (pending processing).
-      // The route enqueues a job and the Mac MLX consumer drains it. Setting
-      // extraction_state explicitly is required: the column defaults to
-      // 'captured', so any insert that omits it would otherwise read as pending
-      // forever even on paths that never enqueue.
-      `INSERT INTO receipt_records
-        (id, captured_at, captured_by, source, original_filename,
-         payment_path, expense_type,
-         alcohol_present, attendees_required, status, extraction_state,
-         original_r2_key, original_sha256, original_content_type, original_size_bytes,
-         legacy, retention_until, legal_hold,
-         source_type, preservation_status, qualified_invoice_status,
-         device_id, client_capture_id, captured_at_client, upload_origin,
-         currency,
-         created_at, updated_at)
-       VALUES
-        (?, ?, ?, 'mobile_capture', ?,
-         ?, 'UNKNOWN',
-         0, 0, 'captured', 'captured',
-         ?, ?, ?, ?,
-         0, ?, 1,
-         'paper_scanned', 'captured', 'not_checked',
-         ?, ?, ?, 'mobile',
-         'JPY',
-         ?, ?)`,
-    )
-    .bind(
-      id,
-      now,
-      input.actor,
-      input.originalFilename,
-      input.paymentPath,
-      input.originalR2Key,
-      input.originalSha256,
-      input.originalContentType,
-      input.originalSizeBytes,
-      retentionUntilIso(now),
-      input.deviceId,
-      input.clientCaptureId,
-      input.capturedAtClient,
-      now,
-      now,
-    )
-    .run();
-
-  await createAuditEntry(db, {
-    actor: input.actor,
-    action: "receipt.uploaded",
-    objectType: "receipt",
-    objectId: id,
-    newValueJson: stringifyJson({
-      source: "mobile_capture",
-      source_type: "paper_scanned",
-      upload_origin: "mobile",
-      payment_path: input.paymentPath,
-      device_id: input.deviceId,
-      client_capture_id: input.clientCaptureId,
-      app_version: input.appVersion,
-      note: input.note,
-    }),
-  });
-
-  return id;
 }

--- a/lib/receipts/types.ts
+++ b/lib/receipts/types.ts
@@ -712,6 +712,20 @@ export interface CreateReceiptInput {
   // synchronous path). The async capture path (ADR 0001) passes 'captured',
   // which also seeds extraction_state='captured' (pending processing).
   status?: ReceiptStatus;
+  // Mobile-capture provenance (backlog #18 merge — createMobileReceiptRecord's
+  // divergent INSERT folded in). device_id/client_capture_id/captured_at_client/
+  // upload_origin are written to receipt_records columns; the 0015 partial
+  // UNIQUE index on (device_id, client_capture_id) enforces idempotency AT
+  // INSERT (so it fires for mobile, never for non-mobile where both are NULL).
+  // app_version/note are audit-JSON ONLY (never columns) — the receipt.uploaded
+  // audit emits them when present, or mobile captures lose device provenance
+  // (same class of loss the promote path guards against via SPF/DKIM).
+  deviceId?: string;
+  clientCaptureId?: string;
+  capturedAtClient?: string | null;
+  uploadOrigin?: string;
+  appVersion?: string | null;
+  note?: string | null;
 }
 
 export interface UpdateReceiptInput {

--- a/lib/receipts/types.ts
+++ b/lib/receipts/types.ts
@@ -312,6 +312,11 @@ export interface ReceiptRecord {
   // Extraction queue state (0016_extraction_queue.sql, ADR 0001)
   extraction_state?: ExtractionState;
   extraction_enqueued_at?: string | null;
+  // Backlog #20 (0038): set when enqueueExtractionJob returned false, so a queue
+  // outage is distinguishable from a forgotten enqueue (both otherwise look like
+  // captured + enqueued_at NULL). NULL when the enqueue succeeded or was never
+  // attempted (needs_render path). See lib/receipts/capture.ts.
+  extraction_enqueue_failed_at?: string | null;
   extraction_processed_at?: string | null;
   extraction_attempts?: number;
   extraction_processor?: string | null;

--- a/tests/receipts/capture-contract.test.ts
+++ b/tests/receipts/capture-contract.test.ts
@@ -1,0 +1,61 @@
+// THE DELIVERABLE OF #18 (ii): the capture completeness contract enforced
+// structurally, not by convention. Two source-tree assertions. Assertion (2)
+// is PRIMARY — it is the one that would have caught the mobile path's second
+// INSERT (createMobileReceiptRecord) that the importer test alone is blind to.
+//
+// A capture is complete iff: (a) a receipt_records row [one insert path],
+// (b) an is_original receipt_files row, (c) an enqueued job OR needs_render=1
+// — all through captureReceipt (lib/receipts/capture.ts). This test guarantees
+// the NEXT capture path can't bypass it the way the fourth (mobile) did.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+/** Tracked source files (app/lib/components — NOT tests) containing `needle`. */
+function sourceFilesContaining(needle: string): string[] {
+  const out = execFileSync(
+    "git",
+    ["grep", "-l", "-e", needle, "app/", "lib/", "components/"],
+    { encoding: "utf8" },
+  );
+  return out.trim().split("\n").filter(Boolean);
+}
+
+/** A real INSERT statement, not a comment: in this codebase all D1 SQL is a
+ *  `.prepare(``...``)` template literal, so a real INSERT has a backtick before
+ *  it on the line. Comments (e.g. mobile-upload.ts's history note) don't. */
+const SQL_INSERT_INTO_RECEIPT_RECORDS = /`\s*INSERT\s+INTO\s+receipt_records/;
+
+test("#18 enforcement (PRIMARY): exactly one INSERT INTO receipt_records — db.ts", () => {
+  // createMobileReceiptRecord was a SECOND insert path with its own raw INSERT +
+  // divergent columns; it bypassed createReceiptRecord entirely, so the importer
+  // assertion below could not see it. After the merge, db.ts owns the only INSERT.
+  // A future path that adds another INSERT fails this test.
+  const candidates = sourceFilesContaining("INSERT INTO receipt_records");
+  const offenders = candidates.filter((f) =>
+    SQL_INSERT_INTO_RECEIPT_RECORDS.test(readFileSync(f, "utf8")),
+  );
+  assert.deepEqual(
+    offenders.sort(),
+    ["lib/receipts/db.ts"],
+    `expected only db.ts to INSERT INTO receipt_records; found: ${offenders.join(", ")}`,
+  );
+});
+
+test("#18 enforcement: createReceiptRecord has exactly one importer — capture.ts", () => {
+  // The single door. db.ts defines createReceiptRecord (not an importer); every
+  // capture path reaches it through captureReceipt. A new direct importer fails.
+  const files = sourceFilesContaining("createReceiptRecord");
+  const importers = files.filter((f) =>
+    /import\s*\{[^}]*\bcreateReceiptRecord\b[^}]*\}\s*from/.test(
+      readFileSync(f, "utf8"),
+    ),
+  );
+  assert.deepEqual(
+    importers.sort(),
+    ["lib/receipts/capture.ts"],
+    `expected only capture.ts to import createReceiptRecord; found: ${importers.join(", ")}`,
+  );
+});

--- a/tests/receipts/capture-contract.test.ts
+++ b/tests/receipts/capture-contract.test.ts
@@ -7,47 +7,74 @@
 // (b) an is_original receipt_files row, (c) an enqueued job OR needs_render=1
 // — all through captureReceipt (lib/receipts/capture.ts). This test guarantees
 // the NEXT capture path can't bypass it the way the fourth (mobile) did.
+//
+// SCOPE: app/ lib/ components/ only. scripts/ is DELIBERATELY out of scope —
+// one-off scripts (e.g. backfill-missing-manifest.ts) legitimately run ad-hoc
+// receipt SQL; the contract governs the runtime capture paths, not tooling.
 
 import test from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 
-/** Tracked source files (app/lib/components — NOT tests) containing `needle`. */
-function sourceFilesContaining(needle: string): string[] {
+/** A real INSERT into receipt_records in ANY form — including INSERT OR IGNORE
+ *  INTO / INSERT OR REPLACE INTO, which a future idempotent capture path would
+ *  reach for and which a naive "INSERT INTO receipt_records" grep misses. The
+ *  optional `OR <word>` clause is the part a weaker test would let through. */
+const OFFENDER = /INSERT\s+(OR\s+\w+\s+)?INTO\s+receipt_records/;
+
+/** Strip comment LINES (not inline) so a history comment like mobile-upload.ts's
+ *  "// the second INSERT INTO receipt_records" doesn't false-positive. Solving
+ *  the comment problem by requiring backticks instead opens a worse hole: a
+ *  double-quoted .prepare("INSERT INTO …") becomes a candidate but matches no
+ *  backtick regex. Stripping comments keeps the test honest AND quote-agnostic. */
+function stripCommentLines(src: string): string {
+  return src
+    .split("\n")
+    .filter((line) => {
+      const t = line.trim();
+      return !(t.startsWith("//") || t.startsWith("*") || t.startsWith("/*"));
+    })
+    .join("\n");
+}
+
+/** Candidate source files (app/lib/components — NOT tests, NOT scripts/) whose
+ *  text mentions an INSERT … receipt_records. Broad on purpose: catches INSERT
+ *  OR IGNORE INTO too (a plain "INSERT INTO receipt_records" grep would miss it). */
+function candidateFiles(): string[] {
   const out = execFileSync(
     "git",
-    ["grep", "-l", "-e", needle, "app/", "lib/", "components/"],
+    ["grep", "-l", "-E", "INSERT.*receipt_records", "app/", "lib/", "components/"],
     { encoding: "utf8" },
   );
   return out.trim().split("\n").filter(Boolean);
 }
 
-/** A real INSERT statement, not a comment: in this codebase all D1 SQL is a
- *  `.prepare(``...``)` template literal, so a real INSERT has a backtick before
- *  it on the line. Comments (e.g. mobile-upload.ts's history note) don't. */
-const SQL_INSERT_INTO_RECEIPT_RECORDS = /`\s*INSERT\s+INTO\s+receipt_records/;
-
-test("#18 enforcement (PRIMARY): exactly one INSERT INTO receipt_records — db.ts", () => {
+test("#18 enforcement (PRIMARY): exactly one INSERT into receipt_records — db.ts", () => {
   // createMobileReceiptRecord was a SECOND insert path with its own raw INSERT +
   // divergent columns; it bypassed createReceiptRecord entirely, so the importer
   // assertion below could not see it. After the merge, db.ts owns the only INSERT.
-  // A future path that adds another INSERT fails this test.
-  const candidates = sourceFilesContaining("INSERT INTO receipt_records");
-  const offenders = candidates.filter((f) =>
-    SQL_INSERT_INTO_RECEIPT_RECORDS.test(readFileSync(f, "utf8")),
+  // A future path that adds another INSERT — including INSERT OR IGNORE — fails
+  // this test. Comment lines are stripped so history notes don't read as code.
+  const offenders = candidateFiles().filter((f) =>
+    OFFENDER.test(stripCommentLines(readFileSync(f, "utf8"))),
   );
   assert.deepEqual(
     offenders.sort(),
     ["lib/receipts/db.ts"],
-    `expected only db.ts to INSERT INTO receipt_records; found: ${offenders.join(", ")}`,
+    `expected only db.ts to INSERT into receipt_records; found: ${offenders.join(", ")}`,
   );
 });
 
 test("#18 enforcement: createReceiptRecord has exactly one importer — capture.ts", () => {
   // The single door. db.ts defines createReceiptRecord (not an importer); every
   // capture path reaches it through captureReceipt. A new direct importer fails.
-  const files = sourceFilesContaining("createReceiptRecord");
+  const out = execFileSync(
+    "git",
+    ["grep", "-l", "-e", "createReceiptRecord", "app/", "lib/", "components/"],
+    { encoding: "utf8" },
+  );
+  const files = out.trim().split("\n").filter(Boolean);
   const importers = files.filter((f) =>
     /import\s*\{[^}]*\bcreateReceiptRecord\b[^}]*\}\s*from/.test(
       readFileSync(f, "utf8"),
@@ -58,4 +85,45 @@ test("#18 enforcement: createReceiptRecord has exactly one importer — capture.
     ["lib/receipts/capture.ts"],
     `expected only capture.ts to import createReceiptRecord; found: ${importers.join(", ")}`,
   );
+});
+
+// ─── fixtures: the test must not fail open on the known evasions ─────────────
+
+test("offender regex catches INSERT OR IGNORE INTO (the idempotent-capture evasion)", () => {
+  // A future idempotent capture path would reach for INSERT OR IGNORE; the old
+  // "INSERT INTO receipt_records" candidate grep never matched this string, so
+  // the file was never read. The offender regex + broad candidate grep catch it.
+  assert.equal(
+    OFFENDER.test("await db.prepare(`INSERT OR IGNORE INTO receipt_records (id) VALUES (?)`)"),
+    true,
+  );
+  assert.equal(
+    OFFENDER.test("INSERT OR REPLACE INTO receipt_records (id) VALUES (?)"),
+    true,
+  );
+});
+
+test("offender regex is quote-agnostic (backtick AND double-quoted .prepare)", () => {
+  // The old backtick-requiring regex let a double-quoted .prepare("INSERT …")
+  // through. This regex matches either quote style.
+  assert.equal(
+    OFFENDER.test('db.prepare("INSERT INTO receipt_records (id) VALUES (?)")'),
+    true,
+  );
+  assert.equal(
+    OFFENDER.test("db.prepare(`INSERT INTO receipt_records (id) VALUES (?)`)"),
+    true,
+  );
+});
+
+test("comment lines are stripped (history notes don't false-positive)", () => {
+  // mobile-upload.ts carries a comment documenting that createMobileReceiptRecord
+  // was the second INSERT path. That's history, not code — stripping comment
+  // lines keeps it out of the offender set without weakening the regex.
+  const withComment =
+    "// createMobileReceiptRecord was the second INSERT INTO receipt_records (raw, …)\nexport function findMobileReceiptByIdempotency() {}\n";
+  assert.equal(OFFENDER.test(stripCommentLines(withComment)), false);
+  const withCode =
+    "await db.prepare(`INSERT INTO receipt_records (id) VALUES (?)`);\n";
+  assert.equal(OFFENDER.test(stripCommentLines(withCode)), true);
 });

--- a/tests/receipts/capture.test.ts
+++ b/tests/receipts/capture.test.ts
@@ -1,0 +1,91 @@
+// Tests for the capture contract's pure pieces (lib/receipts/capture.ts).
+// captureReceipt itself is binding-coupled (D1 + R2 + Queue); its decisions are
+// extracted as pure helpers and covered here. The contract enforcement (one
+// createReceiptRecord importer; one INSERT path) lives in capture-contract.test.ts.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildCaptureFileInput,
+  decideCaptureMark,
+  isMobileIdempotencyCollision,
+  CaptureIdempotencyConflict,
+  CaptureManifestFailure,
+} from "@/lib/receipts/capture";
+
+// ─── decideCaptureMark (the #20 marker logic) ───────────────────────────────
+
+test("decideCaptureMark: not attempted (needs_render) → captured, no timestamps", () => {
+  const m = decideCaptureMark({ attempted: false, enqueued: false, now: "NOW" });
+  assert.equal(m.extractionState, "captured");
+  assert.equal(m.extractionEnqueuedAt, null);
+  assert.equal(m.extractionEnqueueFailedAt, null);
+});
+
+test("decideCaptureMark: attempted + enqueued → queued + enqueued_at, no failed_at", () => {
+  const m = decideCaptureMark({ attempted: true, enqueued: true, now: "NOW" });
+  assert.equal(m.extractionState, "queued");
+  assert.equal(m.extractionEnqueuedAt, "NOW");
+  assert.equal(m.extractionEnqueueFailedAt, null);
+});
+
+test("decideCaptureMark: attempted + FAILED (queue outage) → captured + failed_at marker (#20)", () => {
+  // This is the marker that distinguishes a queue outage from a forgotten enqueue.
+  const m = decideCaptureMark({ attempted: true, enqueued: false, now: "NOW" });
+  assert.equal(m.extractionState, "captured");
+  assert.equal(m.extractionEnqueuedAt, null);
+  assert.equal(m.extractionEnqueueFailedAt, "NOW");
+});
+
+// ─── buildCaptureFileInput (the manifest row) ────────────────────────────────
+
+test("buildCaptureFileInput: r2Key is the given key, isOriginal true, fields mapped", () => {
+  const f = buildCaptureFileInput({
+    receiptId: "r1",
+    r2Key: "receipts/2026/08/r1/abc.pdf",
+    file: { sha256: "deadbeef", sizeBytes: 99, contentType: "application/pdf", filename: "r.pdf" },
+    actor: "op@dazbeez.com",
+  });
+  assert.equal(f.r2Key, "receipts/2026/08/r1/abc.pdf");
+  assert.equal(f.isOriginal, true);
+  assert.equal(f.objectType, "receipt");
+  assert.equal(f.objectId, "r1");
+  assert.equal(f.role, "original");
+  assert.equal(f.r2Bucket, "receipts");
+  assert.equal(f.sha256Hash, "deadbeef");
+  assert.equal(f.fileSizeBytes, 99);
+  assert.equal(f.originalFilename, "r.pdf");
+  assert.equal(f.uploadedBy, "op@dazbeez.com");
+});
+
+// ─── isMobileIdempotencyCollision (the #18 ii-c(b) classification) ──────────
+
+test("isMobileIdempotencyCollision: D1 UNIQUE on device_id/client_capture_id → true (race)", () => {
+  assert.equal(
+    isMobileIdempotencyCollision(
+      new Error("UNIQUE constraint failed: receipt_records.device_id, receipt_records.client_capture_id"),
+    ),
+    true,
+  );
+});
+
+test("isMobileIdempotencyCollision: a manifest/other error → false (NOT a race)", () => {
+  // This is the crux of (b): a manifest failure must NOT be mistaken for a race,
+  // or the route returns duplicate:true on a row it just deleted.
+  assert.equal(isMobileIdempotencyCollision(new Error("some other db error")), false);
+  assert.equal(isMobileIdempotencyCollision(new CaptureManifestFailure()), false);
+  assert.equal(isMobileIdempotencyCollision(null), false);
+});
+
+// ─── typed errors are distinguishable (the route branches on them) ──────────
+
+test("typed errors: CaptureIdempotencyConflict and CaptureManifestFailure are distinct", () => {
+  const race = new CaptureIdempotencyConflict();
+  const manifest = new CaptureManifestFailure();
+  assert.equal(race instanceof CaptureIdempotencyConflict, true);
+  assert.equal(manifest instanceof CaptureManifestFailure, true);
+  assert.equal(race instanceof CaptureManifestFailure, false);
+  assert.equal(manifest instanceof CaptureIdempotencyConflict, false);
+  assert.equal(race.kind, "CaptureIdempotencyConflict");
+  assert.equal(manifest.kind, "CaptureManifestFailure");
+});

--- a/tests/receipts/email-intake.test.ts
+++ b/tests/receipts/email-intake.test.ts
@@ -18,8 +18,6 @@ import {
   listPendingIntake,
   rejectIntake,
   buildPromoteReceiptInput,
-  buildPromoteExtractionJob,
-  buildPromoteFileInput,
   assertPromotable,
   isBodyOnlyIntake,
 } from "@/lib/receipts/email-intake";
@@ -530,103 +528,6 @@ test("buildPromoteReceiptInput: copies R2 metadata from the intake row", () => {
 });
 
 // ─── buildPromoteExtractionJob (pure half of the attachment enqueue) ────────
-
-test("buildPromoteExtractionJob: r2Key is the STANDARD key, NEVER the intake key", () => {
-  const standardKey = "receipts/2026/08/rcpt-1/abc-r.pdf";
-  const intakeKey = "receipts-intake/2026/08/intake-1/xyz-r.pdf";
-  const job = buildPromoteExtractionJob({
-    receiptId: "rcpt-1",
-    standardKey,
-    intakeContentType: "application/pdf",
-  });
-  assert.equal(job.r2Key, standardKey, "enqueues the standard key");
-  assert.notEqual(
-    job.r2Key,
-    intakeKey,
-    "never enqueues the intake key (deleted in step 5)",
-  );
-  assert.ok(
-    !job.r2Key.startsWith("receipts-intake/"),
-    "standard key uses the receipts/ prefix, not receipts-intake/",
-  );
-});
-
-test("buildPromoteExtractionJob: stamps receiptId + falls back contentType to octet-stream when null", () => {
-  const job = buildPromoteExtractionJob({
-    receiptId: "rcpt-2",
-    standardKey: "receipts/2026/08/rcpt-2/abc.png",
-    intakeContentType: null,
-  });
-  assert.equal(job.receiptId, "rcpt-2");
-  assert.equal(
-    job.contentType,
-    "application/octet-stream",
-    "null intake contentType falls back to a safe default",
-  );
-  assert.ok(job.enqueuedAt, "enqueuedAt is stamped on the job");
-});
-
-// ─── buildPromoteFileInput (pure half of the attachment manifest write) ─────
-
-test("buildPromoteFileInput: r2Key is the STANDARD key (never the intake key); isOriginal true", () => {
-  const standardKey = "receipts/2026/08/rcpt-1/abc-r.pdf";
-  const intakeKey = "receipts-intake/2026/08/intake-1/xyz-r.pdf";
-  const file = buildPromoteFileInput({
-    receiptId: "rcpt-1",
-    standardKey,
-    intake: intakeRow({ attachment_r2_key: intakeKey, attachment_sha256: "deadbeef" }),
-    fileSizeFallbackBytes: 999,
-    actor: "operator@dazbeez.com",
-  });
-  assert.equal(file.r2Key, standardKey, "manifest row points at the standard key");
-  assert.notEqual(file.r2Key, intakeKey, "never the intake key (deleted in step 5)");
-  assert.ok(!file.r2Key.startsWith("receipts-intake/"), "uses the receipts/ prefix");
-  assert.equal(file.isOriginal, true, "the attachment IS the receipt's true original");
-  assert.equal(file.objectType, "receipt");
-  assert.equal(file.objectId, "rcpt-1");
-  assert.equal(file.role, "original");
-  assert.equal(file.r2Bucket, "receipts");
-  assert.equal(file.uploadedBy, "operator@dazbeez.com");
-});
-
-test("buildPromoteFileInput: maps intake metadata with safe fallbacks", () => {
-  const file = buildPromoteFileInput({
-    receiptId: "rcpt-2",
-    standardKey: "receipts/2026/08/rcpt-2/abc.pdf",
-    intake: intakeRow({
-      attachment_filename: "invoice.pdf",
-      attachment_content_type: "application/pdf",
-      attachment_size_bytes: 4321,
-      attachment_sha256: "abc123",
-    }),
-    fileSizeFallbackBytes: 0,
-    actor: "a",
-  });
-  assert.equal(file.originalFilename, "invoice.pdf");
-  assert.equal(file.contentType, "application/pdf");
-  assert.equal(file.fileSizeBytes, 4321, "uses stored size when present");
-  assert.equal(file.sha256Hash, "abc123");
-});
-
-test("buildPromoteFileInput: falls back filename/contentType/size when intake metadata is null", () => {
-  const file = buildPromoteFileInput({
-    receiptId: "rcpt-3",
-    standardKey: "receipts/2026/08/rcpt-3/abc",
-    intake: intakeRow({
-      attachment_filename: null,
-      attachment_content_type: null,
-      attachment_size_bytes: null,
-      attachment_sha256: "h",
-    }),
-    fileSizeFallbackBytes: 7000,
-    actor: "a",
-  });
-  assert.equal(file.originalFilename, "attachment");
-  assert.equal(file.contentType, "application/octet-stream");
-  assert.equal(file.fileSizeBytes, 7000, "falls back to the provided byte length");
-});
-
-// ─── assertPromotable (pure half of promote) ────────────────────────────────
 
 test("assertPromotable: refuses when there is neither attachment nor body", () => {
   assert.throws(

--- a/tests/receipts/preservation-status.test.ts
+++ b/tests/receipts/preservation-status.test.ts
@@ -1,0 +1,30 @@
+// Tests for derivePreservationStatus (lib/receipts/db.ts) — migration 0014's
+// backfill CASE as the single authority for preservation_status (#18 audit / #23).
+// Both capture paths previously hardcoded a literal ('needs_review' / 'captured'),
+// disagreeing with 0014's 'needs_metadata' for status='captured'.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { derivePreservationStatus } from "@/lib/receipts/db";
+import type { ReceiptStatus } from "@/lib/receipts/types";
+
+const s = (v: string): ReceiptStatus => v as ReceiptStatus;
+
+test("derivePreservationStatus: 0014 CASE — status → preservation_status", () => {
+  assert.equal(derivePreservationStatus(s("captured")), "needs_metadata");
+  assert.equal(derivePreservationStatus(s("reviewed")), "reviewed");
+  assert.equal(derivePreservationStatus(s("reconciled")), "reviewed");
+  assert.equal(derivePreservationStatus(s("exported")), "exported");
+  assert.equal(derivePreservationStatus(s("archived")), "archived");
+  assert.equal(derivePreservationStatus(s("needs_review")), "needs_review"); // ELSE
+  assert.equal(derivePreservationStatus(undefined), "needs_review"); // default status
+});
+
+test("derivePreservationStatus: a capture (status=captured) is needs_metadata — ends the 3-way disagreement", () => {
+  // createReceiptRecord hardcoded 'needs_review'; createMobileReceiptRecord
+  // 'captured'; 0014's authority is 'needs_metadata'. The derivation makes the
+  // merged insert correct; existing rows are backfilled separately (#23).
+  assert.equal(derivePreservationStatus(s("captured")), "needs_metadata");
+  assert.notEqual(derivePreservationStatus(s("captured")), "needs_review");
+  assert.notEqual(derivePreservationStatus(s("captured")), "captured");
+});


### PR DESCRIPTION
## Why
`createReceiptRecord` was "single-sourced" in prose while the *rest* of a capture (manifest + enqueue) was copy-pasted per route — and a **second insert path** (`createMobileReceiptRecord`) existed that the prose rule couldn't see. On 2026-08-09 `promoteIntake` was found to have omitted both the enqueue and the manifest. This makes the contract **structural**: one door, one insert path, enforced by a test that protects the *next* path.

## The invariant (now enforced)
A capture is complete iff **(a)** a `receipt_records` row + **(b)** an `is_original` `receipt_files` row + **(c)** an enqueued job OR `needs_render=1` — all through `captureReceipt` (`lib/receipts/capture.ts`).

## Changes
- **`captureReceipt()`** — the single door: create (a) → manifest (b) → enqueue/needs_render (c), with `r2Strategy: uploaded | intake-copy`. Manifest fails **LOUD** (`hardDeleteReceipt` + throw); enqueue is **best-effort** (sets the #20 marker).
- **`createMobileReceiptRecord` folded into `createReceiptRecord`** — optional `deviceId`/`clientCaptureId`/`capturedAtClient`/`uploadOrigin` (so the 0015 partial UNIQUE index still fires at insert). `createReceiptRecord` is now the **only** insert path.
- **`preservation_status` derived** from `status` via 0014's CASE (was a 3-way `'needs_review'`/`'captured'`/`'needs_metadata'` inconsistency — #23; existing rows backfilled separately).
- **Audit superset** — mobile provenance (incl. audit-only `app_version`/`note`) emitted when present (#18 ii-c(a)).
- **Typed errors** — `CaptureIdempotencyConflict` vs `CaptureManifestFailure`, so the mobile route's race-vs-manifest catch can't misfire (#18 ii-c(b)).
- **#20** — `extraction_enqueue_failed_at` column (migration 0038, applied) distinguishes a queue outage from a forgotten enqueue; `/enqueue` clears it on recovery.
- 4 paths rewired (upload, mobile, promoteIntake attachment, promoteBodyIntake); `buildPromoteExtractionJob`/`buildPromoteFileInput` deleted (subsumed).

## The deliverable of #18 — `tests/receipts/capture-contract.test.ts`
Asserts **both**: (1) exactly one `createReceiptRecord` importer (`capture.ts`), **and (2) exactly one `INSERT INTO receipt_records` (`db.ts`)**. Assertion (2) is PRIMARY — it's what would have caught the mobile bypass that the importer test is blind to.

## Verification
- `tsc` clean · `npm test` **1178 pass / 0 fail** · `build:cf` green
- Migration 0038 applied to prod (additive, no backfill) · deployed (Worker `fc44dc5a`) · smoke passed · `extraction_enqueue_failed_at` confirmed present

## Deferred (flagged, not done)
- **Class 1b dashboard split** (#20 vi): the marker is **written** by `captureReceipt` + cleared by `/enqueue`, but the dashboard doesn't yet split it into a separate "enqueue failed" class — a failed-enqueue receipt still shows as class 1 *with its Enqueue button* (so recovery isn't blocked; only the labeling isn't perfected). No regression vs pre-marker. Small follow-up.
- **Per-path live capture (B4)**: needs organic captures (mobile needs a device; upload/promote need Clerk/intake) — David's Step 4. Part A's dashboard staying all-clear is the instrument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)