### PR TITLE
fix(receipts): make Business purpose DOM-owned so Sonoma WebKit keeps marked text [HOTFIX]

### DIFF
--- a/components/receipts/review/form-pane.tsx
+++ b/components/receipts/review/form-pane.tsx
@@ -139,9 +139,11 @@ export function FormPane(props: FormPaneProps) {
     formatAmountInput(receipt.amount_minor, receipt.currency),
   );
   const [currency, setCurrency] = useState(receipt.currency || "JPY");
-  const [businessPurpose, setBusinessPurpose] = useState(
-    receipt.business_purpose ?? "",
-  );
+  // Keep this one input DOM-owned. Sonoma WebKit loses native Japanese marked
+  // text when React writes a controlled `value` during composition.
+  const businessPurposeValueRef = useRef(receipt.business_purpose ?? "");
+  const businessPurposeComposingRef = useRef(false);
+  const businessPurposeInputRef = useRef<HTMLInputElement | null>(null);
   const [attendees, setAttendees] = useState<string[]>(
     props.initialAttendees.map((a) => a.attendee_name),
   );
@@ -200,8 +202,11 @@ export function FormPane(props: FormPaneProps) {
       setAmountDisplay(formatAmountInput(ex.amountMinor, ex.currency ?? currency));
       filled++;
     }
