### PR TITLE
feat(receipts): delivery composer — finalize → review email → send

### DIFF
--- a/app/(receipt-system)/receipts/export/[month]/send/page.tsx
+++ b/app/(receipt-system)/receipts/export/[month]/send/page.tsx
@@ -1,0 +1,49 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { composeDelivery, NoSealedExportError } from "@/lib/receipts/delivery-compose";
+import { assertReceiptsPageAccess } from "@/lib/receipts/auth-request";
+import { formatMonth } from "@/lib/receipts/format";
+import { DeliveryComposer } from "@/components/receipts/export/delivery-composer";
+
+export const dynamic = "force-dynamic";
+
+type Params = Promise<{ month: string }>;
+
+/**
+ * Delivery composer — /receipts/export/{month}/send.
+ *
+ * The missing last mile (finalize → review email → send). The delivery backend
+ * (POST .../send) had no UI; this page is it. A server component that composes
+ * the delivery through the SAME {@link composeDelivery} the send route and the
+ * preview endpoint use — the body the operator reads here is byte-identical to
+ * the body the send route will emit. The client {@link DeliveryComposer} handles
+ * the two-step confirm + in-flight send states; it posts an EMPTY body (the send
+ * route composes everything server-side).
+ */
+export default async function SendPage({ params }: { params: Params }) {
+  await assertReceiptsPageAccess();
+  const { month } = await params;
+  if (!/^\d{4}-\d{2}$/.test(month)) notFound();
+
+  let composed;
+  try {
+    composed = await composeDelivery(month);
+  } catch (error) {
+    if (error instanceof NoSealedExportError) notFound();
+    throw error;
+  }
+
+  return (
+    <div className="px-8 py-8">
+      <div className="mb-5">
+        <Link
+          href={`/receipts/export?month=${month}`}
+          className="text-[12px] font-medium text-gray-500 hover:text-amber-700"
+        >
+          ‹ {formatMonth(month)} のエクスポートに戻る
+        </Link>
+      </div>
+      <DeliveryComposer composed={composed} monthLabel={formatMonth(month)} />
+    </div>
+  );
+}

--- a/app/(receipt-system)/receipts/export/page.tsx
+++ b/app/(receipt-system)/receipts/export/page.tsx
@@ -33,7 +33,9 @@ import {
 } from "@/lib/receipts/settings";
 import { buildExportBundle } from "@/lib/receipts/month-closing";
 import { BUNDLE_DOWNLOAD_LINK_DEFS } from "@/lib/receipts/export";
+import { deriveFinalizedMonthsDeliveryState } from "@/lib/receipts/delivery-status";
 import { CreateRevisionButton } from "@/components/receipts/export/create-revision-button";
+import { DeliveryMonthBanner } from "@/components/receipts/export/delivery-month-banner";
 
 export const dynamic = "force-dynamic";
 
