### PR TITLE
test(receipts): assert exhaustive reads throw at cap (T1-7)

### DIFF
--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -486,8 +486,8 @@ export interface ListReceiptsFilter {
 
 export async function listReceiptRecords(
   filter?: ListReceiptsFilter,
+  db: D1Database = getReceiptsDb(),
 ): Promise<ReceiptRecord[]> {
-  const db = getReceiptsDb();
   const conditions: string[] = ["deleted_at IS NULL"];
   const binds: unknown[] = [];
 
@@ -628,21 +628,25 @@ export async function countCapturedSince(startIso: string): Promise<number> {
  */
 export async function listAllReceiptsInMonth(
   month: string,
-  opts?: { paymentPath?: string; hardCap?: number },
+  opts?: { paymentPath?: string; hardCap?: number; db?: D1Database },
 ): Promise<ReceiptRecord[]> {
   const paymentPath = opts?.paymentPath;
   const hardCap = opts?.hardCap ?? 10000;
+  const db = opts?.db;
   const PAGE = 500;
   const out: ReceiptRecord[] = [];
   let offset = 0;
   // Loop with offset until a page comes back short or we hit the cap.
   for (;;) {
-    const page = await listReceiptRecords({
-      month,
-      paymentPath,
-      limit: PAGE,
-      offset,
-    });
+    const page = await listReceiptRecords(
+      {
+        month,
+        paymentPath,
+        limit: PAGE,
+        offset,
+      },
+      db,
+    );
     out.push(...page);
     if (page.length < PAGE) return out;
     offset += PAGE;
@@ -692,9 +696,9 @@ const RECONCILE_RECEIPT_COLUMNS =
  */
 export async function listAmexReceiptsForReconcile(
   window: { start: string; end: string },
-  opts: { hardCap?: number } = {},
+  opts: { hardCap?: number; db?: D1Database } = {},
 ): Promise<ReceiptRecord[]> {
-  const db = getReceiptsDb();
+  const db = opts.db ?? getReceiptsDb();
   const hardCap = opts.hardCap ?? 5000;
   const PAGE = 500;
   const out: ReceiptRecord[] = [];

--- a/tests/receipts/exhaustive-read-throw-at-cap.test.ts
+++ b/tests/receipts/exhaustive-read-throw-at-cap.test.ts
@@ -1,0 +1,155 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  listAllReceiptsInMonth,
+  listAmexReceiptsForReconcile,
+} from "@/lib/receipts/db";
+import type { ReceiptRecord } from "@/lib/receipts/types";
+
+// T1-7 (audited 2026-08-12, docs/audits/2026-08-backlog-questions.md §5): the two
+// exhaustive reads that feed the SEALED export bundle (listAllReceiptsInMonth) and
+// the reconcile view (listAmexReceiptsForReconcile) page internally and THROW at a
+// hard cap rather than silently truncate — because a receipt omitted from the
+// sealed bundle is a receipt the accountant never sees (worst-class failure on a
+// 10-year tax record). The throw was the safety, and nothing asserted it: deleting
+// the guard would have failed no test. These tests pin the throw itself.
+//
+// Both functions take an optional `db` (on `opts`) purely as a testability seam —
+// same convention as softDeleteReceipt / unfinalizeReconciliation (production
+// callers omit it; the default resolves the live D1 binding). The fake dispatches
+// on SQL: the BETWEEN window query is the dated reconcile read, the
+// `transaction_date IS NULL` query is the undated reconcile read, and anything
+// else is the generic listReceiptRecords read that listAllReceiptsInMonth pages
+// through. Rows are opaque stubs — the throw path only counts them, it does not
+// read fields.
+
+let seq = 0;
+function mkReceipt(): ReceiptRecord {
+  seq += 1;
+  return { id: `r${seq}` } as unknown as ReceiptRecord;
+}
+
+/** A full 500-row page is the smallest input that reaches a throw, because the
+ *  paging loops short-circuit (`page.length < PAGE`) on any shorter page. */
+function fullPage(n = 500): ReceiptRecord[] {
+  return Array.from({ length: n }, () => mkReceipt());
+}
+
+interface FakeCfg {
+  /** Successive pages for the generic listReceiptRecords read. */
+  receiptPages?: ReceiptRecord[][];
+  /** Successive pages for the dated BETWEEN reconcile read. */
+  datedPages?: ReceiptRecord[][];
+  /** Rows for the undated `transaction_date IS NULL` reconcile read. */
+  undatedRows?: ReceiptRecord[];
+}
+
+function fakeDb(cfg: FakeCfg) {
+  let receiptI = 0;
+  let datedI = 0;
+
+  function dispatch(sql: string): ReceiptRecord[] {
+    if (/BETWEEN \? AND \?/i.test(sql)) {
+      const pages = cfg.datedPages ?? [];
+      return datedI < pages.length ? pages[datedI++] : [];
+    }
+    if (/transaction_date IS NULL/i.test(sql)) {
+      return cfg.undatedRows ?? [];
+    }
+    const pages = cfg.receiptPages ?? [];
+    return receiptI < pages.length ? pages[receiptI++] : [];
+  }
+
+  // `prepare` returns a bound statement; `.bind()` returns the same object so both
+  // `.prepare(sql).all()` (undated query) and `.prepare(sql).bind(...).all()` work.
+  function prepare(sql: string) {
+    const bound = {
+      bind(..._args: unknown[]) {
+        return this;
+      },
+      async all<T>(): Promise<{
+        results: T[];
+        success: true;
+        meta: { changes: number };
+      }> {
+        return {
+          results: dispatch(sql) as T[],
+          success: true,
+          meta: { changes: 0 },
+        };
+      },
+      async first<T>(): Promise<T | null> {
+        return null;
+      },
+      async run() {
+        return { success: true, meta: { changes: 0 } };
+      },
+    };
+    return bound;
+  }
+
+  return { db: { prepare } as unknown as D1Database };
+}
+
+// ─── listAllReceiptsInMonth ──────────────────────────────────────────────────
+
+test("listAllReceiptsInMonth: throws at hardCap instead of silently truncating", async () => {
+  // hardCap=3 but the first full 500-row page already blows past it — the throw
+  // fires before the trailing short page is ever read.
+  const { db } = fakeDb({ receiptPages: [fullPage(), fullPage(), []] });
+  await assert.rejects(
+    listAllReceiptsInMonth("2026-07", { hardCap: 3, db }),
+    /listAllReceiptsInMonth\(2026-07\) hit hard cap of 3 rows/,
+  );
+});
+
+test("listAllReceiptsInMonth: returns every row when the month is under the cap", async () => {
+  // A short first page (2 < 500) returns immediately — proves the throw above is
+  // cap-specific, not triggered by any full page.
+  const { db } = fakeDb({ receiptPages: [[mkReceipt(), mkReceipt()]] });
+  const out = await listAllReceiptsInMonth("2026-07", { db });
+  assert.equal(out.length, 2);
+});
+
+// ─── listAmexReceiptsForReconcile ────────────────────────────────────────────
+
+test("listAmexReceiptsForReconcile: throws at the dated-row cap mid-window", async () => {
+  const { db } = fakeDb({ datedPages: [fullPage(), fullPage(), []] });
+  await assert.rejects(
+    listAmexReceiptsForReconcile(
+      { start: "2026-07-01", end: "2026-07-31" },
+      { hardCap: 3, db },
+    ),
+    /hard cap of 3 dated rows/,
+  );
+});
+
+test("listAmexReceiptsForReconcile: throws after union with undated rows crosses the cap", async () => {
+  // Dated window returns a SHORT page (4 < 500) so the dated loop exits WITHOUT
+  // throwing; the separate undated query then pushes the total (4 + 3 = 7) past
+  // hardCap=5, firing the post-union guard — a distinct throw site from the
+  // mid-window one above.
+  const { db } = fakeDb({
+    datedPages: [[mkReceipt(), mkReceipt(), mkReceipt(), mkReceipt()]],
+    undatedRows: [mkReceipt(), mkReceipt(), mkReceipt()],
+  });
+  await assert.rejects(
+    listAmexReceiptsForReconcile(
+      { start: "2026-07-01", end: "2026-07-31" },
+      { hardCap: 5, db },
+    ),
+    /after union with undated rows/,
+  );
+});
+
+test("listAmexReceiptsForReconcile: returns dated + undated rows when under the cap", async () => {
+  const { db } = fakeDb({
+    datedPages: [[mkReceipt(), mkReceipt()]],
+    undatedRows: [mkReceipt()],
+  });
+  const out = await listAmexReceiptsForReconcile(
+    { start: "2026-07-01", end: "2026-07-31" },
+    { db },
+  );
+  assert.equal(out.length, 3);
+});


### PR DESCRIPTION
Stage 1 of the 2026-08-12 stage-UI + one-shot session. Turns the PR #176 finding (T1-7, `docs/audits/2026-08-backlog-questions.md` §5) into a test.

## What

The two exhaustive reads that feed the **sealed export bundle** (`listAllReceiptsInMonth`) and the **reconcile view** (`listAmexReceiptsForReconcile`) page internally and **throw** at a hard cap (defaults 10000 / 5000) rather than silently truncate. The throw was the only safety, and nothing asserted it — deleting the guard would have failed no test, and a >10000-receipt month would silently omit receipts from the sealed bundle (worst-class failure on a 10-year tax record).

## Change

- Adds the codebase's standard optional `db` testability seam (default resolves the live D1 binding; production callers omit it) to `listReceiptRecords`, `listAllReceiptsInMonth`, and `listAmexReceiptsForReconcile`. Same convention as `softDeleteReceipt` / `unfinalizeReconciliation`. The seam threads through `listReceiptRecords` because `listAllReceiptsInMonth` pages through it. **Behavior-preserving** — no production call site changes.
- New test `tests/receipts/exhaustive-read-throw-at-cap.test.ts` asserts the throw itself (not a downstream symptom).

## Throw sites covered — 3

Two reads have the shape; one of them throws twice. Fail-then-pass verified — removing the guards fails exactly these three tests (happy-paths stay green, no infinite loop):

1. `listAllReceiptsInMonth` hit-hard-cap
2. `listAmexReceiptsForReconcile` dated-window cap (mid-loop)
3. `listAmexReceiptsForReconcile` post-union-with-undated cap (after the separate undated query pushes the total over)

## Verification

- `npm test`: **1270 tests, 1269 pass, 0 fail, 1 skipped** (baseline 1265 → +5).
- `tsc --noEmit`: clean.
- `npm run build:cf`: clean (OpenNext build complete).
- Fail-then-pass: guards removed → 3 throw-tests fail with "Missing expected rejection"; restored → all 5 pass.

No other T1 invariants touched (scope is T1-7 only, per the session prompt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)