### PR TITLE
feat(receipts): backlog #27 — attendee roster confirmation surface (Part A + B)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -661,6 +661,41 @@ starts. Design consequences:
     doctrine: sealing locks edits — the deletion path is the one hole in
     that guarantee and it currently has no code review surface.
 
+27. **Attendee roster has no confirmation surface — it only exists as a
+    sealed CSV.** NOT STARTED. Raised by the operator 2026-08-12: "where is
+    the attendee list now, how can it be confirmed each month without
+    sending to the accountant?" The answer today is: you cannot, until
+    after you seal.
+    **Current state.** `参加者一覧` is built by `buildAttendeesExportCsv`
+    (`export.ts:305`) into `exports/{month}/{exportId}-attendees.csv` — a
+    sealed, per-revision artifact containing name/company/title for the
+    attendees referenced by that month's rows. Per D9 (2026-08-07, the
+    accountant's written request) it is NOT in the delivered ZIP and the
+    会議-出席者ID column was removed from the delivered 照合CSVs; only 人数
+    ships. It is downloadable by the operator from the sealed-bundle panel.
+    The directory behind it is `receipt_attendee_directory` via
+    `/api/receipts/attendee-directory`, populated per-receipt through
+    `attendee-editor.tsx` in the review form.
+    **Gap 1 — no pre-seal review.** `review-screen.tsx` has NO attendee
+    section (zero matches). The roster first materialises at seal time, so
+    the only way to inspect the month's attendees is to finalize and
+    download the CSV — confirmation after the irreversible step. The
+    finalize gate already blocks on `attendees_required` /
+    `attendee_unresolved`, so the data to show is already computed; it just
+    is not rendered anywhere the operator can act on it in time.
+    **Gap 2 — no directory surface.** The API exists; nothing renders it.
+    D9 makes this worse, not better: `reconciliation-files.ts:13` states
+    "retention now matters MORE — we are the only copy." A tax-relevant
+    roster that is the only copy has no browse, correct, or audit screen.
+    **Fix shape.** (1) An attendee section on the export review screen
+    listing, for the month, each referenced attendee with company/title and
+    the receipts they appear on, unresolved names flagged inline against
+    the existing gate codes — confirmation belongs at Review, alongside
+    everything else about the month. (2) A directory management screen
+    (browse / correct / merge duplicates). Consider whether the roster
+    should be an explicit month-close acknowledgement like the operator
+    message decision (`message_not_reviewed`), rather than passive display.
+
 19. **Never-enqueued receipts are undetectable — wire a pipeline health
     surface.** NOT DISPATCHED — same prompt as #18, Part A (do it FIRST).
     `getExtractionHealth` (`lib/receipts/extraction-state.ts:69`) is written

--- a/app/(receipt-system)/receipts/export/[month]/review/page.tsx
+++ b/app/(receipt-system)/receipts/export/[month]/review/page.tsx
@@ -138,6 +138,9 @@ export default async function ReviewPage({ params }: { params: Params }) {
       prefaceNoticeInput={prefaceNoticeInput}
       prefaceNames={prefaceNames}
       stages={stages}
+      attendeeMap={bundle.attendeeMap}
+      amexAttendees={bundle.amexAttendees}
+      attendeeDirectory={bundle.attendeeDirectory}
     />
   );
 }

