### PR TITLE
test(receipts): pin Tier-1 delivery invariants T1-6 + T1-5 (opts.db seam)

### DIFF
--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -3386,8 +3386,8 @@ export async function listDeliveriesForMonth(
 export async function markDeliverySent(
   id: string,
   providerMessageId: string,
+  db: D1Database = getReceiptsDb(),
 ): Promise<void> {
-  const db = getReceiptsDb();
   const now = nowIso();
   await db.batch([
     db
@@ -3412,8 +3412,11 @@ export async function markDeliverySent(
  * export's delivery_state='sealed_undelivered' (retryable; month NOT closed)
  * in one transaction. The seal is untouched — only the reporting state moves.
  */
-export async function markDeliveryFailed(id: string, error: string): Promise<void> {
-  const db = getReceiptsDb();
+export async function markDeliveryFailed(
+  id: string,
+  error: string,
+  db: D1Database = getReceiptsDb(),
+): Promise<void> {
   const now = nowIso();
   await db.batch([
     db
@@ -3440,8 +3443,11 @@ export async function markDeliveryFailed(id: string, error: string): Promise<voi
  * deduplicates), and the month's delivery_state is sealed_undelivered (not
  * closed). The seal is untouched. Counterpart to {@link markDeliveryFailed}
  * (which is for definitive 4xx rejections, terminal). */
-export async function markDeliveryAmbiguous(id: string, error: string): Promise<void> {
-  const db = getReceiptsDb();
+export async function markDeliveryAmbiguous(
+  id: string,
+  error: string,
+  db: D1Database = getReceiptsDb(),
+): Promise<void> {
   const now = nowIso();
   await db.batch([
     db

--- a/tests/receipts/tier1-invariants.test.ts
+++ b/tests/receipts/tier1-invariants.test.ts
@@ -1,0 +1,106 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  markDeliveryAmbiguous,
+  markDeliveryFailed,
+  markDeliverySent,
+} from "@/lib/receipts/db";
+
+// Tier-1 documented-but-untested invariants (docs/audits/2026-08-backlog-questions.md
+// §6), ranked by blast radius on a sealed/delivered month. Each test FAILS if the
+// invariant's enforcement is removed (fail-then-pass verified). The opts.db seam
+// (same convention as softDeleteReceipt / unfinalizeReconciliation / the T1-7
+// throw-at-cap test) makes these D1-coupled functions unit-testable.
+
+/** A recording fake D1: captures every statement passed to db.batch([...]) as
+ *  its SQL string, so tests can assert on what a function wrote (and what it did
+ *  NOT write) without bindings. */
+function recordingDb() {
+  const batches: string[][] = [];
+  const runs: string[] = [];
+  function prepare(sql: string) {
+    const stmt = {
+      _sql: sql,
+      bind(..._args: unknown[]) {
+        return this;
+      },
+      async all<T = unknown>() {
+        return { results: [] as T[], success: true as const, meta: { changes: 0 } };
+      },
+      async first<T = unknown>(): Promise<T | null> {
+        return null;
+      },
+      async run() {
+        runs.push(this._sql);
+        return { success: true as const, meta: { changes: 1 } };
+      },
+    };
+    return stmt;
+  }
+  const db = {
+    prepare,
+    async batch(stmts: ReturnType<typeof prepare>[]) {
+      batches.push(stmts.map((s) => s._sql));
+      return stmts.map(() => ({ success: true as const, meta: { changes: 1 } }));
+    },
+  };
+  return { db: db as unknown as D1Database, batches, runs };
+}
+
+// The sealed-bundle identity columns. A delivery mutation must never touch any.
+const SEALED_COLUMNS = [
+  "archive_r2_key",
+  "manifest_r2_key",
+  "archive_sha256",
+  "manifest_sha256",
+  "proofs_r2_key",
+  "proofs_sha256",
+  "finalization_hash",
+  "finalized_at",
+];
+
+// ─── T1-6 (rank 1) — a failed send never touches the seal ────────────────────
+
+for (const [name, call] of [
+  ["markDeliverySent", (db: D1Database) => markDeliverySent("att-1", "msg-id", db)],
+  ["markDeliveryFailed", (db: D1Database) => markDeliveryFailed("att-1", "boom", db)],
+  ["markDeliveryAmbiguous", (db: D1Database) => markDeliveryAmbiguous("att-1", "timeout", db)],
+] as const) {
+  test(`T1-6: ${name} touches only delivery_state — never a sealed-bundle column`, async () => {
+    const { db, batches } = recordingDb();
+    await call(db);
+    const sql = batches.flat().join("\n  ");
+    for (const col of SEALED_COLUMNS) {
+      assert.ok(
+        !sql.includes(col),
+        `${name} must not write sealed column ${col}; saw:\n  ${sql}`,
+      );
+    }
+    // Positive anchor: it DOES move the reporting state.
+    assert.ok(/delivery_state\s*=\s*'/.test(sql), `${name} sets delivery_state`);
+  });
+}
+
+// ─── T1-5 (rank 5) — delivery_state is written in the SAME batch as the attempt ──
+
+for (const [name, call] of [
+  ["markDeliverySent", (db: D1Database) => markDeliverySent("att-1", "msg-id", db)],
+  ["markDeliveryFailed", (db: D1Database) => markDeliveryFailed("att-1", "boom", db)],
+  ["markDeliveryAmbiguous", (db: D1Database) => markDeliveryAmbiguous("att-1", "timeout", db)],
+] as const) {
+  test(`T1-5: ${name} writes the attempt row + receipt_exports.delivery_state in ONE db.batch`, async () => {
+    const { db, batches } = recordingDb();
+    await call(db);
+    assert.equal(batches.length, 1, "the two writes are a single db.batch (transaction)");
+    const [stmts] = batches;
+    assert.equal(stmts.length, 2, "exactly two statements — the attempt UPDATE + the delivery_state UPDATE");
+    assert.ok(
+      stmts.some((s) => /UPDATE export_deliveries/i.test(s)),
+      "the attempt row UPDATE is in the batch",
+    );
+    assert.ok(
+      stmts.some((s) => /UPDATE receipt_exports/i.test(s) && /delivery_state/i.test(s)),
+      "the receipt_exports.delivery_state UPDATE is in the SAME batch",
+    );
+  });
+}


### PR DESCRIPTION
§3 of the post-#179 review prompt — first cohort of the Tier-1 invariant tests (\`docs/audits/2026-08-backlog-questions.md\` §6), ranked by sealed/delivered blast radius. Uses the \`opts.db\` seam (same convention as \`softDeleteReceipt\` / \`unfinalizeReconciliation\` / the T1-7 throw-at-cap test). **No behaviour change** — the seam defaults to the live binding.

## T1-6 (rank 1) — a failed send never touches the seal
\`markDeliverySent\` / \`markDeliveryFailed\` / \`markDeliveryAmbiguous\` each touch only \`delivery_state\` + the attempt row — never a sealed-bundle column. The whole delivery design rests on this doctrine, and it was held by nothing but a comment.

## T1-5 (rank 5) — delivery_state same-batch
The attempt-row UPDATE and the \`receipt_exports.delivery_state\` UPDATE are one \`db.batch([...])\` (one transaction) — list queries can never disagree with attempt history.

## Fail-then-pass (verified)
Splitting \`markDeliveryFailed\`'s batch into two \`.run()\` calls → T1-5 fails; adding \`finalization_hash\` to it → T1-6 fails. Restored → all 6 pass.

## Split note (per "split by invariant past ~5 tests")
T1-6 + T1-5 share the delivery-wrapper seam + a recording fake (one cohort, 6 tests). The remaining three each need their own seam/refactor on sealing-authority code and are **separate PRs**:
- **T1-9** (\`finalizeExport\` refuses twice) — seam must thread through \`recordExportBundle\` (shared helper).
- **T1-10** (\`updateAmexReconciliation\` cross-month sealed-claim guard) — seam on that function.
- **T1-2** (\`buildExportBundle\` matched-receipt-once) — needs a pure-core extraction (multi-D1-call, not a single seam); the biggest, and load-bearing on every sealed pack.

Keeping each focused so the sole sealing authority and the bundle builder each get their own review.

\`npm test\` 1314/1313/0; \`tsc\` + \`build:cf\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)