-    if (ex.businessPurpose && !businessPurpose) {
-      setBusinessPurpose(ex.businessPurpose);
+    if (ex.businessPurpose && !businessPurposeValueRef.current) {
+      businessPurposeValueRef.current = ex.businessPurpose;
+      if (businessPurposeInputRef.current) {
+        businessPurposeInputRef.current.value = ex.businessPurpose;
+      }
       filled++;
     }
     return filled;
@@ -245,6 +250,9 @@ export function FormPane(props: FormPaneProps) {
     (markReviewed: boolean) => {
       if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
       saveTimerRef.current = setTimeout(async () => {
+        // A composition may have started after this timer was scheduled. Do
+        // not update SaveBadge or any other React state until WebKit commits.
+        if (businessPurposeComposingRef.current) return;
         inFlightRef.current?.abort();
         const ctrl = new AbortController();
         inFlightRef.current = ctrl;
@@ -270,7 +278,7 @@ export function FormPane(props: FormPaneProps) {
               merchant: merchant.trim() || null,
               amountMinor,
               currency,
-              businessPurpose: businessPurpose.trim() || null,
+              businessPurpose: businessPurposeValueRef.current.trim() || null,
               attendees: attendees.map((a) => a.trim()).filter(Boolean),
               // Audit 2026-07-21 Phase 1: ordinary autosaves NEVER send status —
               // a stale client value must not be able to overwrite a lifecycle
@@ -287,6 +295,9 @@ export function FormPane(props: FormPaneProps) {
             error?: string;
             warnings?: string[];
           };
+          // Abort normally wins when composition begins during a request, but
+          // a response can already be resolving. Avoid its state updates too.
+          if (businessPurposeComposingRef.current) return;
           if (!res.ok) {
             setSave({
               kind: "error",
@@ -315,9 +326,23 @@ export function FormPane(props: FormPaneProps) {
       merchant,
       amountDisplay,
       currency,
-      businessPurpose,
       attendees,
     ],
+  );
+
+  const handleBusinessPurposeCompositionStart = useCallback(() => {
+    businessPurposeComposingRef.current = true;
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    inFlightRef.current?.abort();
+  }, []);
+
+  const handleBusinessPurposeCompositionEnd = useCallback(
+    (value: string) => {
+      businessPurposeValueRef.current = value;
+      businessPurposeComposingRef.current = false;
+      triggerSave(false);
+    },
+    [triggerSave],
   );
 
   // ADR 0006 §D6: discretionary export_statement_month override. Explicit (not
@@ -359,7 +384,7 @@ export function FormPane(props: FormPaneProps) {
     // Sealed receipt: never fire the autosave debounce. The fields are disabled
     // so they can't change, but this guards against programmatic state changes
     // and is the explicit "suppress entirely" the lock requires.
-    if (isLocked) return;
+    if (isLocked || businessPurposeComposingRef.current) return;
     triggerSave(false);
   }, [
     paymentPath,
@@ -368,7 +393,6 @@ export function FormPane(props: FormPaneProps) {
     merchant,
     amountDisplay,
     currency,
-    businessPurpose,
     attendees,
     isLocked,
     triggerSave,
@@ -400,7 +424,7 @@ export function FormPane(props: FormPaneProps) {
             merchant: merchant.trim() || null,
             amountMinor,
             currency,
-            businessPurpose: businessPurpose.trim() || null,
+            businessPurpose: businessPurposeValueRef.current.trim() || null,
             attendees: attendees.map((a) => a.trim()).filter(Boolean),
             // Promote to reviewed only when still in a pre-review state. For an
             // already-reviewed/reconciled/exported/archived receipt the server
@@ -441,7 +465,6 @@ export function FormPane(props: FormPaneProps) {
     merchant,
     amountDisplay,
     currency,
-    businessPurpose,
     attendees,
     nextReceiptId,
     queryParams,
@@ -741,8 +764,21 @@ export function FormPane(props: FormPaneProps) {
             hint={needsAttendees ? "Required" : "Optional"}
           >
             <TextInput
-              value={businessPurpose}
-              onChange={(e) => setBusinessPurpose(e.target.value)}
+              inputRef={businessPurposeInputRef}
+              defaultValue={receipt.business_purpose ?? ""}
+              onChange={(e) => {
+                businessPurposeValueRef.current = e.currentTarget.value;
+                if (!businessPurposeComposingRef.current) triggerSave(false);
+              }}
+              onCompositionStart={handleBusinessPurposeCompositionStart}
+              onCompositionEnd={(e) =>
+                handleBusinessPurposeCompositionEnd(e.currentTarget.value)
+              }
+              onBlur={(e) => {
+                businessPurposeValueRef.current = e.currentTarget.value;
+                businessPurposeComposingRef.current = false;
+                triggerSave(false);
+              }}
               disabled={isLocked}
               placeholder="e.g. Client dinner — Acme product review"
             />

--- a/components/ui/field.tsx
+++ b/components/ui/field.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ReactNode, InputHTMLAttributes } from "react";
+import type { ReactNode, InputHTMLAttributes, Ref } from "react";
 
 export function Field({
   label,
@@ -54,6 +54,7 @@ export interface TextInputProps
   prefix?: ReactNode;
   suffix?: ReactNode;
   containerClassName?: string;
+  inputRef?: Ref<HTMLInputElement>;
 }
 
 export function TextInput({
@@ -62,6 +63,7 @@ export function TextInput({
   suffix,
   className = "",
   containerClassName = "",
+  inputRef,
   readOnly,
   ...rest
 }: TextInputProps) {
@@ -78,6 +80,7 @@ export function TextInput({
     >
       {prefix && <span className="text-[13px] text-gray-400">{prefix}</span>}
       <input
+        ref={inputRef}
         readOnly={readOnly}
         className={[
           "min-w-0 flex-1 bg-transparent text-sm text-gray-900 outline-none tabular-nums placeholder:text-gray-400",

--- a/tests/receipts/ime-focus-safety.test.ts
+++ b/tests/receipts/ime-focus-safety.test.ts
@@ -31,28 +31,31 @@ test("review autosave never refreshes the route while an operator is typing", ()
   assert.doesNotMatch(autosave, /router\.refresh\(/);
 });
 
-test("Business purpose remains a plain controlled input without IME-time state updates", () => {
-  // PR #189 added composition-start state updates to this controlled input.
-  // On Sonoma WebKit that render can write React's previous value over the
-  // browser's uncommitted marked text, making the field appear not to accept
-  // input at all. Do not restore that field-specific lifecycle.
-  assert.doesNotMatch(
+test("Business purpose is DOM-owned and its composition guard is ref-only", () => {
+  // Both state at compositionstart and a controlled value during later renders
+  // have broken Sonoma WebKit IME. The DOM owns marked text until commit.
+  assert.match(
     reviewForm,
-    /isBusinessPurposeComposing|businessPurposeComposingRef/,
+    /const businessPurposeComposingRef = useRef\(false\)/,
   );
+  assert.doesNotMatch(reviewForm, /isBusinessPurposeComposing/);
+  assert.doesNotMatch(reviewForm, /setBusinessPurpose/);
+  const compositionStart = section(
+    reviewForm,
+    "const handleBusinessPurposeCompositionStart",
+    "const handleBusinessPurposeCompositionEnd",
+  );
+  assert.doesNotMatch(compositionStart, /\bset[A-Z]\w*\(/);
+  assert.match(compositionStart, /businessPurposeComposingRef\.current = true/);
   const documentationField = section(
     reviewForm,
     'label="Business purpose"',
     'label="Attendees"',
   );
-  assert.doesNotMatch(
-    documentationField,
-    /onCompositionStart|onCompositionEnd/,
-  );
-  assert.match(
-    documentationField,
-    /onChange=\{\(e\) => setBusinessPurpose\(e\.target\.value\)\}/,
-  );
+  assert.match(documentationField, /onCompositionStart=/);
+  assert.match(documentationField, /onCompositionEnd=/);
+  assert.match(documentationField, /defaultValue=/);
+  assert.doesNotMatch(documentationField, /\svalue=\{/);
 });
 
 test("IME Enter does not blur the Missing receipt reason field", () => {


### PR DESCRIPTION
## Third IME hotfix — Business purpose still uneditable on Sonoma after #190

**Production evidence after PR #190:** removing `router.refresh()` from autosave was **necessary but insufficient**. Missing receipt reason now works, but **Business purpose stays uneditable on Sonoma** (works on Tahoe).

**Root cause:** Business purpose was still a **controlled** input. Its 450 ms autosave calls `setSave()`, which rerenders the controlled `value` while Sonoma WebKit owns uncommitted Japanese marked text → the marked text is clobbered. Missing receipt reason works because its draft stays **DOM-owned** until intentional blur. This PR matches that model for the one field.

### `components/ui/field.tsx`
- Add optional `inputRef?: Ref<HTMLInputElement>` to `TextInput`, passed to the native `<input ref>`. No other change to shared behavior.

### `components/receipts/review/form-pane.tsx` — Business purpose becomes uncontrolled
- Remove its React value state; render with `defaultValue`, not `value`.
- Track text in `businessPurposeValueRef`; hold the native input via `businessPurposeInputRef`; composition status in `businessPurposeComposingRef` only.
- `compositionstart`: set composing ref + clear timer + abort in-flight — **no React state update** (setState here is exactly what #189 broke).
- Every autosave timer rechecks the composing ref before `setSave()`/request; a resolving response also rechecks before any state update.
- `compositionend`: capture committed DOM value, release ref, debounced save.
- ordinary `onChange`: update value ref, schedule debounced save (guarded).
- `blur`: capture DOM value, release any stale composing flag, schedule save.
- Both PATCH payloads (autosave + Mark Reviewed) read `businessPurposeValueRef`.
- OCR fill-in updates the value ref **and** the native input via `businessPurposeInputRef`.
- PR #190's removal of `router.refresh()` from ordinary autosave preserved. No focus restoration; no React state at composition start; no controlled `value`.

### `tests/receipts/ime-focus-safety.test.ts`
- Keeps the no-autosave-refresh and Missing-receipt-reason protections.
- Business purpose test now enforces DOM ownership: `defaultValue` present, no controlled `value`, no `setBusinessPurpose`, ref-only composition status, no React setter inside composition-start, handlers stay connected.

Missing receipt reason needs no further source change — PR #190 is working in production.

## Verification
- [x] `npx tsx --test tests/receipts/ime-focus-safety.test.ts` — 3/3 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on all 3 files — clean
- [x] `npm run build:cf` — `OpenNext build complete`
- [x] Staged set confirmed: exactly the 3 intended files

This RCA is evidence-based but remains an inference until validated on the actual Sonoma machine (CLI checks do not prove native IME behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)