### PR TITLE
refactor(receipts): single-source the attendees gate rule (backlog #6, Part D)

### DIFF
--- a/lib/receipts/attendee-requirement.ts
+++ b/lib/receipts/attendee-requirement.ts
@@ -1,0 +1,54 @@
+import type { ReceiptAttendeeDirectoryEntry } from "@/lib/receipts/attendee-directory";
+import { resolveAttendeeNames } from "@/lib/receipts/attendee-directory";
+import { requiresAttendees } from "@/lib/receipts/categories";
+
+// Backlog #6 (one-shot Part D): the single source for the attendees gate logic.
+// The finalize gate (`validateMonthReadyForExportCore`'s receipt loop, for
+// CASH/DIGITAL receipts) and the AMEX-line signoff checker
+// (`evaluateAmexLineSignoff`, for receipts matched to AMEX lines) previously
+// each inlined the SAME logic — `requiresAttendees(category)` then, when
+// attendees are present, `resolveAttendeeNames` to find unresolved names. With
+// the seal-only path retired, the finalize gate is the sole sealing authority,
+// so duplicate rule implementations are more dangerous than they were (no second
+// path to cross-check). Both callers now go through this predicate.
+//
+// The two callers differ only in WHAT they feed in: the gate passes a receipt's
+// category + its attendees; the AMEX checker passes the line-resolved category +
+// the union of receipt- and line-level attendees. The decision is identical, so
+// it lives here once. Each caller maps the result to its own output shape
+// (ExportBlocker codes for the gate; AmexLineSignoffCode for the AMEX checker).
+
+/** The outcome of the attendees requirement check for one category + attendee set. */
+export interface AttendeeRequirementResult {
+  /** false ⇒ the category needs no attendees — no attendee checks apply. */
+  required: boolean;
+  /** Whether any attendee names were provided. When `required` is true and this
+   *  is false, the signal is "attendees_required" (missing); when true, the
+   *  signal is "attendee_unresolved" for each name in `unresolved`. */
+  attendeesPresent: boolean;
+  /** Attendee names that did NOT resolve to a directory entry. Empty when all
+   *  resolve, or when no attendees were provided. */
+  unresolved: string[];
+}
+
+/**
+ * Evaluate the attendees requirement for a single category + attendee list
+ * against the attendee directory. Pure; unit-testable. This is the one place
+ * the attendees gate rule is defined — the finalize gate (CASH/DIGITAL receipts)
+ * and `evaluateAmexLineSignoff` (AMEX-matched receipts) both call it, so the two
+ * cannot drift.
+ */
+export function evaluateAttendeeRequirement(
+  category: string | null | undefined,
+  attendees: string[],
+  directory: ReceiptAttendeeDirectoryEntry[],
+): AttendeeRequirementResult {
+  if (!requiresAttendees(category)) {
+  return { required: false, attendeesPresent: false, unresolved: [] };
+  }
+  if (attendees.length === 0) {
+    return { required: true, attendeesPresent: false, unresolved: [] };
+  }
+  const { unresolved } = resolveAttendeeNames(attendees, directory);
+  return { required: true, attendeesPresent: true, unresolved };
+}

--- a/lib/receipts/month-closing.ts
+++ b/lib/receipts/month-closing.ts
@@ -1,6 +1,6 @@
-import { getCategoryByCode, requiresAttendees } from "@/lib/receipts/categories";
+import { getCategoryByCode } from "@/lib/receipts/categories";
 import type { ReceiptAttendeeDirectoryEntry } from "@/lib/receipts/attendee-directory";
-import { resolveAttendeeNames } from "@/lib/receipts/attendee-directory";
+import { evaluateAttendeeRequirement } from "@/lib/receipts/attendee-requirement";
 import {
   getExport,
   getFinalizedReconciliationForMonth,
@@ -456,21 +456,25 @@ export function validateMonthReadyForExportCoreDetailed(
         message: `Receipt ${receipt.id}: missing expense category`,
       });
     }