@@ -57,10 +59,14 @@ export default async function ExportPage({
       ? params.month
       : null;
 
-  const [lineCountsByMonth, reconciliationStatusByMonth] = await Promise.all([
-    listAmexLineCountsByMonth(),
-    listReconciliationStatusByMonth(),
-  ]);
+  const [lineCountsByMonth, reconciliationStatusByMonth, deliveryByMonth] =
+    await Promise.all([
+      listAmexLineCountsByMonth(),
+      listReconciliationStatusByMonth(),
+      // §6: one server-side Map<month, DeliveryState|null> drives every alert
+      // surface (this page's banner + pills, the dashboard banner).
+      deriveFinalizedMonthsDeliveryState(),
+    ]);
 
   const availableMonths: MonthOption[] = [...lineCountsByMonth.entries()]
     .map(([optionMonth, counts]) => ({
@@ -68,6 +74,12 @@ export default async function ExportPage({
       lineCount: counts.total,
       unmatchedCount: counts.unmatched,
       status: reconciliationStatusByMonth.get(optionMonth) ?? null,
+      // Only finalized months are in the delivery map. has() distinguishes
+      // "not finalized → undefined (legacy pill)" from "finalized never sent →
+      // null (red pill)" — `?? undefined` alone would wrongly drop the null.
+      deliveryState: deliveryByMonth.has(optionMonth)
+        ? (deliveryByMonth.get(optionMonth) ?? null)
+        : undefined,
     }))
     .sort((a, b) => a.month.localeCompare(b.month));
 
@@ -128,6 +140,13 @@ export default async function ExportPage({
   const draftStats = computeDraftStats(bundle.rows);
   const breakdown = computeBreakdown(bundle.rows);
 
+  // §6: the active month's delivery state — drives the banner above the sealed
+  // bundle. latestFinalized implies the month is finalized ⇒ in the delivery map
+  // (get() returns DeliveryState|null; the ?? null is a safe fallback).
+  const monthDeliveryState = latestFinalized
+    ? (deliveryByMonth.get(month) ?? null)
+    : null;
+
   return (
     <>
       <div className="border-b border-gray-200 bg-gray-50 px-8 py-4">
@@ -148,6 +167,13 @@ export default async function ExportPage({
         breakdown={breakdown}
         unassignableReceipts={unassignable}
       />
+      {latestFinalized && (
+        <DeliveryMonthBanner
+          month={month}
+          monthLabel={monthLabel}
+          state={monthDeliveryState}
+        />
+      )}
       {/* Sealed bundle — latest FINALIZED revision. Served even while a
           revision draft is open (getLatestFinalizedExport, NOT getExport, so an
           open draft never makes the sealed package undownloadable). */}

--- a/app/(receipt-system)/receipts/page.tsx
+++ b/app/(receipt-system)/receipts/page.tsx
@@ -23,6 +23,11 @@ import {
   listNeverEnqueuedReceipts,
   PIPELINE_ALL_CLEAR,
 } from "@/lib/receipts/pipeline-health";
+import {
+  deriveFinalizedMonthsDeliveryState,
+  needsDeliveryAction,
+} from "@/lib/receipts/delivery-status";
+import { SealedUndeliveredAlert } from "@/components/receipts/sealed-undelivered-alert";
 import { getReceiptsDb } from "@/lib/cloudflare-runtime";
 
 export const dynamic = "force-dynamic";
@@ -88,7 +93,7 @@ export default async function ReceiptsDashboardPage() {
     /* alerts optional */
   }
 
-  const [monthReceipts, allLines, exports, complianceSummary, pipelineHealth] =
+  const [monthReceipts, allLines, exports, complianceSummary, pipelineHealth, deliveryByMonth] =
     await Promise.all([
       listReceiptRecords({ month, limit: RECEIPT_BULK_LIMIT }),
       listAmexLineCountsByMonth(),
@@ -104,7 +109,16 @@ export default async function ReceiptsDashboardPage() {
       // Crashes fall back to all-clear — a health check that breaks the page is
       // worse than none.
       getPipelineHealth(getReceiptsDb()).catch(() => PIPELINE_ALL_CLEAR),
+      // §6: sealed-undelivered months for the dashboard banner. Falls back to an
+      // empty map on failure so a delivery-state query error never breaks the
+      // dashboard (mirrors the pipeline-health degrade-gracefully pattern).
+      deriveFinalizedMonthsDeliveryState().catch(() => new Map()),
     ]);
+
+  const sealedUndeliveredMonths = [...deliveryByMonth.entries()]
+    .filter(([, state]) => needsDeliveryAction(state))
+    .map(([m, state]) => ({ month: m, state }))
+    .sort((a, b) => b.month.localeCompare(a.month));
 
   // Load the class-1 receipts only when class 1 is lit (rare) — for the
   // per-receipt Enqueue action.
@@ -137,6 +151,8 @@ export default async function ReceiptsDashboardPage() {
         lit={pipelineHealth.lit}
         neverEnqueuedReceipts={neverEnqueuedReceipts}
       />
+
+      <SealedUndeliveredAlert months={sealedUndeliveredMonths} />
 
       {missingAlerts.length > 0 && (
         <div className="mb-6 space-y-3">

--- a/app/api/receipts/export/[month]/delivery-preview/route.ts
+++ b/app/api/receipts/export/[month]/delivery-preview/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+import { requireReceiptsActor } from "@/lib/receipts/auth";
+import {
+  composeDelivery,
+  NoSealedExportError,
+  type ComposedDelivery,
+} from "@/lib/receipts/delivery-compose";
+
+type RouteContext = { params: Promise<{ month: string }> };
+
+/**
+ * GET /api/receipts/export/{month}/delivery-preview
+ *
+ * Returns the composed delivery (recipients, subject, body, attachment sha/size,
+ * preflight, send decision) for a sealed month — the SAME {@link composeDelivery}
+ * the send route and the composer page use, so preview and send cannot disagree.
+ *
+ * Clerk-protected like the rest of /api/receipts/* (matched via
+ * /api/receipts/:path*, NOT in PUBLIC_ROUTES — asserted in the middleware-routing
+ * test). 400 on a malformed month, 404 when no sealed export exists for the
+ * month. The response carries no secret (no API key); `from` is the configured
+ * sender address.
+ */
+export async function GET(request: Request, { params }: RouteContext) {
+  try {
+    await requireReceiptsActor(request.headers);
+    const { month } = await params;
+    if (!/^\d{4}-\d{2}$/.test(month)) {
+      return NextResponse.json(
+        { error: "Invalid month format." },
+        { status: 400 },
+      );
+    }
+    const composed: ComposedDelivery = await composeDelivery(month);
+    return NextResponse.json(composed, { status: 200 });
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Unauthorized")) {
+      return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+    }
+    if (error instanceof NoSealedExportError) {
+      return NextResponse.json(
+        { error: "No sealed export for this month. Finalize before sending." },
+        { status: 404 },
+      );
+    }
+    console.error("[api/receipts/export/[month]/delivery-preview] GET failed", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to compose delivery." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/receipts/export/[month]/send/route.ts
+++ b/app/api/receipts/export/[month]/send/route.ts
@@ -14,25 +14,14 @@ import {
   getReceiptsArchiveBucket,
   getReceiptsDb,
   getResendApiKeyOrNull,
-  getNotifyFromAddress,
-  getAccountantEmail,
 } from "@/lib/cloudflare-runtime";
-import { getComplianceSettings } from "@/lib/receipts/settings";
-import { resolveNotificationRecipient, isValidDeliveryAddress } from "@/lib/receipts/notify";
-import { computeSha256Hex } from "@/lib/receipts/storage";
 import {
   decideSendAction,
   idempotencyKeyForAttempt,
   ATTEMPT_STATE,
 } from "@/lib/receipts/delivery-state";
-import {
-  performDelivery,
-  assertDeliverySize,
-  buildDeliveryEmail,
-  MAX_DELIVERY_ZIP_BYTES,
-} from "@/lib/receipts/delivery-send";
-import { runPreflightOnSealedZip } from "@/lib/receipts/delivery-preflight";
-import { packZipName } from "@/lib/receipts/pack-naming";
+import { performDelivery, assertDeliverySize } from "@/lib/receipts/delivery-send";
+import { composeDelivery } from "@/lib/receipts/delivery-compose";
 
 type RouteContext = { params: Promise<{ month: string }> };
 
@@ -43,13 +32,25 @@ type RouteContext = { params: Promise<{ month: string }> };
  * manager — Change 5) as an attached ZIP. Fires strictly AFTER the seal commit
  * (D1); the seal is immutable and this only moves the month's delivery_state.
  *
+ * Composition (recipients, subject/body, preflight, attachment sha/filename) is
+ * single-sourced in {@link composeDelivery} — the SAME function the preview
+ * endpoint and the composer page use — so preview and send cannot disagree by
+ * construction. This handler owns only the send-specific concerns: the
+ * `force_new`-aware new/resume/blocked decision, the B-2 R2 HEAD-before-GET
+ * fetch, the delivery-row lifecycle, and the Resend call.
+ *
  * Boundary order:
  *  - B-2 (isolate memory): R2 HEAD size check BEFORE the body is streamed in.
  *  - B-1 (Resend ceiling): defence-in-depth size check inside performDelivery,
  *    before base64. [Two call sites — both reported in the commit.]
- *  - Change 3: preflight runs on the fetched bytes AFTER the delivery row exists
- *    and BEFORE performDelivery; a preflight failure marks the row failed (never
- *    leaves it pending, or a blocked send becomes the stuck-pending duplicate).
+ *  - Change 3: preflight runs on the fetched bytes BEFORE performDelivery (read
+ *    from the composed result — no re-run); a preflight failure is audited and
+ *    blocks before any delivery row is created.
+ *
+ * The POST body is IGNORED. Subject/body/To/Cc are NEVER accepted from the
+ * client — they are re-composed server-side from the sealed pack + Settings via
+ * composeDelivery (delivery-composer decision 2). A client that posts an edited
+ * body has no way to change what is sent.
  *
  * `force_new` is the DISTINCT override for the double-send guard (D6). Without
  * it: a resumeable pending is RESUMED (same attempt_id ⇒ same key ⇒ Resend
@@ -66,6 +67,9 @@ export async function POST(request: Request, { params }: RouteContext) {
       return NextResponse.json({ error: "Invalid month format." }, { status: 400 });
     }
     const forceNew = new URL(request.url).searchParams.get("force_new") === "true";
+    // The request body is deliberately unread — subject/body/To/Cc are never
+    // accepted from the client (decision 2). Send proceeds solely from the
+    // sealed pack + Settings via composeDelivery below.
 
     // ── Load the sealed export (D1: send is post-seal) ───────────────────────
     const exportRecord = await getLatestFinalizedExport(month);
@@ -76,7 +80,10 @@ export async function POST(request: Request, { params }: RouteContext) {
       );
     }
 
-    // ── Decide new vs resume vs blocked (D6 + the stuck-pending guard) ───────
+    // ── Decide new vs resume vs blocked (D6 + the stuck-pending guard). This
+    //    is the send-specific, force_new-aware decision; composeDelivery runs a
+    //    forceNew:false decision for DISPLAY only. Kept BEFORE the R2 fetch so a
+    //    double-send 409 rejects cheaply.
     const deliveries = (await listDeliveriesForMonth(month)).map((d) => ({
       id: d.id,
       exportId: d.export_id,
@@ -109,51 +116,6 @@ export async function POST(request: Request, { params }: RouteContext) {
       );
     }
 
-    // ── Recipients + transport config (Settings/config — not pack state) ─────
-    // To: accountant (settings.notification_recipient → ACCOUNTANT_EMAIL
-    // fallback). Cc: business manager (settings.notification_cc_recipient — no
-    // fallback). Cc is OPTIONAL (Change 5): unset → omitted from the Resend
-    // payload entirely (performDelivery passes cc:null → undefined; B-4: never
-    // cc:null/cc:""). To is REQUIRED: no resolvable To = a partially-configured
-    // recipient list → refuse, do not deliver.
-    const settings = await getComplianceSettings();
-    const to = resolveNotificationRecipient(
-      settings.notification_recipient,
-      getAccountantEmail(),
-    ).email;
-    const cc = (settings.notification_cc_recipient ?? "").trim() || null;
-    // Change 5 boundaries — checked BEFORE the send (a malformed address is a
-    // definitive Resend 4xx; correct, but a wasted attempt + confusing audit):
-    //  - Both unset / no resolvable To → refuse (partially-configured list).
-    //  - Validate BOTH addresses. To may arrive via the unvalidated
-    //    ACCOUNTANT_EMAIL fallback, so it is not trusted from save-time alone.
-    if (!to) {
-      return NextResponse.json(
-        { error: "No delivery recipient (To) configured (set it in Settings → Compliance)." },
-        { status: 422 },
-      );
-    }
-    if (!isValidDeliveryAddress(to)) {
-      return NextResponse.json(
-        { error: `Delivery recipient (To) is not a valid email address: ${to}` },
-        { status: 422 },
-      );
-    }
-    if (cc !== null && !isValidDeliveryAddress(cc)) {
-      return NextResponse.json(
-        { error: `Delivery Cc recipient is not a valid email address: ${cc}` },
-        { status: 422 },
-      );
-    }
-    const apiKey = getResendApiKeyOrNull();
-    const from = getNotifyFromAddress();
-    if (!apiKey || !from) {
-      return NextResponse.json(
-        { error: "Delivery not configured (RESEND_API_KEY / NOTIFY_FROM_ADDRESS)." },
-        { status: 422 },
-      );
-    }
-
     // ── B-2: size check via R2 HEAD BEFORE streaming the body into memory ────
     const bucket = getReceiptsArchiveBucket();
     const proofsKey = exportRecord.proofs_r2_key;
@@ -182,27 +144,41 @@ export async function POST(request: Request, { params }: RouteContext) {
       );
     }
     const zipBytes = new Uint8Array(await new Response(object.body).arrayBuffer());
-    const zipSha256 = await computeSha256Hex(zipBytes);
-    const zipFilename = packZipName(month); // ASCII container name (B-4, asserted in performDelivery)
 
-    // ── Change 3: preflight on the ACTUAL sealed bytes — a gate that checks a
-    //    different object than the one being sent is not a gate. Uses the SAME
-    //    zipBytes fetched once (no second R2 read). Runs BEFORE createDelivery:
-    //    a failing check rejects the pack at the gate — no delivery row is
-    //    created, so there is no pending row to get stuck (the duplicate-send
-    //    path the stuck-pending guard prevents). The report is returned to the
-    //    caller so Phase C can render it.
-    const { report: preflight, summary } = await runPreflightOnSealedZip({
-      zipBytes,
-      month,
-      paymentDueDate: exportRecord.payment_due_date ?? null,
-      maxPackBytes: MAX_DELIVERY_ZIP_BYTES,
-      operatorMessage: exportRecord.operator_message ?? null,
-    });
-    if (!preflight.passed) {
-      const failedChecks = preflight.results
+    // ── Compose (recipients / subject / body / preflight / sha / filename).
+    //    Pass the already-fetched bytes IN so compose runs the preflight on the
+    //    EXACT bytes that ship and does not fetch a second time. This is the
+    //    single composition path — the preview endpoint and composer page call
+    //    the same function, so preview/send cannot drift.
+    const composed = await composeDelivery(month, { zipBytes });
+
+    // Config problems (missing To, invalid address, no Resend key / From, missing
+    // ZIP) make sending impossible. The composer surfaces these BEFORE the
+    // operator clicks Send; this is the defensive guard for a race/direct POST.
+    const apiKey = getResendApiKeyOrNull();
+    if (
+      composed.configErrors.length > 0 ||
+      !composed.to ||
+      !composed.from ||
+      !apiKey
+    ) {
+      return NextResponse.json(
+        {
+          error: composed.configErrors[0] ?? "Delivery not configured.",
+          configErrors: composed.configErrors,
+        },
+        { status: 422 },
+      );
+    }
+
+    // ── Change 3: preflight gate on the sealed bytes. Read from the composed
+    //    result — compose already ran it on these exact bytes (no re-run). A
+    //    failing check rejects the pack at the gate, audited, BEFORE any
+    //    delivery row is created (so there is no pending row to get stuck).
+    if (!composed.preflight.passed) {
+      const failedChecks = composed.preflight.results
         .filter((r) => !r.passed)
-        .map((r) => r.check)
+        .map((r) => r.name)
         .join(", ");
       await createAuditEntry(getReceiptsDb(), {
         actor,
@@ -212,16 +188,10 @@ export async function POST(request: Request, { params }: RouteContext) {
         newValueJson: stringifyJson({ month, blockedBy: "preflight", failedChecks }),
       });
       return NextResponse.json(
-        { error: "Pre-send preflight failed.", report: preflight },
+        { error: "Pre-send preflight failed.", preflight: composed.preflight },
         { status: 422 },
       );
     }
-
-    // ── Email body — sealed values only (B-5). SINGLE path. The summary comes
-    //    from the preflight's parse of the sealed 集計 (D4 — regenerated at
-    //    send, not a stale snapshot). ──
-    const operatorMessage = exportRecord.operator_message ?? null; // 0037: same stored value the pack notice carries (O7)
-    const email = buildDeliveryEmail({ month, operatorMessage, summary });
 
     // ── attempt_id: resume reuses the pending one; a new send mints one ──────
     const attemptId = action.action === "resume" ? action.attemptId : newUuid();
@@ -236,17 +206,18 @@ export async function POST(request: Request, { params }: RouteContext) {
     }
 
     // ── Record the delivery attempt (pending) with the now-known bytes + sha ─
+    const operatorMessage = exportRecord.operator_message ?? null; // 0037: same stored value the pack notice carries (O7)
     const deliveryId = await createDelivery({
       exportId: exportRecord.id,
       attemptId,
       idempotencyKey: idempotencyKeyForAttempt(attemptId),
-      toAddress: to,
-      ccAddress: cc,
-      subject: email.subject,
-      body: email.text,
+      toAddress: composed.to,
+      ccAddress: composed.cc,
+      subject: composed.subject,
+      body: composed.text,
       operatorMessage,
-      zipFilename,
-      zipSha256,
+      zipFilename: composed.zipFilename,
+      zipSha256: composed.zipSha256,
       zipBytes: zipBytes.byteLength,
     });
 
@@ -255,13 +226,13 @@ export async function POST(request: Request, { params }: RouteContext) {
     //    the Idempotency-Key. Never throws across the boundary.
     const result = await performDelivery({
       apiKey,
-      from,
-      to,
-      cc,
-      subject: email.subject,
-      text: email.text,
-      html: email.html,
-      zipFilename,
+      from: composed.from,
+      to: composed.to,
+      cc: composed.cc,
+      subject: composed.subject,
+      text: composed.text,
+      html: composed.html,
+      zipFilename: composed.zipFilename,
       zipBytes,
       idempotencyKey: idempotencyKeyForAttempt(attemptId),
     });
@@ -277,7 +248,7 @@ export async function POST(request: Request, { params }: RouteContext) {
         newValueJson: stringifyJson({
           month,
           attemptId,
-          to,
+          to: composed.to,
           messageId: result.messageId ?? null,
         }),
       });
@@ -318,8 +289,8 @@ export async function POST(request: Request, { params }: RouteContext) {
         deliveryId,
         error: result.error,
         classification,
-        // Phase C renders "resume" (reuse the attempt) vs "retry" (new attempt)
-        // from this — ambiguous within 24h is resumable.
+        // The composer renders "resume" (reuse the attempt) vs "retry" (new
+        // attempt) from this — ambiguous within 24h is resumable.
         resumable: classification === "ambiguous",
       },
       { status: 200 },

--- a/app/api/receipts/settings/compliance/route.ts
+++ b/app/api/receipts/settings/compliance/route.ts
@@ -91,6 +91,28 @@ export async function PATCH(request: Request) {
       );
     }
 
+    // Delivery-composer decision 3: the email-only signature is free text,
+    // capped at 1000 chars and trimmed. Empty is allowed (→ no signature
+    // appended). Reject over-cap rather than silently truncating so the editor
+    // sees the real boundary.
+    if (body.delivery_signature !== undefined) {
+      if (typeof body.delivery_signature !== "string") {
+        return NextResponse.json(
+          { error: "delivery_signature must be a string." },
+          { status: 400 },
+        );
+      }
+      if (body.delivery_signature.length > 1000) {
+        return NextResponse.json(
+          { error: "delivery_signature must be 1000 characters or fewer." },
+          { status: 400 },
+        );
+      }
+      // Trim before storing so the empty→null mapping in composeDelivery is
+      // exact and there is no trailing-whitespace drift between save and send.
+      body.delivery_signature = body.delivery_signature.trim();
+    }
+
     const before = await getComplianceSettings();
     const settings = await updateComplianceSettings(body, actor);
 

--- a/components/receipts/ComplianceSettingsForm.tsx
+++ b/components/receipts/ComplianceSettingsForm.tsx
@@ -30,6 +30,7 @@ const LABELS: Record<keyof ComplianceSettings, string> = {
   track_tax_breakdown: "Track tax rate / amount breakdown",
   notification_recipient: "通知先 (Notification recipient)",
   notification_cc_recipient: "CC (Business manager / Cc recipient)",
+  delivery_signature: "配信メール署名 (Delivery email signature)",
   homebase_signals: "Homebase signals (ADR 0010)",
 };
 
@@ -288,6 +289,23 @@ export function ComplianceSettingsForm({
             </p>
           ) : null}
         </div>
+      </Row>
+
+      <Row
+        label={LABELS.delivery_signature}
+        hint="配信メールの末尾（「ご不明な点があればお知らせください。」の後）に追加される署名です。確定した封筒内の通知には含まれません（送信メールのみ）。空欄なら追加されません。"
+      >
+        <textarea
+          value={settings.delivery_signature}
+          onChange={(e) => update("delivery_signature", e.target.value)}
+          rows={4}
+          maxLength={1000}
+          className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm sm:w-96"
+          placeholder={"山田 太郎\nDazbeez合同会社\neditor@dazbeez.com"}
+        />
+        <p className="mt-1 text-[11px] text-gray-400">
+          {settings.delivery_signature.length}/1000
+        </p>
       </Row>
 
       <Row

--- a/components/receipts/export/delivery-composer.tsx
+++ b/components/receipts/export/delivery-composer.tsx
@@ -1,0 +1,505 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import type { ComposedDelivery } from "@/lib/receipts/delivery-compose";
+
+/**
+ * Delivery composer UI (delivery-composer §4). Renders the server-composed
+ * delivery (From/To/Cc, subject, body, attachment, preflight) READ-ONLY and
+ * provides the two-step Confirm → Send flow. The Send button posts an EMPTY
+ * body to POST /api/receipts/export/{month}/send — the route recomposes
+ * server-side from the sealed pack + Settings, so a client cannot change what is
+ * sent (decision 2). Sealing ≠ closing (decision 5): every string respects that
+ * the seal is the midpoint, delivery closes the month for reporting.
+ */
+export function DeliveryComposer({
+  composed,
+  monthLabel,
+}: {
+  composed: ComposedDelivery;
+  monthLabel: string;
+}) {
+  const month = composed.month;
+  const hasBytes = composed.zipSha256.length > 0;
+  const configBlocked = composed.configErrors.length > 0 || !hasBytes;
+
+  // Two-step confirm for the primary (new / resume) send.
+  const [confirmed, setConfirmed] = useState(false);
+  // Separate confirm for the de-emphasised force-new re-send.
+  const [forceConfirmed, setForceConfirmed] = useState(false);
+  const [phase, setPhase] = useState<"idle" | "sending" | "sent" | "failed">(
+    "idle",
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [sentInfo, setSentInfo] = useState<{
+    to: string | null;
+    messageId: string | null;
+    at: string;
+  } | null>(null);
+
+  const passedCount = composed.preflight.results.filter((r) => r.passed).length;
+  const totalCount = composed.preflight.results.length;
+  const preflightBlocked = hasBytes && !composed.preflight.passed;
+
+  async function doSend(forceNew: boolean) {
+    setPhase("sending");
+    setError(null);
+    try {
+      const url = `/api/receipts/export/${month}/send${forceNew ? "?force_new=true" : ""}`;
+      // Empty body: subject/body/To/Cc are NEVER sent from the client (decision 2).
+      const res = await fetch(url, { method: "POST" });
+      const data = (await res.json().catch(() => ({}))) as {
+        state?: string;
+        error?: string;
+        messageId?: string | null;
+        configErrors?: string[];
+        reason?: string;
+        classification?: string;
+        resumable?: boolean;
+      };
+      if (res.ok && data.state === "delivered") {
+        setSentInfo({
+          to: composed.to,
+          messageId: data.messageId ?? null,
+          at: new Date().toLocaleString("ja-JP"),
+        });
+        setPhase("sent");
+        return;
+      }
+      if (res.status === 409) {
+        // Double-send guard fired between load and click (race) or the displayed
+        // action was 'blocked'. Surface the route's reason and stay on the
+        // composer so the operator can re-send with force_new if intended.
+        setError(
+          data.error ??
+            "This month cannot be sent right now (double-send guard). Reload to refresh.",
+        );
+        setPhase("failed");
+        return;
+      }
+      if (res.status === 422) {
+        setError(data.error ?? "Pre-send check failed.");
+        setPhase("failed");
+        return;
+      }
+      if (res.ok && data.state === "sealed_undelivered") {
+        setError(
+          (data.error ?? "Send failed.") +
+            (data.resumable
+              ? " — 再開可能（同じ idempotency key で再試行できます）。"
+              : " — 再試行してください。"),
+        );
+        setPhase("failed");
+        return;
+      }
+      setError(data.error ?? `Send failed (HTTP ${res.status}).`);
+      setPhase("failed");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Network error.");
+      setPhase("failed");
+    }
+  }
+
+  // ── Success state — show confirmation, do NOT auto-redirect (decision 4). ──
+  if (phase === "sent" && sentInfo) {
+    return (
+      <div className="rounded-2xl border border-green-200 bg-green-50 p-6">
+        <h1 className="text-lg font-bold text-green-900">送信完了</h1>
+        <p className="mt-2 text-sm text-green-800">
+          {monthLabel} の領収証憑一式を{" "}
+          <span className="font-mono font-semibold">{sentInfo.to}</span>{" "}
+          宛てに送信しました。この月のレポート出力用のクローズ処理が完了しました。
+        </p>
+        <p className="mt-1 text-xs text-green-700">
+          送信日時: {sentInfo.at}
+          {sentInfo.messageId ? ` · Resend message id: ${sentInfo.messageId}` : ""}
+        </p>
+        <div className="mt-4 flex gap-3">
+          <Link
+            href={`/receipts/export?month=${month}`}
+            className="rounded-xl bg-amber-500 px-4 py-2 text-sm font-semibold text-white hover:bg-amber-600"
+          >
+            エクスポート画面に戻る
+          </Link>
+          <Link
+            href="/receipts"
+            className="rounded-xl border border-gray-300 bg-white px-4 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50"
+          >
+            ダッシュボード
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      {/* Header — decision 5: sealed ≠ delivered. */}
+      <div>
+        <h1 className="text-[22px] font-bold text-gray-900">
+          {monthLabel} の送信
+        </h1>
+        <p className="mt-1 text-[13px] text-gray-600">
+          {composed.sealedAt ? (
+            <>
+              確定（seal）済み ·{" "}
+              <span className="text-gray-500">
+                {new Date(composed.sealedAt).toLocaleString("ja-JP")}
+              </span>
+            </>
+          ) : (
+            "確定（seal）済み"
+          )}{" "}
+          · <strong className="text-amber-700">まだ送信されていません</strong>
+          。この月は送信完了までレポート用にクローズされません。
+        </p>
+      </div>
+
+      {/* Config-error state — replaces the From/To/Cc block; Send disabled. */}
+      {configBlocked ? (
+        <div className="rounded-2xl border border-red-200 bg-red-50 p-5">
+          <h2 className="text-sm font-semibold text-red-800">
+            送信できません — 設定を確認してください
+          </h2>
+          <ul className="mt-2 space-y-1 text-[13px] text-red-700">
+            {composed.configErrors.map((e, i) => (
+              <li key={i}>• {e}</li>
+            ))}
+          </ul>
+          <Link
+            href="/receipts/settings/compliance"
+            className="mt-3 inline-block rounded-lg bg-white px-3 py-1.5 text-[12px] font-semibold text-amber-700 border border-amber-300 hover:bg-amber-50"
+          >
+            Settings → Compliance で編集
+          </Link>
+        </div>
+      ) : (
+        <div className="rounded-2xl border border-gray-200 bg-white p-5 space-y-3">
+          <ReadonlyRow label="From" value={composed.from} mono />
+          <ReadonlyRow label="To" value={composed.to} mono />
+          <ReadonlyRow
+            label="Cc"
+            value={composed.cc ?? null}
+            mono
+            emptyDisplay="（なし）"
+          />
+        </div>
+      )}
+
+      {/* Subject — read-only */}
+      <div className="rounded-2xl border border-gray-200 bg-white p-5">
+        <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">
+          件名 / Subject
+        </div>
+        <div className="mt-1 text-[14px] font-medium text-gray-900">
+          {composed.subject}
+        </div>
+      </div>
+
+      {/* Body preview — read-only, pre-wrap, visually distinct. */}
+      {hasBytes && (
+        <div className="rounded-2xl border border-amber-200 bg-amber-50/40 p-5">
+          <div className="flex items-center justify-between">
+            <div className="text-[11px] font-semibold uppercase tracking-wide text-amber-700">
+              本文プレビュー / Body (read-only)
+            </div>
+            <Link
+              href="/receipts/settings/compliance"
+              className="text-[11px] font-medium text-gray-500 hover:text-amber-700"
+            >
+              署名を Settings で編集
+            </Link>
+          </div>
+          <pre className="mt-2 whitespace-pre-wrap break-words rounded-lg border border-amber-200 bg-white px-4 py-3 font-sans text-[13px] leading-relaxed text-gray-800">
+            {composed.text}
+          </pre>
+          <div className="mt-1.5 text-[11px] text-gray-500">
+            署名:{" "}
+            {composed.signature
+              ? "あり（本文末尾に挿入）"
+              : "なし（Settings → Compliance で設定可能）"}
+          </div>
+        </div>
+      )}
+
+      {/* Attachment — filename, size, SHA-256 + copy. */}
+      {hasBytes && (
+        <div className="rounded-2xl border border-gray-200 bg-white p-5">
+          <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">
+            添付 / Attachment
+          </div>
+          <div className="mt-2 flex flex-wrap items-baseline gap-x-4 gap-y-1 text-[13px]">
+            <span className="font-medium text-gray-900">{composed.zipFilename}</span>
+            <span className="text-gray-500">{formatBytes(composed.zipBytes)}</span>
+          </div>
+          <ShaCopy sha={composed.zipSha256} />
+        </div>
+      )}
+
+      {/* Preflight — collapsed green or expanded red. */}
+      {hasBytes && (
+        <PreflightBlock
+          passed={composed.preflight.passed}
+          passedCount={passedCount}
+          totalCount={totalCount}
+          results={composed.preflight.results}
+        />
+      )}
+
+      {error && (
+        <div className="rounded-2xl border border-red-200 bg-red-50 p-4 text-[13px] text-red-700">
+          {error}
+        </div>
+      )}
+
+      {/* Action area — new / resume / blocked, with the two-step confirm.
+          Hidden entirely when config-blocked: sending is impossible regardless
+          of action, and the config-error panel + Settings link is the only CTA
+          needed (avoids a misleading "blocked/stale" panel beside a missing-ZIP
+          error). */}
+      {!configBlocked &&
+        (composed.action === "blocked" ? (
+          <BlockedAction
+            blockedReason={composed.blockedReason ?? "stale"}
+            forceConfirmed={forceConfirmed}
+            setForceConfirmed={setForceConfirmed}
+            sending={phase === "sending"}
+            onSend={() => doSend(true)}
+          />
+        ) : (
+          <PrimaryAction
+            action={composed.action}
+            monthLabel={monthLabel}
+            confirmed={confirmed}
+            setConfirmed={setConfirmed}
+            sending={phase === "sending"}
+            disabled={
+              configBlocked ||
+              preflightBlocked ||
+              !confirmed ||
+              phase === "sending"
+            }
+            onSend={() => doSend(false)}
+          />
+        ))}
+    </div>
+  );
+}
+
+// ─── Subcomponents ───────────────────────────────────────────────────────────
+
+function ReadonlyRow({
+  label,
+  value,
+  mono,
+  emptyDisplay,
+}: {
+  label: string;
+  value: string | null;
+  mono?: boolean;
+  emptyDisplay?: string;
+}) {
+  return (
+    <div className="flex flex-col gap-0.5 sm:flex-row sm:items-center sm:gap-4">
+      <div className="w-16 shrink-0 text-[11px] font-semibold uppercase tracking-wide text-gray-500">
+        {label}
+      </div>
+      <div
+        className={`text-[13px] text-gray-900 ${mono ? "font-mono" : ""} ${
+          value ? "" : "text-gray-400"
+        }`}
+      >
+        {value ?? emptyDisplay ?? "—"}
+      </div>
+    </div>
+  );
+}
+
+function ShaCopy({ sha }: { sha: string }) {
+  const [copied, setCopied] = useState(false);
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(sha);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* clipboard unavailable — the full sha is still selectable in the monospace block */
+    }
+  }
+  const short = sha.length > 16 ? `${sha.slice(0, 12)}…${sha.slice(-8)}` : sha;
+  return (
+    <div className="mt-2 flex items-center gap-2">
+      <span className="font-mono text-[11px] text-gray-500" title={sha}>
+        SHA-256: {short}
+      </span>
+      <button
+        type="button"
+        onClick={copy}
+        className="rounded border border-gray-300 bg-white px-2 py-0.5 text-[10px] font-semibold text-gray-600 hover:bg-gray-50"
+      >
+        {copied ? "コピー済み" : "コピー"}
+      </button>
+    </div>
+  );
+}
+
+function PreflightBlock({
+  passed,
+  passedCount,
+  totalCount,
+  results,
+}: {
+  passed: boolean;
+  passedCount: number;
+  totalCount: number;
+  results: { name: string; passed: boolean; detail?: string }[];
+}) {
+  if (passed) {
+    return (
+      <div className="rounded-2xl border border-green-200 bg-green-50 px-5 py-3 text-[13px] text-green-800">
+        <strong>Pre-flight: {passedCount}/{totalCount} checks passed</strong>
+        <span className="ml-2 text-green-600">— pack is ready to send.</span>
+      </div>
+    );
+  }
+  const failed = results.filter((r) => !r.passed);
+  return (
+    <div className="rounded-2xl border border-red-200 bg-red-50 p-5">
+      <div className="text-[13px] font-semibold text-red-800">
+        Pre-flight: {passedCount}/{totalCount} checks passed — 送信できません
+      </div>
+      <ul className="mt-2 space-y-1 text-[12px] text-red-700">
+        {failed.map((r, i) => (
+          <li key={i}>
+            <span className="font-mono">✗ {r.name}</span>
+            {r.detail ? <span className="text-red-600"> — {r.detail}</span> : null}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function PrimaryAction({
+  action,
+  monthLabel,
+  confirmed,
+  setConfirmed,
+  sending,
+  disabled,
+  onSend,
+}: {
+  action: "new" | "resume";
+  monthLabel: string;
+  confirmed: boolean;
+  setConfirmed: (v: boolean) => void;
+  sending: boolean;
+  disabled: boolean;
+  onSend: () => void;
+}) {
+  return (
+    <div className="rounded-2xl border border-gray-200 bg-white p-5">
+      {action === "resume" && (
+        <p className="mb-3 text-[12px] text-gray-600">
+          前回の送信試行を再開します（同じ idempotency key を再利用するため、Resend
+          が重複配送することはありません）。
+        </p>
+      )}
+      <label className="flex items-start gap-2.5 text-[13px] text-gray-700">
+        <input
+          type="checkbox"
+          checked={confirmed}
+          onChange={(e) => setConfirmed(e.target.checked)}
+          className="mt-0.5 h-4 w-4 rounded border-gray-300 text-amber-500"
+        />
+        <span>
+          宛先・件名・本文・添付を確認しました。{" "}
+          <strong>{`「送信」をクリックすると ${monthLabel} の領収証憑一式が送信されます。`}</strong>
+        </span>
+      </label>
+      <button
+        type="button"
+        onClick={onSend}
+        disabled={disabled}
+        className="mt-4 w-full rounded-xl bg-amber-500 px-4 py-3 text-sm font-semibold text-white hover:bg-amber-600 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {sending
+          ? "送信中… この画面を閉じないでください"
+          : action === "resume"
+            ? "送信を再開"
+            : "送信する"}
+      </button>
+    </div>
+  );
+}
+
+function BlockedAction({
+  blockedReason,
+  forceConfirmed,
+  setForceConfirmed,
+  sending,
+  onSend,
+}: {
+  blockedReason: "sent" | "stale";
+  forceConfirmed: boolean;
+  setForceConfirmed: (v: boolean) => void;
+  sending: boolean;
+  onSend: () => void;
+}) {
+  const delivered = blockedReason === "sent";
+  return (
+    <div className="space-y-3">
+      <div
+        className={`rounded-2xl border px-5 py-4 text-[13px] ${
+          delivered
+            ? "border-green-200 bg-green-50 text-green-800"
+            : "border-amber-200 bg-amber-50 text-amber-800"
+        }`}
+      >
+        {delivered ? (
+          <span>
+            <strong>この月は既に送信済みです。</strong> レポート用のクローズ処理も完了しています。
+          </span>
+        ) : (
+          <span>
+            前回の送信試行から Resend の 24 時間 idempotency window を超過したため、安全な再開ができません。
+          </span>
+        )}
+      </div>
+      <details className="rounded-2xl border border-gray-200 bg-white p-4">
+        <summary className="cursor-pointer text-[12px] font-medium text-gray-500 hover:text-gray-700">
+          再送信（監査記録あり） — force_new
+        </summary>
+        <p className="mt-2 text-[12px] text-gray-600">
+          新しい attempt id で再送信します。この操作は監査ログに記録されます（export.delivery_override）。
+        </p>
+        <label className="mt-3 flex items-start gap-2.5 text-[13px] text-gray-700">
+          <input
+            type="checkbox"
+            checked={forceConfirmed}
+            onChange={(e) => setForceConfirmed(e.target.checked)}
+            className="mt-0.5 h-4 w-4 rounded border-gray-300 text-amber-500"
+          />
+          <span>再送信することを確認しました。</span>
+        </label>
+        <button
+          type="button"
+          onClick={onSend}
+          disabled={!forceConfirmed || sending}
+          className="mt-3 rounded-xl border border-gray-300 bg-white px-4 py-2 text-[12px] font-semibold text-gray-600 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {sending ? "送信中…" : "再送信（監査記録あり）"}
+        </button>
+      </details>
+    </div>
+  );
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KiB`;
+  return `${(n / (1024 * 1024)).toFixed(2)} MiB`;
+}

--- a/components/receipts/export/delivery-month-banner.tsx
+++ b/components/receipts/export/delivery-month-banner.tsx
@@ -1,0 +1,62 @@
+import Link from "next/link";
+import {
+  deliveryStateToPill,
+  type DeliveryState,
+} from "@/lib/receipts/delivery-state";
+
+/**
+ * Per-month delivery banner for the export page (delivery-composer §6, surface
+ * 1). Rendered above the sealed-bundle panel ONLY when the month has a sealed
+ * (finalized) export. Red + a 送信する link to the composer when sealed-
+ * undelivered (failed or never attempted — 2026-06 today); blue when pending
+ * (in-flight); green confirmation line when delivered. Sealing ≠ closing
+ * (decision 5): the red state says explicitly the month is sealed but not yet
+ * closed for reporting. Pure server component (links only, no interactivity).
+ */
+export function DeliveryMonthBanner({
+  month,
+  monthLabel,
+  state,
+}: {
+  month: string;
+  monthLabel: string;
+  state: DeliveryState | null;
+}) {
+  const pill = deliveryStateToPill(state);
+
+  if (pill === "delivered") {
+    return (
+      <div className="border-t border-green-200 bg-green-50 px-8 py-4 text-[13px] text-green-800">
+        <strong>送信済み</strong> — {monthLabel} は会計士宛てに配信済みです。レポート用のクローズ処理が完了しています。
+      </div>
+    );
+  }
+
+  if (pill === "pending") {
+    return (
+      <div className="border-t border-blue-200 bg-blue-50 px-8 py-4 text-[13px] text-blue-800">
+        <strong>送信中</strong> — {monthLabel} の配信が進行中です。完了までしばらくお待ちください。
+      </div>
+    );
+  }
+
+  // undelivered (sealed_undelivered OR null = sealed, never attempted)
+  const neverAttempted = state === null;
+  return (
+    <div className="border-t border-red-200 bg-red-50 px-8 py-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="text-[13px] text-red-800">
+          <strong>未送信 — 未クローズ</strong> — {monthLabel} は確定（seal）済みですが
+          {neverAttempted ? "一度も送信されていません" : "前回の送信に失敗しました"}。
+          この月は送信完了までレポート用にクローズされません。
+        </div>
+        <Link
+          href={`/receipts/export/${month}/send`}
+          className="shrink-0 rounded-xl bg-amber-500 px-4 py-2 text-[12px] font-semibold text-white hover:bg-amber-600"
+        >
+          送信する →
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/components/receipts/export/finalize-card.tsx
+++ b/components/receipts/export/finalize-card.tsx
@@ -80,7 +80,13 @@ export function FinalizeCard({
         return;
       }
       setConfirmType("");
-      router.refresh();
+      // Delivery-composer §5: on a successful finalize, hand the operator to
+      // the composer (sealed → review email → send). Sealing is the midpoint,
+      // not completion (decision 5) — finalize stays a separate operation from
+      // delivery (D1/D2); this is a CLIENT navigation only, no auto-send and no
+      // server-side coupling. The composer renders the sealed-undelivered state
+      // and the operator clicks Send himself.
+      router.push(`/receipts/export/${month}/send`);
     } catch {
       setError("Network error.");
     } finally {

--- a/components/receipts/month-switcher.tsx
+++ b/components/receipts/month-switcher.tsx
@@ -1,11 +1,21 @@
 import Link from "next/link";
 import { withWorkMonth } from "@/lib/receipts/work-month";
+import {
+  deliveryStateToPill,
+  type DeliveryState,
+} from "@/lib/receipts/delivery-state";
 
 export interface MonthOption {
   month: string;
   lineCount: number;
   unmatchedCount: number;
   status: "draft" | "finalized" | null;
+  /** Per-month delivery state (delivery-composer §6). OPTIONAL because
+   *  MonthSwitcher is shared with the reconcile and AMEX pages, which must keep
+   *  compiling and rendering unchanged — only the export page populates it.
+   *  `undefined` = not provided (keep existing pill behaviour). `null` = sealed,
+   *  never attempted (a real value → red, action-needed). */
+  deliveryState?: DeliveryState | null;
 }
 
 interface MonthSwitcherProps {
@@ -91,7 +101,12 @@ function MonthPill({
       <span className={active ? "text-amber-50" : "text-gray-500"}>
         {option.lineCount} line{option.lineCount !== 1 ? "s" : ""}
       </span>
-      <StatusDot status={option.status} unmatchedCount={option.unmatchedCount} active={active} />
+      <StatusDot
+        status={option.status}
+        unmatchedCount={option.unmatchedCount}
+        active={active}
+        deliveryState={option.deliveryState}
+      />
     </Link>
   );
 }
@@ -100,12 +115,43 @@ function StatusDot({
   status,
   unmatchedCount,
   active,
+  deliveryState,
 }: {
   status: "draft" | "finalized" | null;
   unmatchedCount: number;
   active: boolean;
+  deliveryState?: DeliveryState | null;
 }) {
   if (status === "finalized") {
+    // Only colour by delivery when the caller populated deliveryState (export
+    // page). Reconcile/AMEX pages leave it undefined → keep the legacy green ✓.
+    if (deliveryState !== undefined) {
+      const pill = deliveryStateToPill(deliveryState);
+      if (pill === "undelivered") {
+        return (
+          <span
+            className={`inline-flex h-4 w-4 items-center justify-center rounded-full text-[10px] ${
+              active ? "bg-white text-red-600" : "bg-red-100 text-red-700"
+            }`}
+            title="未送信 — 未クローズ (sealed, not yet delivered)"
+          >
+            !
+          </span>
+        );
+      }
+      if (pill === "pending") {
+        return (
+          <span
+            className={`inline-flex h-4 w-4 items-center justify-center rounded-full text-[10px] ${
+              active ? "bg-white text-blue-600" : "bg-blue-100 text-blue-700"
+            }`}
+            title="送信中 (delivery in flight)"
+          >
+            …
+          </span>
+        );
+      }
+    }
     return (
       <span
         className={`inline-flex h-4 w-4 items-center justify-center rounded-full text-[10px] ${

--- a/components/receipts/sealed-undelivered-alert.tsx
+++ b/components/receipts/sealed-undelivered-alert.tsx
@@ -1,0 +1,57 @@
+import Link from "next/link";
+import {
+  deliveryStateToPill,
+  type DeliveryState,
+} from "@/lib/receipts/delivery-state";
+import { formatMonth } from "@/lib/receipts/format";
+
+/**
+ * Dashboard banner listing every finalized month that is NOT yet delivered
+ * (delivery-composer §6, surface 2). Modelled on pipeline-health-alert for
+ * visual consistency. Each month links to its composer. Returns null when every
+ * finalized month is delivered (the all-clear state). Pure server component.
+ *
+ * "Sealed-undelivered" here is the broad, actionable reading: sealed_undelivered
+ * (failed), pending (in-flight), and null (sealed, never attempted) all leave the
+ * month not-yet-closed-for-reporting. The per-month label distinguishes them.
+ */
+export function SealedUndeliveredAlert({
+  months,
+}: {
+  months: { month: string; state: DeliveryState | null }[];
+}) {
+  if (months.length === 0) return null;
+
+  return (
+    <div className="mb-6 rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm">
+      <p className="font-semibold text-red-800">
+        送信待ちの確定済み月があります
+      </p>
+      <p className="mt-0.5 text-[12px] text-red-700">
+        これらの月は確定（seal）済みですが、会計士への送信が完了していません。レポート用のクローズには送信が必要です。
+      </p>
+      <ul className="mt-2 space-y-1">
+        {months.map(({ month, state }) => {
+          const pill = deliveryStateToPill(state);
+          const label =
+            pill === "pending"
+              ? "送信中"
+              : state === null
+                ? "未送信（送信未実行）"
+                : "送信失敗（再送信可）";
+          return (
+            <li key={month} className="flex items-center gap-2 text-[13px]">
+              <Link
+                href={`/receipts/export/${month}/send`}
+                className="font-semibold text-red-800 underline hover:text-red-900"
+              >
+                {formatMonth(month)}
+              </Link>
+              <span className="text-red-600">· {label}</span>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/db/receipts/0040_delivery_signature.sql
+++ b/db/receipts/0040_delivery_signature.sql
@@ -1,0 +1,19 @@
+-- 0040_delivery_signature.sql
+--
+-- Email-only delivery signature (delivery-composer decision 3). Appended to the
+-- delivery email body AFTER the sealed pack notice's closing line; it does NOT
+-- enter buildPackNotice (the notice inside the sealed ZIP is unchanged) — it is
+-- a transport-layer adornment on the delivery email only, configured under
+-- Settings → Compliance.
+--
+-- NOTE: receipt_settings is a KEY/VALUE table (key TEXT PRIMARY KEY, value TEXT
+-- NOT NULL — see 0014_compliance.sql), NOT a wide table. So a new setting is
+-- added as a seeded ROW, not via ALTER TABLE ADD COLUMN — exactly how
+-- notification_recipient / notification_cc_recipient were introduced (as app-
+-- code keys, read with a COMPLIANCE_DEFAULTS fallback). This seed row mirrors
+-- 0014's seed block purely for migration-trail discoverability; the app reads
+-- the key with an empty-string default whether or not the row exists
+-- (INSERT OR IGNORE makes re-runs safe and the row effectively a no-op).
+-- Additive only; no backfill.
+INSERT OR IGNORE INTO receipt_settings (key, value, updated_at, updated_by)
+VALUES ('delivery_signature', '', strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), 'system');

--- a/lib/receipts/delivery-compose.ts
+++ b/lib/receipts/delivery-compose.ts
@@ -1,0 +1,343 @@
+// Delivery composer — the single composition authority for a month's pack
+// delivery (delivery-composer §1).
+//
+// The send route (POST /api/receipts/export/{month}/send), the preview endpoint
+// (GET .../delivery-preview), and the composer page (/receipts/export/{month}/
+// send) ALL build the delivery through this function. A preview that re-derives
+// recipients / subject / body / preflight separately WILL drift from the send —
+// the exact §7 failure mode this codebase was burned by twice (the notice named
+// files that weren't in the ZIP). Funneling every surface through composeDelivery
+// makes preview/send disagreement impossible by construction: there is one
+// recipient-resolution path, one address validation, one buildDeliveryEmail call,
+// one preflight run. Do not duplicate any of them.
+//
+// The send path passes its already-fetched sealed bytes IN (opts.zipBytes) so
+// composeDelivery runs the preflight + sha on the EXACT bytes that will be
+// delivered and the send path does not fetch twice. The preview/page path omits
+// zipBytes and composeDelivery performs the B-2 R2 HEAD size check ahead of the
+// GET itself.
+
+import {
+  getLatestFinalizedExport,
+  listDeliveriesForMonth,
+} from "@/lib/receipts/db";
+import {
+  getReceiptsArchiveBucket,
+  getResendApiKeyOrNull,
+  getNotifyFromAddress,
+  getAccountantEmail,
+} from "@/lib/cloudflare-runtime";
+import { getComplianceSettings } from "@/lib/receipts/settings";
+import {
+  resolveNotificationRecipient,
+  isValidDeliveryAddress,
+} from "@/lib/receipts/notify";
+import { computeSha256Hex } from "@/lib/receipts/storage";
+import { nowIso } from "@/lib/receipts/db-utils";
+import {
+  decideSendAction,
+  type DeliveryState,
+} from "@/lib/receipts/delivery-state";
+import {
+  buildDeliveryEmail,
+  MAX_DELIVERY_ZIP_BYTES,
+  assertDeliverySize,
+} from "@/lib/receipts/delivery-send";
+import { runPreflightOnSealedZip } from "@/lib/receipts/delivery-preflight";
+import { packZipName } from "@/lib/receipts/pack-naming";
+
+/** Thrown when a month has no sealed (finalized + proofs) export to deliver.
+ *  Callers translate: the preview endpoint → 404, the composer page →
+ *  notFound(), the send route already 409s before calling compose. */
+export class NoSealedExportError extends Error {
+  constructor(public month: string) {
+    super(`No sealed export for ${month}. Finalize before sending.`);
+    this.name = "NoSealedExportError";
+  }
+}
+
+export interface ComposedPreflightResult {
+  name: string;
+  passed: boolean;
+  detail?: string;
+}
+
+export interface ComposedDelivery {
+  month: string;
+  exportId: string;
+  /** When the latest finalized revision was sealed (receipt_exports.finalized_at).
+   *  The composer header renders "sealed on {date}, NOT yet delivered" — sealing
+   *  is the midpoint, not completion (decision 5). Added beyond the spec'd
+   *  interface to avoid a second getLatestFinalizedExport fetch in the page. */
+  sealedAt: string | null;
+  to: string | null;
+  cc: string | null;
+  /** Resolved From address. null when NOTIFY_FROM_ADDRESS is unset (also a
+   *  configError). The interface in the spec read `from: string`; null is the
+   *  truthful shape — a missing From is a configError, not an empty string. */
+  from: string | null;
+  subject: string;
+  text: string;
+  html: string;
+  /** The email-only signature actually applied (delivery-composer decision 3).
+   *  null when unset/empty — what buildDeliveryEmail received. */
+  signature: string | null;
+  zipFilename: string;
+  zipSha256: string;
+  /** Pack size in bytes (display). The raw bytes are NOT on this object — the
+   *  send path keeps its own reference and passes them in via opts.zipBytes. */
+  zipBytes: number;
+  /** Preflight results on the sealed bytes — the SAME run the send performs. */
+  preflight: {
+    passed: boolean;
+    results: ComposedPreflightResult[];
+  };
+  /** Config problems that make sending impossible (missing To, invalid address,
+   *  no Resend key / From, missing/oversized sealed ZIP). Empty = sendable. */
+  configErrors: string[];
+  /** What the Send button should offer, from decideSendAction(forceNew:false).
+   *  The send route re-decides with the real forceNew from the query; this is
+   *  the display verdict (the natural-state action the operator first sees). */
+  action: "new" | "resume" | "blocked";
+  /** Present only when action === "blocked". The real enum from
+   *  decideSendAction is "sent" | "stale" (the spec wrote "stale_pending";
+   *  the code's authority is "stale" — same case, the 24h-window-expired
+   *  pending). */
+  blockedReason?: "sent" | "stale";
+  priorAttemptId?: string;
+}
+
+/**
+ * Compose a month's delivery — recipients, subject, body, attachment metadata,
+ * preflight, and the send decision. Single-sourced; called by the send route,
+ * the preview endpoint, and the composer page.
+ *
+ * `opts.zipBytes`: the sealed proofs-ZIP bytes, when the caller already has
+ * them (the send path fetches once and passes them in so compose runs the
+*  preflight on the exact bytes that ship). When omitted, compose fetches from R2
+ *  itself (HEAD size check → GET), which is what the preview/page path uses.
+ */
+export async function composeDelivery(
+  month: string,
+  opts: { zipBytes?: Uint8Array } = {},
+): Promise<ComposedDelivery> {
+  // ── Load the sealed export (D1: send is post-seal) ───────────────────────
+  const exportRecord = await getLatestFinalizedExport(month);
+  if (!exportRecord || !exportRecord.proofs_r2_key) {
+    throw new NoSealedExportError(month);
+  }
+  const proofsKey = exportRecord.proofs_r2_key;
+
+  // ── Recipients + transport config (Settings/config — not pack state) ─────
+  // To: accountant (settings.notification_recipient → ACCOUNTANT_EMAIL
+  // fallback). Cc: business manager (settings.notification_cc_recipient — no
+  // fallback); unset → null → omitted from the Resend payload.
+  const settings = await getComplianceSettings();
+  const to = resolveNotificationRecipient(
+    settings.notification_recipient,
+    getAccountantEmail(),
+  ).email;
+  const cc = (settings.notification_cc_recipient ?? "").trim() || null;
+  const signature = (settings.delivery_signature ?? "").trim() || null;
+  const apiKey = getResendApiKeyOrNull();
+  const from = getNotifyFromAddress();
+
+  const configErrors = computeDeliveryConfigErrors({
+    to,
+    cc,
+    from,
+    hasResendKey: !!apiKey,
+  });
+
+  // ── The sealed bytes: caller-provided (send path, already HEAD-checked) or
+  //    fetched here (preview/page) with the B-2 size check ahead of the GET.
+  let zipBytes: Uint8Array;
+  if (opts.zipBytes) {
+    zipBytes = opts.zipBytes;
+  } else {
+    const bucket = getReceiptsArchiveBucket();
+    const head = await bucket.head(proofsKey);
+    if (!head) {
+      configErrors.push(`Sealed proofs ZIP "${proofsKey}" is missing from storage.`);
+      // No bytes ⇒ no sha, no preflight. Return early with the configError; the
+      // composer disables Send. Use a placeholder sha so the shape is satisfied
+      // (the composer won't render the attachment block when configErrors block
+      // the ZIP — but the field is non-optional on the interface).
+      return noBytesResult(month, exportRecord.id, to, cc, from, signature, configErrors);
+    }
+    try {
+      assertDeliverySize(head.size); // B-2 — guards the isolate before the GET
+    } catch (err) {
+      configErrors.push(
+        err instanceof Error ? err.message : "Pack exceeds the delivery ceiling.",
+      );
+      return noBytesResult(month, exportRecord.id, to, cc, from, signature, configErrors);
+    }
+    const object = await bucket.get(proofsKey);
+    if (!object) {
+      configErrors.push("Sealed proofs ZIP vanished between HEAD and GET.");
+      return noBytesResult(month, exportRecord.id, to, cc, from, signature, configErrors);
+    }
+    zipBytes = new Uint8Array(await new Response(object.body).arrayBuffer());
+  }
+
+  const zipSha256 = await computeSha256Hex(zipBytes);
+  const zipFilename = packZipName(month); // ASCII container name (B-4)
+
+  // ── Change 3: preflight on the ACTUAL sealed bytes. A gate that checks a
+  //    different object than the one being sent is not a gate. The send route
+  //    reads this same `preflight` from the composed result — no re-run.
+  const { report: preflightReport, summary } = await runPreflightOnSealedZip({
+    zipBytes,
+    month,
+    paymentDueDate: exportRecord.payment_due_date ?? null,
+    maxPackBytes: MAX_DELIVERY_ZIP_BYTES,
+    operatorMessage: exportRecord.operator_message ?? null,
+  });
+
+  // ── Email body — sealed values only (B-5). SINGLE path (buildDeliveryEmail).
+  const email = buildDeliveryEmail({
+    month,
+    operatorMessage: exportRecord.operator_message ?? null, // 0037: same stored value the pack notice carries (O7)
+    summary,
+    signature,
+  });
+
+  // ── Decide new vs resume vs blocked for DISPLAY (forceNew:false). The send
+  //    route re-decides with the real forceNew from the query.
+  const deliveries = (await listDeliveriesForMonth(month)).map((d) => ({
+    id: d.id,
+    exportId: d.export_id,
+    attemptId: d.attempt_id,
+    state: d.state,
+    createdAt: d.created_at,
+  }));
+  const decision = decideSendAction({
+    latestExportId: exportRecord.id,
+    deliveries,
+    now: nowIso(),
+    forceNew: false,
+  });
+
+  let action: ComposedDelivery["action"];
+  let blockedReason: ComposedDelivery["blockedReason"];
+  let priorAttemptId: string | undefined;
+  if (decision.action === "new") {
+    action = "new";
+  } else if (decision.action === "resume") {
+    action = "resume";
+    priorAttemptId = decision.attemptId;
+  } else {
+    action = "blocked";
+    blockedReason = decision.reason; // "sent" | "stale"
+    priorAttemptId = decision.priorAttemptId;
+  }
+
+  return {
+    month,
+    exportId: exportRecord.id,
+    sealedAt: exportRecord.finalized_at ?? null,
+    to,
+    cc,
+    from,
+    subject: email.subject,
+    text: email.text,
+    html: email.html,
+    signature,
+    zipFilename,
+    zipSha256,
+    zipBytes: zipBytes.byteLength,
+    preflight: {
+      passed: preflightReport.passed,
+      results: preflightReport.results.map((r) => ({
+        name: r.check,
+        passed: r.passed,
+        ...(r.detail ? { detail: r.detail } : {}),
+      })),
+    },
+    configErrors,
+    action,
+    ...(blockedReason ? { blockedReason } : {}),
+    ...(priorAttemptId ? { priorAttemptId } : {}),
+  };
+}
+
+/** Early-return shape when the sealed bytes could not be loaded (missing /
+ *  oversized ZIP): there is no sha and no preflight to report, only the
+ *  configError(s). The composer renders the error state and disables Send. */
+function noBytesResult(
+  month: string,
+  exportId: string,
+  to: string | null,
+  cc: string | null,
+  from: string | null,
+  signature: string | null,
+  configErrors: string[],
+): ComposedDelivery {
+  return {
+    month,
+    exportId,
+    sealedAt: null,
+    to,
+    cc,
+    from,
+    subject: "",
+    text: "",
+    html: "",
+    signature,
+    zipFilename: packZipName(month),
+    zipSha256: "",
+    zipBytes: 0,
+    preflight: { passed: false, results: [] },
+    configErrors,
+    action: "blocked",
+    blockedReason: "stale",
+  };
+}
+
+// Re-export so alert surfaces can reuse the month-state derivation without a
+// second import path. (delivery-status.ts is the canonical helper for the
+// multi-month Map; this is just the type.)
+export type { DeliveryState };
+
+/**
+ * Pure recipient/transport config validation — the testable core of the
+ * {@link ComposedDelivery.configErrors} computation. Extracted so the four
+ * config-error paths (no To, invalid To, invalid Cc, no Resend key / From) are
+ * unit-testable without D1/R2 bindings; {@link composeDelivery} calls this with
+ * the resolved values and then appends any ZIP/storage errors separately.
+ *
+ * To is REQUIRED (no resolvable To = a partially-configured list → refuse). Cc
+ * is OPTIONAL (null → omitted from the payload, never an error). Both addresses
+ * are validated at compose time because To may arrive via the unvalidated
+ * ACCOUNTANT_EMAIL fallback. Either a missing Resend key OR a missing From
+ * address makes delivery impossible.
+ */
+export function computeDeliveryConfigErrors(opts: {
+  to: string | null;
+  cc: string | null;
+  from: string | null;
+  hasResendKey: boolean;
+}): string[] {
+  const errors: string[] = [];
+  if (!opts.to) {
+    errors.push(
+      "No delivery recipient (To) configured. Set it in Settings → Compliance.",
+    );
+  } else if (!isValidDeliveryAddress(opts.to)) {
+    errors.push(
+      `Delivery recipient (To) is not a valid email address: ${opts.to}`,
+    );
+  }
+  if (opts.cc !== null && !isValidDeliveryAddress(opts.cc)) {
+    errors.push(
+      `Delivery Cc recipient is not a valid email address: ${opts.cc}`,
+    );
+  }
+  if (!opts.hasResendKey || !opts.from) {
+    errors.push(
+      "Delivery not configured (RESEND_API_KEY / NOTIFY_FROM_ADDRESS).",
+    );
+  }
+  return errors;
+}

--- a/lib/receipts/delivery-send.ts
+++ b/lib/receipts/delivery-send.ts
@@ -153,6 +153,12 @@ export function buildDeliveryEmail(opts: {
   /** Category totals from the sealed 集計.csv (D4 — regenerated at send from
    *  the sealed pack, not a stale snapshot). NULL when the 集計 is absent. */
   summary: { monthLabel: string; categoryTotals: { ja: string; count: number; totalMinor: number }[] } | null;
+  /** Email-only signature (delivery-composer decision 3), appended AFTER the
+   *  closing `ご不明な点があればお知らせください。` separated by a blank line.
+   *  Does NOT enter the sealed pack notice. Optional + defaults to null so the
+   *  existing callers/tests (which omit it) produce byte-identical output to
+   *  pre-signature behaviour — a hard requirement. Trimmed; empty → omitted. */
+  signature?: string | null;
 }): DeliveryEmail {
   const monthLabel = opts.summary?.monthLabel ?? `${opts.month.slice(0, 4)}年${Number(opts.month.slice(5, 7))}月`;
   const lines: string[] = [];
@@ -172,6 +178,15 @@ export function buildDeliveryEmail(opts: {
     lines.push("");
   }
   lines.push("ご不明な点があればお知らせください。");
+  // Decision 3: append the email-only signature after the closing line,
+  // separated by a blank line. Appended to `text` (not hand-built markup) so
+  // the pre-wrap HTML branch picks it up through escapeHtml(text) unchanged —
+  // one assembly path, no second builder. null/empty → nothing appended.
+  const sig = opts.signature?.trim() ?? "";
+  if (sig.length > 0) {
+    lines.push("");
+    lines.push(sig);
+  }
   const text = lines.join("\r\n");
   return {
     subject: `【領収証憑】${monthLabel}分`, // O2: no revision info

--- a/lib/receipts/delivery-state.ts
+++ b/lib/receipts/delivery-state.ts
@@ -72,6 +72,25 @@ export const DELIVERY_STATE = {
 } as const;
 export type DeliveryState = (typeof DELIVERY_STATE)[keyof typeof DELIVERY_STATE];
 
+/** The pill/colour discriminant for a month's delivery state (delivery-composer
+ *  §6 table). Pure + client-safe (this module has no D1/R2 imports) so the shared
+ *  MonthSwitcher component and the server helper in delivery-status.ts both
+ *  import it from here — one mapping authority, no drift. */
+export type DeliveryPillState = "delivered" | "pending" | "undelivered";
+
+/** Map a month's derived delivery state to its pill tone. `delivered` → green ✓,
+ *  `pending` → blue (in-flight), and BOTH `sealed_undelivered` (failed) AND null
+ *  (sealed, never attempted) → `undelivered` (red). The null→undelivered mapping
+ *  is the whole point: a sealed-but-never-sent month must read as action-needed
+ *  red, not neutral grey. */
+export function deliveryStateToPill(
+  state: DeliveryState | null | undefined,
+): DeliveryPillState {
+  if (state === DELIVERY_STATE.DELIVERED) return "delivered";
+  if (state === DELIVERY_STATE.PENDING) return "pending";
+  return "undelivered";
+}
+
 /** Prefix for the Resend `Idempotency-Key` header. */
 export const IDEMPOTENCY_KEY_PREFIX = "dazbeez-delivery-";
 

--- a/lib/receipts/delivery-status.ts
+++ b/lib/receipts/delivery-status.ts
@@ -1,0 +1,69 @@
+// Delivery status across finalized months (delivery-composer §6).
+//
+// Three alert surfaces — the export page banner, the dashboard banner, and the
+// month-pill colours — all need to know, per finalized month, whether it is
+// delivered / pending / sealed-undelivered. This is the ONE server helper they
+// share so the state is computed once and cannot drift between surfaces.
+//
+// The state is DERIVED from the attempt history via deriveMonthDeliveryState
+// (the pure consistency check), not read from the denormalised
+// receipt_exports.delivery_state column — same authority the send path's
+// decideSendAction trusts. A month with a finalized export and no attempt rows
+// (2026-06 today) derives to NULL, which the pill maps to "undelivered" (sealed,
+// never sent) — the state the composer must handle first.
+
+import { listExports, listDeliveriesForMonth } from "@/lib/receipts/db";
+import {
+  deriveMonthDeliveryState,
+  deliveryStateToPill,
+  ATTEMPT_STATE,
+  type AttemptState,
+  type DeliveryState,
+  type DeliveryPillState,
+} from "@/lib/receipts/delivery-state";
+
+// Re-export the pure pill mapping so alert surfaces can import it from the
+// server helper alongside the month-Map; the mapping itself lives in the pure
+// delivery-state module (client-safe) so the shared MonthSwitcher imports it
+// directly from there.
+export { deliveryStateToPill, type DeliveryPillState };
+
+/**
+ * Map<month, DeliveryState | null> for every finalized month. One row per
+ * statement month (the latest finalized revision carries the month's delivery
+ * state; deliveries span revisions and are read across all of them via
+ * listDeliveriesForMonth). Drives the export-page banner, the dashboard banner,
+ * and the month pills.
+ */
+export async function deriveFinalizedMonthsDeliveryState(): Promise<
+  Map<string, DeliveryState | null>
+> {
+  const all = await listExports();
+  const finalizedMonths = new Set(
+    all.filter((e) => e.status === "finalized").map((e) => e.export_month),
+  );
+  const result = new Map<string, DeliveryState | null>();
+  for (const month of finalizedMonths) {
+    const deliveries = await listDeliveriesForMonth(month);
+    const attempts = deliveries.map((d) => ({
+      attemptId: d.attempt_id,
+      // The DB column allows 'ambiguous' at runtime (markDeliveryAmbiguous);
+      // the static type narrows to three values, so cast through the authority.
+      state: (d.state as AttemptState) ?? ATTEMPT_STATE.PENDING,
+      createdAt: d.created_at,
+    }));
+    result.set(month, deriveMonthDeliveryState(attempts));
+  }
+  return result;
+}
+
+/** A finalized month needs operator delivery action when it is NOT delivered —
+ *  i.e. sealed_undelivered, pending, or never-attempted (null). Used by the
+ *  dashboard banner to list every month that is not yet closed for reporting. */
+export function needsDeliveryAction(
+  state: DeliveryState | null | undefined,
+): boolean {
+  return deliveryStateToPill(state) !== "delivered";
+}
+
+export type { DeliveryState };

--- a/lib/receipts/settings.ts
+++ b/lib/receipts/settings.ts
@@ -24,6 +24,9 @@ export const COMPLIANCE_DEFAULTS: ComplianceSettings = {
   // fallback (there is no BUSINESS_MANAGER_EMAIL var). Read at send; empty →
   // the Cc field is omitted from the Resend payload entirely (not cc:"").
   notification_cc_recipient: "",
+  // Delivery-composer decision 3: email-only signature, appended after the
+  // sealed notice's closing line. Empty default; composer maps empty → null.
+  delivery_signature: "",
   // ADR 0010 D3: verbatim former TOKYO_SIGNALS. Behavior unchanged until the
   // operator edits Settings → Compliance.
   homebase_signals: DEFAULT_HOMEBASE_SIGNALS,
@@ -120,6 +123,8 @@ export function parseComplianceSettings(
     notification_cc_recipient:
       map.get("notification_cc_recipient") ??
       COMPLIANCE_DEFAULTS.notification_cc_recipient,
+    delivery_signature:
+      map.get("delivery_signature") ?? COMPLIANCE_DEFAULTS.delivery_signature,
     homebase_signals: parseHomebaseSignals(map.get("homebase_signals")),
   };
 }

--- a/lib/receipts/types.ts
+++ b/lib/receipts/types.ts
@@ -658,6 +658,12 @@ export interface ComplianceSettings {
    *  D15/§15). Empty = the Cc field is omitted from the Resend payload. No env
    *  fallback. */
   notification_cc_recipient: string;
+  /** Email-only signature appended to the delivery email body AFTER the sealed
+   *  pack notice's closing line (delivery-composer decision 3). Stored as a
+   *  trimmed string (empty when unset); the composer maps empty → null at the
+   *  email boundary. Does NOT enter the sealed pack notice (buildPackNotice is
+   *  unchanged) — it is a transport-layer adornment on the delivery email only. */
+  delivery_signature: string;
   /**
    * Homebase location signals (ADR 0010 D3). A merchant whose string carries
    * one of these is treated as an at-homebase charge (not a trip anchor).

--- a/tests/middleware-routing.test.ts
+++ b/tests/middleware-routing.test.ts
@@ -78,6 +78,26 @@ test("matcher: the monthly-delivery send endpoint is Clerk-protected (auth.prote
   );
 });
 
+test("matcher: the delivery-preview endpoint is Clerk-protected (auth.protect() applies)", () => {
+  // GET /api/receipts/export/:month/delivery-preview returns the composed
+  // delivery (recipients, subject/body, attachment SHA-256) for a sealed month.
+  // It is the read-only preview the composer page could fetch, and it MUST stay
+  // under auth.protect() — a future edit that added it to PUBLIC_ROUTES (the
+  // processor-key exemption list) would leak the composed pack metadata. Same
+  // guard as the send route above.
+  const previewRequest = new NextRequest(
+    "https://dazbeez.com/api/receipts/export/2026-06/delivery-preview",
+  );
+  assert.ok(
+    MATCHER.includes("/api/receipts/:path*"),
+    "the broad receipts gate covers the preview route",
+  );
+  assert.ok(
+    !isPublicRoute(previewRequest),
+    "the delivery-preview route must NOT be exempted from auth.protect() (not in PUBLIC_ROUTES)",
+  );
+});
+
 test("PUBLIC_ROUTES: the /enqueue recovery endpoint IS exempted (processor-key auth reaches the handler)", () => {
   // POST /api/receipts/[id]/enqueue does layered processor-key OR Clerk auth
   // inside the handler (mirroring /render, /promote). It MUST be in PUBLIC_ROUTES

--- a/tests/receipts/delivery-compose.test.ts
+++ b/tests/receipts/delivery-compose.test.ts
@@ -1,0 +1,154 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import {
+  computeDeliveryConfigErrors,
+  type ComposedDelivery,
+} from "@/lib/receipts/delivery-compose";
+import { buildDeliveryEmail } from "@/lib/receipts/delivery-send";
+
+// ─── §1 config-error paths (computeDeliveryConfigErrors — the pure core of
+//     ComposedDelivery.configErrors; composeDelivery calls this with resolved
+//     values, so these paths are unit-testable without D1/R2 bindings) ──────────
+
+const VALID = { to: "cpa@example.com", cc: null, from: "notify@dazbeez.com", hasResendKey: true };
+
+test("configErrors: empty when fully configured (happy path)", () => {
+  assert.deepEqual(computeDeliveryConfigErrors(VALID), []);
+});
+
+test("configErrors: no To (null) → 'No delivery recipient (To) configured'", () => {
+  const errs = computeDeliveryConfigErrors({ ...VALID, to: null });
+  assert.ok(errs.some((e) => e.includes("No delivery recipient (To)")));
+  assert.equal(errs.length, 1);
+});
+
+test("configErrors: invalid To → names the bad address", () => {
+  const errs = computeDeliveryConfigErrors({ ...VALID, to: "not-an-email" });
+  assert.ok(errs.some((e) => e.includes("not a valid email address") && e.includes("not-an-email")));
+  assert.equal(errs.length, 1);
+});
+
+test("configErrors: invalid Cc → names the bad Cc (null Cc is fine)", () => {
+  const errs = computeDeliveryConfigErrors({ ...VALID, cc: "bad-cc" });
+  assert.ok(errs.some((e) => e.includes("Cc recipient is not a valid") && e.includes("bad-cc")));
+  // null Cc alone is NOT an error (Cc is optional).
+  assert.deepEqual(
+    computeDeliveryConfigErrors({ ...VALID, cc: null }),
+    [],
+    "null Cc is valid (omitted from payload)",
+  );
+});
+
+test("configErrors: no Resend key → 'Delivery not configured'", () => {
+  const errs = computeDeliveryConfigErrors({ ...VALID, hasResendKey: false });
+  assert.ok(errs.some((e) => e.includes("RESEND_API_KEY / NOTIFY_FROM_ADDRESS")));
+  assert.equal(errs.length, 1);
+});
+
+test("configErrors: no From address → same 'Delivery not configured' message", () => {
+  const errs = computeDeliveryConfigErrors({ ...VALID, from: null });
+  assert.ok(errs.some((e) => e.includes("RESEND_API_KEY / NOTIFY_FROM_ADDRESS")));
+  assert.equal(errs.length, 1);
+});
+
+test("configErrors: multiple problems accumulate (no To AND no key)", () => {
+  const errs = computeDeliveryConfigErrors({
+    to: null,
+    cc: null,
+    from: null,
+    hasResendKey: false,
+  });
+  assert.equal(errs.length, 2, "one for missing To, one for missing transport");
+});
+
+// ─── §3 preview/send parity — the one that matters ──────────────────────────
+//
+// composeDelivery exists so the preview endpoint and the send route CANNOT
+// disagree on subject/body. Two guarantees make that true by construction:
+//   (1) buildDeliveryEmail is imported by exactly ONE non-test source file
+//       (lib/receipts/delivery-compose.ts). The send route and the preview
+//       endpoint must NOT compose the body themselves — they go through
+//       composeDelivery. If someone re-inlines body composition in either
+//       route, this fails. (Same source-tree-assertion shape as the capture
+//       contract test for #18.)
+//   (2) buildDeliveryEmail is deterministic — identical inputs ⇒ identical
+//       subject/text/html — so two composeDelivery calls for the same month
+//       (one preview, one send) produce byte-identical bodies.
+
+/** Source files (app/lib/components — NOT tests, NOT .next) referencing a token.
+ *  Uses a filesystem grep (not `git grep`) so newly-added, still-untracked files
+ *  like delivery-compose.ts itself are seen — the parity guarantee must hold
+ *  before the first commit, not only after. */
+function sourceFilesReferencing(token: string): string[] {
+  const out = execFileSync(
+    "grep",
+    ["-rlE", token, "app/", "lib/", "components/"],
+    { encoding: "utf8" },
+  );
+  return out.trim().split("\n").filter(Boolean);
+}
+
+test("parity (PRIMARY): buildDeliveryEmail has exactly ONE importer — delivery-compose.ts (send & preview share it)", () => {
+  // delivery-send.ts DEFINES buildDeliveryEmail; every OTHER reference must be
+  // the single import in delivery-compose.ts. A second importer (e.g. the send
+  // route re-deriving the body) breaks preview/send parity.
+  const refs = sourceFilesReferencing("buildDeliveryEmail").filter(
+    (f) => f !== "lib/receipts/delivery-send.ts",
+  );
+  assert.deepEqual(
+    refs.sort(),
+    ["lib/receipts/delivery-compose.ts"],
+    "buildDeliveryEmail must be imported only by delivery-compose.ts",
+  );
+});
+
+test("parity: the send route and the preview endpoint both import composeDelivery (not a local re-derivation)", () => {
+  const send = readFileSync(
+    "app/api/receipts/export/[month]/send/route.ts",
+    "utf8",
+  );
+  const preview = readFileSync(
+    "app/api/receipts/export/[month]/delivery-preview/route.ts",
+    "utf8",
+  );
+  assert.ok(
+    /import\s*\{[^}]*composeDelivery[^}]*\}\s*from\s*"@\/lib\/receipts\/delivery-compose"/.test(
+      send,
+    ),
+    "send route imports composeDelivery",
+  );
+  assert.ok(
+    /import\s*\{[^}]*composeDelivery[^}]*\}\s*from\s*"@\/lib\/receipts\/delivery-compose"/.test(
+      preview,
+    ),
+    "preview endpoint imports composeDelivery",
+  );
+});
+
+test("parity: buildDeliveryEmail is deterministic — same inputs ⇒ byte-identical subject/text/html", () => {
+  const opts = {
+    month: "2026-06",
+    operatorMessage: "今月のご連絡",
+    summary: {
+      monthLabel: "2026年6月",
+      categoryTotals: [{ ja: "交通費", count: 2, totalMinor: 15000 }],
+    },
+    signature: "DB",
+  };
+  const a = buildDeliveryEmail(opts);
+  const b = buildDeliveryEmail(opts);
+  assert.deepEqual(a, b);
+});
+
+test("shape: ComposedDelivery's preflight result names map from the pack-preflight `check` field", () => {
+  // The composer renders preflight.results[].name; the underlying pack-preflight
+  // report uses `check`. composeDelivery maps check → name. Assert the type
+  // carries `name` (compile-time shape guarantee for the composer binding).
+  const sample: ComposedDelivery["preflight"]["results"][number] = {
+    name: "container-names-ascii",
+    passed: true,
+  };
+  assert.equal(sample.name, "container-names-ascii");
+});

--- a/tests/receipts/delivery-email-signature.test.ts
+++ b/tests/receipts/delivery-email-signature.test.ts
@@ -1,0 +1,83 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildDeliveryEmail } from "@/lib/receipts/delivery-send";
+
+// delivery-composer §2: the email-only signature is appended AFTER the sealed
+// notice's closing line, separated by a blank line, in BOTH text and html. The
+// null/absent case MUST be byte-identical to pre-signature output — a hard
+// requirement (existing callers/tests omit the param).
+
+const MONTH = "2026-06";
+const BASE_OPTS = {
+  month: MONTH,
+  operatorMessage: null,
+  summary: null,
+} as const;
+
+test("buildDeliveryEmail: omitting signature (today's callers) is byte-identical to signature:null/''/whitespace", () => {
+  const omitted = buildDeliveryEmail(BASE_OPTS);
+  const nullSig = buildDeliveryEmail({ ...BASE_OPTS, signature: null });
+  const emptySig = buildDeliveryEmail({ ...BASE_OPTS, signature: "" });
+  const wsSig = buildDeliveryEmail({ ...BASE_OPTS, signature: "   \n  " });
+
+  assert.deepEqual(nullSig, omitted, "signature:null ≡ omitted");
+  assert.deepEqual(emptySig, omitted, "signature:'' ≡ omitted");
+  assert.deepEqual(wsSig, omitted, "whitespace-only signature ≡ omitted (trimmed → nothing)");
+});
+
+test("buildDeliveryEmail: the null-case output is pinned (catches accidental drift of the sealed body)", () => {
+  const { subject, text, html } = buildDeliveryEmail(BASE_OPTS);
+  assert.equal(subject, "【領収証憑】2026年6月分");
+  // The sealed body ends at the closing line — no signature, no trailing blank.
+  assert.equal(
+    text,
+    "2026年6月 の領収証憑一式を添付にてお送りします。\r\n\r\nご不明な点があればお知らせください。",
+  );
+  // HTML is the pre-wrap div over the escaped text; unchanged by the signature
+  // feature when no signature is supplied.
+  assert.ok(html.includes("white-space:pre-wrap"));
+  assert.ok(html.includes("ご不明な点があればお知らせください。"));
+  assert.ok(!html.includes("山田"), "no signature markup leaks when null");
+});
+
+test("buildDeliveryEmail: a signature is appended after the closing line, blank-line separated, in text AND html", () => {
+  const sig = "山田 太郎\nDazbeez合同会社";
+  const { subject, text, html } = buildDeliveryEmail({ ...BASE_OPTS, signature: sig });
+
+  // Subject is unaffected by the signature.
+  assert.equal(subject, "【領収証憑】2026年6月分");
+
+  // The signature follows the closing line, separated by a blank line. Trimmed.
+  assert.equal(
+    text,
+    "2026年6月 の領収証憑一式を添付にてお送りします。\r\n\r\n" +
+      "ご不明な点があればお知らせください。\r\n\r\n" +
+      "山田 太郎\nDazbeez合同会社",
+  );
+
+  // The HTML branch picks the signature up through escapeHtml(text) — the same
+  // pre-wrap div, no hand-built signature markup. Both lines render.
+  assert.ok(html.includes("山田 太郎"));
+  assert.ok(html.includes("Dazbeez合同会社"));
+  assert.ok(html.includes("white-space:pre-wrap"), "still the single pre-wrap div assembly");
+  // Only ONE div/body — no second builder was added for the signature.
+  assert.equal(html.match(/<div/g)?.length, 1, "single div — no hand-built signature markup");
+});
+
+test("buildDeliveryEmail: a signature with an operator message + summary still lands after the closing line", () => {
+  const { text } = buildDeliveryEmail({
+    month: MONTH,
+    operatorMessage: "今月は海外出張の領収書が含まれています。",
+    summary: {
+      monthLabel: "2026年6月",
+      categoryTotals: [{ ja: "交通費", count: 2, totalMinor: 15000 }],
+    },
+    signature: "-- DB",
+  });
+  // The signature MUST be the last thing, after ご不明な点… — never spliced into
+  // the operator message or the summary block.
+  const closingIdx = text.indexOf("ご不明な点があればお知らせください。");
+  const sigIdx = text.indexOf("-- DB");
+  assert.ok(closingIdx > -1 && sigIdx > closingIdx, "signature after the closing line");
+  assert.ok(text.endsWith("-- DB"), "signature is the final content");
+});

--- a/tests/receipts/delivery-pill.test.ts
+++ b/tests/receipts/delivery-pill.test.ts
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  deliveryStateToPill,
+  DELIVERY_STATE,
+} from "@/lib/receipts/delivery-state";
+import { needsDeliveryAction } from "@/lib/receipts/delivery-status";
+
+// delivery-composer §6 table — the month-pill colour mapping. Pure; the unit
+// test is the authority for the table. The critical case is null → "undelivered":
+// a sealed-but-never-sent month (2026-06 today) must read as action-needed red,
+// not neutral grey.
+
+test("deliveryStateToPill: delivered → delivered (green ✓)", () => {
+  assert.equal(deliveryStateToPill(DELIVERY_STATE.DELIVERED), "delivered");
+});
+
+test("deliveryStateToPill: pending → pending (blue, in-flight)", () => {
+  assert.equal(deliveryStateToPill(DELIVERY_STATE.PENDING), "pending");
+});
+
+test("deliveryStateToPill: sealed_undelivered (failed) → undelivered (red)", () => {
+  assert.equal(
+    deliveryStateToPill(DELIVERY_STATE.SEALED_UNDELIVERED),
+    "undelivered",
+  );
+});
+
+test("deliveryStateToPill: null (sealed, never attempted) → undelivered (red) — the 2026-06 case", () => {
+  assert.equal(deliveryStateToPill(null), "undelivered");
+});
+
+test("deliveryStateToPill: undefined (not provided, reconcile/AMEX pages) → undelivered default", () => {
+  // Undefined means the caller didn't populate deliveryState. The pure mapping
+  // treats it as not-delivered; the MonthSwitcher guards separately (only
+  // colours when deliveryState !== undefined) so reconcile/AMEX pills are
+  // unaffected. Asserted here so the default is explicit.
+  assert.equal(deliveryStateToPill(undefined), "undelivered");
+});
+
+test("needsDeliveryAction: true for everything except delivered", () => {
+  assert.equal(needsDeliveryAction(DELIVERY_STATE.DELIVERED), false);
+  assert.equal(needsDeliveryAction(DELIVERY_STATE.PENDING), true);
+  assert.equal(needsDeliveryAction(DELIVERY_STATE.SEALED_UNDELIVERED), true);
+  assert.equal(needsDeliveryAction(null), true);
+  assert.equal(needsDeliveryAction(undefined), true);
+});


### PR DESCRIPTION
The delivery backend (`POST /api/receipts/export/{month}/send`) shipped with **no UI** — an operator could finalize a month and hit *"This export is immutable"* with no path to actually send it. **2026-06 is sealed-and-undelivered right now** for exactly that reason. This adds the composer + alerting that makes an unsent month impossible to forget.

## What changed

- **§1 `composeDelivery`** (`lib/receipts/delivery-compose.ts`) — one composition authority. Recipients, subject/body, preflight, attachment SHA-256, and the send decision all live here. The send route, the new preview endpoint, and the composer page all call it → **preview and send cannot disagree by construction**. Send passes its already-fetched bytes IN (one fetch); preview/page fetch with the B-2 HEAD-before-GET.
- **§2 Email-only signature** (Settings → Compliance): `delivery_signature` setting + migration `0040`. `buildDeliveryEmail` appends it after the sealed notice's closing line; `null`/absent is byte-identical to today.
- **§3 `GET /api/receipts/export/[month]/delivery-preview`** — Clerk-protected (asserted NOT in `PUBLIC_ROUTES`), 404 when no sealed export.
- **§4 Composer page** `/receipts/export/[month]/send` — read-only preview, two-step Confirm → Send, resume / blocked(sent) / blocked(stale) handling. **Posts an empty body** — subject/body/To/Cc are never accepted from the client.
- **§5 Finalize hands off** — `finalize-card.tsx` navigates to the composer on success (client nav only; no auto-send).
- **§6 Alerts** from one helper (`lib/receipts/delivery-status.ts`, `Map<month, DeliveryState|null>`): export-page banner (red/blue/green + 送信する), dashboard sealed-undelivered banner, month-pill colours (export-page-only).

## Verification

- `tsc --noEmit` clean
- `npm test` — **1207 pass / 0 fail** (21 new: composeDelivery config-error paths, buildDeliveryEmail signature byte-identity, deliveryState→pill mapping, **preview/send parity** via single-importer source assertion)
- `npm run build:cf` green
- Live D1 (§0): 2026-06 finalized rev 3, `delivery_state=NULL`, **0 delivery attempts**, `notification_recipient=admin@dazbeez.com`, Cc unset, no signature — the "sealed, never sent" happy path.

## ⚠️ NOT done — needs operator/architect

- **Screenshots (§4/§5)** + the live *"open it and look"* check require a prod deploy (cf:dev can't serve `/receipts/*` — Clerk `pk_live` rejects localhost, and local miniflare has no real 2026-06 data). Deferred to post-merge; the CI migration→deploy→smoke flow runs `0040` automatically.
- **2026-06 was NOT sent.** The composer stops at the confirm step. The operator sends it himself.

## Assumptions the spec made that the code contradicts (flagged, not silently fixed)

1. **Migration 0040 is a seed ROW, not `ALTER TABLE ADD COLUMN`.** `receipt_settings` is a key/value table (`key TEXT PRIMARY KEY, value TEXT NOT NULL`); `notification_recipient` / `notification_cc_recipient` were added with *no* migration. `0040` seeds the `delivery_signature` row for migration-trail discoverability (matches 0014's seed block); the app reads it with an empty-string default whether or not the row exists.
2. **`ComposedDelivery.blockedReason` is `"sent" | "stale"`** — the real enum from `decideSendAction`. The spec wrote `"stale_pending"`; same case (the 24h-window-expired pending), code's vocabulary preserved rather than introducing a third name.
3. **`export_deliveries` has no `month` column** (it's on `receipt_exports`); the §0 live query was joined accordingly. The spec's `SELECT month, … FROM export_deliveries` would error.
4. **`ComposedDelivery` gained `sealedAt`** (beyond the spec'd interface) so the composer header can render "sealed on {date}" without a second `getLatestFinalizedExport` fetch.
5. **`buildDeliveryEmail.signature` is optional** (`signature?: string \| null`) so existing callers/tests that omit it stay byte-identical (a hard requirement), rather than required as the spec implied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)