### PR TITLE
fix(receipts): suppress autosave/router.refresh during Japanese IME composition

### DIFF
--- a/components/receipts/review/form-pane.tsx
+++ b/components/receipts/review/form-pane.tsx
@@ -142,6 +142,12 @@ export function FormPane(props: FormPaneProps) {
   const [businessPurpose, setBusinessPurpose] = useState(
     receipt.business_purpose ?? "",
   );
+  // WebKit can interrupt a native Japanese IME conversion when a render that
+  // refreshes the route lands mid-composition. Keep this separate from the
+  // field value: React still displays every composing character, but autosave
+  // waits until the IME commits the final text.
+  const [isBusinessPurposeComposing, setIsBusinessPurposeComposing] =
+    useState(false);
   const [attendees, setAttendees] = useState<string[]>(
     props.initialAttendees.map((a) => a.attendee_name),
   );
@@ -240,6 +246,9 @@ export function FormPane(props: FormPaneProps) {
   const initialRenderRef = useRef(true);
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const inFlightRef = useRef<AbortController | null>(null);
+  // A ref is needed in the async save path, where state from a previous render
+  // could otherwise permit router.refresh() while the IME is composing.
+  const businessPurposeComposingRef = useRef(false);
 
   const triggerSave = useCallback(
     (markReviewed: boolean) => {
@@ -299,7 +308,9 @@ export function FormPane(props: FormPaneProps) {
           // Refresh server-rendered CompliancePanel without manual reload.
           // router.refresh() preserves client state (focused input, useState
           // field values) — React reconciles rather than replacing the DOM.
-          router.refresh();
+          // Do not run it in the middle of a native Japanese IME composition:
+          // Safari can drop the input's focus before the conversion commits.
+          if (!businessPurposeComposingRef.current) router.refresh();
         } catch (error) {
           if ((error as DOMException | undefined)?.name === "AbortError") return;
           setSave({ kind: "error", message: "Network error" });
@@ -360,7 +371,7 @@ export function FormPane(props: FormPaneProps) {
     // Sealed receipt: never fire the autosave debounce. The fields are disabled
     // so they can't change, but this guards against programmatic state changes
     // and is the explicit "suppress entirely" the lock requires.
-    if (isLocked) return;
+    if (isLocked || isBusinessPurposeComposing) return;
     triggerSave(false);
   }, [
     paymentPath,
@@ -372,8 +383,26 @@ export function FormPane(props: FormPaneProps) {
     businessPurpose,
     attendees,
     isLocked,
+    isBusinessPurposeComposing,
     triggerSave,
   ]);
+
+  const handleBusinessPurposeCompositionStart = useCallback(() => {
+    businessPurposeComposingRef.current = true;
+    setIsBusinessPurposeComposing(true);
+    // A save scheduled just before composition began could still refresh the
+    // route midway through conversion, so cancel it (and any active request).
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    inFlightRef.current?.abort();
+  }, []);
+
+  const handleBusinessPurposeCompositionEnd = useCallback((value: string) => {
+    businessPurposeComposingRef.current = false;
+    // Some WebKit IME sequences deliver the final value with compositionend;
+    // keeping it here makes the subsequent autosave use the committed text.
+    setBusinessPurpose(value);
+    setIsBusinessPurposeComposing(false);
+  }, []);
 
   // ─── keyboard shortcuts ─────────────────────────────────────────────
   const onMarkReviewed = useCallback(() => {
@@ -744,6 +773,10 @@ export function FormPane(props: FormPaneProps) {
             <TextInput
               value={businessPurpose}
               onChange={(e) => setBusinessPurpose(e.target.value)}
+              onCompositionStart={handleBusinessPurposeCompositionStart}
+              onCompositionEnd={(e) =>
+                handleBusinessPurposeCompositionEnd(e.currentTarget.value)
+              }
               disabled={isLocked}
               placeholder="e.g. Client dinner — Acme product review"
             />


### PR DESCRIPTION
## Problem

On macOS Sonoma Safari/WebKit, the Receipts Review → **Business purpose** field loses focus while converting Japanese characters via the native IME. Root cause: the 450ms autosave calls `router.refresh()` during an active WebKit composition. Tahoe does not reproduce it, but WebKit must not be interrupted mid-composition.

## Fix

Guard the composition lifecycle on the Business purpose `TextInput`:

- **`onCompositionStart`** — mark composing (state + ref), clear the pending 450ms debounce, and abort any in-flight save (`AbortError` is swallowed silently).
- **While composing** — the autosave effect early-returns, and `router.refresh()` is suppressed via a ref read in the async save path.
- **`onCompositionEnd`** — commit the final value and release the guard so the ordinary debounced autosave runs normally.

The **ref** guards the async `setTimeout` path (state from a prior render could otherwise permit `router.refresh()` mid-composition); the **state** guards the effect. No focus-restoration workaround — the refresh is prevented at its source. Ordinary non-IME editing is unchanged.

## Verification

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint components/receipts/review/form-pane.tsx` — clean
- [x] `npm run build:cf` — `OpenNext build complete`
- [x] Staged set confirmed: only `components/receipts/review/form-pane.tsx` (+35/-2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)