### PR TITLE
fix(reconcile): a reasonless "no receipt" line is not settled — surface, focus, navigate

### DIFF
--- a/app/api/receipts/reconcile/finalize/route.ts
+++ b/app/api/receipts/reconcile/finalize/route.ts
@@ -14,7 +14,7 @@ import {
 } from "@/lib/receipts/db";
 import { RECEIPT_BULK_LIMIT, hasReceiptBulkOverflow } from "@/lib/receipts/list-policy";
 import { hashCsvContent } from "@/lib/receipts/export";
-import { buildReconciliationManifestCsv, validateAmexLinesForSignoff } from "@/lib/receipts/reconciliation-signoff";
+import { buildReconciliationManifestCsv, validateAmexLinesForSignoffDetailed } from "@/lib/receipts/reconciliation-signoff";
 import { deriveStatementWindow, isReceiptInWindow } from "@/lib/receipts/statement-window";
 import { archiveManifest, deleteArchiveObject } from "@/lib/receipts/storage";
 import type { ReceiptRecord } from "@/lib/receipts/types";
@@ -103,7 +103,10 @@ export async function POST(request: Request) {
       if (entry) receiptAttendeeMap.set(entry[0], entry[1]);
     }
 
-    const blockers = validateAmexLinesForSignoff(
+    // Detailed blockers carry the line id so the sign-off banner can link each
+    // to its line (select it in the rail) — not flat text the operator must hunt
+    // for. lineId is null for consolidated (multi-line) blockers.
+    const blockers = validateAmexLinesForSignoffDetailed(
       amexLines,
       amexAttendees,
       receiptAttendeeMap,

--- a/components/receipts/reconcile/reconcile-screen.tsx
+++ b/components/receipts/reconcile/reconcile-screen.tsx
@@ -103,6 +103,12 @@ export function ReconcileScreen(props: ReconcileScreenProps) {
   const [activeId, setActiveId] = useState<string | null>(
     () => props.amexLines[0]?.id ?? null,
   );
+  // §3: after marking a line "no receipt expected", drop the operator into the
+  // reason field so supplying it is the obvious next keystroke. Set here (both
+  // the `n` shortcut and the button route through reconcile); consumed below once
+  // the refreshed row mounts its reason input. The operator can press Enter to
+  // leave it blank (the n-through-a-list flow is not blocked — see §1/§2).
+  const [reasonFocusId, setReasonFocusId] = useState<string | null>(null);
   const [tab, setTab] = useState<Tab>("lines");
   const [busy, setBusy] = useState<string | null>(null);
   const [signoffBusy, setSignoffBusy] = useState(false);
@@ -111,6 +117,11 @@ export function ReconcileScreen(props: ReconcileScreenProps) {
     total: number;
   } | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // §4: structured sign-off blockers — each carries the line id so the banner can
+  // link to the line (select it in the rail) instead of naming it as flat text.
+  const [signoffBlockers, setSignoffBlockers] = useState<
+    { lineId: string | null; message: string }[] | null
+  >(null);
   // Audit finding A2: finalize cleanup warnings (e.g. R2 archive-object
   // delete failed post-commit). Persistent across router.refresh() so the
   // operator sees the banner even after the page reloads the new state.
@@ -179,6 +190,11 @@ export function ReconcileScreen(props: ReconcileScreenProps) {
 
   const counts = useMemo(() => {
     const confirmed = props.amexLines.filter((l) => isSettled(l)).length;
+    // A no_receipt line with no reason is incomplete (§1) — surface the count so
+    // the operator sees the work before pressing sign-off, not after the gate.
+    const needsReason = props.amexLines.filter(
+      (l) => l.match_status === "no_receipt" && !isSettled(l),
+    ).length;
     const obvious = linesWithBand.filter(
       (l) => l.band === "obvious" && !isSettled(l.line),
     ).length;
@@ -190,6 +206,7 @@ export function ReconcileScreen(props: ReconcileScreenProps) {
     return {
       total: props.amexLines.length,
       confirmed,
+      needsReason,
       obvious,
       likely,
       review,
@@ -212,6 +229,7 @@ export function ReconcileScreen(props: ReconcileScreenProps) {
       if (locked) return;
       setBusy(amexLineId);
       setError(null);
+      if (matchStatus === "no_receipt") setReasonFocusId(amexLineId);
       try {
         const res = await fetch("/api/receipts/reconcile", {
           method: "POST",
@@ -234,6 +252,18 @@ export function ReconcileScreen(props: ReconcileScreenProps) {
     },
     [locked, router],
   );
+
+  // Focus the just-marked line's reason input once the refreshed row has mounted
+  // it. Deps include props.amexLines so this re-runs after router.refresh() lands
+  // (the row becomes no_receipt → NoReceiptFields mounts → the input exists).
+  useEffect(() => {
+    if (!reasonFocusId) return;
+    const el = document.getElementById(`missing-reason-${reasonFocusId}`);
+    if (el) {
+      el.focus();
+      setReasonFocusId(null);
+    }
+  }, [reasonFocusId, props.amexLines]);
 
   const updateCategory = useCallback(
     async (lineId: string, code: string) => {
@@ -341,6 +371,7 @@ export function ReconcileScreen(props: ReconcileScreenProps) {
     if (confirmType.toLowerCase().trim() !== props.month.toLowerCase()) return;
     setSignoffBusy(true);
     setError(null);
+    setSignoffBlockers(null);
     try {
       const res = await fetch("/api/receipts/reconcile/finalize", {
         method: "POST",
@@ -349,15 +380,18 @@ export function ReconcileScreen(props: ReconcileScreenProps) {
       });
       const json = (await res.json().catch(() => ({}))) as {
         error?: string;
-        blockers?: string[];
+        blockers?: { lineId: string | null; message: string }[];
         warnings?: string[];
       };
       if (!res.ok) {
-        setError(
-          json.blockers?.length
-            ? `${json.error ?? "Blocked"}: ${json.blockers.join("; ")}`
-            : json.error ?? "Sign-off failed.",
-        );
+        if (json.blockers && json.blockers.length > 0) {
+          // Structured blockers — show as a clickable banner on the main screen
+          // (each links to its line), not a flattened error string in the modal.
+          setSignoffBlockers(json.blockers);
+          setShowFinalizeModal(false);
+        } else {
+          setError(json.error ?? "Sign-off failed.");
+        }
         // Audit finding A2: surface R2 cleanup failures even when the
         // request itself failed (race-loser case). Without this the
         // operator could finalize-successfully later and never know an
@@ -440,6 +474,11 @@ export function ReconcileScreen(props: ReconcileScreenProps) {
           <span className="text-[13px] font-semibold tabular-nums text-gray-900">
             {counts.confirmed} of {counts.total} confirmed
           </span>
+          {counts.needsReason > 0 && (
+            <span className="text-[12px] font-medium tabular-nums text-amber-700">
+              {counts.needsReason} need{counts.needsReason === 1 ? "" : "s"} a reason
+            </span>
+          )}
           <div className="flex h-2 max-w-[320px] flex-1 overflow-hidden rounded bg-gray-100">
             <div
               className="bg-green-500"
@@ -519,6 +558,30 @@ export function ReconcileScreen(props: ReconcileScreenProps) {
       {error && (
         <div className="border-b border-red-200 bg-red-50 px-8 py-2 text-sm text-red-700">
           {error}
+        </div>
+      )}
+
+      {signoffBlockers && signoffBlockers.length > 0 && (
+        <div className="border-b border-red-200 bg-red-50 px-8 py-2.5 text-[13px] text-red-700">
+          <div className="font-semibold">Cannot sign off — resolve these issues first:</div>
+          <ul className="mt-1 space-y-0.5">
+            {signoffBlockers.map((b, i) => (
+              <li key={i} className="flex items-start gap-1.5">
+                <span aria-hidden>•</span>
+                {b.lineId ? (
+                  <button
+                    type="button"
+                    onClick={() => setActiveId(b.lineId)}
+                    className="text-left text-red-700 underline decoration-red-300 underline-offset-2 hover:text-red-900"
+                  >
+                    {b.message}
+                  </button>
+                ) : (
+                  <span>{b.message}</span>
+                )}
+              </li>
+            ))}
+          </ul>
         </div>
       )}
 
@@ -925,11 +988,16 @@ function LineRow({
               needs category
             </span>
           )}
-          {noReceipt && (
-            <Pill tone="gray" size="sm">
-              no receipt expected
-            </Pill>
-          )}
+          {noReceipt &&
+            (line.receipt_missing_reason?.trim() ? (
+              <Pill tone="gray" size="sm">
+                no receipt expected
+              </Pill>
+            ) : (
+              <Pill tone="amber" size="sm">
+                needs a reason
+              </Pill>
+            ))}
           {confirmed && !noReceipt && (
             <Pill tone="green" size="sm">
               confirmed
@@ -1611,6 +1679,7 @@ function NoReceiptFields({
       </Field>
       <Field label="Missing receipt reason" required>
         <TextInput
+          id={`missing-reason-${line.id}`}
           disabled={locked}
           value={missingReasonDraft}
           onChange={(e) => setMissingReasonDraft(e.target.value)}

--- a/lib/receipts/reconcile-grouping.ts
+++ b/lib/receipts/reconcile-grouping.ts
@@ -15,12 +15,22 @@
 import type { AmexStatementLine, ReconciliationMatch } from "@/lib/receipts/types";
 import type { ConfidenceBand } from "@/lib/receipts/confidence";
 
-/** A line the operator has settled — either matched-and-confirmed or
- *  explicitly marked "no receipt expected". Both are terminal; neither
- *  needs attention. Single source of truth for the header count and the rail
- *  grouping, which had drifted apart (see module header). */
+/** A line the operator has settled — terminal AND complete.
+ *
+ *  `confirmed` is settled unconditionally. `no_receipt` is settled ONLY when it
+ *  carries a non-empty `receipt_missing_reason`: a reasonless `no_receipt` is
+ *  incomplete (the finalize gate's evaluateAmexLineSignoff emits `missing_reason`
+ *  for it — "missing receipt requires a reason"), so it stays in Needs attention
+ *  until the operator supplies one. This keeps such lines out of the confirmed
+ *  count and visible, instead of wearing a gray "done" pill that the sign-off
+ *  gate then rejects. Single source of truth for the header count and the rail
+ *  grouping (see module header). */
 export function isSettled(line: AmexStatementLine): boolean {
-  return line.match_status === "confirmed" || line.match_status === "no_receipt";
+  if (line.match_status === "confirmed") return true;
+  if (line.match_status === "no_receipt") {
+    return !!line.receipt_missing_reason?.trim();
+  }
+  return false;
 }
 
 export interface LineWithBand {

--- a/lib/receipts/reconciliation-signoff.ts
+++ b/lib/receipts/reconciliation-signoff.ts
@@ -346,14 +346,28 @@ export function crossMonthAmbiguousReceiptIds(
  * must show company + title). Directory rows enforce company/title NOT NULL, so
  * resolution alone proves completeness.
  */
-export function validateAmexLinesForSignoff(
+/** A sign-off blocker with the line it belongs to. `lineId` is null for
+ *  multi-line (consolidated) blockers — those are not clickable to one line. The
+ *  reconcile sign-off banner uses `lineId` to select the line in the rail so a
+ *  blocker links to the control that clears it (the ExportBlocker.href doctrine
+ *  applied to reconciliation), rather than the operator reading a merchant name
+ *  out of an error string and hunting for it. */
+export interface AmexSignoffBlocker {
+  lineId: string | null;
+  message: string;
+}
+
+/** Detailed sign-off validation — the single source. Returns one entry per
+ *  blocker message, tagged with its line id (null for consolidated mismatches).
+ *  Pure. */
+export function validateAmexLinesForSignoffDetailed(
   amexLines: AmexStatementLine[],
   amexAttendees: Record<string, string[]>,
   receiptAttendeeMap: Map<string, string[]>,
   receiptMap: Map<string, ReceiptRecord>,
   attendeeDirectory: ReceiptAttendeeDirectoryEntry[],
-): string[] {
-  const blockers: string[] = [];
+): AmexSignoffBlocker[] {
+  const blockers: AmexSignoffBlocker[] = [];
 
   for (const line of amexLines) {
     const receipt = line.matched_receipt_id
@@ -370,14 +384,35 @@ export function validateAmexLinesForSignoff(
       receiptAttendees,
       attendeeDirectory,
     );
-    blockers.push(...formatAmexLineSignoffMessages(line, result));
+    for (const message of formatAmexLineSignoffMessages(line, result)) {
+      blockers.push({ lineId: line.id, message });
+    }
   }
 
   for (const m of collectConsolidatedMismatches(amexLines, receiptMap)) {
-    blockers.push(
-      `Consolidated receipt ${m.label}: ${m.lineCount} confirmed lines sum to ${m.sum} but receipt total is ${m.total}`,
-    );
+    blockers.push({
+      lineId: null,
+      message: `Consolidated receipt ${m.label}: ${m.lineCount} confirmed lines sum to ${m.sum} but receipt total is ${m.total}`,
+    });
   }
 
   return blockers;
+}
+
+export function validateAmexLinesForSignoff(
+  amexLines: AmexStatementLine[],
+  amexAttendees: Record<string, string[]>,
+  receiptAttendeeMap: Map<string, string[]>,
+  receiptMap: Map<string, ReceiptRecord>,
+  attendeeDirectory: ReceiptAttendeeDirectoryEntry[],
+): string[] {
+  // Project the detailed blockers to the original string[] contract (the export
+  // gate consumes string[]). The detailed variant is the single rule source.
+  return validateAmexLinesForSignoffDetailed(
+    amexLines,
+    amexAttendees,
+    receiptAttendeeMap,
+    receiptMap,
+    attendeeDirectory,
+  ).map((b) => b.message);
 }

--- a/tests/receipts/reconcile-grouping.test.ts
+++ b/tests/receipts/reconcile-grouping.test.ts
@@ -8,61 +8,71 @@ import {
 import type { AmexStatementLine, AmexMatchStatus } from "@/lib/receipts/types";
 import type { ConfidenceBand } from "@/lib/receipts/confidence";
 
-// groupLinesByStatus reads only line.match_status (via isSettled) and the
-// wrapper's band, so a minimal stub is sufficient and stays readable.
+// groupLinesByStatus reads only line.match_status (via isSettled), the line's
+// receipt_missing_reason (via isSettled), and the wrapper's band — so a minimal
+// stub is sufficient and stays readable.
+function line(
+  id: string,
+  match_status: AmexMatchStatus,
+  receipt_missing_reason: string | null = null,
+): AmexStatementLine {
+  return { id, match_status, receipt_missing_reason } as AmexStatementLine;
+}
 function banded(
   id: string,
   match_status: AmexMatchStatus,
   band: ConfidenceBand,
+  receipt_missing_reason: string | null = null,
 ): LineWithBand {
-  return { line: { id, match_status } as AmexStatementLine, band, match: undefined };
+  return { line: line(id, match_status, receipt_missing_reason), band, match: undefined };
 }
 
-test("isSettled: confirmed and no_receipt are terminal; matched/unmatched are not", () => {
-  assert.equal(isSettled({ match_status: "confirmed" } as AmexStatementLine), true);
-  assert.equal(isSettled({ match_status: "no_receipt" } as AmexStatementLine), true);
-  assert.equal(isSettled({ match_status: "matched" } as AmexStatementLine), false);
-  assert.equal(isSettled({ match_status: "unmatched" } as AmexStatementLine), false);
+// ─── §1: isSettled — no_receipt is settled ONLY with a reason ────────────────
+
+test("isSettled: confirmed is settled; matched/unmatched are not", () => {
+  assert.equal(isSettled(line("c", "confirmed")), true);
+  assert.equal(isSettled(line("m", "matched")), false);
+  assert.equal(isSettled(line("u", "unmatched")), false);
 });
 
-test("groupLinesByStatus: a no_receipt line is settled, not 'needs attention'", () => {
-  // June-2026 shape: a no_receipt line carries no auto-match, so bandForLine
-  // gives it band "none" — exactly what the old groupReview filter caught,
-  // producing the phantom "Needs attention · 3" next to "32 of 32 confirmed".
-  const lines: LineWithBand[] = [
+test("isSettled: no_receipt is settled ONLY with a non-empty trimmed reason", () => {
+  assert.equal(isSettled(line("nr-reason", "no_receipt", "annual fee")), true);
+  // null / empty / whitespace ⇒ NOT settled (incomplete — needs a reason).
+  assert.equal(isSettled(line("nr-null", "no_receipt", null)), false);
+  assert.equal(isSettled(line("nr-empty", "no_receipt", "")), false);
+  assert.equal(isSettled(line("nr-ws", "no_receipt", "   ")), false);
+});
+
+// ─── grouping + count follow from isSettled alone (single source) ────────────
+
+test("groupLinesByStatus: a no_receipt WITH a reason settles (confirmed); WITHOUT it lands in Needs attention", () => {
+  const groups = groupLinesByStatus([
     banded("confirmed-1", "confirmed", "obvious"),
-    banded("no-receipt-1", "no_receipt", "none"),
-    banded("no-receipt-2", "no_receipt", "none"),
-    banded("no-receipt-3", "no_receipt", "none"),
+    banded("nr-with-reason", "no_receipt", "none", "card annual fee"),
+    banded("nr-no-reason-1", "no_receipt", "none"), // reasonless → needs attention
+    banded("nr-no-reason-2", "no_receipt", "none"),
     banded("unmatched-1", "unmatched", "none"),
-  ];
-  const groups = groupLinesByStatus(lines);
+  ]);
 
-  // The three settled no_receipt lines must NOT appear under "Needs attention".
-  assert.equal(groups.review.length, 1);
-  assert.deepEqual(
-    groups.review.map((g) => g.line.id),
-    ["unmatched-1"],
-  );
-
-  // They ARE counted as confirmed (settled) — the rail shows "5 of 5", not
-  // "2 of 5" alongside a phantom "Needs attention · 3".
-  assert.equal(groups.confirmed.length, 4);
+  // Confirmed section = confirmed + the reasoned no_receipt only.
   assert.deepEqual(
     groups.confirmed.map((g) => g.line.id),
-    ["confirmed-1", "no-receipt-1", "no-receipt-2", "no-receipt-3"],
+    ["confirmed-1", "nr-with-reason"],
+  );
+  // Needs attention = unmatched + the two reasonless no_receipt lines. The
+  // header count (confirmed.length) excludes them automatically.
+  assert.deepEqual(
+    groups.review.map((g) => g.line.id).sort(),
+    ["nr-no-reason-1", "nr-no-reason-2", "unmatched-1"],
   );
   assert.equal(groups.likely.length, 0);
   assert.equal(groups.obvious.length, 0);
 });
 
-test("groupLinesByStatus: a no_receipt line with an obvious/likely suggestion still settles", () => {
-  // Operator overrode a suggested match with "no receipt expected". It is
-  // settled regardless of the suggestion band — and excluded from the
-  // bulk-confirm-obvious candidates (which now key on !isSettled).
+test("groupLinesByStatus: a no_receipt line WITH a reason overrides an obvious/likely suggestion and settles", () => {
   const groups = groupLinesByStatus([
-    banded("nr-obvious", "no_receipt", "obvious"),
-    banded("nr-likely", "no_receipt", "likely"),
+    banded("nr-obvious", "no_receipt", "obvious", "settled reason"),
+    banded("nr-likely", "no_receipt", "likely", "settled reason"),
   ]);
   assert.equal(groups.obvious.length, 0);
   assert.equal(groups.likely.length, 0);


### PR DESCRIPTION
Unblocks the operator's 2026-07 reconciliation. A \`no_receipt\` line with an empty \`receipt_missing_reason\` was counted as settled (gray "done" pill, counted toward confirmed), then sign-off failed naming it. June's Fix B removed false positives; it introduced false negatives.

## §1 — root cause (\`lib/receipts/reconcile-grouping.ts\`)
\`no_receipt\` is settled **only** when \`receipt_missing_reason\` is a non-empty trimmed string; \`confirmed\` unchanged. This is the single authority for grouping + counting (#166), so reasonless lines return to **Needs attention** and the confirmed count excludes them — both verified to flow from \`isSettled\` alone (header \`reconcile-screen:181\` + \`groupLinesByStatus\` key on it; no single-source drift). **Fail-then-pass verified.**

## §2 — line row pill
Reason present → gray "no receipt expected" (unchanged). Reason missing → **amber "needs a reason"**.

## §3 — focus the reason field after marking
After the \`n\` shortcut / button marks a line \`no_receipt\`, focus the MISSING RECEIPT REASON field (consumed post-\`router.refresh\` via a \`reasonFocusId\` state + element id). **Not a hard block** — Enter leaves it blank; the keyboard handler skips shortcuts in inputs, so focus is a nudge, not a trap that breaks the n-through-a-list flow.

## §4 — clickable sign-off blockers
\`validateAmexLinesForSignoffDetailed\` (new, **single source**; \`validateAmexLinesForSignoff\` projects to its \`string[]\` contract for the export gate, unchanged) returns \`{lineId, message}[]\`. The finalize route returns them structured; the banner renders each with a \`lineId\` as a button that **selects the line in the rail** (\`lineId: null\` = consolidated → plain text). No merchant-name regex — the id is threaded server-side.

## §5 — header count
Always-visible **"K need(s) a reason"** (amber) when >0, from the same \`isSettled\` authority in the counts \`useMemo\`.

## Verification
\`npm test\` 1309/1308/0; \`tsc --noEmit\` clean; \`npm run build:cf\` clean. No existing test consumed the route's blockers; the export gate's \`validateAmexLinesForSignoff\` (\`string[]\`) contract is preserved (it projects from the new Detailed variant).

**Live check is the operator's (Clerk):** on \`/receipts/reconcile?month=2026-07\` the reasonless \`no_receipt\` lines appear under NEEDS ATTENTION with an amber "needs a reason" pill; the header count excludes them; clicking a sign-off blocker selects its line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)