### PR TITLE
fix(receipts): composition hash — reject stale-render sends (Codex P1 #2)

### DIFF
--- a/app/api/receipts/export/[month]/send/route.ts
+++ b/app/api/receipts/export/[month]/send/route.ts
@@ -47,10 +47,15 @@ type RouteContext = { params: Promise<{ month: string }> };
  *    from the composed result — no re-run); a preflight failure is audited and
  *    blocks before any delivery row is created.
  *
- * The POST body is IGNORED. Subject/body/To/Cc are NEVER accepted from the
- * client — they are re-composed server-side from the sealed pack + Settings via
- * composeDelivery (delivery-composer decision 2). A client that posts an edited
- * body has no way to change what is sent.
+ * The POST body carries ONLY `{ compositionHash }` (Item 2) — the fingerprint of
+ * the composition the operator reviewed. Subject/body/To/Cc are NEVER accepted
+ * from the client (they are re-composed server-side from the sealed pack +
+ * Settings via composeDelivery — delivery-composer decision 2); the hash is a
+ * staleness check, not content. The route recomposes, recomputes its own hash,
+ * and on mismatch 409s with the fresh composition so a stale render (Settings
+ * edited, or a new revision finalized) can never silently send a different
+ * body/recipient/pack. A client that posts an edited body still has no way to
+ * change what is sent.
  *
  * `force_new` is the DISTINCT override for the double-send guard (D6). Without
  * it: a resumeable pending is RESUMED (same attempt_id ⇒ same key ⇒ Resend
@@ -67,9 +72,20 @@ export async function POST(request: Request, { params }: RouteContext) {
       return NextResponse.json({ error: "Invalid month format." }, { status: 400 });
     }
     const forceNew = new URL(request.url).searchParams.get("force_new") === "true";
-    // The request body is deliberately unread — subject/body/To/Cc are never
-    // accepted from the client (decision 2). Send proceeds solely from the
-    // sealed pack + Settings via composeDelivery below.
+    // The request body carries ONLY the compositionHash fingerprint (Item 2) —
+    // never subject/body/To/Cc (decision 2 stands: those are recomposed
+    // server-side from the sealed pack + Settings via composeDelivery below).
+    // The hash is a staleness check, not content; an absent/invalid hash (direct
+    // POST, pre-hash client) simply skips the check.
+    let postedCompositionHash: string | undefined;
+    try {
+      const body = (await request.json()) as { compositionHash?: unknown };
+      if (typeof body?.compositionHash === "string") {
+        postedCompositionHash = body.compositionHash;
+      }
+    } catch {
+      // No JSON body — pre-hash caller; the integrity check is skipped.
+    }
 
     // ── Load the sealed export (D1: send is post-seal) ───────────────────────
     const exportRecord = await getLatestFinalizedExport(month);
@@ -164,6 +180,25 @@ export async function POST(request: Request, { params }: RouteContext) {
           configErrors: composed.configErrors,
         },
         { status: 422 },
+      );
+    }
+
+    // ── Item 2: composition-integrity check. If the client posted a
+    //    compositionHash, the composition it reviewed must equal the one we just
+    //    recomposed. A mismatch means To/Cc/signature changed in Settings, or a
+    //    new revision was finalized, after the page rendered — Send would
+    //    deliver a different body / recipient / pack than the operator reviewed.
+    //    REJECT (409) with the FRESH composition so the UI re-renders and asks
+    //    for re-confirmation. Never silently proceed; never warn-and-continue.
+    if (postedCompositionHash && postedCompositionHash !== composed.compositionHash) {
+      return NextResponse.json(
+        {
+          error:
+            "Composition changed since you reviewed it. Please re-confirm the updated delivery.",
+          compositionStale: true,
+          composition: composed,
+        },
+        { status: 409 },
       );
     }
 

