### PR TITLE
June 2026 final-review fixes: notice copy, reconcile grouping, actionable gate, draft downloads, editable preface

### DIFF
--- a/app/(receipt-system)/receipts/export/[month]/review/page.tsx
+++ b/app/(receipt-system)/receipts/export/[month]/review/page.tsx
@@ -1,8 +1,10 @@
 import { notFound } from "next/navigation";
 import {
   buildExportBundle,
-  validateMonthReadyForExport,
+  validateMonthReadyForExportDetailed,
 } from "@/lib/receipts/month-closing";
+import { derivePackNoticeInput } from "@/lib/receipts/proofs";
+import { buildPackNames, type PackNames } from "@/lib/receipts/pack-naming";
 import {
   getExport,
   getFinalizedReconciliationForMonth,
@@ -60,8 +62,9 @@ export default async function ReviewPage({ params }: { params: Params }) {
     monthLines.length > 0 ? deriveStatementWindow(monthLines, month) : null;
 
   // Authoritative gate verdict — pass the prebuilt bundle + reconciliation so
-  // the gate doesn't re-fetch them.
-  const gateBlockers = await validateMonthReadyForExport(
+  // the gate doesn't re-fetch them. Detailed (ExportBlocker[]) so the review
+  // screen can render gate 1 as a link to Reconcile instead of dead prose.
+  const gateBlockers = await validateMonthReadyForExportDetailed(
     month,
     bundle,
     reconciliation ?? null,
@@ -85,6 +88,27 @@ export default async function ReviewPage({ params }: { params: Params }) {
     expenseCategoryCode: r.expense_category_code,
   }));
 
+  // E2: notice input + pack names for the preface editor's live preview. The
+  // operatorMessage field is overridden client-side with the live draft; these
+  // are the month-static inputs. names needs the AMEX payment-due date — when
+  // it's unavailable (an AMEX month whose draft predates the 0035 snapshot)
+  // buildPackNames throws and the preview is hidden (names=null), not crashed.
+  const prefaceNoticeInput = derivePackNoticeInput(month, bundle.rows, {
+    rowCount: bundle.rows.length,
+    receiptCount: bundle.receipts.length,
+  });
+  let prefaceNames: PackNames | null = null;
+  try {
+    const hasAmex = bundle.rows.some((r) => r.rowType === "amex_line");
+    prefaceNames = buildPackNames(
+      month,
+      currentExport?.payment_due_date ?? null,
+      hasAmex,
+    );
+  } catch {
+    prefaceNames = null;
+  }
+
   return (
     <ReviewScreen
       month={month}
@@ -100,6 +124,8 @@ export default async function ReviewPage({ params }: { params: Params }) {
       tripReports={tripReports}
       tripLines={tripLines}
       categoryRules={categoryRules}
+      prefaceNoticeInput={prefaceNoticeInput}
+      prefaceNames={prefaceNames}
     />
   );
 }

--- a/app/(receipt-system)/receipts/export/page.tsx
+++ b/app/(receipt-system)/receipts/export/page.tsx
@@ -202,23 +202,25 @@ export default async function ExportPage({
           {currentExport.bundle_built_at ? (
             <>
               <p className="mt-1 text-xs text-amber-800">
-                Open draft, NOT yet sealed. These are the candidate-seal bytes
-                (identical to what Finalize will seal). Downloaded filenames are
-                prefixed <code>DRAFT-</code> so they&apos;re unmistakable — verify,
-                then finalize.
+                Open draft, NOT yet sealed. <strong>証憑あり</strong> is
+                byte-identical to what Finalize will seal; <strong>証憑なし</strong>{" "}
+                is the pack root only (照合CSVs + 集計.csv + ご連絡事項.txt, no
+                images/PDFs). The word <code>Draft</code> in the filename is the
+                not-sealed signal — verify, then finalize.
               </p>
               <div className="mt-3 flex flex-wrap gap-3">
-                {BUNDLE_DOWNLOAD_LINKS.filter(
-                  ({ file }) => file !== "proofs" || !!currentExport.proofs_r2_key,
-                ).map(({ file, label }) => (
-                  <a
-                    key={file}
-                    href={`/api/receipts/export/${month}/download?file=${file}&draft=true`}
-                    className="rounded-xl border border-amber-400 bg-amber-100 px-4 py-2 text-xs font-semibold text-amber-900 hover:bg-amber-200"
-                  >
-                    {`DRAFT-${label}`}
-                  </a>
-                ))}
+                <a
+                  href={`/api/receipts/export/${month}/download?file=draft_nr&draft=true`}
+                  className="rounded-xl border border-amber-400 bg-amber-100 px-4 py-2 text-xs font-semibold text-amber-900 hover:bg-amber-200"
+                >
+                  下書き（証憑なし）
+                </a>
+                <a
+                  href={`/api/receipts/export/${month}/download?file=draft_wr&draft=true`}
+                  className="rounded-xl border border-amber-400 bg-amber-100 px-4 py-2 text-xs font-semibold text-amber-900 hover:bg-amber-200"
+                >
+                  下書き（証憑あり）
+                </a>
               </div>
             </>
           ) : (

--- a/app/api/receipts/export/[month]/message/route.ts
+++ b/app/api/receipts/export/[month]/message/route.ts
@@ -1,0 +1,89 @@
+import { NextResponse } from "next/server";
+import { requireReceiptsActor } from "@/lib/receipts/auth";
+import { createAuditEntry } from "@/lib/receipts/audit";
+import { stringifyJson } from "@/lib/receipts/db-utils";
+import { getExport, updateExportOperatorMessage } from "@/lib/receipts/db";
+import { getReceiptsDb } from "@/lib/cloudflare-runtime";
+
+type RouteContext = { params: Promise<{ month: string }> };
+
+/** Max operator-message length in characters (E1). Enforced server-side; the
+ *  UI mirrors the same cap on its character counter. */
+const MAX_OPERATOR_MESSAGE_LENGTH = 2000;
+
+/**
+ * PATCH /api/receipts/export/[month]/message — the ONE storage path the GUI
+ * writes for the editable preface (【今月のご連絡】). Pre-E1 nothing wrote
+ * operator_message from the UI, and a rebuild that omitted it from the body
+ * nulled the stored column (fixed separately in the rebuild route).
+ *
+ * - 400 when the trimmed message exceeds 2000 characters.
+ * - Trim on write; empty/whitespace stores NULL (buildPackNotice then omits the
+ *   whole 【今月のご連絡】 heading — preserved).
+ * - 409 when the month has no open draft (finalized with no open revision): the
+ *   sealed bundle is immutable; create a revision first. This reuses the same
+ *   draft/sealed predicate the download route uses (getExport → status==='draft').
+ * - Line endings are stored as-is; buildPackNotice normalizes to CRLF at render.
+ *
+ * Touches ONLY operator_message (updateExportOperatorMessage) — it deliberately
+ * does not advance bundle_built_at, so editing a built draft leaves it stale and
+ * the finalize gate (E3, message_stale) requires a rebuild before sealing.
+ */
+export async function PATCH(request: Request, { params }: RouteContext) {
+  try {
+    const actor = await requireReceiptsActor(request.headers);
+    const { month } = await params;
+
+    if (!/^\d{4}-\d{2}$/.test(month)) {
+      return NextResponse.json({ error: "Invalid month format." }, { status: 400 });
+    }
+
+    let body: { message?: unknown };
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+    }
+    const trimmed = (typeof body.message === "string" ? body.message : "").trim();
+    if (trimmed.length > MAX_OPERATOR_MESSAGE_LENGTH) {
+      return NextResponse.json(
+        {
+          error: `Message is too long (max ${MAX_OPERATOR_MESSAGE_LENGTH} characters).`,
+        },
+        { status: 400 },
+      );
+    }
+
+    // Reuse the existing draft/sealed predicate: getExport returns the current
+    // row, which is a draft iff one is open. Sealed (or no row) → 409.
+    const current = await getExport(month);
+    if (!current || current.status !== "draft") {
+      return NextResponse.json(
+        { error: `${month} is sealed. Create a revision to change the message.` },
+        { status: 409 },
+      );
+    }
+
+    const stored = trimmed.length > 0 ? trimmed : null;
+    await updateExportOperatorMessage(current.id, stored);
+
+    await createAuditEntry(getReceiptsDb(), {
+      actor,
+      action: "export.message_updated",
+      objectType: "export",
+      objectId: current.id,
+      newValueJson: stringifyJson({ month, operatorMessage: stored }),
+    });
+
+    return NextResponse.json({ operatorMessage: stored });
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Unauthorized")) {
+      return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+    }
+    console.error("[api/receipts/export/[month]/message] PATCH failed", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to save message." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/receipts/export/month/route.ts
+++ b/app/api/receipts/export/month/route.ts
@@ -22,6 +22,7 @@ import {
   buildSummaryKey,
   buildAttendeesKey,
   buildProofsKey,
+  buildProofsNoReceiptsKey,
   buildManifestCsv,
   buildReadmeKey,
   buildExportReadme,
@@ -166,6 +167,16 @@ export async function POST(request: Request) {
     const exportRevision = exportRecord?.export_revision ?? 1;
     const supersedesExportId = exportRecord?.supersedes_export_id ?? null;
     const correctionReason = exportRecord?.correction_reason ?? null;
+    // E1: the operator message must survive a rebuild that omits it from the
+    // request body. Resolve it ONCE — body wins when explicitly present,
+    // otherwise the stored draft row's value carries forward. Pre-E1 every
+    // rebuild bound `body.operatorMessage ?? null`, so a rebuild triggered
+    // without the message nulled the stored column and it vanished from the
+    // next notice (the preflight O7 check then flagged the drift). Trim + the
+    // 2000-char cap are enforced by the PATCH writer; the rebuild only carries
+    // the resolved value forward verbatim.
+    const operatorMessage =
+      body.operatorMessage ?? exportRecord?.operator_message ?? null;
 
     // Record exactly which receipts and AMEX lines ship in this bundle. The
     // one-draft-per-month invariant means an existing draft's items get
@@ -454,7 +465,7 @@ export async function POST(request: Request) {
         bundle.rows,
         { rowCount: bundle.rows.length, receiptCount: proofsEntries.length },
       ),
-      operatorMessage: body.operatorMessage ?? undefined,
+      operatorMessage: operatorMessage ?? undefined,
     };
 
     const proofsKey = buildProofsKey(month, exportId);
@@ -471,6 +482,32 @@ export async function POST(request: Request) {
     );
     const proofsSha256 = await computeSha256Hex(proofsZipBytes);
     await getReceiptsArchiveBucket().put(proofsKey, proofsZipBytes, {
+      httpMetadata: { contentType: "application/zip" },
+      customMetadata: retentionMetadata(),
+    });
+
+    // ── NoReceipts draft variant (D) ──────────────────────────────────────
+    // The SAME assembleProofsZip call as above with `entries: []` — identical
+    // packNames / noticeInput / summaryShipped / recon CSVs, zero image/PDF
+    // entries. Built here at rebuild (where those arguments are in scope) rather
+    // than at download time: it guarantees the shared entries (照合CSVs + 集計 +
+    // ご連絡) are byte-identical to the WithReceipts pack by construction, and
+    // keeps the download route a thin verbatim R2 proxy. The notice still reads
+    // 証憑ファイル数: <receiptCount> — the counts describe the month, not the
+    // zip you're holding (decision 1). Draft-only; finalize never seals this.
+    const proofsNoReceiptsKey = buildProofsNoReceiptsKey(month, exportId);
+    const proofsNoReceiptsBytes = assembleProofsZip(
+      packNames,
+      [],
+      proofsNoticeInput,
+      summaryShipped,
+      {
+        amex: amexReconShipped,
+        cash: cashReconShipped,
+        digital: digitalReconShipped,
+      },
+    );
+    await getReceiptsArchiveBucket().put(proofsNoReceiptsKey, proofsNoReceiptsBytes, {
       httpMetadata: { contentType: "application/zip" },
       customMetadata: retentionMetadata(),
     });
@@ -621,7 +658,7 @@ export async function POST(request: Request) {
         // the preflight date check + pack naming; operator_message drives the
         // O7 one-message-two-surfaces check #19).
         amexArtifact?.payment_due_date ?? null,
-        body.operatorMessage ?? null,
+        operatorMessage,
       );
       // A7: non-blocking warning when an earlier statement month is still
       // open. Surfaced in the finalize response so the operator's toast on
@@ -643,7 +680,7 @@ export async function POST(request: Request) {
         proofsKey,
         proofsSha256,
         amexArtifact?.payment_due_date ?? null,
-        body.operatorMessage ?? null,
+        operatorMessage,
       );
       // Audit the rebuild (finalize:false) — "export.generated" was defined
       // for this. The finalize:true path is audited by finalizeExport

--- a/components/receipts/export/preface-editor.tsx
+++ b/components/receipts/export/preface-editor.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Btn } from "@/components/ui/btn";
+import { buildPackNotice, type PackNoticeInput } from "@/lib/receipts/proofs";
+import type { PackNames } from "@/lib/receipts/pack-naming";
+
+/**
+ * Editable preface (【今月のご連絡】) editor for the export review screen (E2).
+ * The ONLY UI that writes operator_message — it PATCHes
+ * /api/receipts/export/[month]/message (E1), which stores on the open draft
+ * revision only and 409s when the month is sealed.
+ *
+ * - Explicit Save button (autosave is out of scope): the message is frozen into
+ *   the sealed bytes at pack-build, so an unsaved edit must never silently ship.
+ * - Saved / unsaved indicator + character count against the 2000-char server cap.
+ * - Live preview: the first ~10 lines of the REAL buildPackNotice output (never
+ *   a reimplementation of the layout), with the unsaved draft spliced in so the
+ *   operator sees the preface sitting above 【この資料について】.
+ * - Disabled with an explanation when there is no open draft (sealed), matching
+ *   the 409 condition the PATCH endpoint enforces server-side.
+ */
+export function PrefaceEditor({
+  month,
+  initialMessage,
+  editable,
+  noticeInput,
+  names,
+}: {
+  month: string;
+  initialMessage: string | null;
+  editable: boolean;
+  /** Server-derived notice input (counts, missing-receipt lines, hasAmex/…).
+   *  The operatorMessage field is overridden client-side with the live draft. */
+  noticeInput: PackNoticeInput;
+  /** Pack names from the single naming authority. null only when the AMEX
+   *  payment-due date is unavailable (an AMEX month whose statement artifact
+   *  predates the 0035 snapshot) — the preview is hidden in that case. */
+  names: PackNames | null;
+}) {
+  const [draft, setDraft] = useState(initialMessage ?? "");
+  const [saved, setSaved] = useState(initialMessage ?? "");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [savedAt, setSavedAt] = useState<string | null>(null);
+
+  const dirty = draft !== saved;
+  const overCap = draft.length > 2000;
+
+  // Live preview via the real builder — operatorMessage is the live draft, every
+  // other input is the server-derived month state. Sliced to ~10 lines so the
+  // operator sees the preface + the 【この資料について】 heading it sits above.
+  const preview = useMemo(() => {
+    if (!names) return null;
+    const full = buildPackNotice(
+      { ...noticeInput, operatorMessage: draft },
+      names,
+    );
+    return full.split(/\r?\n/).slice(0, 10).join("\n");
+  }, [names, noticeInput, draft]);
+
+  async function save() {
+    if (!editable || saving || overCap) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/receipts/export/${month}/message`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message: draft }),
+      });
+      const json = (await res.json().catch(() => ({}))) as {
+        operatorMessage?: string | null;
+        error?: string;
+      };
+      if (!res.ok) {
+        setError(json.error ?? "保存に失敗しました。");
+        return;
+      }
+      // Normalize to the server-stored (trimmed / NULL-cleared) value so the
+      // dirty flag settles even when the server trims whitespace.
+      const stored = json.operatorMessage ?? "";
+      setSaved(stored);
+      setDraft(stored);
+      setSavedAt(
+        new Date().toLocaleTimeString("ja-JP", { hour: "2-digit", minute: "2-digit" }),
+      );
+    } catch {
+      setError("通信エラーが発生しました。");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="mx-8 mb-4 rounded-xl border border-gray-200 bg-white px-5 py-4">
+      <div className="flex items-baseline justify-between gap-3">
+        <label htmlFor="preface" className="text-[13px] font-semibold text-gray-900">
+          今月のご連絡（任意）
+        </label>
+        <span
+          className={[
+            "text-[11px]",
+            overCap ? "font-semibold text-red-600" : "text-gray-400",
+          ].join(" ")}
+        >
+          {draft.length} / 2000
+        </span>
+      </div>
+      <p className="mt-1 text-[11.5px] text-gray-500">
+        パックのご連絡事項.txt と送信メールの両方に、同じ文面が入ります。件数や集計は変わりません。
+      </p>
+
+      {editable ? (
+        <>
+          <textarea
+            id="preface"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            rows={5}
+            placeholder="例：今月は出張費用が多めです（6/10–6/12 大阪）。詳細は領収書をご確認ください。"
+            className="mt-2.5 w-full resize-y rounded-lg border border-gray-300 bg-white px-3 py-2 text-[13px] leading-relaxed text-gray-900 outline-none focus:border-amber-500"
+          />
+          <div className="mt-2.5 flex flex-wrap items-center gap-3">
+            <Btn
+              kind="primary"
+              size="md"
+              onClick={save}
+              disabled={!dirty || saving || overCap}
+            >
+              {saving ? "保存中…" : "保存"}
+            </Btn>
+            <span className="text-[11.5px] text-gray-500">
+              {dirty ? (
+                <span className="text-amber-700">未保存</span>
+              ) : savedAt ? (
+                <span>保存済み（{savedAt}）</span>
+              ) : initialMessage ? (
+                <span>保存済み</span>
+              ) : (
+                <span>未入力</span>
+              )}
+            </span>
+            {error && (
+              <span className="text-[11.5px] text-red-600">{error}</span>
+            )}
+          </div>
+        </>
+      ) : (
+        <>
+          <div className="mt-2.5 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-[13px] leading-relaxed text-gray-700">
+            {initialMessage ? (
+              <span className="whitespace-pre-wrap">{initialMessage}</span>
+            ) : (
+              <span className="text-gray-400">（未入力）</span>
+            )}
+          </div>
+          <p className="mt-2 text-[11.5px] text-gray-500">
+            {month} は封印済みです。メッセージを変更するには改訂を作成してください。
+          </p>
+        </>
+      )}
+
+      {preview && (
+        <div className="mt-4">
+          <div className="mb-1 text-[10.5px] font-bold uppercase tracking-[0.05em] text-gray-500">
+            プレビュー — ご連絡事項.txt の先頭
+          </div>
+          <pre className="overflow-x-auto whitespace-pre-wrap rounded-lg border border-gray-150 bg-gray-50 px-3 py-2 font-mono text-[11px] leading-relaxed text-gray-700">
+            {preview}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/receipts/export/review-screen.tsx
+++ b/components/receipts/export/review-screen.tsx
@@ -14,6 +14,7 @@ import {
   type Blocker,
   type DuplicateBadge,
 } from "@/lib/receipts/blockers";
+import type { ExportBlocker } from "@/lib/receipts/month-closing";
 import type {
   AmexStatementLine,
   BusinessTripReport,
@@ -23,7 +24,10 @@ import type {
 } from "@/lib/receipts/types";
 import type { StatementWindow } from "@/lib/receipts/statement-window";
 import type { CategoryRule } from "@/lib/receipts/category-rules";
+import type { PackNoticeInput } from "@/lib/receipts/proofs";
+import type { PackNames } from "@/lib/receipts/pack-naming";
 import { withWorkMonth } from "@/lib/receipts/work-month";
+import { PrefaceEditor } from "@/components/receipts/export/preface-editor";
 
 export interface ReviewScreenProps {
   month: string;
@@ -34,7 +38,7 @@ export interface ReviewScreenProps {
   receipts: ReceiptRecord[];
   currentExport: ReceiptExport | null;
   reconciliationSealed: boolean;
-  gateBlockers: string[];
+  gateBlockers: ExportBlocker[];
   tileBlockers: Blocker[];
   warnings: Blocker[];
   tripReports: BusinessTripReport[];
@@ -42,6 +46,12 @@ export interface ReviewScreenProps {
   /** Active category pattern rules → live suggestion affordance on unmatched,
    *  uncategorized AMEX lines (ADR: category-rules). */
   categoryRules: CategoryRule[];
+  /** Server-derived notice input for the preface editor's live preview (E2). The
+   *  operatorMessage field is overridden client-side with the live draft. */
+  prefaceNoticeInput: PackNoticeInput;
+  /** Pack names for the preview, from the single naming authority. null when the
+   *  AMEX payment-due date is unavailable (preview hidden). */
+  prefaceNames: PackNames | null;
 }
 
 export function ReviewScreen(props: ReviewScreenProps) {
@@ -107,6 +117,20 @@ export function ReviewScreen(props: ReviewScreenProps) {
           )}
         />
       </div>
+
+      {/* Editable preface (E2) — the ONE UI surface that writes operator_message.
+          Rendered whenever an export exists (draft → editable; sealed → disabled
+          with an explanation). Sits above the finalize card so the operator sets
+          the message before sealing it into the pack. */}
+      {props.currentExport && (
+        <PrefaceEditor
+          month={props.month}
+          initialMessage={props.currentExport.operator_message ?? null}
+          editable={props.currentExport.status === "draft"}
+          noticeInput={props.prefaceNoticeInput}
+          names={props.prefaceNames}
+        />
+      )}
 
       <FinalizeCard
         month={props.month}
@@ -202,7 +226,7 @@ function GateVerdict({
   warnings,
   finalized,
 }: {
-  gateBlockers: string[];
+  gateBlockers: ExportBlocker[];
   tileBlockers: Blocker[];
   warnings: Blocker[];
   finalized: boolean;
@@ -224,7 +248,15 @@ function GateVerdict({
           <code>validateMonthReadyForExport</code>:
           <ul className="mt-1.5 list-disc space-y-0.5 pl-5 text-[12.5px]">
             {gateBlockers.map((b, i) => (
-              <li key={i}>{b}</li>
+              <li key={`${b.code}-${i}`}>
+                {b.href ? (
+                  <Link href={b.href} className="underline decoration-amber-600/60 underline-offset-2 hover:text-amber-700">
+                    {b.message}
+                  </Link>
+                ) : (
+                  b.message
+                )}
+              </li>
             ))}
           </ul>
         </div>

--- a/components/receipts/reconcile/reconcile-screen.tsx
+++ b/components/receipts/reconcile/reconcile-screen.tsx
@@ -54,6 +54,7 @@ import {
   matchExplanation,
   type ConfidenceBand,
 } from "@/lib/receipts/confidence";
+import { isSettled, groupLinesByStatus } from "@/lib/receipts/reconcile-grouping";
 
 export interface ReconcileScreenProps {
   amexLines: AmexStatementLine[];
@@ -177,11 +178,9 @@ export function ReconcileScreen(props: ReconcileScreenProps) {
   );
 
   const counts = useMemo(() => {
-    const confirmed = props.amexLines.filter(
-      (l) => l.match_status === "confirmed" || l.match_status === "no_receipt",
-    ).length;
+    const confirmed = props.amexLines.filter((l) => isSettled(l)).length;
     const obvious = linesWithBand.filter(
-      (l) => l.band === "obvious" && l.line.match_status !== "confirmed",
+      (l) => l.band === "obvious" && !isSettled(l.line),
     ).length;
     const likely = linesWithBand.filter((l) => l.band === "likely").length;
     const review = linesWithBand.filter((l) => l.band === "review").length;
@@ -305,7 +304,7 @@ export function ReconcileScreen(props: ReconcileScreenProps) {
       (l) =>
         l.band === "obvious" &&
         l.match &&
-        l.line.match_status !== "confirmed",
+        !isSettled(l.line),
     );
     if (candidates.length === 0) return;
     setBulkProgress({ current: 0, total: candidates.length });
@@ -679,20 +678,8 @@ function LinesPane({
   duplicateCandidates: Map<string, AmexDuplicateCandidate[]>;
   onOpenCluster: (ids: string[]) => void;
 }) {
-  const groupReview = linesWithBand.filter(
-    (l) =>
-      (l.band === "review" || l.band === "none") &&
-      l.line.match_status !== "confirmed",
-  );
-  const groupLikely = linesWithBand.filter(
-    (l) => l.band === "likely" && l.line.match_status !== "confirmed",
-  );
-  const groupObvious = linesWithBand.filter(
-    (l) => l.band === "obvious" && l.line.match_status !== "confirmed",
-  );
-  const groupConfirmed = linesWithBand.filter(
-    (l) => l.line.match_status === "confirmed",
-  );
+  const { review: groupReview, likely: groupLikely, obvious: groupObvious, confirmed: groupConfirmed } =
+    groupLinesByStatus(linesWithBand);
 
   return (
     <div className="flex h-full flex-col overflow-hidden border-r border-gray-200 bg-white">

--- a/db/receipts/0039_export_operator_message_updated_at.sql
+++ b/db/receipts/0039_export_operator_message_updated_at.sql
@@ -1,0 +1,18 @@
+-- 0039_export_operator_message_updated_at.sql
+--
+-- Last-write timestamp for operator_message (E3). The editable preface is frozen
+-- into the sealed pack bytes at build time (buildPackNotice runs at rebuild, the
+-- notice is sealed + hashed inside the proofs ZIP). Editing the message on an
+-- already-built draft therefore makes the built bundle stale: the bytes an
+-- operator previewed no longer match what finalize would seal. Without a signal,
+-- finalize would silently seal a pack whose notice the operator never reviewed.
+--
+-- This column lets the finalize gate compare operator_message's last write
+-- against bundle_built_at: if the message was edited after the bundle was built,
+-- gate code `message_stale` blocks finalize and requires a rebuild first.
+--
+-- Written by updateExportOperatorMessage (the PATCH /message writer) and by
+-- recordExportBundle (the rebuild writer, in lockstep with bundle_built_at, so a
+-- fresh rebuild clears staleness). Additive only; NULL on legacy rows (no
+-- staleness signal → no message_stale blocker, matching pre-E3 behaviour).
+ALTER TABLE receipt_exports ADD COLUMN operator_message_updated_at TEXT;

--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -3072,7 +3072,8 @@ export async function recordExportBundle(
            proofs_sha256 = ?,
            bundle_built_at = ?,
            payment_due_date = ?,
-           operator_message = ?
+           operator_message = ?,
+           operator_message_updated_at = ?
        WHERE id = ? AND status = 'draft'`,
     )
     .bind(
@@ -3085,8 +3086,36 @@ export async function recordExportBundle(
       now,
       paymentDueDate ?? null,
       operatorMessage ?? null,
+      now,
       exportId,
     )
+    .run();
+}
+
+/**
+ * Update ONLY operator_message on an open draft revision (E1 — the editable
+ * preface). Deliberately touches no other column: it must NOT advance
+ * bundle_built_at (that would mask the staleness the finalize gate detects —
+ * E3) and must not re-write the sealed bundle columns the way recordExportBundle
+ * does. The WHERE status='draft' guard means a sealed month is never mutated;
+ * the PATCH /message caller checks for an open draft first and 409s otherwise,
+ * so this update should always match exactly one draft row. Trim + the 2000-char
+ * cap are applied by the caller; null clears the column (buildPackNotice then
+ * omits the whole 【今月のご連絡】 heading).
+ */
+export async function updateExportOperatorMessage(
+  exportId: string,
+  operatorMessage: string | null,
+): Promise<void> {
+  const db = getReceiptsDb();
+  await db
+    .prepare(
+      `UPDATE receipt_exports
+       SET operator_message = ?,
+           operator_message_updated_at = ?
+       WHERE id = ? AND status = 'draft'`,
+    )
+    .bind(operatorMessage, nowIso(), exportId)
     .run();
 }
 

--- a/lib/receipts/export.ts
+++ b/lib/receipts/export.ts
@@ -5,7 +5,7 @@ import {
   ACCOUNTANT_DISCLAIMER_EN,
   ACCOUNTANT_DISCLAIMER_JA,
 } from "@/lib/receipts/settings";
-import { packZipName, buildPackNames } from "@/lib/receipts/pack-naming";
+import { packZipName, buildPackNames, monthCode } from "@/lib/receipts/pack-naming";
 
 /**
  * CSV cell escaper.
@@ -333,6 +333,18 @@ export function buildProofsKey(month: string, exportId: string): string {
   return `exports/${month}/${exportId}-proofs.zip`;
 }
 
+/**
+ * NoReceipts draft variant of the proofs ZIP (D). Same pack root as
+ * {@link buildProofsKey} — the 照合CSVs + 集計.csv + ご連絡事項.txt — with ZERO
+ * image/PDF entries. Built at rebuild time from the identical assembleProofsZip
+ * arguments as the WithReceipts zip (only `entries` differs: `[]`), so the
+ * shared entries are byte-identical by construction. Draft-only convenience;
+ * never sealed (finalize seals only the WithReceipts proofs zip).
+ */
+export function buildProofsNoReceiptsKey(month: string, exportId: string): string {
+  return `exports/${month}/${exportId}-proofs-noreceipts.zip`;
+}
+
 // ─── Reconciliation-file keys (monthly closing review #2) ────────────────────
 // Derived keys like summary/attendees — no column on receipt_exports. Old
 // sealed revisions predate these artifacts and simply 404 from R2.
@@ -479,6 +491,12 @@ export const EXPORT_DOWNLOAD_FILES = [
   "amex",
   "cash",
   "digital",
+  // Draft-only whole-pack downloads (D): the two-link draft panel. draft_wr is
+  // the full candidate-seal pack; draft_nr is the NoReceipts variant (CSVs +
+  // notice, zero images). Handled entirely in resolveBundleDownload's draft
+  // branch; the finalized path 404s them (resolveExportDownload returns no key).
+  "draft_wr",
+  "draft_nr",
 ] as const;
 
 export type ExportDownloadFile = (typeof EXPORT_DOWNLOAD_FILES)[number];
@@ -637,6 +655,13 @@ export function resolveExportDownload(
         contentType: csv,
         filename: buildPackNames(month, null, false).digitalReconciliationCsv,
       };
+    case "draft_wr":
+    case "draft_nr":
+      // Draft-only (D). These never resolve from the finalized path —
+      // resolveBundleDownload's draft branch maps them to the staged proofs /
+      // proofs-noreceipts keys with a ${yyyymm}_Draft_*.zip name. Returning no
+      // key here makes any finalized-path request 404.
+      return { r2Key: null, contentType: "application/zip", filename: "" };
   }
 }
 
@@ -711,6 +736,33 @@ export function resolveBundleDownload(opts: {
         ok: false,
         status: 404,
         message: "Draft not rebuilt yet — click Rebuild draft first.",
+      };
+    }
+    // Draft-only whole-pack downloads (D). Two links instead of the per-artifact
+    // grid: draft_wr = the full candidate-seal pack (the staged proofs ZIP);
+    // draft_nr = the NoReceipts variant staged alongside it at rebuild from the
+    // identical assembleProofsZip inputs (so shared entries are byte-identical).
+    // Both carry a ${yyyymm}_Draft_*.zip name — "Draft" in the filename is the
+    // not-sealed signal, replacing the old DRAFT- prefix for the draft panel.
+    if (file === "draft_wr" || file === "draft_nr") {
+      const yyyymm = monthCode(month);
+      if (file === "draft_wr") {
+        return {
+          ok: true,
+          r2Key: buildProofsKey(month, draftRecord.id),
+          contentType: "application/zip",
+          filename: `${yyyymm}_Draft_WithReceipts.zip`,
+          exportId: draftRecord.id,
+          draft: true,
+        };
+      }
+      return {
+        ok: true,
+        r2Key: buildProofsNoReceiptsKey(month, draftRecord.id),
+        contentType: "application/zip",
+        filename: `${yyyymm}_Draft_NoReceipts.zip`,
+        exportId: draftRecord.id,
+        draft: true,
       };
     }
     const target = resolveExportDownload(month, draftRecord, file);

--- a/lib/receipts/month-closing.ts
+++ b/lib/receipts/month-closing.ts
@@ -2,6 +2,7 @@ import { getCategoryByCode, requiresAttendees } from "@/lib/receipts/categories"
 import type { ReceiptAttendeeDirectoryEntry } from "@/lib/receipts/attendee-directory";
 import { resolveAttendeeNames } from "@/lib/receipts/attendee-directory";
 import {
+  getExport,
   getFinalizedReconciliationForMonth,
   listAmexLineAttendeeNamesByMonth,
   listAmexLines,
@@ -271,18 +272,55 @@ export interface ValidateMonthReadyInput {
   /** Gate 7: receipt_files row count per shipped receipt id (absent = 0). A
    *  shipped receipt with zero rows has no proof to include in the ZIP. */
   receiptFileCounts: Map<string, number>;
+  /** E3 (gate 1.5): the open draft's build + operator-message timestamps. The
+   *  preface is frozen into the sealed bytes at build time, so a message edited
+   *  after the build makes the bundle stale. When operatorMessageUpdatedAt >
+   *  bundleBuiltAt, emit `message_stale`. null/undefined when there is no draft
+   *  or nothing is built yet — no staleness check (matches pre-E3 behaviour). */
+  exportBuild?: { bundleBuiltAt: string | null; operatorMessageUpdatedAt: string | null } | null;
 }
 
 /**
- * Pure synchronous core of the export-finalize gate. Given the data the gates
- * need (fetched by {@link validateMonthReadyForExport}), returns the blocker
- * strings in the gate's canonical order (1 → 2 → 2.5 → 3 → 4 → 5 → 6).
- * Extracted verbatim from the former inline body so the gate is unit-testable
- * without D1 and so the tile (Task 3) can share the exact same rule logic.
+ * A single finalize-gate blocker with a stable code and (optionally) an in-app
+ * destination that clears it. {@link validateMonthReadyForExportCoreDetailed}
+ * returns these; the original string[] contract
+ * ({@link validateMonthReadyForExportCore}) projects them to `.message`. Tests
+ * assert on `code`, never on prose. `href` is set only where a concrete in-app
+ * remedy exists (gate 1 → Reconcile); for every other blocker it is undefined —
+ * do not guess destinations. `message_stale` is reserved for the editable-preface
+ * staleness gate (E3); it is in the union now so the review screen can type it.
  */
-export function validateMonthReadyForExportCore(
+export interface ExportBlocker {
+  code:
+    | "reconciliation_not_finalized"
+    | "payment_path_unknown"
+    | "receipt_unreviewed"
+    | "receipt_field_missing"
+    | "attendees_required"
+    | "attendee_unresolved"
+    | "amex_line"
+    | "compliance"
+    | "cross_month"
+    | "missing_proof_file"
+    | "message_stale";
+  message: string;
+  /** In-app destination that lets the operator clear this blocker. */
+  href?: string;
+}
+
+/**
+ * Pure synchronous core of the export-finalize gate — DETAILED variant. Same
+ * gate logic and canonical order (1 → 2 → 2.5 → 3 → 4 → 5 → 6 → 7) as the
+ * original string[] core, but each blocker carries a stable `code` and, for
+ * gate 1, a link to Reconcile so the pre-finalize review renders it as an
+ * actionable link instead of dead prose. The string[] core delegates here, so
+ * there is exactly one rule implementation. Extracted verbatim from the former
+ * inline body so the gate is unit-testable without D1 and so the tile (Task 3)
+ * shares the exact same rule logic.
+ */
+export function validateMonthReadyForExportCoreDetailed(
   input: ValidateMonthReadyInput,
-): string[] {
+): ExportBlocker[] {
   const {
     month,
     reconciliation,
@@ -295,21 +333,47 @@ export function validateMonthReadyForExportCore(
     crossMonthMatchedLines,
     receiptFileCounts,
   } = input;
-  const blockers: string[] = [];
+  const blockers: ExportBlocker[] = [];
 
-  // (1) Statement-sealed gate.
+  // (1) Statement-sealed gate. The integrity anchor: the pack asserts it
+  // reconciles against a sealed statement. Downgrading would let a pack be
+  // built against a statement that can still change underneath it; only the
+  // presentation changes — it becomes a link to Reconcile (June review).
   if (!reconciliation) {
-    blockers.push(
-      `No finalized reconciliation for ${month}. Sign off the reconciliation first.`,
-    );
+    blockers.push({
+      code: "reconciliation_not_finalized",
+      message: `No finalized reconciliation for ${month}. Sign off the reconciliation first.`,
+      href: `/receipts/reconcile?month=${month}`,
+    });
+  }
+
+  // (1.5) Message staleness (E3). The editable preface is frozen into the sealed
+  // bytes at build time (buildPackNotice runs at rebuild; the notice is sealed
+  // + hashed inside the proofs ZIP). Editing it afterwards makes the built
+  // bundle stale — the bytes the operator previewed no longer match what
+  // finalize would seal. Require a rebuild (which re-bakes the message and
+  // re-syncs operator_message_updated_at to bundle_built_at) before finalizing.
+  // ISO-8601 strings compare lexicographically in chronological order.
+  const build = input.exportBuild;
+  if (
+    build?.bundleBuiltAt &&
+    build?.operatorMessageUpdatedAt &&
+    build.operatorMessageUpdatedAt > build.bundleBuiltAt
+  ) {
+    blockers.push({
+      code: "message_stale",
+      message:
+        "Message edited after the draft was built. Rebuild the draft before finalizing.",
+    });
   }
 
   // (2) UNKNOWN payment_path gate.
   for (const row of unknownReceipts) {
     const label = row.merchant ?? row.id;
-    blockers.push(
-      `Receipt ${label}: payment_path is UNKNOWN — classify as AMEX, CASH, or DIGITAL before export`,
-    );
+    blockers.push({
+      code: "payment_path_unknown",
+      message: `Receipt ${label}: payment_path is UNKNOWN — classify as AMEX, CASH, or DIGITAL before export`,
+    });
   }
 
   // (2.5) Unreviewed-receipt gate. isPendingProcessing exclusion matches the
@@ -319,62 +383,76 @@ export function validateMonthReadyForExportCore(
   for (const r of unreviewedReceipts) {
     if (!isUnreviewedReceipt(r)) continue;
     const label = r.merchant ?? r.id;
-    blockers.push(
-      `Receipt ${label}: unreviewed (status='needs_review') — mark reviewed before exporting`,
-    );
+    blockers.push({
+      code: "receipt_unreviewed",
+      message: `Receipt ${label}: unreviewed (status='needs_review') — mark reviewed before exporting`,
+    });
   }
 
   // (3) Receipt-level checks on CASH/DIGITAL receipts in the bundle.
   for (const receipt of bundle.receipts) {
     if (receipt.payment_path === "AMEX") continue;
     const label = receipt.merchant ?? receipt.id;
-    if (!receipt.transaction_date) blockers.push(`Receipt ${receipt.id}: missing date`);
-    if (!receipt.merchant) blockers.push(`Receipt ${receipt.id}: missing merchant`);
-    if (receipt.amount_minor === null) blockers.push(`Receipt ${receipt.id}: missing amount`);
+    if (!receipt.transaction_date) {
+      blockers.push({ code: "receipt_field_missing", message: `Receipt ${receipt.id}: missing date` });
+    }
+    if (!receipt.merchant) {
+      blockers.push({ code: "receipt_field_missing", message: `Receipt ${receipt.id}: missing merchant` });
+    }
+    if (receipt.amount_minor === null) {
+      blockers.push({ code: "receipt_field_missing", message: `Receipt ${receipt.id}: missing amount` });
+    }
     if (!receipt.expense_category_code) {
-      blockers.push(`Receipt ${receipt.id}: missing expense category`);
+      blockers.push({
+        code: "receipt_field_missing",
+        message: `Receipt ${receipt.id}: missing expense category`,
+      });
     }
     if (requiresAttendees(receipt.expense_category_code)) {
       const attendees = bundle.attendeeMap.get(receipt.id) ?? [];
       if (attendees.length === 0) {
-        blockers.push(`Receipt ${label}: requires attendees`);
+        blockers.push({ code: "attendees_required", message: `Receipt ${label}: requires attendees` });
       } else {
         // Attendees present → every name must resolve to a directory entry
         // (company/title). Unresolved names block finalize (business-manager
         // review: every 会議費/接待交際費 attendee must show company + title).
         const { unresolved } = resolveAttendeeNames(attendees, bundle.attendeeDirectory);
         for (const name of unresolved) {
-          blockers.push(
-            `Receipt ${label}: attendee "${name}" is not registered in the attendee directory (company/title required)`,
-          );
+          blockers.push({
+            code: "attendee_unresolved",
+            message: `Receipt ${label}: attendee "${name}" is not registered in the attendee directory (company/title required)`,
+          });
         }
       }
     }
   }
 
-  // (4) AMEX-line checks.
+  // (4) AMEX-line checks. validateAmexLinesForSignoff returns prose strings;
+  // each is tagged with the gate-level code `amex_line`.
   const receiptMap = new Map<string, ReceiptRecord>();
   for (const r of bundle.receipts) receiptMap.set(r.id, r);
-  blockers.push(
-    ...validateAmexLinesForSignoff(
-      bundle.amexLines,
-      amexAttendees,
-      bundle.attendeeMap,
-      receiptMap,
-      bundle.attendeeDirectory,
-    ),
-  );
+  for (const message of validateAmexLinesForSignoff(
+    bundle.amexLines,
+    amexAttendees,
+    bundle.attendeeMap,
+    receiptMap,
+    bundle.attendeeDirectory,
+  )) {
+    blockers.push({ code: "amex_line", message });
+  }
 
   // (5) Compliance-engine gate.
   if (complianceSummary.blockers > 0) {
-    blockers.push(
-      `${complianceSummary.blockers} open compliance blocker(s) on receipts in ${month}`,
-    );
+    blockers.push({
+      code: "compliance",
+      message: `${complianceSummary.blockers} open compliance blocker(s) on receipts in ${month}`,
+    });
   }
   if (complianceSettings.export_block_on_warnings && complianceSummary.warnings > 0) {
-    blockers.push(
-      `${complianceSummary.warnings} open compliance warning(s) in ${month} (export_block_on_warnings=true)`,
-    );
+    blockers.push({
+      code: "compliance",
+      message: `${complianceSummary.warnings} open compliance warning(s) in ${month} (export_block_on_warnings=true)`,
+    });
   }
 
   // (6) Cross-month match integrity (audit A7). A receipt matched to lines in
@@ -391,9 +469,10 @@ export function validateMonthReadyForExportCore(
   for (const [receiptId, months] of monthsByReceipt) {
     if (months.size > 1 && months.has(month)) {
       const others = [...months].filter((m) => m !== month).join(", ");
-      blockers.push(
-        `Receipt ${receiptId}: matched to AMEX lines in multiple statement months (${[...months].join(", ")}). Disambiguate before finalizing ${month} (other month(s): ${others}).`,
-      );
+      blockers.push({
+        code: "cross_month",
+        message: `Receipt ${receiptId}: matched to AMEX lines in multiple statement months (${[...months].join(", ")}). Disambiguate before finalizing ${month} (other month(s): ${others}).`,
+      });
     }
   }
 
@@ -403,19 +482,33 @@ export function validateMonthReadyForExportCore(
   // Missing proof_copy is NOT a blocker (the ZIP falls back to the original).
   for (const receipt of receiptsMissingProofFiles(bundle.receipts, receiptFileCounts)) {
     const label = receipt.merchant ?? receipt.id;
-    blockers.push(
-      `Receipt ${label}: no proof file on record (no original or proof_copy) — cannot build the proofs bundle`,
-    );
+    blockers.push({
+      code: "missing_proof_file",
+      message: `Receipt ${label}: no proof file on record (no original or proof_copy) — cannot build the proofs bundle`,
+    });
   }
 
   return blockers;
 }
 
-export async function validateMonthReadyForExport(
+/**
+ * Pure synchronous core — ORIGINAL string[] contract, kept for every existing
+ * caller (API routes, finalize-card, backfill script, tests). Now a thin
+ * projection over {@link validateMonthReadyForExportCoreDetailed} so there is
+ * exactly one rule implementation; the messages are byte-identical to the
+ * former inline body.
+ */
+export function validateMonthReadyForExportCore(
+  input: ValidateMonthReadyInput,
+): string[] {
+  return validateMonthReadyForExportCoreDetailed(input).map((b) => b.message);
+}
+
+export async function validateMonthReadyForExportDetailed(
   month: string,
   prebuiltBundle?: ExportBundle,
   preloadedReconciliation?: AmexReconciliation | null,
-): Promise<string[]> {
+): Promise<ExportBlocker[]> {
   // (1) Statement-sealed gate. Callers that already fetched the reconciliation
   // (e.g. /api/receipts/export/month to populate the manifest pointer) may
   // pass it in to avoid a second D1 round-trip.
@@ -486,7 +579,17 @@ export async function validateMonthReadyForExport(
     bundle.receipts.map((r) => r.id),
   );
 
-  return validateMonthReadyForExportCore({
+  // (1.5) Message staleness (E3): the open draft's build vs operator-message
+  // timestamps. getExport returns the current row (draft iff one is open).
+  const exportRecord = await getExport(month);
+  const exportBuild = exportRecord
+    ? {
+        bundleBuiltAt: exportRecord.bundle_built_at ?? null,
+        operatorMessageUpdatedAt: exportRecord.operator_message_updated_at ?? null,
+      }
+    : null;
+
+  return validateMonthReadyForExportCoreDetailed({
     month,
     reconciliation,
     bundle,
@@ -497,7 +600,25 @@ export async function validateMonthReadyForExport(
     complianceSettings: settings,
     crossMonthMatchedLines: matchedLineMonths.results ?? [],
     receiptFileCounts,
+    exportBuild,
   });
+}
+
+/**
+ * Async wrapper — ORIGINAL string[] contract, kept for every existing caller.
+ * Now a thin projection over {@link validateMonthReadyForExportDetailed} so the
+ * fetch logic lives in one place; the messages are byte-identical to before.
+ */
+export async function validateMonthReadyForExport(
+  month: string,
+  prebuiltBundle?: ExportBundle,
+  preloadedReconciliation?: AmexReconciliation | null,
+): Promise<string[]> {
+  return (await validateMonthReadyForExportDetailed(
+    month,
+    prebuiltBundle,
+    preloadedReconciliation,
+  )).map((b) => b.message);
 }
 
 /**

--- a/lib/receipts/proofs.ts
+++ b/lib/receipts/proofs.ts
@@ -141,7 +141,7 @@ export function buildPackNotice(input: PackNoticeInput, names: PackNames): strin
   // digital rows names the DIGITAL list (the previously-unmentioned case).
   if (hasAmex) {
     lines.push(
-      `・カード明細の照合表（${names.amexReconciliationCsv}）は、カード会社の明細CSVをそのまま再現し、右側に「科目＆No.」「事業目的」「人数」「領収書ファイル名」の列を追記したものです。`,
+      `・カード明細の照合表（${names.amexReconciliationCsv}）は、カード会社の明細CSVを基に、右側に「科目＆No.」「事業目的」「人数」「領収書ファイル名」の列を追記したものです。`,
     );
   }
   if (hasCash) {
@@ -161,7 +161,7 @@ export function buildPackNotice(input: PackNoticeInput, names: PackNames): strin
     "・紙の領収書は一つにまとめたPDFではなく、1件ずつの画像ファイルとして同封しています。",
   );
   lines.push(
-    "・証憑画像は容量削減のため再圧縮しています（長辺1600px・JPEG品質75）。原本は当方で保管しており、ご要望があれば原本データをご提供します。",
+    "・証憑画像は容量削減のため再圧縮しています（長辺1600px・JPEG品質75）。原本は当方で保管しており、ご要望があれば原本データを提出致します。",
   );
   lines.push(
     "・PDFの領収書は原本をそのまま同封しています（テキスト情報を保つため再圧縮していません）。",

--- a/lib/receipts/reconcile-grouping.ts
+++ b/lib/receipts/reconcile-grouping.ts
@@ -1,0 +1,54 @@
+// Rail-section grouping for the AMEX Reconcile screen. Lifted out of
+// reconcile-screen.tsx so the settled-vs-needs-attention split is a single
+// pure, unit-testable rule instead of a status comparison spelled out
+// separately at the header count and at each rail section filter.
+//
+// June-2026 review defect this corrects: the header already counted a
+// `no_receipt` line as confirmed (`=== "confirmed" || === "no_receipt"`), but
+// the rail section filters keyed only on `!== "confirmed"`, so a settled
+// `no_receipt` line fell through every section filter and landed in
+// "Needs attention" — producing "32 of 32 confirmed" alongside a spurious
+// "Needs attention · 3". A `no_receipt` line carries no auto-match, so
+// bandForLine assigns it band "none", which groupReview catches. The fix is
+// one predicate used everywhere the settled/attention boundary is drawn.
+
+import type { AmexStatementLine, ReconciliationMatch } from "@/lib/receipts/types";
+import type { ConfidenceBand } from "@/lib/receipts/confidence";
+
+/** A line the operator has settled — either matched-and-confirmed or
+ *  explicitly marked "no receipt expected". Both are terminal; neither
+ *  needs attention. Single source of truth for the header count and the rail
+ *  grouping, which had drifted apart (see module header). */
+export function isSettled(line: AmexStatementLine): boolean {
+  return line.match_status === "confirmed" || line.match_status === "no_receipt";
+}
+
+export interface LineWithBand {
+  line: AmexStatementLine;
+  band: ConfidenceBand;
+  match: ReconciliationMatch | undefined;
+}
+
+export interface ReconcileLineGroups {
+  review: LineWithBand[];
+  likely: LineWithBand[];
+  obvious: LineWithBand[];
+  confirmed: LineWithBand[];
+}
+
+/** Split banded AMEX lines into the four rail sections. Every settled line
+ *  (confirmed OR no_receipt) lands in `confirmed`; the review / likely /
+ *  obvious sections contain only lines still awaiting an operator decision.
+ *  A settled line keeps whatever pill its match_status already renders in
+ *  LineRow (gray "no receipt expected" vs green "confirmed") — this helper
+ *  only decides the section, not the pill. Pure. */
+export function groupLinesByStatus(lines: LineWithBand[]): ReconcileLineGroups {
+  return {
+    review: lines.filter(
+      (l) => (l.band === "review" || l.band === "none") && !isSettled(l.line),
+    ),
+    likely: lines.filter((l) => l.band === "likely" && !isSettled(l.line)),
+    obvious: lines.filter((l) => l.band === "obvious" && !isSettled(l.line)),
+    confirmed: lines.filter((l) => isSettled(l.line)),
+  };
+}

--- a/lib/receipts/types.ts
+++ b/lib/receipts/types.ts
@@ -136,6 +136,7 @@ export type AuditAction =
   | "export.finalized"
   | "export.revision_created"
   | "export.downloaded"
+  | "export.message_updated"
   | "export.notification_sent"
   | "export.notification_failed"
   | "export.notification_test"
@@ -536,6 +537,14 @@ export interface ReceiptExport {
   // build time, and into the delivery email body at send time. NULL when no
   // message.
   operator_message?: string | null;
+  // Last-write timestamp for operator_message (0039 / E3). The preface is frozen
+  // into the sealed bytes at build time, so editing it after a build makes the
+  // built bundle stale. The finalize gate compares this against bundle_built_at
+  // (operator_message_updated_at > bundle_built_at ⇒ message_stale). NULL on
+  // legacy rows predating 0039 (no staleness signal — no blocker, matching
+  // pre-E3 behaviour). Written in lockstep with bundle_built_at by
+  // recordExportBundle, and alone by updateExportOperatorMessage.
+  operator_message_updated_at?: string | null;
 }
 
 /**

--- a/tests/receipts/bundle-download.test.ts
+++ b/tests/receipts/bundle-download.test.ts
@@ -144,10 +144,17 @@ test("draft=true 404s when there is no draft revision", () => {
   }
 });
 
-// ─── DRAFT- prefix on EVERY file kind ───────────────────────────────────────
+// ─── Draft filename conventions ─────────────────────────────────────────────
+// Two schemes by design (D): the 9 verbatim artifacts keep the DRAFT- prefix
+// (a draft receipts CSV is unmistakable); the two whole-pack draft downloads
+// use a ${yyyymm}_Draft_*.zip name where "Draft" is the not-sealed signal,
+// replacing the DRAFT- prefix for the draft panel's two links.
 
-test("draft=true prefixes DRAFT- on every file kind; default never does", () => {
-  for (const file of EXPORT_DOWNLOAD_FILES) {
+test("draft=true prefixes DRAFT- on every verbatim artifact; default never does", () => {
+  const verbatimFiles = EXPORT_DOWNLOAD_FILES.filter(
+    (f) => f !== "draft_wr" && f !== "draft_nr",
+  );
+  for (const file of verbatimFiles) {
     const d = ok(
       resolveBundleDownload({
         month,
@@ -177,6 +184,50 @@ test("draft=true prefixes DRAFT- on every file kind; default never does", () => 
       `finalized ${file} must NOT be DRAFT- prefixed (got ${f.filename})`,
     );
     assert.equal(f.draft, false);
+  }
+});
+
+test("D: draft_wr / draft_nr are draft-only whole-pack downloads with Draft_ names", () => {
+  // WithReceipts = the staged proofs ZIP; NoReceipts = the proofs-noreceipts
+  // ZIP staged alongside it at rebuild. Both carry a ${yyyymm}_Draft_*.zip name
+  // and are NEVER served from the finalized path (no sealed counterpart).
+  const wr = ok(
+    resolveBundleDownload({
+      month,
+      file: "draft_wr",
+      draft: true,
+      draftRecord: draftRebuilt,
+      finalizedRecord: finalized,
+    }),
+  );
+  assert.equal(wr.r2Key, "exports/2026-06/exp-draft-proofs.zip");
+  assert.equal(wr.filename, "202606_Draft_WithReceipts.zip");
+  assert.equal(wr.draft, true);
+
+  const nr = ok(
+    resolveBundleDownload({
+      month,
+      file: "draft_nr",
+      draft: true,
+      draftRecord: draftRebuilt,
+      finalizedRecord: finalized,
+    }),
+  );
+  assert.equal(nr.r2Key, "exports/2026-06/exp-draft-proofs-noreceipts.zip");
+  assert.equal(nr.filename, "202606_Draft_NoReceipts.zip");
+  assert.equal(nr.draft, true);
+
+  // Finalized path: draft-only files have no sealed counterpart → 404.
+  for (const file of ["draft_wr", "draft_nr"] as const) {
+    const r = resolveBundleDownload({
+      month,
+      file,
+      draft: false,
+      draftRecord: draftRebuilt,
+      finalizedRecord: finalized,
+    });
+    assert.equal(r.ok, false, `${file} must not resolve from the finalized path`);
+    if (!r.ok) assert.equal(r.status, 404);
   }
 });
 

--- a/tests/receipts/reconcile-grouping.test.ts
+++ b/tests/receipts/reconcile-grouping.test.ts
@@ -1,0 +1,70 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  isSettled,
+  groupLinesByStatus,
+  type LineWithBand,
+} from "@/lib/receipts/reconcile-grouping";
+import type { AmexStatementLine, AmexMatchStatus } from "@/lib/receipts/types";
+import type { ConfidenceBand } from "@/lib/receipts/confidence";
+
+// groupLinesByStatus reads only line.match_status (via isSettled) and the
+// wrapper's band, so a minimal stub is sufficient and stays readable.
+function banded(
+  id: string,
+  match_status: AmexMatchStatus,
+  band: ConfidenceBand,
+): LineWithBand {
+  return { line: { id, match_status } as AmexStatementLine, band, match: undefined };
+}
+
+test("isSettled: confirmed and no_receipt are terminal; matched/unmatched are not", () => {
+  assert.equal(isSettled({ match_status: "confirmed" } as AmexStatementLine), true);
+  assert.equal(isSettled({ match_status: "no_receipt" } as AmexStatementLine), true);
+  assert.equal(isSettled({ match_status: "matched" } as AmexStatementLine), false);
+  assert.equal(isSettled({ match_status: "unmatched" } as AmexStatementLine), false);
+});
+
+test("groupLinesByStatus: a no_receipt line is settled, not 'needs attention'", () => {
+  // June-2026 shape: a no_receipt line carries no auto-match, so bandForLine
+  // gives it band "none" — exactly what the old groupReview filter caught,
+  // producing the phantom "Needs attention · 3" next to "32 of 32 confirmed".
+  const lines: LineWithBand[] = [
+    banded("confirmed-1", "confirmed", "obvious"),
+    banded("no-receipt-1", "no_receipt", "none"),
+    banded("no-receipt-2", "no_receipt", "none"),
+    banded("no-receipt-3", "no_receipt", "none"),
+    banded("unmatched-1", "unmatched", "none"),
+  ];
+  const groups = groupLinesByStatus(lines);
+
+  // The three settled no_receipt lines must NOT appear under "Needs attention".
+  assert.equal(groups.review.length, 1);
+  assert.deepEqual(
+    groups.review.map((g) => g.line.id),
+    ["unmatched-1"],
+  );
+
+  // They ARE counted as confirmed (settled) — the rail shows "5 of 5", not
+  // "2 of 5" alongside a phantom "Needs attention · 3".
+  assert.equal(groups.confirmed.length, 4);
+  assert.deepEqual(
+    groups.confirmed.map((g) => g.line.id),
+    ["confirmed-1", "no-receipt-1", "no-receipt-2", "no-receipt-3"],
+  );
+  assert.equal(groups.likely.length, 0);
+  assert.equal(groups.obvious.length, 0);
+});
+
+test("groupLinesByStatus: a no_receipt line with an obvious/likely suggestion still settles", () => {
+  // Operator overrode a suggested match with "no receipt expected". It is
+  // settled regardless of the suggestion band — and excluded from the
+  // bulk-confirm-obvious candidates (which now key on !isSettled).
+  const groups = groupLinesByStatus([
+    banded("nr-obvious", "no_receipt", "obvious"),
+    banded("nr-likely", "no_receipt", "likely"),
+  ]);
+  assert.equal(groups.obvious.length, 0);
+  assert.equal(groups.likely.length, 0);
+  assert.equal(groups.confirmed.length, 2);
+});


### PR DESCRIPTION
Five items from the operator's 2026-06 pack final review (A–E). Architect spec: `prompts/WORKER-PROMPT-june-final-review.md`.

## A — Notice copy
`buildPackNotice` (`lib/receipts/proofs.ts`): `カード会社の明細CSVをそのまま再現し` → `を基に`; `原本データをご提供します` → `を提出致します`. No test asserted on the old literals.

## B — Reconcile: settled `no_receipt` no longer "Needs attention"
New `lib/receipts/reconcile-grouping.ts` (`isSettled()` + `groupLinesByStatus()`) single-sources the settled boundary across the header count, bulk-confirm candidates, and the four rail sections. The header already counted `no_receipt` as confirmed; the rail grouping keyed only on `!== "confirmed"`, so settled `no_receipt` lines (band `none`) fell into **Needs attention · 3** next to **32 of 32 confirmed**. +3 unit tests.

## C — Finalize gate blockers are actionable
Additive `ExportBlocker { code; message; href? }` + `validateMonthReadyForExportCoreDetailed` / `…Detailed`. The original `string[]` variants delegate via `.map(b => b.message)` — messages byte-identical, every existing caller unchanged. Gate 1 (`reconciliation_not_finalized`) carries `href: /receipts/reconcile?month=…` and renders as a link. Gate stays a hard blocker; only presentation changes.

## D — Draft panel: two downloads
`下書き（証憑なし）` / `下書き（証憑あり）` replace the per-artifact draft grid. `draft_wr` = the staged proofs ZIP; `draft_nr` = the NoReceipts variant.

> **⚠️ Placement deviation (needs architect sign-off).** The spec said "`draft_nr` calls `assembleProofsZip` **in the download route**". But the download route (`app/api/receipts/export/[month]/download/route.ts`) is a thin verbatim R2 proxy — it serves staged objects and never builds. The assembleProofsZip arguments (`packNames`, `noticeInput`, `summaryShipped`, recon CSVs) exist **only at the rebuild site** (`month/route.ts:461`). So `draft_nr` is built at rebuild, next to the WithReceipts zip, with `entries: []` and identical args, and staged as a second R2 object the download route serves verbatim. This is the only reading that satisfies decision 4 ("same call path, empty entries, never re-zip") **and** the byte-identity verification (shared entries identical by construction). If you want a live build at download time instead, it's a localized change — say so.

## E1 — Persist `operator_message`, fix the rebuild drop
New `PATCH /api/receipts/export/[month]/message` (trim, 2000-char cap, empty→NULL, **409 when sealed**). Rebuild now resolves `operatorMessage = body.operatorMessage ?? exportRecord.operator_message ?? null`, so a rebuild that omits it no longer nulls the stored value (the bug).

## E2 — Editable preface UI
New client `preface-editor.tsx`: textarea + explicit Save + saved/unsaved + `x / 2000` + live preview via the **real** `buildPackNotice` (notice input + pack names computed server-side). Disabled with explanation when sealed.

## E3 — Freeze at finalize (`message_stale`)
Migration **0039** adds `operator_message_updated_at`. `recordExportBundle` stamps it in lockstep with `bundle_built_at` (rebuild clears staleness); `updateExportOperatorMessage` stamps it alone. Gate 1.5 emits `message_stale` when `operator_message_updated_at > bundle_built_at` → finalize requires a rebuild after a message edit. Mechanism chosen because no export-bundle staleness concept existed.

## Verification
- `npm test`: **1186 green** (1185 pass, 1 pre-existing skip)
- `tsc --noEmit`: clean
- `build:cf`: clean
- Migration 0039 applied live (column verified on `receipt_exports`)
- Notice dump via the real `buildPackNotice` + real 2026-06 values: preface under 【今月のご連絡】, 【この資料について】 unchanged, both A edits present, counts 40/34
- **Handed off (need deploy):** rebuild-twice message survival (E1), draft-zip `unzip -l`, reconcile rail screenshot, gate-link screenshot, sealed 9-link panel. Existing built drafts (2026-06 rev3) need one rebuild to stage `draft_nr` and populate the new timestamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)