### PR TITLE
fix(receipts): IME focus safety — revert #189 composition lifecycle + drop autosave refresh [HOTFIX]

### DIFF
--- a/components/receipts/reconcile/reconcile-screen.tsx
+++ b/components/receipts/reconcile/reconcile-screen.tsx
@@ -1684,11 +1684,6 @@ function NoReceiptFields({
           value={missingReasonDraft}
           onChange={(e) => setMissingReasonDraft(e.target.value)}
           onBlur={saveMissingReason}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") {
-              e.currentTarget.blur();
-            }
-          }}
           placeholder="e.g. card fee, online charge, receipt lost"
         />
       </Field>

--- a/components/receipts/review/form-pane.tsx
+++ b/components/receipts/review/form-pane.tsx
@@ -142,12 +142,6 @@ export function FormPane(props: FormPaneProps) {
   const [businessPurpose, setBusinessPurpose] = useState(
     receipt.business_purpose ?? "",
   );
-  // WebKit can interrupt a native Japanese IME conversion when a render that
-  // refreshes the route lands mid-composition. Keep this separate from the
-  // field value: React still displays every composing character, but autosave
-  // waits until the IME commits the final text.
-  const [isBusinessPurposeComposing, setIsBusinessPurposeComposing] =
-    useState(false);
   const [attendees, setAttendees] = useState<string[]>(
     props.initialAttendees.map((a) => a.attendee_name),
   );
@@ -246,9 +240,6 @@ export function FormPane(props: FormPaneProps) {
   const initialRenderRef = useRef(true);
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const inFlightRef = useRef<AbortController | null>(null);
-  // A ref is needed in the async save path, where state from a previous render
-  // could otherwise permit router.refresh() while the IME is composing.
-  const businessPurposeComposingRef = useRef(false);
 
   const triggerSave = useCallback(
     (markReviewed: boolean) => {
@@ -305,12 +296,10 @@ export function FormPane(props: FormPaneProps) {
           }
           setApiWarnings(json.warnings ?? []);
           setSave({ kind: "saved", at: Date.now() });
-          // Refresh server-rendered CompliancePanel without manual reload.
-          // router.refresh() preserves client state (focused input, useState
-          // field values) — React reconciles rather than replacing the DOM.
-          // Do not run it in the middle of a native Japanese IME composition:
-          // Safari can drop the input's focus before the conversion commits.
-          if (!businessPurposeComposingRef.current) router.refresh();
+          // Do not refresh the route after ordinary field autosaves. A refresh
+          // can interrupt an active WebKit IME conversion and steal focus from
+          // any text field; the local form state is already authoritative for
+          // the editor. Explicit actions and navigation still refresh normally.
         } catch (error) {
           if ((error as DOMException | undefined)?.name === "AbortError") return;
           setSave({ kind: "error", message: "Network error" });
@@ -328,7 +317,6 @@ export function FormPane(props: FormPaneProps) {
       currency,
       businessPurpose,
       attendees,
-      router,
     ],
   );
 
@@ -371,7 +359,7 @@ export function FormPane(props: FormPaneProps) {
     // Sealed receipt: never fire the autosave debounce. The fields are disabled
     // so they can't change, but this guards against programmatic state changes
     // and is the explicit "suppress entirely" the lock requires.
-    if (isLocked || isBusinessPurposeComposing) return;
+    if (isLocked) return;
     triggerSave(false);
   }, [
     paymentPath,
@@ -383,26 +371,8 @@ export function FormPane(props: FormPaneProps) {
     businessPurpose,
     attendees,
     isLocked,
-    isBusinessPurposeComposing,
     triggerSave,
   ]);
-
-  const handleBusinessPurposeCompositionStart = useCallback(() => {
-    businessPurposeComposingRef.current = true;
-    setIsBusinessPurposeComposing(true);
-    // A save scheduled just before composition began could still refresh the
-    // route midway through conversion, so cancel it (and any active request).
-    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
-    inFlightRef.current?.abort();
-  }, []);
-
-  const handleBusinessPurposeCompositionEnd = useCallback((value: string) => {
-    businessPurposeComposingRef.current = false;
-    // Some WebKit IME sequences deliver the final value with compositionend;
-    // keeping it here makes the subsequent autosave use the committed text.
-    setBusinessPurpose(value);
-    setIsBusinessPurposeComposing(false);
-  }, []);
 
   // ─── keyboard shortcuts ─────────────────────────────────────────────
   const onMarkReviewed = useCallback(() => {
@@ -773,10 +743,6 @@ export function FormPane(props: FormPaneProps) {
             <TextInput
               value={businessPurpose}
               onChange={(e) => setBusinessPurpose(e.target.value)}
-              onCompositionStart={handleBusinessPurposeCompositionStart}
-              onCompositionEnd={(e) =>
-                handleBusinessPurposeCompositionEnd(e.currentTarget.value)
-              }
               disabled={isLocked}
               placeholder="e.g. Client dinner — Acme product review"
             />

--- a/tests/receipts/ime-focus-safety.test.ts
+++ b/tests/receipts/ime-focus-safety.test.ts
@@ -1,0 +1,69 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const reviewForm = readFileSync(
+  "components/receipts/review/form-pane.tsx",
+  "utf8",
+);
+const reconcileScreen = readFileSync(
+  "components/receipts/reconcile/reconcile-screen.tsx",
+  "utf8",
+);
+
+function section(source: string, start: string, end: string): string {
+  const from = source.indexOf(start);
+  const to = source.indexOf(end, from);
+  assert.notEqual(from, -1, `missing start marker: ${start}`);
+  assert.notEqual(to, -1, `missing end marker: ${end}`);
+  return source.slice(from, to);
+}
+
+test("review autosave never refreshes the route while an operator is typing", () => {
+  // WebKit Japanese IME composition is interrupted by a route refresh. This
+  // protects EVERY editable review field, rather than a single field-specific
+  // composition handler that can regress normal input.
+  const autosave = section(
+    reviewForm,
+    "const triggerSave = useCallback(",
+    "// ADR 0006 §D6",
+  );
+  assert.doesNotMatch(autosave, /router\.refresh\(/);
+});
+
+test("Business purpose remains a plain controlled input without IME-time state updates", () => {
+  // PR #189 added composition-start state updates to this controlled input.
+  // On Sonoma WebKit that render can write React's previous value over the
+  // browser's uncommitted marked text, making the field appear not to accept
+  // input at all. Do not restore that field-specific lifecycle.
+  assert.doesNotMatch(
+    reviewForm,
+    /isBusinessPurposeComposing|businessPurposeComposingRef/,
+  );
+  const documentationField = section(
+    reviewForm,
+    'label="Business purpose"',
+    'label="Attendees"',
+  );
+  assert.doesNotMatch(
+    documentationField,
+    /onCompositionStart|onCompositionEnd/,
+  );
+  assert.match(
+    documentationField,
+    /onChange=\{\(e\) => setBusinessPurpose\(e\.target\.value\)\}/,
+  );
+});
+
+test("IME Enter does not blur the Missing receipt reason field", () => {
+  // Enter confirms a Japanese candidate. Blurring from its keydown handler
+  // drops focus before the operator has finished typing; persistence remains
+  // on a normal blur instead.
+  const noReceiptFields = section(
+    reconcileScreen,
+    "function NoReceiptFields(",
+    "function FinalizeModal(",
+  );
+  assert.doesNotMatch(noReceiptFields, /currentTarget\.blur\(/);
+  assert.match(noReceiptFields, /onBlur=\{saveMissingReason\}/);
+});


### PR DESCRIPTION
## Emergency hotfix for PR #189 regression

Independent RCA confirmed **two separate causes** of Japanese IME focus loss on macOS Sonoma WebKit. Both are fixed here.

### 1. Review "Business purpose" — `components/receipts/review/form-pane.tsx`
PR #189's `onCompositionStart` called `setIsBusinessPurposeComposing(true)` on a **controlled** input. On Sonoma WebKit that React render can write the previous controlled value over the browser's uncommitted marked text → the field appeared **not to accept input**.

- Fully revert #189's field-specific composition lifecycle: no `isBusinessPurposeComposing`, no `businessPurposeComposingRef`, no `onCompositionStart`/`onCompositionEnd`. Plain controlled `value` + `onChange` again.
- **Remove `router.refresh()` from the ordinary debounced autosave success path** — a route refresh can interrupt an active WebKit IME conversion in *any* review text field. PATCH, SaveBadge, API warnings, abort behavior, explicit actions (`handleOverride`), and navigation are unchanged.

### 2. Reconcile "Missing receipt reason" — `components/receipts/reconcile/reconcile-screen.tsx`
Its `onKeyDown` handler blurred the input on every Enter. Enter confirms a Japanese candidate, so the app itself forced blur/save/refresh during conversion.
- Remove the Enter-to-blur handler. Saving stays on intentional `onBlur`. **Not** replaced with `isComposing` (Safari's Enter/composition event ordering is unreliable).

### Regression tests — `tests/receipts/ime-focus-safety.test.ts`
- ordinary Review autosave cannot call `router.refresh()`
- Business purpose cannot regain #189's composition state/ref/handlers
- Missing receipt reason cannot blur itself on Enter

### Accepted emergency tradeoff (do not broaden this PR)
Server-derived Review display state — CompliancePanel, queue position/membership, header transaction date, merchant-derived category suggestions — may remain visually stale after an autosave until navigation or manual reload. The PATCH still persists the edit and server-side compliance recomputation still occurs.

## Verification
- [x] `npx tsx --test tests/receipts/ime-focus-safety.test.ts` — 3/3 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on all 3 files — clean
- [x] `npm run build:cf` — `OpenNext build complete`
- [x] Staged set confirmed: exactly the 3 intended files

🤖 Generated with [Claude Code](https://claude.com/claude-code)