--- a/components/receipts/export/delivery-composer.tsx
+++ b/components/receipts/export/delivery-composer.tsx
@@ -7,19 +7,27 @@ import type { ComposedDelivery } from "@/lib/receipts/delivery-compose";
 /**
  * Delivery composer UI (delivery-composer §4). Renders the server-composed
  * delivery (From/To/Cc, subject, body, attachment, preflight) READ-ONLY and
- * provides the two-step Confirm → Send flow. The Send button posts an EMPTY
- * body to POST /api/receipts/export/{month}/send — the route recomposes
- * server-side from the sealed pack + Settings, so a client cannot change what is
- * sent (decision 2). Sealing ≠ closing (decision 5): every string respects that
- * the seal is the midpoint, delivery closes the month for reporting.
+ * provides the two-step Confirm → Send flow. The Send button posts ONLY the
+ * `{ compositionHash }` fingerprint to POST /api/receipts/export/{month}/send
+ * — the route recomposes server-side from the sealed pack + Settings, compares
+ * its own hash, and 409s on mismatch, so a client cannot change what is sent
+ * (decision 2) and a stale render cannot silently send a different pack (Item
+ * 2). Sealing ≠ closing (decision 5): the seal is the midpoint, delivery closes
+ * the month for reporting.
  */
 export function DeliveryComposer({
-  composed,
+  composed: initialComposed,
   monthLabel,
 }: {
   composed: ComposedDelivery;
   monthLabel: string;
 }) {
+  // The composition can change under the operator (a Settings edit, or a new
+  // revision finalized while the page is open). Hold it in state so a 409
+  // composition-stale response can swap in the FRESH composition and require
+  // re-confirmation (Item 2) — never silently send a different pack than the
+  // one reviewed.
+  const [composed, setComposed] = useState(initialComposed);
   const month = composed.month;
   const hasBytes = composed.zipSha256.length > 0;
   const configBlocked = composed.configErrors.length > 0 || !hasBytes;
@@ -47,8 +55,14 @@ export function DeliveryComposer({
     setError(null);
     try {
       const url = `/api/receipts/export/${month}/send${forceNew ? "?force_new=true" : ""}`;
-      // Empty body: subject/body/To/Cc are NEVER sent from the client (decision 2).
-      const res = await fetch(url, { method: "POST" });
+      // Body carries ONLY the compositionHash fingerprint — never
+      // subject/body/To/Cc (decision 2). The route recomposes server-side and
+      // compares this hash to detect a stale render (Item 2).
+      const res = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ compositionHash: composed.compositionHash }),
+      });
       const data = (await res.json().catch(() => ({}))) as {
         state?: string;
         error?: string;
@@ -57,6 +71,8 @@ export function DeliveryComposer({
         reason?: string;
         classification?: string;
         resumable?: boolean;
+        compositionStale?: boolean;
+        composition?: ComposedDelivery;
       };
       if (res.ok && data.state === "delivered") {
         setSentInfo({
@@ -68,6 +84,22 @@ export function DeliveryComposer({
         return;
       }
       if (res.status === 409) {
+        // Composition-stale (Item 2): the composition changed between render and
+        // send (Settings edited, or a new revision finalized). Replace the
+        // displayed composition with the FRESH one from the route and require
+        // re-confirmation — never silently send the updated pack. Distinct from
+        // the double-send guard below, which is a different 409.
+        if (data.compositionStale && data.composition) {
+          setComposed(data.composition);
+          setConfirmed(false);
+          setForceConfirmed(false);
+          setPhase("idle");
+          setError(
+            data.error ??
+              "提出内容が変わりました。もう一度確認のうえ送信してください。",
+          );
+          return;
+        }
         // Double-send guard fired between load and click (race) or the displayed
         // action was 'blocked'. Surface the route's reason and stay on the
         // composer so the operator can re-send with force_new if intended.

--- a/lib/receipts/delivery-compose.ts
+++ b/lib/receipts/delivery-compose.ts
@@ -66,6 +66,14 @@ export interface ComposedPreflightResult {
 export interface ComposedDelivery {
   month: string;
   exportId: string;
+  /** Plain SHA-256 fingerprint of this composition ({exportId, zipSha256, to,
+   *  cc, subject, text}; Item 2). The composer posts it back on Send; the send
+   *  route recomposes, recomputes, and returns 409 on mismatch so a stale render
+   *  (Settings edited, or a new revision finalized after the page loaded) can
+   *  never silently send a different body / recipient / pack than the operator
+   *  reviewed. NOT the ZIP bytes (zipSha256 already pins the pack); NOT content
+   *  the client controls — it is a fingerprint the server recomputes. */
+  compositionHash: string;
   /** When the latest finalized revision was sealed (receipt_exports.finalized_at).
    *  The composer header renders "sealed on {date}, NOT yet delivered" — sealing
    *  is the midpoint, not completion (decision 5). Added beyond the spec'd
@@ -121,6 +129,47 @@ export interface ComposedDelivery {
    *  The composer copy branches on this so it never claims the earlier pack WAS
    *  delivered when the evidence is uncertain. */
   priorAttemptState?: AttemptState;
+}
+
+/**
+ * Plain SHA-256 fingerprint of a delivery composition — the identity of exactly
+ * what the operator reviewed on the composer page. Over {exportId, zipSha256,
+ * to, cc, subject, text} (the signature is part of the body, so it is included
+ * via `text`). NOT the ZIP bytes (the pack's sha already pins it).
+ *
+ * This is a CONCURRENCY / staleness check, NOT an auth boundary: plain SHA-256,
+ * no HMAC, no signing. The threat is a second tab or a new revision finalized
+ * after the page rendered — not a hostile client (the send route recomposes
+ * server-side and trusts nothing from the body but this fingerprint, which it
+ * recomputes). The composer posts { compositionHash } and nothing else; the
+ * route recomposes, hashes its own result, and on mismatch returns 409 with the
+ * fresh composition so the UI re-renders and asks for re-confirmation. Reject,
+ * never warn — a click-through warning is the failure mode being fixed.
+ *
+ * Determinism is the whole point: the page render and the send route both call
+ * {@link composeDelivery}, so both arrive at this hash via the same field set ⇒
+ * a matching hash proves the reviewed composition equals the one about to ship.
+ * The canonical form is a fixed-key-order JSON object (with a `v` tag so a
+ * future field-set change forces re-confirmation instead of silently colliding).
+ */
+export async function computeCompositionHash(input: {
+  exportId: string;
+  zipSha256: string;
+  to: string | null;
+  cc: string | null;
+  subject: string;
+  text: string;
+}): Promise<string> {
+  const canonical = JSON.stringify({
+    v: 1,
+    exportId: input.exportId,
+    zipSha256: input.zipSha256,
+    to: input.to,
+    cc: input.cc,
+    subject: input.subject,
+    text: input.text,
+  });
+  return computeSha256Hex(new TextEncoder().encode(canonical));
 }
 
 /**
@@ -256,9 +305,19 @@ export async function composeDelivery(
     priorAttemptId = decision.priorAttemptId;
   }
 
+  const compositionHash = await computeCompositionHash({
+    exportId: exportRecord.id,
+    zipSha256,
+    to,
+    cc,
+    subject: email.subject,
+    text: email.text,
+  });
+
   return {
     month,
     exportId: exportRecord.id,
+    compositionHash,
     sealedAt: exportRecord.finalized_at ?? null,
     to,
     cc,
@@ -303,6 +362,10 @@ function noBytesResult(
   return {
     month,
     exportId,
+    // No sealed bytes ⇒ no real composition was reviewed (Send is disabled in
+    // this state via configBlocked). An empty fingerprint can never match a real
+    // recomposed hash, so a stray POST would 409 rather than silently send.
+    compositionHash: "",
     sealedAt: null,
     to,
     cc,

--- a/tests/receipts/delivery-compose.test.ts
+++ b/tests/receipts/delivery-compose.test.ts
@@ -4,6 +4,7 @@ import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import {
   computeDeliveryConfigErrors,
+  computeCompositionHash,
   type ComposedDelivery,
 } from "@/lib/receipts/delivery-compose";
 import { buildDeliveryEmail } from "@/lib/receipts/delivery-send";
@@ -165,4 +166,85 @@ test("shape: ComposedDelivery's preflight result names map from the pack-preflig
     passed: true,
   };
   assert.equal(sample.name, "container-names-ascii");
+});
+
+// ─── Item 2: composition hash — the stale-render guard ──────────────────────
+
+test("computeCompositionHash: deterministic — identical inputs ⇒ identical hash", async () => {
+  const input = {
+    exportId: "exp-1",
+    zipSha256: "abc123def",
+    to: "cpa@example.com",
+    cc: "mgr@example.com",
+    subject: "2026年6月の領収証憑一式",
+    text: "お世話になっております。\n株式会社ダズビーズ",
+  };
+  assert.equal(
+    await computeCompositionHash(input),
+    await computeCompositionHash({ ...input }),
+    "two independently-constructed but equal inputs hash the same",
+  );
+});
+
+test("computeCompositionHash: changing ANY of the six fields changes the hash", async () => {
+  const base = {
+    exportId: "exp-1",
+    zipSha256: "abc123def",
+    to: "cpa@example.com",
+    cc: "mgr@example.com",
+    subject: "件名",
+    text: "本文",
+  };
+  const h = await computeCompositionHash(base);
+  for (const [field, value] of [
+    ["exportId", "exp-2"],
+    ["zipSha256", "def456789"],
+    ["to", "someone-else@example.com"],
+    ["cc", "other-cc@example.com"],
+    ["subject", "別の件名"],
+    ["text", "別の本文（署名入り）"],
+  ] as const) {
+    assert.notEqual(
+      await computeCompositionHash({ ...base, [field]: value }),
+      h,
+      `changing ${field} must change the hash — a stale render of any field must be detectable`,
+    );
+  }
+});
+
+test("computeCompositionHash: null vs empty-string To/Cc are distinct fingerprints (empty is meaningful)", async () => {
+  // The silent-overwrite shape Item 6(c) sweeps. The hash must distinguish
+  // null (omitted) from "" (present-but-empty) so a recipient change can't hide
+  // behind a coercion. (Plain equality of the canonical JSON pins this.)
+  const core = { exportId: "e", zipSha256: "z", subject: "s", text: "t" };
+  assert.notEqual(
+    await computeCompositionHash({ ...core, to: null, cc: null }),
+    await computeCompositionHash({ ...core, to: "", cc: "" }),
+  );
+});
+
+test("composition-integrity wiring (Item 2): the send route reads compositionHash and 409s on mismatch; the composer posts it", () => {
+  // Structural guard, same shape as the parity tests above. Before Item 2 the
+  // send route ignored the body entirely and the composer posted an empty body.
+  // If either is reverted, this fails — the guard must be wired, not just defined.
+  const send = readFileSync(
+    "app/api/receipts/export/[month]/send/route.ts",
+    "utf8",
+  );
+  assert.ok(
+    /postedCompositionHash/.test(send),
+    "send route reads postedCompositionHash from the body",
+  );
+  assert.ok(
+    /compositionStale:\s*true/.test(send),
+    "send route returns compositionStale:true on mismatch (409 with the fresh composition)",
+  );
+  const ui = readFileSync(
+    "components/receipts/export/delivery-composer.tsx",
+    "utf8",
+  );
+  assert.ok(
+    /compositionHash:\s*composed\.compositionHash/.test(ui),
+    "composer posts { compositionHash: composed.compositionHash }",
+  );
 });


### PR DESCRIPTION
## What

Codex P1 #2 (overnight run, Item 2). The composer's confirmation was stale-prone: if To/Cc/signature changed in Settings, or a new revision was finalized after the page rendered, the empty POST carried no identity for the composition the operator reviewed — and the route recomposed from current mutable state, so Send could deliver a **different body, recipient, or pack** than the confirm screen displayed.

## Fix

Plain SHA-256 fingerprint over `{exportId, zipSha256, to, cc, subject, text}` (signature included via `text`; NOT the ZIP bytes — the sha already pins the pack). The composer posts `{ compositionHash }` and nothing else; the route recomposes exactly as before, recomputes its own hash, and on mismatch returns **409 with the fresh composition** so the UI re-renders and asks for re-confirmation.

- **Plain SHA-256. No HMAC, no signing.** This is a concurrency/staleness check, not an auth boundary — the threat is a second tab or a new revision, not a hostile client, and the route already trusts nothing from the body.
- **Reject, never warn.** A click-through warning is the failure mode being fixed.
- **Decision 2 stands:** no subject/body/To/Cc reach the send path from the client. The hash is a fingerprint, not content.
- An absent hash (direct POST, pre-hash client) **skips** the check — the guard protects the legitimate UI flow; it is additive, not a hard gate.
- Client holds `composed` in state; a composition-stale 409 swaps in the fresh composition and resets `confirmed`, forcing re-confirmation.

## Changes
- `lib/receipts/delivery-compose.ts` — `computeCompositionHash` (pure, fixed-key-order canonical JSON + `v:1` tag) + `compositionHash` on `ComposedDelivery`, computed inside `composeDelivery` (the single composition authority).
- `app/api/receipts/export/[month]/send/route.ts` — reads ONLY `compositionHash` from the body; 409 + fresh composition on mismatch (after config-error 422, before preflight).
- `components/receipts/export/delivery-composer.tsx` — `composed` lifted to state; posts the hash; handles the composition-stale 409.
- `tests/receipts/delivery-compose.test.ts` — determinism, six-field sensitivity, null-vs-empty To/Cc, and a structural wiring guard.

## Verification (per branch)
- `npx tsc --noEmit` — clean.
- `npm test` — **1241 pass / 0 fail / 1 skipped**.
- `npm run build:cf` — OpenNext build complete.
- **Fail-then-pass**: with the route + component reverted to HEAD (helper kept), the 3 pure hash tests PASS and the **wiring test FAILS** (`send route reads postedCompositionHash from the body` — absent on master). Restored → 16/16.

## ⚠️ Collides with Item 1 (PR #171)
This and #171 both edit `delivery-compose.ts`, `delivery-composer.tsx`, and `send/route.ts`. They touch **different regions** of each (Item 1: action enum / decision / override audit; Item 2: compositionHash field / body read / 409 gate), so they're independently reviewable but **will conflict at merge**. Recommended: merge #171 first, then rebase this onto master. Conflicts should be mechanical.

## What I want verified / least confident
1. The route returns the **full** `ComposedDelivery` as `composition` in the 409 body and the client swaps it into state — confirm the re-render path is correct (I could not exercise it against live bindings).
2. An absent `compositionHash` skips the check (backward-compat with a direct POST). Confirm that's the intended posture vs. requiring the hash.

## Not done (per standing rules)
Not merged, not deployed, nothing sent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)