### PR TITLE
fix(receipts): delivery identity + the lost operator message (A→D)

### DIFF
--- a/app/(receipt-system)/receipts/export/[month]/send/page.tsx
+++ b/app/(receipt-system)/receipts/export/[month]/send/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import { composeDelivery, NoSealedExportError } from "@/lib/receipts/delivery-compose";
 import { assertReceiptsPageAccess } from "@/lib/receipts/auth-request";
-import { formatMonth } from "@/lib/receipts/format";
+import { formatMonthJa } from "@/lib/receipts/format";
 import { DeliveryComposer } from "@/components/receipts/export/delivery-composer";
 
 export const dynamic = "force-dynamic";
@@ -40,10 +40,10 @@ export default async function SendPage({ params }: { params: Params }) {
           href={`/receipts/export?month=${month}`}
           className="text-[12px] font-medium text-gray-500 hover:text-amber-700"
         >
-          ‹ {formatMonth(month)} のエクスポートに戻る
+          ‹ {formatMonthJa(month)} のエクスポートに戻る
         </Link>
       </div>
-      <DeliveryComposer composed={composed} monthLabel={formatMonth(month)} />
+      <DeliveryComposer composed={composed} monthLabel={formatMonthJa(month)} />
     </div>
   );
 }

--- a/app/(receipt-system)/receipts/export/page.tsx
+++ b/app/(receipt-system)/receipts/export/page.tsx
@@ -168,11 +168,7 @@ export default async function ExportPage({
         unassignableReceipts={unassignable}
       />
       {latestFinalized && (
-        <DeliveryMonthBanner
-          month={month}
-          monthLabel={monthLabel}
-          state={monthDeliveryState}
-        />
+        <DeliveryMonthBanner month={month} state={monthDeliveryState} />
       )}
       {/* Sealed bundle — latest FINALIZED revision. Served even while a
           revision draft is open (getLatestFinalizedExport, NOT getExport, so an

--- a/app/api/receipts/export/[month]/send/route.ts
+++ b/app/api/receipts/export/[month]/send/route.ts
@@ -229,6 +229,7 @@ export async function POST(request: Request, { params }: RouteContext) {
       from: composed.from,
       to: composed.to,
       cc: composed.cc,
+      replyTo: composed.replyTo,
       subject: composed.subject,
       text: composed.text,
       html: composed.html,

--- a/app/api/receipts/export/month/route.ts
+++ b/app/api/receipts/export/month/route.ts
@@ -9,6 +9,7 @@ import {
   getFinalizedReconciliationForMonth,
   recordExportBundle,
   replaceExportItems,
+  updateExportOperatorMessage,
 } from "@/lib/receipts/db";
 import {
   bomPrefixedCrlf,
@@ -30,7 +31,7 @@ import {
   buildCashReconciliationKey,
   buildDigitalReconciliationKey,
 } from "@/lib/receipts/export";
-import { resolveOperatorMessageForRebuild } from "@/lib/receipts/operator-message";
+import { resolveOperatorMessageForRebuild, oneShotFinalizeDecision } from "@/lib/receipts/operator-message";
 import {
   buildEvidenceAssignments,
   buildAmexReconciliationCsv,
@@ -101,15 +102,21 @@ export async function POST(request: Request) {
     let reconciliation: AmexReconciliation | null = null;
     if (body.finalize) {
       reconciliation = await getFinalizedReconciliationForMonth(month);
-      const blockers = await validateMonthReadyForExport(
-        month,
-        bundle,
-        reconciliation,
-      );
-      if (blockers.length > 0) {
+      // §1 (Codex P1 on #169): the one-shot finalize path must not bypass
+      // message_not_reviewed. That gate keys on operator_message_updated_at,
+      // which is NULL on a freshly created draft — so the caller must state the
+      // decision explicitly (operatorMessage text, or null/"" for "no message").
+      // Omitted ⇒ 400. The decision is WRITTEN (setting the timestamp, exactly
+      // as the message route would) before validate, below — so the gate sees a
+      // real decision and the one-shot path stays usable, not silently unblockable.
+      const decision = oneShotFinalizeDecision(body.operatorMessage);
+      if (!decision.ok) {
         return NextResponse.json(
-          { error: "Export blocked — resolve these issues first.", blockers },
-          { status: 422 },
+          {
+            error:
+              "One-shot finalize requires an explicit message decision. Supply operatorMessage (the preface text), or operatorMessage: null / \"\" for 'no message this month'.",
+          },
+          { status: 400 },
         );
       }
     }
@@ -179,6 +186,35 @@ export async function POST(request: Request) {
       body.operatorMessage,
       exportRecord?.operator_message ?? null,
     );
+
+    // §1 (Codex P1 on #169): on the one-shot finalize path, write the explicit
+    // decision at creation time → sets operator_message_updated_at (the decision
+    // timestamp), exactly as PATCH /message would (a VERIFIED write — throws on
+    // 0 rows). THEN run the full gate: it now sees a real decision, so
+    // message_not_reviewed does not fire. Validating here (after create + the
+    // decision-write, before any R2 upload) means a blocked one-shot returns 422
+    // with no side effects. The rebuild path (finalize:false) is unchanged.
+    // §1 (Codex P1 on #169): on the one-shot finalize path, write the explicit
+    // decision at creation time → sets operator_message_updated_at (the decision
+    // timestamp), exactly as PATCH /message would (a VERIFIED write — throws on
+    // 0 rows). THEN run the full gate: it now sees a real decision, so
+    // message_not_reviewed does not fire. Validating here (after create + the
+    // decision-write, before any R2 upload) means a blocked one-shot returns 422
+    // with no side effects. The rebuild path (finalize:false) is unchanged.
+    if (body.finalize) {
+      await updateExportOperatorMessage(exportId, operatorMessage);
+      const blockers = await validateMonthReadyForExport(
+        month,
+        bundle,
+        reconciliation,
+      );
+      if (blockers.length > 0) {
+        return NextResponse.json(
+          { error: "Export blocked — resolve these issues first.", blockers },
+          { status: 422 },
+        );
+      }
+    }
 
     // Record exactly which receipts and AMEX lines ship in this bundle. The
     // one-draft-per-month invariant means an existing draft's items get

--- a/app/api/receipts/export/month/route.ts
+++ b/app/api/receipts/export/month/route.ts
@@ -30,6 +30,7 @@ import {
   buildCashReconciliationKey,
   buildDigitalReconciliationKey,
 } from "@/lib/receipts/export";
+import { resolveOperatorMessageForRebuild } from "@/lib/receipts/operator-message";
 import {
   buildEvidenceAssignments,
   buildAmexReconciliationCsv,
@@ -167,16 +168,17 @@ export async function POST(request: Request) {
     const exportRevision = exportRecord?.export_revision ?? 1;
     const supersedesExportId = exportRecord?.supersedes_export_id ?? null;
     const correctionReason = exportRecord?.correction_reason ?? null;
-    // E1: the operator message must survive a rebuild that omits it from the
-    // request body. Resolve it ONCE — body wins when explicitly present,
-    // otherwise the stored draft row's value carries forward. Pre-E1 every
-    // rebuild bound `body.operatorMessage ?? null`, so a rebuild triggered
-    // without the message nulled the stored column and it vanished from the
-    // next notice (the preflight O7 check then flagged the drift). Trim + the
-    // 2000-char cap are enforced by the PATCH writer; the rebuild only carries
-    // the resolved value forward verbatim.
-    const operatorMessage =
-      body.operatorMessage ?? exportRecord?.operator_message ?? null;
+    // E1/A2: the operator message must survive a rebuild that OMITS it from the
+    // request body, but an explicit empty string must CLEAR it. The old
+    // `body.operatorMessage ?? stored` collapsed those two (an empty string,
+    // which is present, overwrote the stored value — the same shape as the
+    // 2026-06 loss). Resolve by field PRESENCE via the shared pure helper.
+    // Trim + the 2000-char cap are enforced by the PATCH writer; the rebuild
+    // only carries the resolved value forward verbatim.
+    const operatorMessage = resolveOperatorMessageForRebuild(
+      body.operatorMessage,
+      exportRecord?.operator_message ?? null,
+    );
 
     // Record exactly which receipts and AMEX lines ship in this bundle. The
     // one-draft-per-month invariant means an existing draft's items get

--- a/app/api/receipts/settings/compliance/route.ts
+++ b/app/api/receipts/settings/compliance/route.ts
@@ -113,6 +113,19 @@ export async function PATCH(request: Request) {
       body.delivery_signature = body.delivery_signature.trim();
     }
 
+    // Delivery-composer §B: Reply-To validated with the same email shape rule as
+    // the To/Cc recipients. Empty is allowed (→ reply_to omitted from payload).
+    if (
+      body.delivery_reply_to !== undefined &&
+      body.delivery_reply_to !== "" &&
+      !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(body.delivery_reply_to)
+    ) {
+      return NextResponse.json(
+        { error: "delivery_reply_to must be a valid email address." },
+        { status: 400 },
+      );
+    }
+
     const before = await getComplianceSettings();
     const settings = await updateComplianceSettings(body, actor);
 

--- a/components/receipts/ComplianceSettingsForm.tsx
+++ b/components/receipts/ComplianceSettingsForm.tsx
@@ -31,6 +31,7 @@ const LABELS: Record<keyof ComplianceSettings, string> = {
   notification_recipient: "通知先 (Notification recipient)",
   notification_cc_recipient: "CC (Business manager / Cc recipient)",
   delivery_signature: "配信メール署名 (Delivery email signature)",
+  delivery_reply_to: "配信 Reply-To (Delivery reply-to)",
   homebase_signals: "Homebase signals (ADR 0010)",
 };
 
@@ -292,6 +293,20 @@ export function ComplianceSettingsForm({
       </Row>
 
       <Row
+        label={LABELS.notification_cc_recipient}
+        hint="月次確定通知の CC（写し先）。空欄なら CC なし（Resend ペイロードから omitted）。"
+      >
+        <input
+          type="email"
+          value={settings.notification_cc_recipient}
+          onChange={(e) => update("notification_cc_recipient", e.target.value)}
+          className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm sm:w-80"
+          maxLength={160}
+          placeholder="ops@example.com"
+        />
+      </Row>
+
+      <Row
         label={LABELS.delivery_signature}
         hint="配信メールの末尾（「ご不明な点があればお知らせください。」の後）に追加される署名です。確定した封筒内の通知には含まれません（送信メールのみ）。空欄なら追加されません。"
       >
@@ -306,6 +321,20 @@ export function ComplianceSettingsForm({
         <p className="mt-1 text-[11px] text-gray-400">
           {settings.delivery_signature.length}/1000
         </p>
+      </Row>
+
+      <Row
+        label={LABELS.delivery_reply_to}
+        hint="月次パック配送メールの Reply-To。会計士が返信ボタンを押したときの着信先です。空欄なら Reply-To なし（From 宛ての返信は Email Routing が別途ルーティングする必要があります）。"
+      >
+        <input
+          type="email"
+          value={settings.delivery_reply_to}
+          onChange={(e) => update("delivery_reply_to", e.target.value)}
+          className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm sm:w-80"
+          maxLength={160}
+          placeholder="tazukowen@gmail.com"
+        />
       </Row>
 
       <Row

--- a/components/receipts/export/delivery-composer.tsx
+++ b/components/receipts/export/delivery-composer.tsx
@@ -184,6 +184,12 @@ export function DeliveryComposer({
             mono
             emptyDisplay="（なし）"
           />
+          <ReadonlyRow
+            label="Reply-To"
+            value={composed.replyTo ?? null}
+            mono
+            emptyDisplay="（なし）"
+          />
         </div>
       )}
 

--- a/components/receipts/export/delivery-month-banner.tsx
+++ b/components/receipts/export/delivery-month-banner.tsx
@@ -3,6 +3,7 @@ import {
   deliveryStateToPill,
   type DeliveryState,
 } from "@/lib/receipts/delivery-state";
+import { formatMonthJa } from "@/lib/receipts/format";
 
 /**
  * Per-month delivery banner for the export page (delivery-composer §6, surface
@@ -15,13 +16,12 @@ import {
  */
 export function DeliveryMonthBanner({
   month,
-  monthLabel,
   state,
 }: {
   month: string;
-  monthLabel: string;
   state: DeliveryState | null;
 }) {
+  const monthLabel = formatMonthJa(month);
   const pill = deliveryStateToPill(state);
 
   if (pill === "delivered") {

--- a/components/receipts/export/finalize-card.tsx
+++ b/components/receipts/export/finalize-card.tsx
@@ -31,6 +31,7 @@ export function FinalizeCard({
   warningCount,
   rowsInDraft,
   hasProofsZip = true,
+  prefaceDirty = false,
 }: {
   month: string;
   monthLabel: string;
@@ -44,6 +45,11 @@ export function FinalizeCard({
    *  never a dead 404. Defaults true (the common case for a freshly finalized
    *  export). */
   hasProofsZip?: boolean;
+  /** True while the preface editor has unsaved edits (client-side half of the
+   *  2026-06 message-loss fix). Finalize is blocked and the reason is named in
+   *  the button state — never a dismissible dialog (an unsaved preface and a
+   *  sealed pack are mutually exclusive states). */
+  prefaceDirty?: boolean;
 }) {
   const router = useRouter();
   const [busy, setBusy] = useState(false);
@@ -54,6 +60,7 @@ export function FinalizeCard({
     !finalized &&
     draftBuilt &&
     blockerCount === 0 &&
+    !prefaceDirty &&
     confirmType.trim().toLowerCase() === monthLabel.toLowerCase();
 
   async function finalize() {
@@ -183,9 +190,11 @@ export function FinalizeCard({
             >
               {busy
                 ? "Finalizing…"
-                : blockerCount > 0
-                  ? `Finalize · resolve ${blockerCount} blocker${blockerCount === 1 ? "" : "s"} first`
-                  : `Finalize ${monthLabel}`}
+                : prefaceDirty
+                  ? "ご連絡を保存してください"
+                  : blockerCount > 0
+                    ? `Finalize · resolve ${blockerCount} blocker${blockerCount === 1 ? "" : "s"} first`
+                    : `Finalize ${monthLabel}`}
             </Btn>
             <div className="mt-2 text-center text-[11px] text-gray-400">
               Signoff uses your Clerk operator identity

--- a/components/receipts/export/preface-editor.tsx
+++ b/components/receipts/export/preface-editor.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
 import { Btn } from "@/components/ui/btn";
 import { buildPackNotice, type PackNoticeInput } from "@/lib/receipts/proofs";
 import type { PackNames } from "@/lib/receipts/pack-naming";
@@ -48,6 +49,7 @@ export function PrefaceEditor({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [savedAt, setSavedAt] = useState<string | null>(null);
+  const router = useRouter();
 
   const dirty = draft !== saved;
   const overCap = draft.length > 2000;
@@ -100,6 +102,14 @@ export function PrefaceEditor({
       setSavedAt(
         new Date().toLocaleTimeString("ja-JP", { hour: "2-digit", minute: "2-digit" }),
       );
+      // §2 (Codex P2 on #169): a verified save (res.ok ⇒ the rows-affected-checked
+      // write persisted) moves the server gate from message_not_reviewed to
+      // message_stale. The gate panel + FinalizeCard.blockerCount are server-
+      // rendered, so refresh them — never on an unverified/failed save. Refresh
+      // preserves this component's client state (draft/saved/savedAt are not
+      // reset by router.refresh), so the saved indicator is not bounced and
+      // unsaved edits are not clobbered.
+      router.refresh();
       return true;
     } catch {
       setError("通信エラーが発生しました。");

--- a/components/receipts/export/preface-editor.tsx
+++ b/components/receipts/export/preface-editor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Btn } from "@/components/ui/btn";
 import { buildPackNotice, type PackNoticeInput } from "@/lib/receipts/proofs";
 import type { PackNames } from "@/lib/receipts/pack-naming";
@@ -26,6 +26,7 @@ export function PrefaceEditor({
   editable,
   noticeInput,
   names,
+  onDirtyChange,
 }: {
   month: string;
   initialMessage: string | null;
@@ -37,6 +38,10 @@ export function PrefaceEditor({
    *  payment-due date is unavailable (an AMEX month whose statement artifact
    *  predates the 0035 snapshot) — the preview is hidden in that case. */
   names: PackNames | null;
+  /** Lifted dirty signal so the Finalize button can disable (and name the
+   *  reason) while the preface has unsaved edits — the client-side half of the
+   *  2026-06 message-loss fix (the server half is the message_not_reviewed gate). */
+  onDirtyChange?: (dirty: boolean) => void;
 }) {
   const [draft, setDraft] = useState(initialMessage ?? "");
   const [saved, setSaved] = useState(initialMessage ?? "");
@@ -46,6 +51,12 @@ export function PrefaceEditor({
 
   const dirty = draft !== saved;
   const overCap = draft.length > 2000;
+
+  // Lift the dirty flag so the finalize gate (a sibling client component) can
+  // block sealing while there are unsaved preface edits.
+  useEffect(() => {
+    onDirtyChange?.(dirty);
+  }, [dirty, onDirtyChange]);
 
   // Live preview via the real builder — operatorMessage is the live draft, every
   // other input is the server-derived month state. Sliced to ~10 lines so the
@@ -59,15 +70,19 @@ export function PrefaceEditor({
     return full.split(/\r?\n/).slice(0, 10).join("\n");
   }, [names, noticeInput, draft]);
 
-  async function save() {
-    if (!editable || saving || overCap) return;
+  /** Persist the preface. `message` is the exact value to store (trimmed server-
+   *  side); pass "" to record an explicit "no message this month" decision — the
+   *  server stores NULL + sets the decision timestamp, clearing the
+   *  message_not_reviewed finalize blocker. */
+  async function persist(message: string) {
+    if (!editable || saving) return;
     setSaving(true);
     setError(null);
     try {
       const res = await fetch(`/api/receipts/export/${month}/message`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ message: draft }),
+        body: JSON.stringify({ message }),
       });
       const json = (await res.json().catch(() => ({}))) as {
         operatorMessage?: string | null;
@@ -75,7 +90,7 @@ export function PrefaceEditor({
       };
       if (!res.ok) {
         setError(json.error ?? "保存に失敗しました。");
-        return;
+        return false;
       }
       // Normalize to the server-stored (trimmed / NULL-cleared) value so the
       // dirty flag settles even when the server trims whitespace.
@@ -85,12 +100,23 @@ export function PrefaceEditor({
       setSavedAt(
         new Date().toLocaleTimeString("ja-JP", { hour: "2-digit", minute: "2-digit" }),
       );
+      return true;
     } catch {
       setError("通信エラーが発生しました。");
+      return false;
     } finally {
       setSaving(false);
     }
   }
+
+  const save = () => persist(draft);
+  /** "No message this month" — a deliberate decision that writes the timestamp
+   *  with a NULL message, clearing message_not_reviewed without typing text. */
+  const decideNoMessage = () => persist("");
+
+  // A successful "no message" save leaves saved === "" with a timestamp; surface
+  // it distinctly so it doesn't read as "forgot to type."
+  const decidedNoMessage = !dirty && saved === "" && savedAt !== null;
 
   return (
     <div className="mx-8 mb-4 rounded-xl border border-gray-200 bg-white px-5 py-4">
@@ -130,9 +156,20 @@ export function PrefaceEditor({
             >
               {saving ? "保存中…" : "保存"}
             </Btn>
+            <Btn
+              kind="soft"
+              size="md"
+              onClick={decideNoMessage}
+              disabled={saving || decidedNoMessage}
+              title="今月はメッセージなしと明示的に記録します（タイムスタンプを書き込みます）"
+            >
+              今月はメッセージなし
+            </Btn>
             <span className="text-[11.5px] text-gray-500">
               {dirty ? (
                 <span className="text-amber-700">未保存</span>
+              ) : decidedNoMessage ? (
+                <span>メッセージなし（保存済み {savedAt}）</span>
               ) : savedAt ? (
                 <span>保存済み（{savedAt}）</span>
               ) : initialMessage ? (

--- a/components/receipts/export/preface-finalize-section.tsx
+++ b/components/receipts/export/preface-finalize-section.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useState } from "react";
+import { PrefaceEditor } from "@/components/receipts/export/preface-editor";
+import { FinalizeCard } from "@/components/receipts/export/finalize-card";
+import type { ReceiptExport } from "@/lib/receipts/types";
+import type { PackNoticeInput } from "@/lib/receipts/proofs";
+import type { PackNames } from "@/lib/receipts/pack-naming";
+
+/**
+ * Pairs the PrefaceEditor and the FinalizeCard behind ONE piece of client state:
+ * whether the preface has unsaved edits. ReviewScreen is a server component and
+ * cannot hold that state, and the two are otherwise independent client islands.
+ *
+ * The dirty flag is the client-side half of the 2026-06 message-loss fix. The
+ * server half is the `message_not_reviewed` finalize gate, which catches a field
+ * the operator never opened; this catches the narrower case the gate cannot see
+ * — an edit made AFTER a prior save (the server only knows the last persisted
+ * value). When dirty, FinalizeCard disables and names the reason in its button.
+ */
+export function PrefaceFinalizeSection({
+  month,
+  monthLabel,
+  currentExport,
+  finalized,
+  draftBuilt,
+  blockerCount,
+  warningCount,
+  rowsInDraft,
+  hasProofsZip,
+  noticeInput,
+  names,
+}: {
+  month: string;
+  monthLabel: string;
+  currentExport: ReceiptExport | null;
+  finalized: boolean;
+  draftBuilt: boolean;
+  blockerCount: number;
+  warningCount: number;
+  rowsInDraft: number;
+  hasProofsZip: boolean;
+  noticeInput: PackNoticeInput;
+  names: PackNames | null;
+}) {
+  const [prefaceDirty, setPrefaceDirty] = useState(false);
+
+  return (
+    <>
+      {currentExport && (
+        <PrefaceEditor
+          month={month}
+          initialMessage={currentExport.operator_message ?? null}
+          editable={currentExport.status === "draft"}
+          noticeInput={noticeInput}
+          names={names}
+          onDirtyChange={setPrefaceDirty}
+        />
+      )}
+
+      <FinalizeCard
+        month={month}
+        monthLabel={monthLabel}
+        finalized={finalized}
+        draftBuilt={draftBuilt}
+        blockerCount={blockerCount}
+        warningCount={warningCount}
+        rowsInDraft={rowsInDraft}
+        hasProofsZip={hasProofsZip}
+        prefaceDirty={prefaceDirty}
+      />
+    </>
+  );
+}

--- a/components/receipts/export/review-screen.tsx
+++ b/components/receipts/export/review-screen.tsx
@@ -1,7 +1,6 @@
 import Link from "next/link";
 import { Card } from "@/components/ui/card";
 import { Pill } from "@/components/ui/pill";
-import { FinalizeCard } from "@/components/receipts/export/finalize-card";
 import { InlineCategoryCell } from "@/components/receipts/export/inline-category-cell";
 import { buildCategoryCellProps } from "@/lib/receipts/category-cell";
 import {
@@ -27,7 +26,7 @@ import type { CategoryRule } from "@/lib/receipts/category-rules";
 import type { PackNoticeInput } from "@/lib/receipts/proofs";
 import type { PackNames } from "@/lib/receipts/pack-naming";
 import { withWorkMonth } from "@/lib/receipts/work-month";
-import { PrefaceEditor } from "@/components/receipts/export/preface-editor";
+import { PrefaceFinalizeSection } from "@/components/receipts/export/preface-finalize-section";
 
 export interface ReviewScreenProps {
   month: string;
@@ -118,29 +117,22 @@ export function ReviewScreen(props: ReviewScreenProps) {
         />
       </div>
 
-      {/* Editable preface (E2) — the ONE UI surface that writes operator_message.
-          Rendered whenever an export exists (draft → editable; sealed → disabled
-          with an explanation). Sits above the finalize card so the operator sets
-          the message before sealing it into the pack. */}
-      {props.currentExport && (
-        <PrefaceEditor
-          month={props.month}
-          initialMessage={props.currentExport.operator_message ?? null}
-          editable={props.currentExport.status === "draft"}
-          noticeInput={props.prefaceNoticeInput}
-          names={props.prefaceNames}
-        />
-      )}
-
-      <FinalizeCard
+      {/* Editable preface (E2) + finalize card, paired behind one client-state
+          flag (preface dirty) so Finalize is blocked while the preface has
+          unsaved edits. The server-side message_not_reviewed / message_stale
+          gates are enforced via blockerCount (the authoritative gate verdict). */}
+      <PrefaceFinalizeSection
         month={props.month}
         monthLabel={props.monthLabel}
+        currentExport={props.currentExport}
         finalized={finalized}
         draftBuilt={Boolean(props.currentExport)}
         blockerCount={props.gateBlockers.length}
         warningCount={props.warnings.reduce((s, w) => s + w.count, 0)}
         rowsInDraft={props.rows.length}
         hasProofsZip={Boolean(props.currentExport?.proofs_r2_key)}
+        noticeInput={props.prefaceNoticeInput}
+        names={props.prefaceNames}
       />
     </div>
   );

--- a/components/receipts/sealed-undelivered-alert.tsx
+++ b/components/receipts/sealed-undelivered-alert.tsx
@@ -3,7 +3,7 @@ import {
   deliveryStateToPill,
   type DeliveryState,
 } from "@/lib/receipts/delivery-state";
-import { formatMonth } from "@/lib/receipts/format";
+import { formatMonthJa } from "@/lib/receipts/format";
 
 /**
  * Dashboard banner listing every finalized month that is NOT yet delivered
@@ -45,7 +45,7 @@ export function SealedUndeliveredAlert({
                 href={`/receipts/export/${month}/send`}
                 className="font-semibold text-red-800 underline hover:text-red-900"
               >
-                {formatMonth(month)}
+                {formatMonthJa(month)}
               </Link>
               <span className="text-red-600">· {label}</span>
             </li>

--- a/db/receipts/0041_delivery_reply_to.sql
+++ b/db/receipts/0041_delivery_reply_to.sql
@@ -1,0 +1,13 @@
+-- 0041_delivery_reply_to.sql
+--
+-- Delivery Reply-To (delivery-composer §B). The Reply-To header on the monthly
+-- pack delivery email — where an accountant's reply lands. Distinct from the
+-- From address so a reply is not parsed as a receipt submission by the public
+-- intake address (ADR 0011). Empty = omitted from the Resend payload entirely.
+--
+-- receipt_settings is a key/value table (key TEXT PRIMARY KEY, value TEXT NOT
+-- NULL — see 0014_compliance.sql); a new setting is a seeded ROW, not an ALTER
+-- TABLE — the same pattern notification_recipient / notification_cc_recipient /
+-- delivery_signature (0040) used. Additive only; no backfill.
+INSERT OR IGNORE INTO receipt_settings (key, value, updated_at, updated_by)
+VALUES ('delivery_reply_to', '', strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), 'system');

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -180,7 +180,7 @@ ADR: `docs/adr/0002-statement-month-export-scope.md`.
 
 ### Single enforcement authority
 
-`validateMonthReadyForExport(month, prebuiltBundle?, preloadedReconciliation?)` in `lib/receipts/month-closing.ts` is the **only** gate. Both finalize paths (`POST /api/receipts/export/month {finalize:true}` and `POST /api/receipts/export/[month]`) call it; UI tiles in `lib/receipts/blockers.ts` are presentation-only.
+`validateMonthReadyForExport(month, prebuiltBundle?, preloadedReconciliation?)` in `lib/receipts/month-closing.ts` is the **only** gate. Both finalize paths (`POST /api/receipts/export/month {finalize:true}` and `POST /api/receipts/export/[month]`) call it; UI tiles in `lib/receipts/blockers.ts` are presentation-only. The one-shot path (`POST /api/receipts/export/month {finalize:true}`) requires an explicit operator-message decision in the body — `operatorMessage` (the preface text) or `operatorMessage: null`/`""` ("no message this month"); omitted ⇒ 400. The decision is written (setting `operator_message_updated_at`) before the gate runs, so the `message_not_reviewed` gate cannot be bypassed on a freshly created draft. The finalize-only route (`POST /api/receipts/export/[month]`, what the UI uses) validates against the already-existing draft and is unaffected.
 
 The validator runs these gates in order (`validateMonthReadyForExportCore` in
 `lib/receipts/month-closing.ts`):

--- a/lib/cloudflare-runtime.ts
+++ b/lib/cloudflare-runtime.ts
@@ -90,3 +90,30 @@ export function getNotifyFromAddress(): string | null {
   const env = getCloudflareEnv() as CloudflareEnv & { NOTIFY_FROM_ADDRESS?: string };
   return env.NOTIFY_FROM_ADDRESS ?? null;
 }
+
+/**
+ * Delivery From address — the sender the accountant sees on the monthly pack
+ * email. Distinct from {@link getNotifyFromAddress}: NOTIFY_FROM_ADDRESS is the
+ * PUBLIC inbound intake address (receipts@dazbeez.com, ADR 0011) which
+ * auto-ingests replies as receipt submissions with no operator click. An
+ * accountant pressing Reply to a delivery sent From the intake address would
+ * have their message parsed as a receipt. The delivery From (target
+ * monthlyreport@dazbeez.com) MUST be a different mailbox that is NOT bound to
+ * the intake worker (operator action: Cloudflare Email Routing routes it to the
+ * operator and it must not be bound to the intake worker).
+ *
+ * Falls back to NOTIFY_FROM_ADDRESS when unset so the contact form and the
+ * channel probe (which use getNotifyFromAddress) are unaffected, and so delivery
+ * still works before the operator sets the secret. The operator must verify the
+ * sender on the Resend domain BEFORE pointing DELIVERY_FROM_ADDRESS at it
+ * (Resend rejects unverified senders). The reply_to (Settings → Compliance)
+ * covers well-behaved clients; the Email Routing rule catches replies aimed at
+ * the From address directly.
+ */
+export function getDeliveryFromAddress(): string | null {
+  const env = getCloudflareEnv() as CloudflareEnv & {
+    DELIVERY_FROM_ADDRESS?: string;
+    NOTIFY_FROM_ADDRESS?: string;
+  };
+  return env.DELIVERY_FROM_ADDRESS ?? env.NOTIFY_FROM_ADDRESS ?? null;
+}

--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -9,6 +9,7 @@ import {
 import { shouldOverwriteMerchant } from "@/lib/receipts/reconciliation";
 import { retentionUntilIso } from "@/lib/receipts/retention";
 import { assignMembershipForReceipt, postPatchMembershipDate } from "@/lib/receipts/membership";
+import { assertExactlyOneRowWritten } from "@/lib/receipts/operator-message";
 import { deleteAmexArtifact } from "@/lib/receipts/storage";
 import { PENDING_EXTRACTION_STATES } from "@/lib/receipts/types";
 import type { ReceiptAttendeeDirectoryEntry } from "@/lib/receipts/attendee-directory";
@@ -3056,7 +3057,14 @@ export async function recordExportBundle(
    *  sealed value (ADR 0009). The O7 preflight check (19th) verifies the
    *  notice's 【今月のご連絡】 matches this stored value at send time.
    *
-   *  REQUIRED (nullable) for the same reason as paymentDueDate. */
+   *  REQUIRED (nullable) for the same reason as paymentDueDate.
+   *
+   *  NOTE: this writes operator_message (the VALUE — O7 needs it sealed into the
+   *  bytes) but deliberately does NOT write operator_message_updated_at. That
+   *  timestamp is the message-DECISION signal (NULL = the operator never decided
+   *  ⇒ the message_not_reviewed finalize blocker); only updateExportOperatorMessage
+   *  (an explicit save / "no message") sets it. message_stale still clears on
+   *  rebuild because bundle_built_at advances past the save timestamp. */
   operatorMessage: string | null,
 ): Promise<void> {
   const db = getReceiptsDb();
@@ -3072,8 +3080,7 @@ export async function recordExportBundle(
            proofs_sha256 = ?,
            bundle_built_at = ?,
            payment_due_date = ?,
-           operator_message = ?,
-           operator_message_updated_at = ?
+           operator_message = ?
        WHERE id = ? AND status = 'draft'`,
     )
     .bind(
@@ -3086,7 +3093,6 @@ export async function recordExportBundle(
       now,
       paymentDueDate ?? null,
       operatorMessage ?? null,
-      now,
       exportId,
     )
     .run();
@@ -3102,13 +3108,25 @@ export async function recordExportBundle(
  * so this update should always match exactly one draft row. Trim + the 2000-char
  * cap are applied by the caller; null clears the column (buildPackNotice then
  * omits the whole 【今月のご連絡】 heading).
+ *
+ * After the 2026-06 message-loss incident: this is the ONLY writer of
+ * operator_message_updated_at (the message-DECISION timestamp; recordExportBundle
+ * no longer touches it). So a successful return here is the single signal that
+ * the operator made a message decision (save text, or "no message" with a NULL
+ * value) — which clears the message_not_reviewed finalize blocker.
+ *
+ * A2 hardening: a D1 UPDATE matching zero rows is an ERROR, not a silent 200.
+ * The 2026-06 loss was hard to diagnose in part because a no-op write would have
+ * returned success; now this throws, the PATCH route surfaces a 500, and the
+ * "saved" indicator never lies. The caller's draft check makes 0 rows a race
+ * (draft sealed between read and write), not normal flow.
  */
 export async function updateExportOperatorMessage(
   exportId: string,
   operatorMessage: string | null,
-): Promise<void> {
+): Promise<{ rowsWritten: number }> {
   const db = getReceiptsDb();
-  await db
+  const result = await db
     .prepare(
       `UPDATE receipt_exports
        SET operator_message = ?,
@@ -3117,6 +3135,9 @@ export async function updateExportOperatorMessage(
     )
     .bind(operatorMessage, nowIso(), exportId)
     .run();
+  const rowsWritten = result.meta?.changes ?? 0;
+  assertExactlyOneRowWritten(rowsWritten, `updateExportOperatorMessage(${exportId})`);
+  return { rowsWritten };
 }
 
 export async function finalizeExport(

--- a/lib/receipts/delivery-compose.ts
+++ b/lib/receipts/delivery-compose.ts
@@ -24,7 +24,7 @@ import {
 import {
   getReceiptsArchiveBucket,
   getResendApiKeyOrNull,
-  getNotifyFromAddress,
+  getDeliveryFromAddress,
   getAccountantEmail,
 } from "@/lib/cloudflare-runtime";
 import { getComplianceSettings } from "@/lib/receipts/settings";
@@ -72,10 +72,14 @@ export interface ComposedDelivery {
   sealedAt: string | null;
   to: string | null;
   cc: string | null;
-  /** Resolved From address. null when NOTIFY_FROM_ADDRESS is unset (also a
-   *  configError). The interface in the spec read `from: string`; null is the
-   *  truthful shape — a missing From is a configError, not an empty string. */
+  /** Resolved From address (the delivery sender — DELIVERY_FROM_ADDRESS, falling
+   *  back to NOTIFY_FROM_ADDRESS). null when both are unset (also a configError).
+   *  Distinct from the intake address so an accountant's Reply is not parsed as
+   *  a receipt submission (delivery-composer §B). */
   from: string | null;
+  /** Resolved Reply-To (Settings → Compliance → delivery_reply_to). null/empty →
+   *  omitted from the Resend payload. Where an accountant's reply lands. */
+  replyTo: string | null;
   subject: string;
   text: string;
   html: string;
@@ -139,12 +143,14 @@ export async function composeDelivery(
   ).email;
   const cc = (settings.notification_cc_recipient ?? "").trim() || null;
   const signature = (settings.delivery_signature ?? "").trim() || null;
+  const replyTo = (settings.delivery_reply_to ?? "").trim() || null;
   const apiKey = getResendApiKeyOrNull();
-  const from = getNotifyFromAddress();
+  const from = getDeliveryFromAddress();
 
   const configErrors = computeDeliveryConfigErrors({
     to,
     cc,
+    replyTo,
     from,
     hasResendKey: !!apiKey,
   });
@@ -163,7 +169,7 @@ export async function composeDelivery(
       // composer disables Send. Use a placeholder sha so the shape is satisfied
       // (the composer won't render the attachment block when configErrors block
       // the ZIP — but the field is non-optional on the interface).
-      return noBytesResult(month, exportRecord.id, to, cc, from, signature, configErrors);
+      return noBytesResult(month, exportRecord.id, to, cc, from, replyTo, signature, configErrors);
     }
     try {
       assertDeliverySize(head.size); // B-2 — guards the isolate before the GET
@@ -171,12 +177,12 @@ export async function composeDelivery(
       configErrors.push(
         err instanceof Error ? err.message : "Pack exceeds the delivery ceiling.",
       );
-      return noBytesResult(month, exportRecord.id, to, cc, from, signature, configErrors);
+      return noBytesResult(month, exportRecord.id, to, cc, from, replyTo, signature, configErrors);
     }
     const object = await bucket.get(proofsKey);
     if (!object) {
       configErrors.push("Sealed proofs ZIP vanished between HEAD and GET.");
-      return noBytesResult(month, exportRecord.id, to, cc, from, signature, configErrors);
+      return noBytesResult(month, exportRecord.id, to, cc, from, replyTo, signature, configErrors);
     }
     zipBytes = new Uint8Array(await new Response(object.body).arrayBuffer());
   }
@@ -240,6 +246,7 @@ export async function composeDelivery(
     to,
     cc,
     from,
+    replyTo,
     subject: email.subject,
     text: email.text,
     html: email.html,
@@ -271,6 +278,7 @@ function noBytesResult(
   to: string | null,
   cc: string | null,
   from: string | null,
+  replyTo: string | null,
   signature: string | null,
   configErrors: string[],
 ): ComposedDelivery {
@@ -281,6 +289,7 @@ function noBytesResult(
     to,
     cc,
     from,
+    replyTo,
     subject: "",
     text: "",
     html: "",
@@ -316,6 +325,7 @@ export type { DeliveryState };
 export function computeDeliveryConfigErrors(opts: {
   to: string | null;
   cc: string | null;
+  replyTo: string | null;
   from: string | null;
   hasResendKey: boolean;
 }): string[] {
@@ -334,9 +344,14 @@ export function computeDeliveryConfigErrors(opts: {
       `Delivery Cc recipient is not a valid email address: ${opts.cc}`,
     );
   }
+  if (opts.replyTo !== null && !isValidDeliveryAddress(opts.replyTo)) {
+    errors.push(
+      `Delivery Reply-To is not a valid email address: ${opts.replyTo}`,
+    );
+  }
   if (!opts.hasResendKey || !opts.from) {
     errors.push(
-      "Delivery not configured (RESEND_API_KEY / NOTIFY_FROM_ADDRESS).",
+      "Delivery not configured (RESEND_API_KEY / DELIVERY_FROM_ADDRESS).",
     );
   }
   return errors;

--- a/lib/receipts/delivery-send.ts
+++ b/lib/receipts/delivery-send.ts
@@ -91,6 +91,11 @@ export async function performDelivery(opts: {
   from: string;
   to: string;
   cc: string | null;
+  /** Reply-To for the delivery (delivery-composer §B). null/empty/omitted →
+   *  omitted from the Resend payload (mirrors cc; never reply_to: null/"").
+   *  Optional so existing callers/tests that don't care about Reply-To default
+   *  to "none"; the send route always passes composeDelivery's resolved value. */
+  replyTo?: string | null;
   subject: string;
   text: string;
   html: string;
@@ -110,6 +115,7 @@ export async function performDelivery(opts: {
     opts.from,
     opts.to,
     opts.cc,
+    opts.replyTo ?? null,
     opts.subject,
     opts.text,
     opts.html,

--- a/lib/receipts/format.ts
+++ b/lib/receipts/format.ts
@@ -20,6 +20,20 @@ export function formatMonth(month: string): string {
 }
 
 /**
+ * Format a YYYY-MM string as Japanese "2026年10月" — for surfaces where the
+ * month label sits inside a Japanese sentence (the delivery composer header
+ * "2026年6月 の送信", the sealed-undelivered banner, the dashboard alert).
+ * `formatMonth` is en-US ("June 2026"); using it inside a Japanese sentence
+ * produced the mixed-locale "June 2026 の送信" slip (delivery-composer §D).
+ * Falls back to the raw input if the month string is malformed.
+ */
+export function formatMonthJa(month: string): string {
+  const [y, m] = month.split("-").map(Number);
+  if (!y || !m) return month;
+  return `${y}年${m}月`;
+}
+
+/**
  * Format a minor-unit amount as JPY ("¥1,234") when no currency is given
  * or when the currency is JPY. Other currencies are rendered with two
  * decimals and the ISO code.

--- a/lib/receipts/month-closing.ts
+++ b/lib/receipts/month-closing.ts
@@ -302,7 +302,8 @@ export interface ExportBlocker {
     | "compliance"
     | "cross_month"
     | "missing_proof_file"
-    | "message_stale";
+    | "message_stale"
+    | "message_not_reviewed";
   message: string;
   /** In-app destination that lets the operator clear this blocker. */
   href?: string;
@@ -351,9 +352,11 @@ export function validateMonthReadyForExportCoreDetailed(
   // bytes at build time (buildPackNotice runs at rebuild; the notice is sealed
   // + hashed inside the proofs ZIP). Editing it afterwards makes the built
   // bundle stale — the bytes the operator previewed no longer match what
-  // finalize would seal. Require a rebuild (which re-bakes the message and
-  // re-syncs operator_message_updated_at to bundle_built_at) before finalizing.
-  // ISO-8601 strings compare lexicographically in chronological order.
+  // finalize would seal. Require a rebuild (which re-bakes the message) before
+  // finalizing. ISO-8601 strings compare lexicographically in chronological order.
+  // (operator_message_updated_at is no longer re-synced to bundle_built_at at
+  // build — see recordExportBundle — but advancing bundle_built_at past the save
+  // timestamp still clears this gate, so "rebuild after edit" works as before.)
   const build = input.exportBuild;
   if (
     build?.bundleBuiltAt &&
@@ -364,6 +367,23 @@ export function validateMonthReadyForExportCoreDetailed(
       code: "message_stale",
       message:
         "Message edited after the draft was built. Rebuild the draft before finalizing.",
+    });
+  }
+
+  // (1.6) Message reviewed. The companion to E3 for the case E3 cannot see: the
+  // operator never opened the preface at all. operator_message_updated_at is
+  // written ONLY by an explicit decision (save text, or "no message this month"
+  // which writes the timestamp with a NULL message) — recordExportBundle no
+  // longer touches it. So a NULL timestamp on the open draft means no decision
+  // was made, and finalizing would silently ship an empty 【今月のご連絡】 that
+  // is indistinguishable from a deliberate "no message." Force the decision.
+  // This is the server-side gate for the 2026-06 loss (the client dirty-block
+  // catches an unsaved typed draft; this catches a field never opened).
+  if (build && build.operatorMessageUpdatedAt === null) {
+    blockers.push({
+      code: "message_not_reviewed",
+      message:
+        "Decide the monthly message before finalizing: save a preface, or mark “no message this month”.",
     });
   }
 

--- a/lib/receipts/notify.ts
+++ b/lib/receipts/notify.ts
@@ -70,18 +70,24 @@ export interface ResendAttachment {
 }
 
 /** Delivery send via Resend. Extends {@link sendViaResend} with the ZIP
- *  attachment, a Cc recipient, and an `Idempotency-Key` header.
+ *  attachment, a Cc recipient, a Reply-To, and an `Idempotency-Key` header.
  *
  *  B-3: the key is derived from the attempt_id — stable across retries of one
  *  attempt, new per operator send — so a response-timeout retry does not
  *  double-send. On success the provider message id is returned so the caller
- *  can record it on the delivery row. */
+ *  can record it on the delivery row.
+ *
+ *  `replyTo` follows the same doctrine as `cc`: null/empty → the field is
+ *  OMITTED from the payload entirely (never `reply_to: null` / `""`). The
+ *  Reply-To is what keeps an accountant's reply out of the public intake
+ *  address that auto-ingests as a receipt (delivery-composer §B). */
 export async function sendDeliveryViaResend(
   fetchImpl: typeof fetch,
   apiKey: string,
   from: string,
   to: string,
   cc: string | null,
+  replyTo: string | null,
   subject: string,
   text: string,
   html: string,
@@ -103,6 +109,7 @@ export async function sendDeliveryViaResend(
         from,
         to: [to],
         cc: cc ? [cc] : undefined,
+        reply_to: replyTo ? replyTo : undefined,
         subject,
         text,
         html,

--- a/lib/receipts/operator-message.ts
+++ b/lib/receipts/operator-message.ts
@@ -1,0 +1,51 @@
+// Pure helpers for the operator-message (【今月のご連絡】) write path, extracted
+// so the two latent bugs behind the 2026-06 message-loss incident are unit-
+// testable at the DB/route layer without D1/R2 bindings.
+//
+// The incident itself was client-side (a typed preface never saved; see the
+// message_not_reviewed finalize gate for the server-side fix). These helpers
+// close the two SERVER-side latent bugs the investigation turned up:
+//   (A2-1) a no-op UPDATE returning success (assertExactlyOneRowWritten)
+//   (A2-2) a rebuild collapsing "omitted" and "empty string" (resolveOperatorMessageForRebuild)
+
+/**
+ * Resolve the operator message for a rebuild from the request body vs the stored
+ * draft value, DISTINGUISHING omitted from empty string (A2-2).
+ *
+ * - bodyValue `undefined` (the field was not sent) → carry `storedValue` forward.
+ * - bodyValue a string (present, including `""`) → that value wins, trimmed;
+ *   empty/whitespace → `null` (clears the message — a deliberate act).
+ *
+ * The old `bodyValue ?? storedValue` collapsed these: an empty string (present)
+ * is NOT nullish, so `??` let it overwrite the stored value — the same shape as
+ * the 2026-06 loss. "Clearing the message must be a deliberate act, never a side
+ * effect of a rebuild."
+ */
+export function resolveOperatorMessageForRebuild(
+  bodyValue: string | undefined,
+  storedValue: string | null,
+): string | null {
+  return bodyValue !== undefined
+    ? bodyValue.trim() || null
+    : (storedValue ?? null);
+}
+
+/**
+ * Assert that a write affected exactly one row (A2-1). A D1 UPDATE that matches
+ * zero rows returns `meta.changes === 0` with no error; before this guard, the
+ * caller returned 200 and the UI reported "saved," making a lost write
+ * undiagnosable (exactly the 2026-06 signal). Now any departure from exactly one
+ * row throws — the write either persisted or the operator sees a 500. `context`
+ * names the writer in the message so the audit trail is diagnosis-ready.
+ */
+export function assertExactlyOneRowWritten(
+  rowsWritten: number,
+  context: string,
+): void {
+  if (rowsWritten !== 1) {
+    throw new Error(
+      `${context}: wrote ${rowsWritten} rows (expected 1). The value was NOT persisted — ` +
+        "the target row was sealed, removed, or never existed between the read and the write.",
+    );
+  }
+}

--- a/lib/receipts/operator-message.ts
+++ b/lib/receipts/operator-message.ts
@@ -9,25 +9,55 @@
 //   (A2-2) a rebuild collapsing "omitted" and "empty string" (resolveOperatorMessageForRebuild)
 
 /**
- * Resolve the operator message for a rebuild from the request body vs the stored
- * draft value, DISTINGUISHING omitted from empty string (A2-2).
+ * Resolve the operator message from the request body vs the stored draft value,
+ * DISTINGUISHING omitted from an explicit decision (A2-2 / Codex P1 on #169).
  *
- * - bodyValue `undefined` (the field was not sent) → carry `storedValue` forward.
+ * - bodyValue `undefined` (the field was not sent) → carry `storedValue` forward
+ *   (a rebuild that omits the field keeps the stored message).
+ * - bodyValue `null` → explicit "no message this month" → `null`.
  * - bodyValue a string (present, including `""`) → that value wins, trimmed;
  *   empty/whitespace → `null` (clears the message — a deliberate act).
  *
  * The old `bodyValue ?? storedValue` collapsed these: an empty string (present)
  * is NOT nullish, so `??` let it overwrite the stored value — the same shape as
  * the 2026-06 loss. "Clearing the message must be a deliberate act, never a side
- * effect of a rebuild."
+ * effect of a rebuild." The one-shot finalize path uses omitted (`undefined`) as
+ * "no decision supplied" → the route blocks, rather than silently bypassing the
+ * message_not_reviewed gate.
  */
 export function resolveOperatorMessageForRebuild(
-  bodyValue: string | undefined,
+  bodyValue: string | null | undefined,
   storedValue: string | null,
 ): string | null {
-  return bodyValue !== undefined
-    ? bodyValue.trim() || null
-    : (storedValue ?? null);
+  if (bodyValue === undefined) return storedValue ?? null;
+  if (bodyValue === null) return null;
+  return bodyValue.trim() || null;
+}
+
+/**
+ * The one-shot finalize decision from the request body (Codex P1 on #169). The
+ * caller must state it explicitly so the path cannot bypass message_not_reviewed:
+ * - `operatorMessage: "<text>"` → preface text.
+ * - `operatorMessage: null` or `""` → explicit "no message this month."
+ * - omitted (`undefined`) → NO decision → `{ ok: false }` and the route blocks
+ *   with a message naming the field, rather than silently finalizing with an
+ *   empty 【今月のご連絡】.
+ *
+ * Chosen over a separate `messageDecision: "none"` flag: it reuses the existing
+ * `operatorMessage` field and the field-PRESENCE doctrine (omitted ≠ present)
+ * already used by the rebuild path, so one field means one thing across both
+ * routes. Nothing calls this path today (no UI, no tests, no scripts — only docs
+ * describe it), so the contract change has zero caller breakage.
+ */
+export function oneShotFinalizeDecision(
+  operatorMessage: string | null | undefined,
+):
+  | { ok: true; operatorMessage: string | null }
+  | { ok: false; reason: "no-decision" } {
+  if (operatorMessage === undefined) {
+    return { ok: false, reason: "no-decision" };
+  }
+  return { ok: true, operatorMessage: resolveOperatorMessageForRebuild(operatorMessage, null) };
 }
 
 /**

--- a/lib/receipts/settings.ts
+++ b/lib/receipts/settings.ts
@@ -27,6 +27,9 @@ export const COMPLIANCE_DEFAULTS: ComplianceSettings = {
   // Delivery-composer decision 3: email-only signature, appended after the
   // sealed notice's closing line. Empty default; composer maps empty → null.
   delivery_signature: "",
+  // Delivery Reply-To: where an accountant's reply lands. Empty = omitted from
+  // the Resend payload (no reply_to). Target tazukowen@gmail.com.
+  delivery_reply_to: "",
   // ADR 0010 D3: verbatim former TOKYO_SIGNALS. Behavior unchanged until the
   // operator edits Settings → Compliance.
   homebase_signals: DEFAULT_HOMEBASE_SIGNALS,
@@ -125,6 +128,8 @@ export function parseComplianceSettings(
       COMPLIANCE_DEFAULTS.notification_cc_recipient,
     delivery_signature:
       map.get("delivery_signature") ?? COMPLIANCE_DEFAULTS.delivery_signature,
+    delivery_reply_to:
+      map.get("delivery_reply_to") ?? COMPLIANCE_DEFAULTS.delivery_reply_to,
     homebase_signals: parseHomebaseSignals(map.get("homebase_signals")),
   };
 }

--- a/lib/receipts/types.ts
+++ b/lib/receipts/types.ts
@@ -537,13 +537,21 @@ export interface ReceiptExport {
   // build time, and into the delivery email body at send time. NULL when no
   // message.
   operator_message?: string | null;
-  // Last-write timestamp for operator_message (0039 / E3). The preface is frozen
-  // into the sealed bytes at build time, so editing it after a build makes the
-  // built bundle stale. The finalize gate compares this against bundle_built_at
-  // (operator_message_updated_at > bundle_built_at ⇒ message_stale). NULL on
-  // legacy rows predating 0039 (no staleness signal — no blocker, matching
-  // pre-E3 behaviour). Written in lockstep with bundle_built_at by
-  // recordExportBundle, and alone by updateExportOperatorMessage.
+  // operator_message_updated_at is the DECISION timestamp — it records the last
+  // time the operator made an explicit preface decision (saving text, or "no
+  // message this month" which stores NULL text + this timestamp). It is written
+  // ONLY by updateExportOperatorMessage (the PATCH /message route). recordExportBundle
+  // (rebuild + finalize) deliberately does NOT write it — doing so at rebuild would
+  // forge a decision the operator never made. NULL therefore reliably means "never
+  // decided," which the finalize gate asserts two ways:
+  //   - message_not_reviewed fires when this is NULL on an open draft (force a
+  //     decision before sealing — the 2026-06 loss fix).
+  //   - message_stale fires when this is set AND > bundle_built_at (the preface is
+  //     frozen into the sealed bytes at build, so an edit after the build makes the
+  //     bundle stale). A rebuild clears staleness because bundle_built_at advances
+  //     past this timestamp — no lockstep write needed (the old lockstep was removed
+  //     because it forged decisions; see db.ts recordExportBundle + the
+  //     operator-message-contract test).
   operator_message_updated_at?: string | null;
 }
 

--- a/lib/receipts/types.ts
+++ b/lib/receipts/types.ts
@@ -664,6 +664,12 @@ export interface ComplianceSettings {
    *  email boundary. Does NOT enter the sealed pack notice (buildPackNotice is
    *  unchanged) — it is a transport-layer adornment on the delivery email only. */
   delivery_signature: string;
+  /** Reply-To for the monthly pack delivery email. Distinct from the From
+   *  address (which is a no-reply-style verified sender on the Resend domain) so
+   *  an accountant's reply lands in the operator's inbox, not the public intake
+   *  address that auto-ingests as a receipt. Empty = the Reply-To field is
+   *  omitted from the Resend payload entirely (never reply_to: null / ""). */
+  delivery_reply_to: string;
   /**
    * Homebase location signals (ADR 0010 D3). A merchant whose string carries
    * one of these is treated as an at-homebase charge (not a trip anchor).

--- a/tests/receipts/codex-169-foldins.test.ts
+++ b/tests/receipts/codex-169-foldins.test.ts
@@ -1,0 +1,107 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { oneShotFinalizeDecision } from "@/lib/receipts/operator-message";
+
+// Regression tests for the two Codex findings folded into #169.
+
+// ─── §1: one-shot finalize must not bypass message_not_reviewed ────────────────
+//
+// The gate keys on operator_message_updated_at, which is NULL on a fresh draft.
+// So the one-shot finalize caller must state the decision explicitly; the route
+// writes it (setting the timestamp) THEN validates. oneShotFinalizeDecision is
+// the pure require-check the route uses.
+
+test("§1 one-shot: omitted operatorMessage ⇒ no decision (the route blocks, not silently bypasses)", () => {
+  const d = oneShotFinalizeDecision(undefined);
+  assert.equal(d.ok, false);
+  if (!d.ok) assert.equal(d.reason, "no-decision");
+});
+
+test("§1 one-shot: explicit text proceeds and is trimmed", () => {
+  const d = oneShotFinalizeDecision("  今月は出張費が多めです。  ");
+  assert.equal(d.ok, true);
+  if (d.ok) assert.equal(d.operatorMessage, "今月は出張費が多めです。");
+});
+
+test("§1 one-shot: null ⇒ explicit 'no message' (proceeds with NULL)", () => {
+  // The chosen contract: operatorMessage: null means "no message this month" —
+  // a real decision, distinct from omitted (undefined). The route writes the
+  // timestamp with a NULL message, exactly as the "no message" UI control does.
+  const d = oneShotFinalizeDecision(null);
+  assert.equal(d.ok, true);
+  if (d.ok) assert.equal(d.operatorMessage, null);
+});
+
+test("§1 one-shot: empty string ⇒ also 'no message' (proceeds with NULL)", () => {
+  const d = oneShotFinalizeDecision("");
+  assert.equal(d.ok, true);
+  if (d.ok) assert.equal(d.operatorMessage, null);
+});
+
+test("§1 one-shot: the two decision forms (text vs none) are distinguishable from no-decision", () => {
+  assert.equal(oneShotFinalizeDecision(undefined).ok, false);
+  assert.equal(oneShotFinalizeDecision("text").ok, true);
+  assert.equal(oneShotFinalizeDecision(null).ok, true);
+  assert.equal(oneShotFinalizeDecision("").ok, true);
+});
+
+test("§1 route: the one-shot finalize path requires the decision (wired to oneShotFinalizeDecision)", () => {
+  // Structural proof the route actually blocks (not just that the helper exists).
+  // Fails against the pre-fix route, which validated before createExport with
+  // exportBuild=null and let an undecided one-shot through.
+  const src = readFileSync("app/api/receipts/export/month/route.ts", "utf8");
+  assert.ok(
+    /oneShotFinalizeDecision\(body\.operatorMessage\)/.test(src),
+    "the finalize path decides from body.operatorMessage via oneShotFinalizeDecision",
+  );
+  assert.ok(
+    /if \(!decision\.ok\)/.test(src),
+    "the route returns 400 when no decision was supplied",
+  );
+  // And the decision is written before validate (sets the timestamp the gate reads).
+  const writeIdx = src.indexOf("updateExportOperatorMessage(exportId, operatorMessage)");
+  const validateIdx = src.indexOf("validateMonthReadyForExport(", writeIdx);
+  assert.ok(writeIdx > -1 && validateIdx > writeIdx, "decision-write precedes validate on the finalize path");
+});
+
+// ─── §2: a verified save refreshes the server-rendered gate; a failed save does not ──
+//
+// PrefaceEditor is a client component; the repo deliberately uses no jsdom, so
+// this is a STRUCTURAL source assertion (the capture-contract pattern): persist
+// must call router.refresh(), and the call must sit AFTER the !res.ok early
+// return so a failed/unverified save never triggers it. (A behavioral component
+// test would require adding jsdom, which this codebase has chosen not to do.)
+
+test("§2 preface save: router.refresh() is called, and only reachable on the verified-save (res.ok) path", () => {
+  // Strip comment lines first so a comment mentioning router.refresh() can't
+  // masquerade as the call (the same hole that let the June bug hide behind a
+  // stale doc comment).
+  const raw = readFileSync("components/receipts/export/preface-editor.tsx", "utf8");
+  const src = raw
+    .split("\n")
+    .filter((l) => {
+      const t = l.trim();
+      return !(t.startsWith("//") || t.startsWith("*") || t.startsWith("/*"));
+    })
+    .join("\n");
+  const persistStart = src.indexOf("async function persist");
+  assert.ok(persistStart >= 0, "persist() exists");
+  // persist() runs up to the next const declaration (save / decideNoMessage).
+  const persistBody = src.slice(
+    persistStart,
+    src.indexOf("const save", persistStart),
+  );
+  assert.ok(
+    persistBody.includes("router.refresh()"),
+    "a verified save must call router.refresh() so the server-rendered gate (message_not_reviewed → message_stale) updates",
+  );
+  // The refresh must be gated by the verified save — i.e. reached only AFTER the
+  // `if (!res.ok) { … return }` early-return, never on the failure path.
+  const notOkReturn = persistBody.indexOf("!res.ok");
+  const refreshCall = persistBody.indexOf("router.refresh()");
+  assert.ok(
+    notOkReturn > -1 && refreshCall > notOkReturn,
+    "router.refresh() must come after the !res.ok early-return (failed/unverified save must not refresh)",
+  );
+});

--- a/tests/receipts/delivery-compose.test.ts
+++ b/tests/receipts/delivery-compose.test.ts
@@ -12,7 +12,7 @@ import { buildDeliveryEmail } from "@/lib/receipts/delivery-send";
 //     ComposedDelivery.configErrors; composeDelivery calls this with resolved
 //     values, so these paths are unit-testable without D1/R2 bindings) ──────────
 
-const VALID = { to: "cpa@example.com", cc: null, from: "notify@dazbeez.com", hasResendKey: true };
+const VALID = { to: "cpa@example.com", cc: null, replyTo: null, from: "notify@dazbeez.com", hasResendKey: true };
 
 test("configErrors: empty when fully configured (happy path)", () => {
   assert.deepEqual(computeDeliveryConfigErrors(VALID), []);
@@ -41,15 +41,28 @@ test("configErrors: invalid Cc → names the bad Cc (null Cc is fine)", () => {
   );
 });
 
+test("configErrors: invalid Reply-To → names the bad address (null Reply-To is fine)", () => {
+  const errs = computeDeliveryConfigErrors({ ...VALID, replyTo: "bad-reply" });
+  assert.ok(
+    errs.some((e) => e.includes("Reply-To is not a valid") && e.includes("bad-reply")),
+  );
+  // null Reply-To alone is NOT an error (Reply-To is optional → omitted).
+  assert.deepEqual(
+    computeDeliveryConfigErrors({ ...VALID, replyTo: null }),
+    [],
+    "null Reply-To is valid (omitted from payload)",
+  );
+});
+
 test("configErrors: no Resend key → 'Delivery not configured'", () => {
   const errs = computeDeliveryConfigErrors({ ...VALID, hasResendKey: false });
-  assert.ok(errs.some((e) => e.includes("RESEND_API_KEY / NOTIFY_FROM_ADDRESS")));
+  assert.ok(errs.some((e) => e.includes("RESEND_API_KEY / DELIVERY_FROM_ADDRESS")));
   assert.equal(errs.length, 1);
 });
 
 test("configErrors: no From address → same 'Delivery not configured' message", () => {
   const errs = computeDeliveryConfigErrors({ ...VALID, from: null });
-  assert.ok(errs.some((e) => e.includes("RESEND_API_KEY / NOTIFY_FROM_ADDRESS")));
+  assert.ok(errs.some((e) => e.includes("RESEND_API_KEY / DELIVERY_FROM_ADDRESS")));
   assert.equal(errs.length, 1);
 });
 
@@ -57,6 +70,7 @@ test("configErrors: multiple problems accumulate (no To AND no key)", () => {
   const errs = computeDeliveryConfigErrors({
     to: null,
     cc: null,
+    replyTo: null,
     from: null,
     hasResendKey: false,
   });

--- a/tests/receipts/delivery-send.test.ts
+++ b/tests/receipts/delivery-send.test.ts
@@ -109,6 +109,38 @@ test("performDelivery: cc=null omits the Cc field from the Resend body (never cc
   assert.equal(body.cc, undefined, "unset Cc ⇒ field absent from the payload (not null / not [])");
 });
 
+test("performDelivery: an omitted Reply-To omits reply_to from the Resend body (never reply_to: null)", async () => {
+  const { fetchImpl, calls } = fakeResend({ ok: true });
+  await performDelivery({
+    fetchImpl: fetchImpl as unknown as typeof fetch,
+    apiKey: "key", from: "from@dazbeez.com", to: "cpa@example.com", cc: null,
+    // replyTo omitted entirely → defaults to null → omitted from the payload
+    // (the cc doctrine: unset ⇒ absent, never reply_to: null / "").
+    subject: "【領収証憑】2026年6月", text: "body", html: "<p>body</p>",
+    zipFilename: "202606_Dazbeez_Monthly_Expense_Report.zip",
+    zipBytes: new Uint8Array([0x50, 0x4b, 0x03, 0x04]),
+    idempotencyKey: "dazbeez-delivery-no-reply",
+  });
+  assert.equal(calls.length, 1);
+  const body = JSON.parse(calls[0]!.init.body as string);
+  assert.equal(body.reply_to, undefined, "unset Reply-To ⇒ field absent from the payload");
+});
+
+test("performDelivery: a set Reply-To is carried as reply_to in the Resend body", async () => {
+  const { fetchImpl, calls } = fakeResend({ ok: true });
+  await performDelivery({
+    fetchImpl: fetchImpl as unknown as typeof fetch,
+    apiKey: "key", from: "monthlyreport@dazbeez.com", to: "cpa@example.com", cc: null,
+    replyTo: "tazukowen@gmail.com",
+    subject: "s", text: "t", html: "h",
+    zipFilename: "pack.zip",
+    zipBytes: new Uint8Array(10),
+    idempotencyKey: "dazbeez-delivery-with-reply",
+  });
+  const body = JSON.parse(calls[0]!.init.body as string);
+  assert.equal(body.reply_to, "tazukowen@gmail.com", "set Reply-To ⇒ carried on the payload");
+});
+
 test("performDelivery: an oversized pack throws BEFORE any Resend call (B-1)", async () => {
   const { fetchImpl, calls } = fakeResend({ ok: true });
   await assert.rejects(

--- a/tests/receipts/month-closing.test.ts
+++ b/tests/receipts/month-closing.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import {
   validateMonthReadyForExportCore,
+  validateMonthReadyForExportCoreDetailed,
   type ExportBundle,
   type ValidateMonthReadyInput,
 } from "@/lib/receipts/month-closing";
@@ -137,6 +138,44 @@ function makeInput(overrides: Partial<ValidateMonthReadyInput> = {}): ValidateMo
 
 test("gate core: clean input returns no blockers", () => {
   assert.deepEqual(validateMonthReadyForExportCore(makeInput()), []);
+});
+
+// (1.6) message_not_reviewed — the server-side fix for the 2026-06 loss. A draft
+// whose operator_message decision timestamp is NULL (the operator never saved a
+// preface nor clicked "no message") must block finalize, so an empty
+// 【今月のご連絡】 can't ship indistinguishable from a deliberate "no message."
+// operator_message_updated_at is written ONLY by an explicit decision now
+// (recordExportBundle no longer touches it), so NULL reliably means undecided.
+test("gate 1.6 (message_not_reviewed): a draft with no message decision blocks finalize", () => {
+  const blockers = validateMonthReadyForExportCoreDetailed(
+    makeInput({
+      exportBuild: { bundleBuiltAt: "2026-08-11T00:00:00Z", operatorMessageUpdatedAt: null },
+    }),
+  );
+  assert.ok(
+    blockers.some((b) => b.code === "message_not_reviewed"),
+    `expected message_not_reviewed; got ${JSON.stringify(blockers)}`,
+  );
+});
+
+test("gate 1.6: a decided message (timestamp set) does NOT block on message_not_reviewed", () => {
+  const blockers = validateMonthReadyForExportCoreDetailed(
+    makeInput({
+      exportBuild: { bundleBuiltAt: "2026-08-11T00:00:00Z", operatorMessageUpdatedAt: "2026-08-11T01:00:00Z" },
+    }),
+  );
+  assert.ok(
+    !blockers.some((b) => b.code === "message_not_reviewed"),
+    `a decided message must not block; got ${JSON.stringify(blockers)}`,
+  );
+});
+
+test("gate 1.6: no draft (exportBuild null) → no message_not_reviewed (nothing to decide)", () => {
+  const blockers = validateMonthReadyForExportCoreDetailed(makeInput());
+  assert.ok(
+    !blockers.some((b) => b.code === "message_not_reviewed"),
+    "no open draft ⇒ no message decision required",
+  );
 });
 
 // (1) Statement-sealed

--- a/tests/receipts/operator-message-contract.test.ts
+++ b/tests/receipts/operator-message-contract.test.ts
@@ -1,0 +1,78 @@
+// The structural invariant behind the 2026-06 message-loss fix, asserted at the
+// source tree (same shape as the capture-contract test for #18). The bug hid
+// partly because no test pinned the old lockstep — so breaking it was silent.
+//
+// operator_message_updated_at is the DECISION timestamp:
+//   - written ONLY by updateExportOperatorMessage (the PATCH /message route: a
+//     saved preface, or an explicit "no message this month");
+//   - NEVER written by recordExportBundle (rebuild + finalize), because doing so
+//     at rebuild would forge a decision the operator never made and destroy the
+//     NULL signal that the message_not_reviewed finalize gate depends on.
+// NULL ⇒ never decided ⇒ message_not_reviewed blocks finalize (the downstream
+// assertion lives in month-closing.test.ts; this file pins the upstream cause:
+// a rebuild cannot clear NULL because it does not touch the timestamp).
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+/** Strip full-line comments (// …, * …, /*) so docstrings discussing the
+ *  timestamp don't read as code. Mirrors the capture-contract test. */
+function stripCommentLines(src: string): string {
+  return src
+    .split("\n")
+    .filter((l) => {
+      const t = l.trim();
+      return !(t.startsWith("//") || t.startsWith("*") || t.startsWith("/*"));
+    })
+    .join("\n");
+}
+
+/** The body of a named `export async function`, up to the next one. */
+function functionBody(src: string, name: string): string {
+  const start = src.indexOf(`export async function ${name}`);
+  assert.ok(start >= 0, `${name} not found in db.ts`);
+  const next = src.indexOf("export async function", start + 10);
+  return src.slice(start, next === -1 ? undefined : next);
+}
+
+const DB = stripCommentLines(readFileSync("lib/receipts/db.ts", "utf8"));
+
+test("recordExportBundle (rebuild + finalize) advances bundle_built_at but NOT operator_message_updated_at", () => {
+  const body = functionBody(DB, "recordExportBundle");
+  // A rebuild clears message_stale by advancing bundle_built_at past the save
+  // timestamp — that is the ONLY timestamp it touches.
+  assert.ok(
+    /bundle_built_at\s*=/.test(body),
+    "recordExportBundle advances bundle_built_at (this is what clears message_stale on rebuild)",
+  );
+  // …and it must NOT write the decision timestamp. The old lockstep wrote both
+  // to now; that forged a decision at rebuild and is why NULL could not be
+  // trusted as "never decided."
+  assert.ok(
+    !/operator_message_updated_at\s*=/.test(body),
+    "recordExportBundle must NOT write operator_message_updated_at — a rebuild/finalize forging a decision would destroy the NULL signal message_not_reviewed depends on",
+  );
+});
+
+test("updateExportOperatorMessage is the SOLE writer of operator_message_updated_at", () => {
+  assert.ok(
+    /operator_message_updated_at\s*=/.test(functionBody(DB, "updateExportOperatorMessage")),
+    "updateExportOperatorMessage must write the decision timestamp (save / 'no message')",
+  );
+  // And nothing outside db.ts writes it.
+  const writers = execFileSync(
+    "grep",
+    ["-rlE", "operator_message_updated_at\\s*=", "lib/", "app/"],
+    { encoding: "utf8" },
+  )
+    .trim()
+    .split("\n")
+    .filter(Boolean);
+  assert.deepEqual(
+    writers,
+    ["lib/receipts/db.ts"],
+    "operator_message_updated_at may be written only in db.ts (by updateExportOperatorMessage)",
+  );
+});

--- a/tests/receipts/operator-message.test.ts
+++ b/tests/receipts/operator-message.test.ts
@@ -1,0 +1,69 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  resolveOperatorMessageForRebuild,
+  assertExactlyOneRowWritten,
+} from "@/lib/receipts/operator-message";
+
+// Regression for the two SERVER-side latent bugs behind the 2026-06 message-loss
+// incident (the incident itself was client-side — see the message_not_reviewed
+// finalize gate). Both helpers are pure so the regressions are unit-testable
+// without D1/R2 bindings. Each test documents the OLD (buggy) behaviour it
+// replaces in the comment, so the "fails against current code" run is implicit:
+// the old `body.operatorMessage ?? stored` and the old no-rows-written-OK path
+// cannot satisfy these assertions.
+
+// ─── A2-2: omitted ≠ empty (resolveOperatorMessageForRebuild) ─────────────────
+
+test("rebuild resolve: an OMITTED body field preserves the stored value", () => {
+  // OLD `body ?? stored`: undefined is nullish → returned stored. Same result
+  // here, but this case must keep working after the field-presence rewrite.
+  assert.equal(resolveOperatorMessageForRebuild(undefined, "保存済みの文面"), "保存済みの文面");
+});
+
+test("rebuild resolve: an explicit EMPTY STRING clears the message (null) — distinguishable from omitted", () => {
+  // OLD `body ?? stored`: "" is NOT nullish, so `??` returned "" — but then it
+  // was bound as operator_message and overwrote the stored value. The bug:
+  // a rebuild carrying "" silently nulled the stored message. The fix: "" is a
+  // deliberate clear → null. This is the §3 "omitted vs empty distinguishable" test.
+  assert.equal(resolveOperatorMessageForRebuild("", "保存済みの文面"), null);
+  assert.notEqual(
+    resolveOperatorMessageForRebuild(undefined, "保存済みの文面"),
+    resolveOperatorMessageForRebuild("", "保存済みの文面"),
+    "omitted (→ stored) and empty (→ null) MUST differ",
+  );
+});
+
+test("rebuild resolve: an explicit non-empty value wins over the stored value", () => {
+  assert.equal(resolveOperatorMessageForRebuild("新しい文面", "古い文面"), "新しい文面");
+});
+
+test("rebuild resolve: whitespace-only body trims to null (clear)", () => {
+  assert.equal(resolveOperatorMessageForRebuild("   \n  ", "保存済み"), null);
+});
+
+test("rebuild resolve: omitted with no stored value → null", () => {
+  assert.equal(resolveOperatorMessageForRebuild(undefined, null), null);
+});
+
+// ─── A2-1: a no-op UPDATE is an error, not a silent 200 (assertExactlyOneRowWritten) ──
+
+test("rows-written guard: exactly one row is accepted", () => {
+  assert.doesNotThrow(() => assertExactlyOneRowWritten(1, "updateExportOperatorMessage(x)"));
+});
+
+test("rows-written guard: zero rows throws (a no-op UPDATE must surface, not return 200)", () => {
+  // OLD path: 0 rows → D1 success → route 200 → UI "saved". The 2026-06 loss
+  // was hard to diagnose partly because a no-op write looked like success.
+  assert.throws(
+    () => assertExactlyOneRowWritten(0, "updateExportOperatorMessage(x)"),
+    /wrote 0 rows.*NOT persisted/,
+  );
+});
+
+test("rows-written guard: two rows throws (a write affecting more than one row is wrong)", () => {
+  assert.throws(
+    () => assertExactlyOneRowWritten(2, "updateExportOperatorMessage(x)"),
+    /wrote 2 rows.*NOT persisted/,
+  );
+});


### PR DESCRIPTION
Three operator-found defects on the sealed-but-unsent **2026-06** confirm screen, plus the two Codex findings folded in after review. **A is a P0 data-loss bug.** June is **not** sent; no revision created.

## A. The saved preface that silently vanished (P0)

**Investigation (read-only, before any fix):** NO \`export.message_updated\` audit row exists for **any** month in 7 days. The message route audits *after* the UPDATE and returns 200, and the “saved” indicator only fires on \`res.ok\` — so a successful save **always** leaves an audit row. None exists ⇒ the operator never saw a successful save.

This **eliminated all three server-side candidates**: silent no-op UPDATE (real latent bug, but would still have audited); rebuild \`??\` empty-string override (latent, but nothing was saved to override); finalize null-write (finalize forwards the value correctly). **The loss was client-side** — a typed preface never saved (no autosave, by design) before Finalize. The text is **not in the audit log** — unrecoverable without a revision.

**Fixes:** \`message_not_reviewed\` blocker (NULL decision timestamp ⇒ block); **decoupled \`recordExportBundle\` from \`operator_message_updated_at\`** (keeps the value for O7; the timestamp is written only by an explicit decision, so NULL reliably = undecided; \`message_stale\` still clears on rebuild); “今月はメッセージなし” control; client dirty-block (\`PrefaceFinalizeSection\`); A2 hardening (\`assertExactlyOneRowWritten\` + \`resolveOperatorMessageForRebuild\` distinguishes omitted from empty). The decouple is pinned by a source-tree contract test (the architect verified the lockstep was only ever a staleness-clearing mechanism, now actively wrong).

## B. Delivery sender identity — replies land in the receipt parser (P1)
\`getDeliveryFromAddress()\` (DELIVERY_FROM_ADDRESS ?? NOTIFY_FROM_ADDRESS); \`reply_to\` support (cc doctrine); \`delivery_reply_to\` setting + migration 0041; \`ComposedDelivery\` carries \`from\`+\`replyTo\`; composer renders Reply-To. ⚠️ **Operator action:** verify \`monthlyreport@dazbeez.com\` on Resend, set the \`DELIVERY_FROM_ADDRESS\` secret, route it in Email Routing (not bound to the intake worker). Could not verify the Resend domain myself (no API key from the CLI).

## C. Cc field was unreachable in Settings (P1)
Rendered \`notification_cc_recipient\` beside the recipient (PATCH already validated it).

## D. Mixed-locale month label
\`formatMonthJa\` (“2026年6月”) for delivery surfaces.

## Codex fold-ins (after review)
- **P1 — one-shot finalize bypassed \`message_not_reviewed\`:** \`month/route.ts\` validated before \`createExport\`, so with no draft the gate couldn’t fire. The caller now states the decision explicitly via \`oneShotFinalizeDecision\` (\`operatorMessage\` text, or \`null\`/\`""\` for no-message; omitted ⇒ 400); it’s written (setting the timestamp) before the gate runs. The finalize-only route (UI + June revision) is **unchanged**.
- **P2 — stale blockers after saving the preface:** \`PrefaceEditor\` now \`router.refresh()\` on a verified save so the server-rendered gate updates.
- **P2 — legacy forged timestamps: NOT fixed, by decision.** Before the decouple, \`recordExportBundle\` wrote \`operator_message_updated_at\` on every rebuild, so an open draft rebuilt pre-fix would carry a forged non-null timestamp the gate would read as “decided.” The forged-timestamp window **closed when \`recordExportBundle\` stopped writing the column**; the only rebuilt draft (2026-06) was already finalized before the change, and the two open drafts (2026-05, 2026-07) are unbuilt with NULL timestamps (zero affected rows). The population cannot grow. No migration.

## Verification
\`tsc --noEmit\` clean; \`npm test\` **1237 pass / 0 fail**; \`npm run build:cf\` green. Fail-then-pass shown for: each A cause (old-vs-new logic demo; \`message_not_reviewed\` disable→fail→restore→pass); the decision-timestamp contract test (lockstep re-added ⇒ fail); §1 (decision-write removed ⇒ “decision-write precedes validate” fails); §2 (refresh removed ⇒ fails; comment-stripped). The finalize-only route is byte-unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)