-    if (requiresAttendees(receipt.expense_category_code)) {
-      const attendees = bundle.attendeeMap.get(receipt.id) ?? [];
-      if (attendees.length === 0) {
-        blockers.push({ code: "attendees_required", message: `Receipt ${label}: requires attendees` });
-      } else {
-        // Attendees present → every name must resolve to a directory entry
-        // (company/title). Unresolved names block finalize (business-manager
-        // review: every 会議費/接待交際費 attendee must show company + title).
-        const { unresolved } = resolveAttendeeNames(attendees, bundle.attendeeDirectory);
-        for (const name of unresolved) {
-          blockers.push({
-            code: "attendee_unresolved",
-            message: `Receipt ${label}: attendee "${name}" is not registered in the attendee directory (company/title required)`,
-          });
-        }
+    // Attendee requirement — single-sourced in evaluateAttendeeRequirement
+    // (backlog #6), shared with evaluateAmexLineSignoff so the gate (CASH/DIGITAL
+    // receipts) and the AMEX-line checker cannot drift.
+    const att = evaluateAttendeeRequirement(
+      receipt.expense_category_code,
+      bundle.attendeeMap.get(receipt.id) ?? [],
+      bundle.attendeeDirectory,
+    );
+    if (att.required && !att.attendeesPresent) {
+      blockers.push({ code: "attendees_required", message: `Receipt ${label}: requires attendees` });
+    } else if (att.required) {
+      // Attendees present → every name must resolve to a directory entry
+      // (company/title). Unresolved names block finalize (business-manager
+      // review: every 会議費/接待交際費 attendee must show company + title).
+      for (const name of att.unresolved) {
+        blockers.push({
+          code: "attendee_unresolved",
+          message: `Receipt ${label}: attendee "${name}" is not registered in the attendee directory (company/title required)`,
+        });
       }
     }
   }

--- a/lib/receipts/reconciliation-signoff.ts
+++ b/lib/receipts/reconciliation-signoff.ts
@@ -1,7 +1,6 @@
 import type { AmexStatementLine, ReceiptRecord } from "@/lib/receipts/types";
 import type { ReceiptAttendeeDirectoryEntry } from "@/lib/receipts/attendee-directory";
-import { resolveAttendeeNames } from "@/lib/receipts/attendee-directory";
-import { requiresAttendees } from "@/lib/receipts/categories";
+import { evaluateAttendeeRequirement } from "@/lib/receipts/attendee-requirement";
 import { resolveLineCategory } from "@/lib/receipts/line-classification";
 import { isUncategorizedLine } from "@/lib/receipts/blockers";
 
@@ -170,17 +169,19 @@ export function evaluateAmexLineSignoff(
   }
 
   const unresolvedAttendeeNames: string[] = [];
-  if (requiresAttendees(resolvedCategory)) {
-    const names = [...receiptAttendees, ...lineAttendees];
-    if (names.length === 0) {
-      codes.push("attendees_required");
-    } else {
-      const { unresolved } = resolveAttendeeNames(names, attendeeDirectory);
-      if (unresolved.length > 0) {
-        codes.push("attendee_unresolved");
-        unresolvedAttendeeNames.push(...unresolved);
-      }
-    }
+  // Attendee requirement — single-sourced in evaluateAttendeeRequirement
+  // (backlog #6), shared with the finalize gate so the AMEX-line checker and the
+  // gate cannot drift.
+  const att = evaluateAttendeeRequirement(
+    resolvedCategory,
+    [...receiptAttendees, ...lineAttendees],
+    attendeeDirectory,
+  );
+  if (att.required && !att.attendeesPresent) {
+    codes.push("attendees_required");
+  } else if (att.required && att.unresolved.length > 0) {
+    codes.push("attendee_unresolved");
+    unresolvedAttendeeNames.push(...att.unresolved);
   }
 
   if (line.business_trip_status === "candidate") {

--- a/tests/receipts/attendee-requirement.test.ts
+++ b/tests/receipts/attendee-requirement.test.ts
@@ -1,0 +1,56 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { evaluateAttendeeRequirement } from "@/lib/receipts/attendee-requirement";
+import type { ReceiptAttendeeDirectoryEntry } from "@/lib/receipts/attendee-directory";
+
+// Backlog #6 (one-shot Part D): evaluateAttendeeRequirement is the single source
+// for the attendees gate rule, called by both the finalize gate (CASH/DIGITAL
+// receipts) and evaluateAmexLineSignoff (AMEX-matched receipts). These pin its
+// contract directly — the four outcomes both callers map to their own blocker
+// shapes.
+
+function dirEntry(name: string): ReceiptAttendeeDirectoryEntry {
+  return { name } as unknown as ReceiptAttendeeDirectoryEntry;
+}
+
+test("evaluateAttendeeRequirement: a category that does not require attendees ⇒ not required (no attendee checks)", () => {
+  const r = evaluateAttendeeRequirement("supplies", ["Alice"], [dirEntry("Alice")]);
+  assert.equal(r.required, false);
+  assert.equal(r.attendeesPresent, false);
+  assert.deepEqual(r.unresolved, []);
+});
+
+test("evaluateAttendeeRequirement: null/unknown category ⇒ not required", () => {
+  assert.equal(evaluateAttendeeRequirement(null, [], []).required, false);
+  assert.equal(evaluateAttendeeRequirement(undefined, [], []).required, false);
+  assert.equal(evaluateAttendeeRequirement("not_a_code", [], []).required, false);
+});
+
+test("evaluateAttendeeRequirement: requires attendees but none provided ⇒ required, attendeesPresent false (the 'attendees_required' signal)", () => {
+  const r = evaluateAttendeeRequirement("entertainment", [], [dirEntry("Alice")]);
+  assert.equal(r.required, true);
+  assert.equal(r.attendeesPresent, false);
+  assert.deepEqual(r.unresolved, []);
+});
+
+test("evaluateAttendeeRequirement: requires attendees, all resolve ⇒ required, present, no unresolved (clean)", () => {
+  const r = evaluateAttendeeRequirement(
+    "meeting",
+    ["Alice", "Bob"],
+    [dirEntry("Alice"), dirEntry("Bob")],
+  );
+  assert.equal(r.required, true);
+  assert.equal(r.attendeesPresent, true);
+  assert.deepEqual(r.unresolved, []);
+});
+
+test("evaluateAttendeeRequirement: requires attendees, some unresolved ⇒ required, present, unresolved names (the 'attendee_unresolved' signal)", () => {
+  const r = evaluateAttendeeRequirement(
+    "entertainment",
+    ["Alice", "  Carol  ", "Bob"], // trimmed on both sides
+    [dirEntry("Alice")], // Bob + Carol absent
+  );
+  assert.equal(r.required, true);
+  assert.equal(r.attendeesPresent, true);
+  assert.deepEqual(r.unresolved.sort(), ["Bob", "Carol"]);
+});


### PR DESCRIPTION
Post-#179 cleanup, **Item 1** (backlog #6 / one-shot Part D). Deferred twice so as not to muddy the UI diff; nothing blocks it now.

## What

The finalize gate (`validateMonthReadyForExportCore`'s receipt loop, for CASH/DIGITAL receipts) and `evaluateAmexLineSignoff` (for receipts matched to AMEX lines) each inlined the **same** attendees logic: `requiresAttendees(category)` → if attendees present, `resolveAttendeeNames` to find unresolved names. With the seal-only path retired the gate is the sole sealing authority, so two copies of a sealing rule is more dangerous than it was (no second path to cross-check).

Extracted `evaluateAttendeeRequirement` (`lib/receipts/attendee-requirement.ts`) — the one predicate both call. Returns `{ required, attendeesPresent, unresolved }`; each caller maps it to its own output shape. The callers differ only in inputs (gate: receipt category + receipt attendees; AMEX: line-resolved category + line∪receipt attendees).

## Duplicated check found

The **attendees requirement** (`attendees_required` / `attendee_unresolved`) was the duplicated check — present in both the gate's gate-3 loop and `evaluateAmexLineSignoff`. The receipt field-missing checks (date/merchant/amount) are gate-only (the AMEX checker doesn't do them), so they were **not** duplicated and stay in the gate.

## No behaviour change

All existing gate tests pass **unmodified** (1289 → 1294; +5 new predicate-contract tests, **0 modified**). `tsc --noEmit` clean. `npm run build:cf` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)