### PR TITLE
fix(receipts): preflight reads AMEX amount by semantic name (unblocks June delivery)

### DIFF
--- a/lib/receipts/delivery-preflight.ts
+++ b/lib/receipts/delivery-preflight.ts
@@ -11,6 +11,8 @@ import {
   runPackPreflight,
   sumReconChargeAmounts,
   parseSummaryTotals,
+  describeAmountColumnFailure,
+  type AmexStatementTotal,
   type PackPreflightEntry,
   type PackPreflightInput,
   type PackPreflightReport,
@@ -82,8 +84,33 @@ export async function runPreflightOnSealedZip(opts: {
   const noticeText = rootText(names.noticeFile) ?? "";
   // AMEX statement total from the sealed AMEX 照合CSV — the INDEPENDENT source
   // for summary-payment-path-reconciles (reading it from 集計 would be circular).
+  // sumReconChargeAmounts never returns a number for "column not found": it
+  // surfaces a structured failure (no-header / zero / multiple 金額 cells) which
+  // we translate into a `parse-error` so the check fails with a named, diagnosis-
+  // ready detail instead of comparing against a fabricated zero.
   const amexText = rootText(names.amexReconciliationCsv);
-  const amexStatementTotalCents = amexText !== null ? sumReconChargeAmounts(amexText) : null;
+  const amexStatementTotal: AmexStatementTotal =
+    amexText === null
+      ? { kind: "none" }
+      : (() => {
+          const r = sumReconChargeAmounts(amexText);
+          if (r.ok) return { kind: "total", cents: r.total };
+          if (r.kind === "no-header") {
+            return {
+              kind: "parse-error",
+              detail: `AMEX recon CSV: no 科目＆No. header row found; first row: [${r.headerCells.join(" | ")}]`,
+            };
+          }
+          return {
+            kind: "parse-error",
+            detail: describeAmountColumnFailure({
+              label: "AMEX",
+              kind: r.kind,
+              matches: r.matches,
+              headerCells: r.headerCells,
+            }),
+          };
+        })();
 
   const input: PackPreflightInput = {
     month: opts.month,
@@ -92,7 +119,7 @@ export async function runPreflightOnSealedZip(opts: {
     entries,
     noticeText,
     csvs,
-    amexStatementTotalCents,
+    amexStatementTotal,
     maxPackBytes: opts.maxPackBytes,
     operatorMessage: opts.operatorMessage ?? null,
   };

--- a/lib/receipts/pack-preflight.ts
+++ b/lib/receipts/pack-preflight.ts
@@ -41,9 +41,13 @@ export interface PackPreflightInput {
   noticeText: string;
   /** The reconciliation + summary CSVs present in the pack. */
   csvs: PreflightCsvInput[];
-  /** AMEX statement total (cents) for the payment-path reconciliation check;
-   *  null when no AMEX artifact. */
-  amexStatementTotalCents: number | null;
+  /** AMEX statement total for the payment-path reconciliation check. Discriminated:
+   *  - `none` — no AMEX 照合CSV in the pack (skip the check, as the old null did).
+   *  - `total` — amount column resolved; cents summed from the sealed AMEX CSV.
+   *  - `parse-error` — the AMEX CSV is present but its amount column (or recon
+   *    header) could not be resolved; the check MUST fail with this detail rather
+   *    than compare a fabricated zero. */
+  amexStatementTotal: AmexStatementTotal;
   /** Configured attachment-size ceiling (bytes) for the transport check. */
   maxPackBytes: number;
   /** The stored operator_message from the export record (0037). Checked against
@@ -63,6 +67,13 @@ export interface PackPreflightReport {
   passed: boolean;
   results: PreflightResult[];
 }
+
+/** The AMEX statement total, as resolved by the caller from the sealed AMEX 照合CSV
+ *  via {@link sumReconChargeAmounts}. See {@link PackPreflightInput.amexStatementTotal}. */
+export type AmexStatementTotal =
+  | { kind: "none" }
+  | { kind: "total"; cents: number }
+  | { kind: "parse-error"; detail: string };
 
 // ─── Small parsing helpers ──────────────────────────────────────────────────
 
@@ -180,22 +191,95 @@ function reconHeaderIndex(rows: string[][]): number {
   return rows.findIndex((r) => r.includes("科目＆No."));
 }
 
+/** The amount column of a reconciliation CSV is located SEMANTICALLY — the one
+ *  header cell that contains 金額 — not positionally. This is deliberate and
+ *  load-bearing: the AMEX importer (validation.ts) reads the amount by POSITION
+ *  (fields[5]) because it owns its own robustness. The preflight is a VERIFICATION
+ *  layer; if it located the amount the same positional way the importer does, a
+ *  column-shift regression would move both sides together and the check would
+ *  become tautological. Deriving the amount by an independent method (semantic
+ *  name match) is what lets the check catch a layout change. The two must
+ *  disagree loudly when the card company moves the column.
+ *
+ *  Exactly-one-match-or-fail: zero matches (the June-2026 AMEX passthrough whose
+ *  amount cell is 利用金額, not 金額, under the old exact-`indexOf("金額")` read) or
+ *  two-or-more (a future 支払金額 alongside 利用金額) both return a NAMED failure
+ *  instead of summing the wrong column or zero. There is no path where an
+ *  unfindable amount column produces a number. */
+export type AmountColumnResult =
+  | { ok: true; index: number }
+  | { ok: false; kind: "zero" | "multiple"; matches: string[] };
+
+/** The index of the single header cell containing 金額, or a named failure.
+ *  `header` is a row of cells (parseCsvRows output). */
+export function amountColumnIndex(header: string[]): AmountColumnResult {
+  const matches: { index: number; cell: string }[] = [];
+  for (let i = 0; i < header.length; i++) {
+    const cell = header[i] ?? "";
+    if (cell.includes("金額")) matches.push({ index: i, cell });
+  }
+  if (matches.length === 1) return { ok: true, index: matches[0]!.index };
+  return {
+    ok: false,
+    kind: matches.length === 0 ? "zero" : "multiple",
+    matches: matches.map((m) => m.cell),
+  };
+}
+
+/** Format a named amount-column failure for a check detail string. Single-sourced
+ *  so the AMEX-total check, the per-category check, and the delivery-preflight
+ *  boundary all report the same shape. Lists the matching cells (for "multiple")
+ *  and the full actual header so the operator can see what the parser saw. */
+export function describeAmountColumnFailure(opts: {
+  label: string;
+  kind: "zero" | "multiple";
+  matches: string[];
+  headerCells: string[];
+}): string {
+  const which =
+    opts.kind === "zero"
+      ? "no header cell contains 金額"
+      : `${opts.matches.length} header cells contain 金額 (${opts.matches.map((m) => `"${m}"`).join(", ")})`;
+  return `${opts.label} recon CSV: ${which}; expected exactly one amount column. Header: [${opts.headerCells.join(" | ")}]`;
+}
+
 /** Sum the 金額 of a reconciliation CSV's charge rows — used to derive the AMEX
  *  statement total from the sealed AMEX 照合CSV (B-5: no live lookup). This is
  *  the INDEPENDENT source for summary-payment-path-reconciles (which compares it
  *  against the 集計's AMEX total); reading the total from 集計 itself would be
- *  circular. Returns 0 if the CSV has no recognisable recon header. */
-export function sumReconChargeAmounts(csvText: string): number {
+ *  circular.
+ *
+ *  Never returns a number for "column not found" — a preflight that reported ¥0
+ *  instead of "I can't find the column" produced a scary wrong "the pack doesn't
+ *  reconcile" instead of "the parser is broken." On any failure to resolve the
+ *  amount column (or the recon header) it returns `ok: false` carrying the actual
+ *  header cells + matches so the caller can surface a named, diagnosis-ready
+ *  check failure. */
+export type ReconAmountSumResult =
+  | { ok: true; total: number }
+  | {
+      ok: false;
+      kind: "no-header" | "zero" | "multiple";
+      headerCells: string[];
+      matches: string[];
+    };
+
+export function sumReconChargeAmounts(csvText: string): ReconAmountSumResult {
   const rows = parseCsvRows(csvText);
   const headerIdx = reconHeaderIndex(rows);
-  if (headerIdx === -1) return 0;
-  const amountIdx = rows[headerIdx]!.indexOf("金額");
-  if (amountIdx === -1) return 0;
+  if (headerIdx === -1) {
+    return { ok: false, kind: "no-header", headerCells: rows[0] ?? [], matches: [] };
+  }
+  const header = rows[headerIdx]!;
+  const col = amountColumnIndex(header);
+  if (!col.ok) {
+    return { ok: false, kind: col.kind, headerCells: header, matches: col.matches };
+  }
   let sum = 0;
   for (const row of reconChargeRows(rows)) {
-    sum += parseAmountCell(row[amountIdx] ?? "") ?? 0;
+    sum += parseAmountCell(row[col.index] ?? "") ?? 0;
   }
-  return sum;
+  return { ok: true, total: sum };
 }
 
 /** Parse the 勘定科目 section of a 集計 CSV → per-category {ja, count, totalMinor}.
@@ -522,11 +606,14 @@ const checks: { key: string; run: Check }[] = [
           total: parseInt(row[2] ?? "0", 10),
         });
       }
-      // Recon rows per category: 科目＆No (col before last 3) → category prefix
-      // (strip the MonYYYY+circled suffix); 金額 (col before last 2). Layouts:
-      //   AMEX: 7 base + [科目＆No, 事業目的, 人数, 領収書ファイル名] → 金額 is field[5]
-      //   CASH/DIGITAL: [No,利用日,店舗名,金額,科目＆No,事業目的,人数,領収書ファイル名]
-      // Compute by locating the 科目＆No + 金額 columns from the header.
+      // Recon rows per category: 科目＆No → category prefix (strip the
+      // MonYYYY+circled suffix); the amount column located SEMANTICALLY via
+      // amountColumnIndex (the single header cell containing 金額) — not by
+      // position, so this verification layer stays independent of the importer
+      // (validation.ts reads amount positionally; the two must disagree loudly
+      // on a column shift). On any failure to resolve the amount column for a
+      // recon CSV, fail THIS check naming that CSV and its actual header — never
+      // silently sum a wrong/missing column.
       const reconByCat = new Map<string, { count: number; total: number }>();
       for (const csv of reconCsvs) {
         const rows = parseCsvRows(csv.text);
@@ -534,10 +621,22 @@ const checks: { key: string; run: Check }[] = [
         if (headerIdx === -1) continue; // 集計-like (no 科目＆No.), skip
         const header = rows[headerIdx]!;
         const kamokuIdx = header.indexOf("科目＆No.");
-        const amountIdx = header.indexOf("金額");
+        const col = amountColumnIndex(header);
+        if (!col.ok) {
+          return {
+            check: "summary-category-reconciles",
+            passed: false,
+            detail: describeAmountColumnFailure({
+              label: csv.label,
+              kind: col.kind,
+              matches: col.matches,
+              headerCells: header,
+            }),
+          };
+        }
         for (const row of reconChargeRows(rows)) {
           const label = row[kamokuIdx] ?? "";
-          const amount = parseAmountCell(row[amountIdx] ?? "") ?? 0;
+          const amount = parseAmountCell(row[col.index] ?? "") ?? 0;
           // Category = label with the MonYYYY+circled suffix removed.
           const m = label.match(/^(.*?)[A-Z][a-z]{2}\d{4}/);
           const cat = m ? m[1]! : label;
@@ -568,7 +667,7 @@ const checks: { key: string; run: Check }[] = [
   },
   {
     key: "summary-payment-path-reconciles",
-    run: ({ csvs, amexStatementTotalCents }) => {
+    run: ({ csvs, amexStatementTotal }) => {
       const summary = csvs.find((c) => c.label === "集計");
       if (!summary) {
         return {
@@ -577,9 +676,20 @@ const checks: { key: string; run: Check }[] = [
           detail: "集計 CSV not supplied",
         };
       }
-      if (amexStatementTotalCents === null) {
+      // No AMEX 照合CSV in the pack ⇒ nothing to reconcile (cash/digital only).
+      if (amexStatementTotal.kind === "none") {
         return { check: "summary-payment-path-reconciles", passed: true };
       }
+      // AMEX CSV present but its amount column could not be resolved ⇒ a NAMED
+      // failure. Never compare against a fabricated zero.
+      if (amexStatementTotal.kind === "parse-error") {
+        return {
+          check: "summary-payment-path-reconciles",
+          passed: false,
+          detail: amexStatementTotal.detail,
+        };
+      }
+      const stmtTotal = amexStatementTotal.cents;
       const rows = parseCsvRows(summary.text);
       let amexTotal: number | null = null;
       let inPaths = false;
@@ -599,12 +709,12 @@ const checks: { key: string; run: Check }[] = [
           detail: "集計 has no AMEX payment-path total to reconcile",
         };
       }
-      return amexTotal === amexStatementTotalCents
+      return amexTotal === stmtTotal
         ? { check: "summary-payment-path-reconciles", passed: true }
         : {
             check: "summary-payment-path-reconciles",
             passed: false,
-            detail: `集計 AMEX total ${amexTotal} ≠ statement total ${amexStatementTotalCents}`,
+            detail: `集計 AMEX total ${amexTotal} ≠ statement total ${stmtTotal}`,
           };
     },
   },

--- a/tests/receipts/pack-preflight.test.ts
+++ b/tests/receipts/pack-preflight.test.ts
@@ -73,7 +73,7 @@ function baseInput(): PackPreflightInput {
       { label: "AMEX", text: AMEX_RECON },
       { label: "CASH", text: CASH_RECON },
     ],
-    amexStatementTotalCents: 6490,
+    amexStatementTotal: { kind: "total", cents: 6490 },
     maxPackBytes: 100_000_000,
   };
 }
@@ -210,7 +210,7 @@ test("summary-category-reconciles: a 集計 category total that drifts fails", (
 
 test("summary-payment-path-reconciles: AMEX total ≠ statement total fails", () => {
   const input = clone(baseInput());
-  input.amexStatementTotalCents = 1; // 集計 says 6490
+  input.amexStatementTotal = { kind: "total", cents: 1 }; // 集計 says 6490
   failsOnly(runPackPreflight(input), "summary-payment-path-reconciles");
 });
 
@@ -329,7 +329,7 @@ test("preflight: a realistic AMEX statement (metadata + header + charges + total
       entry(`${root}/${names.amexFolder}/会議費Jun2026①小田原みなと食堂￥6,490.jpg`, "img1"),
       entry(`${root}/${names.amexFolder}/研究開発費Jun2026①OpenAI￥108,341.pdf`, "img2"),
     ],
-    amexStatementTotalCents: 114831,
+    amexStatementTotal: { kind: "total", cents: 114831 },
     maxPackBytes: 100_000_000,
   };
   const report = runPackPreflight(input);

--- a/tests/receipts/preflight-amount-column.test.ts
+++ b/tests/receipts/preflight-amount-column.test.ts
@@ -1,0 +1,128 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  amountColumnIndex,
+  describeAmountColumnFailure,
+  sumReconChargeAmounts,
+} from "@/lib/receipts/pack-preflight";
+import { PAYMENT_PATH_CSV_HEADERS } from "@/lib/receipts/reconciliation-files";
+
+// Regression for the 2026-06 preflight false-failure. The AMEX 照合CSV is the
+// card's Netアンサー passthrough; its amount column is `利用金額` (not `金額`),
+// and the real detail header sits on line 4 after a 4-line preamble. The old
+// `header.indexOf("金額")` (exact cell match) returned -1 → summed 0 → the check
+// reported "the pack doesn't reconcile" instead of "the parser can't find the
+// amount column." amountColumnIndex locates the amount SEMANTICALLY (the single
+// cell containing 金額) and fails LOUDLY (zero or multiple) — never a silent zero.
+
+// The real 11-column June-2026 AMEX detail header, verbatim as dumped from the
+// sealed ZIP (line 4 of 20260604_AMEXカード利用明細.csv).
+const JUNE_2026_AMEX_HEADER = [
+  "利用日",
+  "ご利用店名及び商品名",
+  "本人・家族区分",
+  "支払区分名称",
+  "締前入金区分",
+  "利用金額",
+  "備考",
+  "科目＆No.",
+  "事業目的",
+  "人数",
+  "領収書ファイル名",
+];
+
+test("amountColumnIndex: the real June-2026 AMEX header → index 5 (利用金額)", () => {
+  const r = amountColumnIndex(JUNE_2026_AMEX_HEADER);
+  assert.equal(r.ok, true);
+  if (r.ok) assert.equal(r.index, 5, "利用金額 is field[5]");
+});
+
+test("amountColumnIndex: PAYMENT_PATH_CSV_HEADERS (CASH/DIGITAL) → index 3 (金額)", () => {
+  // The headers we BUILD for CASH/DIGITAL. The amount cell is exactly `金額` —
+  // a substring match still finds it, so the fix is backward-compatible with the
+  // built CSVs while also catching the AMEX passthrough.
+  const r = amountColumnIndex([...PAYMENT_PATH_CSV_HEADERS]);
+  assert.equal(r.ok, true);
+  if (r.ok) {
+    assert.equal(r.index, 3);
+    assert.equal(PAYMENT_PATH_CSV_HEADERS[r.index], "金額");
+  }
+});
+
+test("amountColumnIndex: zero matches → named failure (kind 'zero')", () => {
+  const r = amountColumnIndex(["利用日", "店名", "備考"]); // no 金額 anywhere
+  assert.equal(r.ok, false);
+  if (!r.ok) {
+    assert.equal(r.kind, "zero");
+    assert.deepEqual(r.matches, []);
+  }
+});
+
+test("amountColumnIndex: two matches → named failure (kind 'multiple') listing both cells", () => {
+  // A hypothetical future layout where both 利用金額 and a new 支払金額 column
+  // exist. This is (A)'s only real weakness; the exactly-one requirement turns
+  // it into a loud named failure instead of a silent wrong-column read.
+  const r = amountColumnIndex(["利用日", "利用金額", "支払金額", "備考"]);
+  assert.equal(r.ok, false);
+  if (!r.ok) {
+    assert.equal(r.kind, "multiple");
+    assert.deepEqual(r.matches, ["利用金額", "支払金額"]);
+  }
+});
+
+test("describeAmountColumnFailure: names the CSV, the kind, the matches, and the real header", () => {
+  const zero = describeAmountColumnFailure({
+    label: "AMEX",
+    kind: "zero",
+    matches: [],
+    headerCells: ["利用日", "店名"],
+  });
+  assert.match(zero, /AMEX recon CSV: no header cell contains 金額/);
+  assert.match(zero, /Header: \[利用日 \| 店名\]/);
+
+  const multi = describeAmountColumnFailure({
+    label: "CASH",
+    kind: "multiple",
+    matches: ["利用金額", "支払金額"],
+    headerCells: ["No", "利用金額", "支払金額"],
+  });
+  assert.match(multi, /CASH recon CSV: 2 header cells contain 金額/);
+  assert.match(multi, /"利用金額", "支払金額"/);
+});
+
+// ─── End-to-end: sumReconChargeAmounts on the REAL Netアンサー layout ──────────
+// The bug layout: 4-line preamble (カード名称 / ご利用者名 / お支払日 / blank is
+// not used here — 今回ご請求額 instead), then the 利用日 header whose amount cell
+// is 利用金額, then charges, then 小計/合計. The old code summed 0; the fix must
+// sum the charges and ignore the totals/metadata.
+test("sumReconChargeAmounts: a real-layout AMEX CSV (利用金額) sums the charges, not 0", () => {
+  const amex = [
+    "カード名称,セゾンプラチナビジネス・アメリカンエキスプレス・カード",
+    "お支払日,2026/06/04",
+    "今回ご請求額,0000114831",
+    "",
+    "利用日,ご利用店名及び商品名,本人・家族区分,支払区分名称,締前入金区分,利用金額,備考,科目＆No.,事業目的,人数,領収書ファイル名",
+    '2026/04/17,小田原みなと食堂,,1回,,6490,,会議費Jun2026①,打ち合わせ,1,"会議費Jun2026①小田原みなと食堂￥6,490.jpg"',
+    '2026/05/02,OpenAI,,1回,,108341,,研究開発費Jun2026①,API,1,"研究開発費Jun2026①OpenAI￥108,341.pdf"',
+    ",【小計】,,,,114831",
+    ",【合計】,,,,114831",
+  ].join("\r\n");
+  const r = sumReconChargeAmounts(amex);
+  assert.equal(r.ok, true);
+  if (r.ok) assert.equal(r.total, 114831, "6490 + 108341, ignoring 小計/合計");
+});
+
+test("sumReconChargeAmounts: an AMEX CSV whose amount cell is absent → ok:false (kind zero), not total:0", () => {
+  // The regression shape: a header with no 金額 cell must NOT silently sum to 0.
+  const amex = [
+    "カード名称,カード",
+    "利用日,店名,備考,科目＆No.,事業目的,人数,領収書ファイル名", // no 金額 cell
+    '2026/04/17,小田原,,1回,,6490,,会議費Jun2026①,打ち合わせ,1,ignored.jpg',
+  ].join("\r\n");
+  const r = sumReconChargeAmounts(amex);
+  assert.equal(r.ok, false, "must surface a named failure, not total:0");
+  if (!r.ok) {
+    assert.equal(r.kind, "zero");
+    assert.ok(r.headerCells.length > 0, "carries the actual header cells for the detail");
+  }
+});


### PR DESCRIPTION
The delivery composer (PR #167) surfaced a latent preflight failure on the sealed **2026-06** pack: 2 of 19 checks failed (`集計 AMEX total 376981 ≠ statement total 0` + per-category mismatch) even though **the pack reconciles exactly**. Root cause: the preflight located the amount column with `header.indexOf(\"金額\")` — an **exact-cell** match. The AMEX 照合CSV is the card's Netアンサー passthrough; its amount cell is **`利用金額`**, so `indexOf` returned -1 and both sites silently summed 0 — producing a scary wrong \"doesn't reconcile\" instead of \"the parser can't find the column.\"

## Fix (architect-approved option A + exactly-one-match)

- **`amountColumnIndex(header)`** — the **single** header cell containing `金額` (substring), or a named failure. **Zero OR two-or-more both fail loudly** with the matching cells + the actual header — never a silent wrong-column read or zero.
- **Deliberately semantic, not positional.** The AMEX importer (`validation.ts`) reads the amount *positionally* (`fields[5]`); the preflight is a **verification layer** and must locate the amount **independently** so a column-shift regression moves only one side and the check catches it. The two are meant to disagree loudly. (Coupling the preflight to the importer's positional rule would make the check tautological — that's why option B was rejected.)
- Both former call sites (`sumReconChargeAmounts` + the `summary-category-reconciles` loop) call `amountColumnIndex` and propagate any failure as a **named check result**. `sumReconChargeAmounts`'s signature changed to a result type — it can no longer return 0 for \"column not found.\"
- `PackPreflightInput.amexStatementTotalCents` (`number|null`) → `amexStatementTotal` (discriminated `none | total | parse-error`), so `summary-payment-path-reconciles` fails with the named detail instead of comparing against a fabricated zero.

## Verified against the REAL sealed June ZIP (6,216,029 B)

**19/19 checks pass.** AMEX total reconciles at **¥376,981** (cardholder 合計 135,830 + 241,151 = `今回ご請求額` = 集計 AMEX total). The sealed pack is **unchanged** — no revision; preflight runs at send time, so this parser fix unblocks delivery.

## Tests
- 7 new in `preflight-amount-column.test.ts`: real 11-col June AMEX header verbatim, `PAYMENT_PATH_CSV_HEADERS`, zero-match, two-match, `describeAmountColumnFailure`, real-layout `sumReconChargeAmounts`, absent-column → `ok:false`.
- Existing `pack-preflight.test.ts` updated for the new signature (existing fixtures use an exact `金額` cell — substring match still finds them, backward compatible).
- `tsc --noEmit` clean; **full suite 1214 / 0 fail**.

## Out of scope
Foreign-currency `parseAmountCell` (`\"12.34\"`→`1234`) is a separate latent defect — June has 0 non-JPY rows so it doesn't contribute here. Filed for a real non-JPY month.

🤖 Generated with [Claude Code](https://claude.com/claude-code)