--- a/app/(receipt-system)/receipts/settings/attendee-directory/page.tsx
+++ b/app/(receipt-system)/receipts/settings/attendee-directory/page.tsx
@@ -1,0 +1,49 @@
+import { assertReceiptsPageAccess } from "@/lib/receipts/auth-request";
+import {
+  listAttendeeDirectory,
+  listAttendeeNameReferenceCounts,
+} from "@/lib/receipts/db";
+import { AttendeeDirectoryManager } from "@/components/receipts/settings/attendee-directory-manager";
+
+export const dynamic = "force-dynamic";
+
+// Backlog #27 Part B: a management surface for the attendee directory (the
+// company/title lookup behind the 参加者一覧 roster). Browse, edit company/title,
+// and spot stale (no referencing receipts) + unregistered (referenced by a
+// receipt but not in the directory — the source of attendee_unresolved at
+// finalize). Editing does NOT change already-sealed months (the CSV is immutable
+// in R2); it changes what FUTURE bundles resolve.
+
+export default async function AttendeeDirectoryPage() {
+  await assertReceiptsPageAccess();
+
+  const [entries, refCountsMap] = await Promise.all([
+    listAttendeeDirectory(),
+    listAttendeeNameReferenceCounts(),
+  ]);
+  const referenceCounts: Record<string, number> = Object.fromEntries(refCountsMap);
+
+  // Unregistered names: referenced by receipts but NOT in the directory. These
+  // are exactly what produces attendee_unresolved at finalize.
+  const directoryNames = new Set(entries.map((e) => e.name));
+  const unregistered = [...refCountsMap.entries()]
+    .filter(([name]) => !directoryNames.has(name))
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => b.count - a.count);
+
+  return (
+    <div className="space-y-6 px-8 py-8">
+      <div>
+        <h2 className="text-[20px] font-bold text-gray-900">Attendee directory</h2>
+        <p className="mt-1 text-sm text-gray-500">
+          The company/title lookup behind the 参加者一覧 roster.
+        </p>
+      </div>
+      <AttendeeDirectoryManager
+        entries={entries}
+        referenceCounts={referenceCounts}
+        unregistered={unregistered}
+      />
+    </div>
+  );
+}

--- a/app/(receipt-system)/receipts/settings/page.tsx
+++ b/app/(receipt-system)/receipts/settings/page.tsx
@@ -83,6 +83,24 @@ export default async function ReceiptsSettingsPage() {
             <span className="text-sm text-amber-700">Manage →</span>
           </Link>
         </li>
+        <li>
+          <Link
+            href="/receipts/settings/attendee-directory"
+            className="flex items-center justify-between p-4 transition-colors hover:bg-amber-50"
+          >
+            <div>
+              <p className="text-sm font-semibold text-gray-900">
+                Attendee directory
+              </p>
+              <p className="mt-1 text-xs text-gray-500">
+                The company/title lookup behind the 参加者一覧 roster. Browse,
+                correct company/title, and spot stale or unregistered names.
+                Editing does not change already-sealed months.
+              </p>
+            </div>
+            <span className="text-sm text-amber-700">Manage →</span>
+          </Link>
+        </li>
       </ul>
     </div>
   );

--- a/app/api/receipts/attendee-directory/[id]/route.ts
+++ b/app/api/receipts/attendee-directory/[id]/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from "next/server";
+import { requireReceiptsActor } from "@/lib/receipts/auth";
+import { updateAttendeeDirectoryEntry } from "@/lib/receipts/db";
+import type { ReceiptAttendeeDirectoryEntry } from "@/lib/receipts/attendee-directory";
+
+// PATCH company/title for an attendee_directory entry. The name (identity / join
+// key) is NOT editable — renaming would orphan receipt_attendees (free-text, no
+// FK) and drift sealed-vs-unsealed resolution. See updateAttendeeDirectoryEntry.
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const actor = await requireReceiptsActor(request.headers);
+    const { id: idStr } = await params;
+    const id = Number(idStr);
+    if (!Number.isInteger(id) || id < 1) {
+      return NextResponse.json({ error: "Invalid entry id." }, { status: 400 });
+    }
+
+    const body = (await request.json().catch(() => ({}))) as {
+      company?: unknown;
+      title?: unknown;
+    };
+    const company = typeof body.company === "string" ? body.company.trim() : "";
+    const title = typeof body.title === "string" ? body.title.trim() : "";
+    if (!company || !title) {
+      return NextResponse.json(
+        { error: "company and title are both required." },
+        { status: 400 },
+      );
+    }
+
+    const entry: ReceiptAttendeeDirectoryEntry = await updateAttendeeDirectoryEntry(
+      id,
+      { company, title },
+      actor,
+    );
+    return NextResponse.json({ entry }, { status: 200 });
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Unauthorized")) {
+      return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+    }
+    const msg = error instanceof Error ? error.message : String(error);
+    if (msg.includes("not found")) {
+      return NextResponse.json({ error: msg }, { status: 404 });
+    }
+    console.error("[api/receipts/attendee-directory/[id]] PATCH failed", error);
+    return NextResponse.json(
+      { error: msg || "Failed to update attendee." },
+      { status: 500 },
+    );
+  }
+}

--- a/components/receipts/export/review-screen.tsx
+++ b/components/receipts/export/review-screen.tsx
@@ -26,6 +26,11 @@ import type { CategoryRule } from "@/lib/receipts/category-rules";
 import type { PackNoticeInput } from "@/lib/receipts/proofs";
 import type { PackNames } from "@/lib/receipts/pack-naming";
 import { withWorkMonth } from "@/lib/receipts/work-month";
+import { resolveRowAttendees } from "@/lib/receipts/export";
+import {
+  resolveAttendeeNames,
+  type ReceiptAttendeeDirectoryEntry,
+} from "@/lib/receipts/attendee-directory";
 import { PrefaceFinalizeSection } from "@/components/receipts/export/preface-finalize-section";
 import { MonthPipeline } from "@/components/receipts/export/month-pipeline";
 import { NextActionCard } from "@/components/receipts/export/next-action-card";
@@ -57,6 +62,14 @@ export interface ReviewScreenProps {
   /** Server-derived month-close stages — drives the shared MonthPipeline +
    *  NextActionCard mounted on every surface (docs/export-workflow-ux-plan.md). */
   stages: MonthStage[];
+  /** bundle.attendeeMap — receipt-id → attendee names. Drives the Attendees
+   *  section's roster (参加者一覧) at Review, before sealing. */
+  attendeeMap: Map<string, string[]>;
+  /** bundle.amexAttendees — AMEX-line-id → attendee names (line-level). */
+  amexAttendees: Record<string, string[]>;
+  /** bundle.attendeeDirectory — the company/title lookup the roster + the
+   *  finalize gate resolve against (single source — never recompute). */
+  attendeeDirectory: ReceiptAttendeeDirectoryEntry[];
 }
 
 export function ReviewScreen(props: ReviewScreenProps) {
@@ -123,6 +136,13 @@ export function ReviewScreen(props: ReviewScreenProps) {
           candidateRows={amexRows.filter(
             (r) => r.businessTripStatus === "candidate",
           )}
+        />
+        <AttendeesSection
+          rows={props.rows}
+          receipts={props.receipts}
+          attendeeMap={props.attendeeMap}
+          amexAttendees={props.amexAttendees}
+          attendeeDirectory={props.attendeeDirectory}
         />
       </div>
 
@@ -722,6 +742,113 @@ function BusinessTripsSection({
 }
 
 // ─── Shared bits ──────────────────────────────────────────────────────────
+
+// Backlog #27 Part A: the month's attendee roster (参加者一覧) at Review, before
+// sealing. The names source is resolveRowAttendees over the bundle rows — the
+// SAME source buildAttendeesExportCsv uses for the sealed CSV and the SAME
+// attendee sets the finalize gate resolves — so this cannot drift from either.
+// Resolution reuses resolveAttendeeNames (shared with the gate); it is NOT
+// recomputed here. Unresolved names use the gate's own attendee_unresolved
+// wording so the two surfaces agree.
+function AttendeesSection({
+  rows,
+  receipts,
+  attendeeMap,
+  amexAttendees,
+  attendeeDirectory,
+}: {
+  rows: ExportRow[];
+  receipts: ReceiptRecord[];
+  attendeeMap: Map<string, string[]>;
+  amexAttendees: Record<string, string[]>;
+  attendeeDirectory: ReceiptAttendeeDirectoryEntry[];
+}) {
+  const names = [
+    ...new Set(rows.flatMap((r) => resolveRowAttendees(r, attendeeMap, amexAttendees))),
+  ].sort();
+  const { entries } = resolveAttendeeNames(names, attendeeDirectory); // entries[i] ↔ names[i]
+  const unresolvedCount = entries.filter((e) => !e).length;
+
+  // name → receipt ids they appear on (for the "appears on" column).
+  const receiptsByName = new Map<string, string[]>();
+  for (const r of rows) {
+    const rid = r.receiptId;
+    if (!rid) continue;
+    for (const name of resolveRowAttendees(r, attendeeMap, amexAttendees)) {
+      const list = receiptsByName.get(name) ?? [];
+      if (!list.includes(rid)) list.push(rid);
+      receiptsByName.set(name, list);
+    }
+  }
+  const receiptMap = new Map(receipts.map((r) => [r.id, r]));
+
+  const sub =
+    names.length === 0
+      ? "No attendees referenced this month"
+      : `${names.length} attendee${names.length === 1 ? "" : "s"}` +
+        (unresolvedCount > 0 ? ` · ${unresolvedCount} unresolved` : "");
+
+  return (
+    <div>
+      <SectionTitle title="Attendees (参加者一覧)" sub={sub} />
+      {names.length === 0 ? (
+        <Card pad={20}>
+          <p className="text-[13px] text-gray-600">
+            No attendees are referenced by this month&apos;s receipts. The 参加者一覧
+            is built only from attendee-bearing rows (会議費/交際費) that carry names.
+          </p>
+        </Card>
+      ) : (
+        <Card pad={0}>
+          <ul className="divide-y divide-gray-100">
+            {names.map((name, i) => {
+              const entry = entries[i];
+              const rids = receiptsByName.get(name) ?? [];
+              return (
+                <li key={name} className="px-5 py-3">
+                  <div className="flex items-baseline justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="text-[13.5px] font-semibold text-gray-900">
+                        {name}
+                      </div>
+                      {entry ? (
+                        <div className="mt-0.5 text-[12px] text-gray-500">
+                          {entry.company}
+                          {entry.title ? ` · ${entry.title}` : ""}
+                        </div>
+                      ) : (
+                        <div className="mt-0.5 text-[12px] font-medium text-amber-700">
+                          attendee &ldquo;{name}&rdquo; is not registered in the
+                          attendee directory (company/title required)
+                        </div>
+                      )}
+                    </div>
+                    <div className="shrink-0 text-right text-[11.5px] text-gray-500">
+                      {rids.length > 0 ? (
+                        rids.map((rid) => {
+                          const r = receiptMap.get(rid);
+                          if (!r) return null;
+                          return (
+                            <div key={rid}>
+                              {r.merchant ?? r.id.slice(0, 8)}
+                              {r.transaction_date ? ` · ${r.transaction_date}` : ""}
+                            </div>
+                          );
+                        })
+                      ) : (
+                        <span className="text-gray-400">AMEX line</span>
+                      )}
+                    </div>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </Card>
+      )}
+    </div>
+  );
+}
 
 function SectionTitle({ title, sub }: { title: string; sub: string }) {
   return (

--- a/components/receipts/settings/attendee-directory-manager.tsx
+++ b/components/receipts/settings/attendee-directory-manager.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useState } from "react";
+import { Btn } from "@/components/ui/btn";
+import { Card } from "@/components/ui/card";
+import { Pill } from "@/components/ui/pill";
+import { Field, TextInput } from "@/components/ui/field";
+import type { ReceiptAttendeeDirectoryEntry } from "@/lib/receipts/attendee-directory";
+
+// Backlog #27 Part B. Browse + edit company/title. Names are NOT editable
+// (rename/merge would orphan receipt_attendees — free-text, no FK — and drift
+// sealed-vs-unsealed resolution; see updateAttendeeDirectoryEntry). The sealed
+// note below states the immutability guarantee.
+
+export function AttendeeDirectoryManager({
+  entries,
+  referenceCounts,
+  unregistered,
+}: {
+  entries: ReceiptAttendeeDirectoryEntry[];
+  referenceCounts: Record<string, number>;
+  unregistered: { name: string; count: number }[];
+}) {
+  return (
+    <div className="space-y-6">
+      <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-[12.5px] text-amber-800">
+        Editing a name&apos;s company or title changes what <strong>future</strong>{" "}
+        months resolve — it does <strong>not</strong> change already-sealed months.
+        The 参加者一覧 CSV is sealed bytes in R2 at finalize time and is never
+        regenerated from the directory. Names are not editable here (renaming would
+        orphan referencing receipts).
+      </div>
+
+      <Card pad={0}>
+        <div className="border-b border-gray-150 px-5 py-3">
+          <span className="text-[13.5px] font-semibold text-gray-900">
+            Directory entries
+          </span>
+          <span className="ml-2 text-[12px] text-gray-500">
+            {entries.length} total
+          </span>
+        </div>
+        <ul className="divide-y divide-gray-100">
+          {entries.map((entry) => (
+            <DirectoryEntryRow
+              key={entry.id}
+              entry={entry}
+              count={referenceCounts[entry.name] ?? 0}
+            />
+          ))}
+        </ul>
+      </Card>
+
+      {unregistered.length > 0 && (
+        <Card pad={20}>
+          <div className="flex items-center gap-2">
+            <span className="text-[13.5px] font-semibold text-amber-700">
+              Unregistered names
+            </span>
+            <Pill tone="amber" size="sm">{unregistered.length}</Pill>
+          </div>
+          <p className="mt-1 text-[12px] text-gray-500">
+            Referenced by receipts but not in the directory. These produce the{" "}
+            <code>attendee_unresolved</code> finalize blocker — register each (name,
+            company, title) to clear it.
+          </p>
+          <ul className="mt-3 space-y-1 text-[12.5px]">
+            {unregistered.map((u) => (
+              <li key={u.name} className="flex items-center justify-between">
+                <span className="font-medium text-gray-900">{u.name}</span>
+                <span className="text-gray-500">{u.count} receipt{u.count === 1 ? "" : "s"}</span>
+              </li>
+            ))}
+          </ul>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+function DirectoryEntryRow({
+  entry,
+  count,
+}: {
+  entry: ReceiptAttendeeDirectoryEntry;
+  count: number;
+}) {
+  const [company, setCompany] = useState(entry.company);
+  const [title, setTitle] = useState(entry.title);
+  const [busy, setBusy] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const dirty = company.trim() !== entry.company || title.trim() !== entry.title;
+
+  async function save() {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/receipts/attendee-directory/${entry.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ company, title }),
+      });
+      if (!res.ok) {
+        const json = (await res.json().catch(() => ({}))) as { error?: string };
+        setError(json.error ?? "Save failed.");
+        return;
+      }
+      setSaved(true);
+      setTimeout(() => setSaved(false), 1500);
+    } catch {
+      setError("Network error.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <li className="px-5 py-3.5">
+      <div className="flex items-baseline justify-between gap-3">
+        <div className="text-[13.5px] font-semibold text-gray-900">{entry.name}</div>
+        <div className="shrink-0">
+          {count === 0 ? (
+            <Pill tone="gray" size="sm">no receipts · stale</Pill>
+          ) : (
+            <Pill tone="blue" size="sm">{count} receipt{count === 1 ? "" : "s"}</Pill>
+          )}
+        </div>
+      </div>
+      <div className="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2">
+        <Field label="Company">
+          <TextInput value={company} onChange={(e) => setCompany(e.target.value)} />
+        </Field>
+        <Field label="Title">
+          <TextInput value={title} onChange={(e) => setTitle(e.target.value)} />
+        </Field>
+      </div>
+      {error && (
+        <p className="mt-1.5 text-[12px] text-red-600">{error}</p>
+      )}
+      <div className="mt-2 flex items-center gap-2">
+        <Btn kind="primary" size="sm" onClick={save} disabled={!dirty || busy}>
+          {busy ? "Saving…" : "Save"}
+        </Btn>
+        {saved && <span className="text-[12px] text-green-600">Saved</span>}
+        {!dirty && !saved && (
+          <span className="text-[11.5px] text-gray-400">No changes</span>
+        )}
+      </div>
+    </li>
+  );
+}

--- a/lib/receipts/db.ts
+++ b/lib/receipts/db.ts
@@ -1012,6 +1012,68 @@ export async function createAttendeeDirectoryEntry(
   return entry;
 }
 
+/**
+ * Update an attendee directory entry's company/title. The name (the identity /
+ * join key) is deliberately NOT editable here: receipt_attendees stores attendee
+ * names as free text with no FK, so renaming would orphan every receipt still
+ * holding the old string AND change what resolveAttendeeNames returns for future
+ * builds (a sealed-vs-unsealed drift). Company/title edits are safe — they
+ * change what FUTURE bundles resolve, but sealed CSV bytes in R2 are immutable
+ * (built at seal time; no re-seal-from-directory path), so a correction does not
+ * propagate backwards into a sealed month. Not subject to export-lock (directory
+ * rows are not receipt_records / receipt_exports).
+ */
+export async function updateAttendeeDirectoryEntry(
+  id: number,
+  input: { company: string; title: string },
+  actor: string,
+): Promise<ReceiptAttendeeDirectoryEntry> {
+  const company = input.company.trim();
+  const title = input.title.trim();
+  if (!company || !title) {
+    throw new Error("company and title are all required (non-empty).");
+  }
+  const db = getReceiptsDb();
+  const now = nowIso();
+  const updated = await db
+    .prepare(
+      `UPDATE attendee_directory SET company = ?, title = ?, updated_at = ?
+       WHERE id = ?
+       RETURNING id, name, company, title`,
+    )
+    .bind(company, title, now, id)
+    .first<ReceiptAttendeeDirectoryEntry>();
+  if (!updated) {
+    throw new Error(`Attendee directory entry ${id} not found.`);
+  }
+  await createAuditEntry(db, {
+    actor,
+    action: "attendee_directory.updated",
+    objectType: "attendee_directory",
+    objectId: String(updated.id),
+    newValueJson: stringifyJson({ name: updated.name, company: updated.company, title: updated.title }),
+  });
+  return updated;
+}
+
+/**
+ * receipt_attendees name → distinct-receipt count (the directory screen's
+ * "how many receipts reference each entry" + the source of `attendee_unresolved`
+ * at finalize — names present here but NOT in the directory are the unregistered
+ * names the gate blocks on). Exact-string match, same as resolveAttendeeNames.
+ */
+export async function listAttendeeNameReferenceCounts(): Promise<Map<string, number>> {
+  const db = getReceiptsDb();
+  const result = await db
+    .prepare(
+      `SELECT attendee_name, COUNT(DISTINCT receipt_id) AS n
+       FROM receipt_attendees
+       GROUP BY attendee_name`,
+    )
+    .all<{ attendee_name: string; n: number }>();
+  return new Map((result.results ?? []).map((r) => [r.attendee_name, r.n]));
+}
+
 // ─── AMEX statement lines ─────────────────────────────────────────────────────
 
 export async function importAmexLines(

--- a/lib/receipts/types.ts
+++ b/lib/receipts/types.ts
@@ -166,6 +166,7 @@ export type AuditAction =
   // Attendee directory (migration 0022): a new entry registered from the
   // review UI. Attended identity = directory name; company/title NOT NULL.
   | "attendee_directory.created"
+  | "attendee_directory.updated"
   // Business trips as first-class entities (ADR 0010). The trip screen owns
   // the lifecycle; detection only suggests ('candidate').
   | "business_trip.created"


### PR DESCRIPTION
Backlog #27 — the operator raised (2026-08-12): the 参加者一覧 only exists as a sealed CSV, so the only way to review a month's attendees was to finalize and download. The directory had an API and no UI. Not urgent for 2026-07's close (the finalize gate already blocks on \`attendee_unresolved\`), but the operator couldn't *see* it in time.

## Part A — attendee section on the export review screen
\`AttendeesSection\` on \`review-screen.tsx\`. Names source = \`resolveRowAttendees\` over the bundle rows — the **same source** \`buildAttendeesExportCsv\` uses for the sealed CSV and the same attendee sets the gate resolves, so it cannot drift from either. Resolution **reuses \`resolveAttendeeNames\`** (shared with the gate); not recomputed. Unresolved names flagged with the gate's own \`attendee_unresolved\` wording. One row per attendee (name, company/title or the unresolved flag, receipts they appear on). Count + unresolved count in the header; empty state for months with no attendee-bearing rows. Threads \`bundle.attendeeMap\` + \`amexAttendees\` + \`attendeeDirectory\` (no new query, no \`ExportBundle\` change).

## Part B — attendee directory screen under \`/receipts/settings/attendee-directory\`
Browse every entry (name, company, title, receipt count), **edit company/title** inline (PATCH \`/api/receipts/attendee-directory/[id]\`), surface **stale** (no referencing receipts) + **unregistered** names (referenced by a receipt but not in the directory — the \`attendee_unresolved\` source). The sealed-bytes immutability guarantee is stated in the UI.

### Guard findings (Part B)
- **Rename/merge NOT shipped.** \`receipt_attendees\` stores names as free text (no FK); renaming a directory name would orphan every receipt still holding the old string AND change what \`resolveAttendeeNames\` returns for future builds (sealed-vs-unsealed drift). Shipped browse + edit-company/title only.
- **Sealed-month guards don't apply to directory edits** — directory rows aren't \`receipt_records\`/\`receipt_exports\`, so export-lock is irrelevant. And sealed CSV bytes are immutable in R2 (built at seal time; no re-seal-from-directory path), so a company/title correction changes only what FUTURE months resolve, not sealed ones. Confirmed + stated in the UI.

## Part C — explicit acknowledgement? (recommendation, not implemented)
Recommendation in the report (not in this PR): the message uses \`message_not_reviewed\` to force an explicit decision. The analog for attendees would be a \`attendee_roster_reviewed\` gate code + a decision timestamp (same shape as \`operator_message_updated_at\`). My recommendation: **do NOT add it yet** — the gate already blocks on \`attendees_required\`/\`attendee_unresolved\` (the data-level invariant), and Part A's Review-section display gives the operator the roster in time. An explicit "roster confirmed" timestamp adds a second, weaker signal (the operator could click it without actually looking) on top of the structural one. Cost if wanted later: one AuditAction, one nullable timestamp column + migration, one gate code, mirroring the \`message_not_reviewed\`/\`message_stale\` machinery. Defer until there's evidence the display isn't enough.

## Verification
\`npm test\` 1310/1309/0; \`tsc\` + \`build:cf\` clean. No existing test modified (no \`ExportBundle\` change). **Live check is the operator's (Clerk):** on 2026-07's review page the attendee section lists the month's attendees with company/title, unresolved names flagged with the gate wording; \`/receipts/settings/attendee-directory\` browses + edits the directory with stale/unregistered surfacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)